### PR TITLE
Supports disabling SSL certificate verification

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Cosmos
             this.MaxConnectionLimit = defaultMaxConcurrentConnectionLimit;
             this.RetryOptions = new RetryOptions();
             this.EnableReadRequestsFallback = null;
+            this.DisableSslVerification = false;
         }
 
         /// <summary>
@@ -318,6 +319,22 @@ namespace Microsoft.Azure.Cosmos
         /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/documentdb/documentdb-performance-tips#429">Handle rate limiting/request rate too large</see>.
         /// </remarks>
         public RetryOptions RetryOptions
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets the flag to determine whether SSL verification will be disabled when connecting to Cosmos DB over HTTPS.
+        /// </summary>
+        /// <remarks>
+        /// When the value of this property is true, the SDK will bypass the normal SSL certificate verification
+        /// process. This is useful when connecting the client to a Cosmos DB emulator across the network as
+        /// some Linux clients do not honor any self-signed certificates that are installed into ca-certificates.
+        /// Do not set this property when targeting Production environments.
+        /// <value>Default value is false.</value>
+        /// </remarks>
+        public bool DisableSslVerification
         {
             get;
             set;

--- a/Microsoft.Azure.Cosmos/src/CosmosConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosConfiguration.cs
@@ -127,6 +127,18 @@ namespace Microsoft.Azure.Cosmos
         internal string AccountKey { get; }
 
         /// <summary>
+        /// Gets or sets the flag to determine whether SSL verification will be disabled when connecting to Cosmos DB over HTTPS.
+        /// </summary>
+        /// <remarks>
+        /// When the value of this property is true, the SDK will bypass the normal SSL certificate verification
+        /// process. This is useful when connecting the client to a Cosmos DB emulator across the network as
+        /// some Linux clients do not honor any self-signed certificates that are installed into ca-certificates.
+        /// Do not set this property when targeting Production environments.
+        /// <value>Default value is false.</value>
+        /// </remarks>
+        public virtual bool DisableSslVerification { get; set; }
+
+        /// <summary>
         /// A suffix to be added to the default user-agent for the Azure Cosmos DB service.
         /// </summary>
         /// <remarks>
@@ -442,6 +454,7 @@ namespace Microsoft.Azure.Cosmos
                 ConnectionProtocol = this.ConnectionProtocol,
                 UserAgentContainer = this.UserAgentContainer,
                 UseMultipleWriteLocations = true,
+                DisableSslVerification = this.DisableSslVerification
             };
 
             if (this.CurrentRegion != null)
@@ -470,6 +483,7 @@ namespace Microsoft.Azure.Cosmos
             this.ConnectionMode = CosmosConfiguration.DefaultConnectionMode;
             this.ConnectionProtocol = CosmosConfiguration.DefaultProtocol;
             this.ApiType = CosmosConfiguration.DefaultApiType;
+            this.DisableSslVerification = false;
         }
 
         private static string GetValueFromSqlConnectionString(DbConnectionStringBuilder builder, string keyName)

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6793,7 +6793,6 @@ namespace Microsoft.Azure.Cosmos
                 var clientHandler = new HttpClientHandler();
                 if (connectionPolicy.DisableSslVerification)
                 {
-                    clientHandler.ClientCertificateOptions = ClientCertificateOption.Manual;
                     clientHandler.ServerCertificateCustomValidationCallback += (message, certificate2, x509Chain, sslPolicyErrors) =>
                     {
                         return true;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConfigurationUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConfigurationUnitTests.cs
@@ -136,5 +136,28 @@ namespace Microsoft.Azure.Cosmos.Tests
             var configuration = new CosmosConfiguration(connectionString);
             Assert.IsInstanceOfType(configuration.CosmosJsonSerializer, typeof(CosmosJsonSerializerWrapper));
         }
+
+        [TestMethod]
+        public void VerifySslVerificationDefaultsToFalse()
+        {
+            var configuration = new CosmosConfiguration(ConnectionString);
+
+            //Verify GetConnectionPolicy returns the correct values for default
+            ConnectionPolicy policy = configuration.GetConnectionPolicy();
+            Assert.AreEqual(false, policy.DisableSslVerification, "DisableSslVerification should default to false");
+        }
+
+        [TestMethod]
+        public void VerifyDisableSslVerificationIsConfigured()
+        {
+            var configuration = new CosmosConfiguration(ConnectionString)
+            {
+                DisableSslVerification = true
+            };
+
+            //Verify that ConnectionPolicy.DisableSslVerification is set by CosmosConfiguration
+            ConnectionPolicy policy = configuration.GetConnectionPolicy();
+            Assert.AreEqual(true, policy.DisableSslVerification, "DisableSslVerification should be set by CosmosConfiguration");
+        }
     }
 }


### PR DESCRIPTION
See [Issue 42](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/42). 

This PR will add the DisableSslVerification property to the CosmosConfiguration. It then gets set on the ConnectionPolicy (this property was present on the the Java and Python SDKs).

Finally the HttpRequestMessageHandler is modified to take the ConnectionPolicy as a constructor parameter. If the DisableSslVerification is true, then a certificate bypass function is added to the HttpClientHandler.

This was tested on a microsoft/dotnet:runtime image running on a Linux container. By setting 
DisableSslVerification to true, and DisableSslVerification ConnectionMode = ConnectionMode.Gateway, then the container can connect to the emulator running on the host machine.

Without these settings, the container complains about unsigned certificates with the "The remote certificate is invalid according to the validation procedure" error. The exception is thrown even if you install the self-signed certificate into the ca-certificates store. This is due to the way the .NET core code interops with the cURL/OpenSSL libraries. (They return error 18 for a self-signed certificate). This does not occur with Windows containers.