### PR TITLE
Issue #42: Added support for a custom HttpMessageHandler

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Azure.Cosmos
                 transportClientHandlerFactory: cosmosClientConfiguration.TransportClientHandlerFactory,
                 connectionPolicy: cosmosClientConfiguration.GetConnectionPolicy(),
                 enableCpuMonitor: cosmosClientConfiguration.EnableCpuMonitor,
-                storeClientFactory: cosmosClientConfiguration.StoreClientFactory);
+                storeClientFactory: cosmosClientConfiguration.StoreClientFactory,
+                handler: cosmosClientConfiguration.HttpMessageHandler);
 
             Init(
                 cosmosClientConfiguration,

--- a/Microsoft.Azure.Cosmos/src/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientBuilder.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
+using System.Net.Http;
+
 namespace Microsoft.Azure.Cosmos
 {
     using System;
@@ -209,6 +211,21 @@ namespace Microsoft.Azure.Cosmos
         {
             this.cosmosClientConfiguration.MaxRetryWaitTimeOnThrottledRequests = maxRetryWaitTimeOnThrottledRequests;
             this.cosmosClientConfiguration.MaxRetryAttemptsOnThrottledRequests = maxRetryAttemptsOnThrottledRequests;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the HTTP handler stack to use for sending requests.
+        /// </summary>
+        /// <param name="handler">The HTTP handler stack to use for sending requests</param>
+        /// <remarks>
+        /// A custom HttpMessageHandler (e.g., HttpClientHandler) may be used to override SSL self-signed certificate verification when connecting to the Cosmos DB emulator
+        /// in a development environment. It may also be used to specify an HTTP proxy.
+        /// </remarks>
+        /// <seealso cref="System.Net.Http.HttpMessageHandler"/>
+        public virtual CosmosClientBuilder UseHttpMessageHandler(HttpMessageHandler handler)
+        {
+            this.cosmosClientConfiguration.HttpMessageHandler = handler;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClientConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientConfiguration.cs
@@ -2,6 +2,8 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
+using System.Net.Http;
+
 namespace Microsoft.Azure.Cosmos
 {
     using System;
@@ -279,6 +281,11 @@ namespace Microsoft.Azure.Cosmos
         /// Optional store client factory instance to use for all transport requests.
         /// </summary>
         internal IStoreClientFactory StoreClientFactory { get; set; }
+
+        /// <summary>
+        /// The HTTP handler stack to use for sending requests (e.g., HttpClientHandler)
+        /// </summary>
+        internal HttpMessageHandler HttpMessageHandler { get; set; }
 
         /// <summary>
         /// Flag that controls whether CPU monitoring thread is created to enrich timeout exceptions with additional diagnostic. Default value is true.


### PR DESCRIPTION
This PR allows the consumer to specify a custom HttpMessageHandler. 

This may be to:
1. override SSL verification and support connecting to the emulator from a Linux machine across the network, for example when connecting from within a Linux container
2. specifying an HTTP proxy if one is needed to connect to the Internet

A new constructor has been added to DocumentClient which has the same signature as the V2 SDK - it allows the consumer to inject an HttpMessageHandler which is then wired up to the InnerHandler of the HttpRequestMessageHandler.

The CosmosClientBuilder has a UseHttpMessageHandler method addded to it.