### PR TITLE
Users/davetheunissen/query metrics option

### DIFF
--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -104,6 +104,17 @@ namespace Microsoft.Azure.Cosmos
         public virtual ConsistencyLevel? ConsistencyLevel { get; set; }
 
         /// <summary>
+        ///  Gets or sets the populate query metrics request option for document query requests in the Azure Cosmos DB service.
+        /// </summary>
+        /// <remarks>
+        /// <para> 
+        /// PopulateQueryMetrics is used to enable/disable getting metrics relating to query execution on document query requests.
+        /// </para>
+        /// </remarks>
+        public bool PopulateQueryMetrics { get; set; }
+
+
+        /// <summary>
         /// Gets or sets the number of concurrent operations run client side during 
         /// parallel query execution in the Azure Cosmos DB service. 
         /// A positive property value limits the number of 
@@ -153,6 +164,7 @@ namespace Microsoft.Azure.Cosmos
                 EnableScanInQuery = this.EnableScanInQuery,
                 EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy,
                 MaxBufferedItemCount = this.MaxBufferedItemCount,
+                PopulateQueryMetrics = this.PopulateQueryMetrics
             };
         }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Azure.Cosmos
     /// <typeparam name="T"></typeparam>
     public class CosmosQueryResponse<T> : IEnumerable<T>
     {
-        private IEnumerable<T> Resources;
+        /// <summary>
+        /// Contains the metadata from the response headers from the Azure Cosmos DB call
+        /// </summary>
+        public IEnumerable<T> Resources;
+
         private bool HasMoreResults;
 
         /// <summary>


### PR DESCRIPTION
This PR relates to issues #21 and #33 

- Added the PopulateQueryMetrics property to the CosmosQueryRequestOptions class and maped to underlying FeedOptions.

- Updated CosmosQueryResponse Resources to be public so that the meta for the response is available to the calling client

- Added a unit test to ensure that QueryMetrics are populated when the PopulateQueryMetrics feed option is set.