### PR TITLE
Bump up direct version in OSS SDK

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -6,8 +6,8 @@
     <Description>This client library enables client applications to connect to Azure Cosmos via the SQL API. Azure Cosmos is a globally distributed, multi-model database service. For more information, refer to http://azure.microsoft.com/services/cosmos-db/. </Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <ClientVersion>3.0.0.6-preview</ClientVersion>
-    <DirectVersion>3.0.0.6-preview</DirectVersion>	
+    <ClientVersion>3.0.0.9-preview</ClientVersion>
+    <DirectVersion>3.0.0.9-preview</DirectVersion>	
     <Version Condition=" '$(IsNightly)' == '1' ">$(ClientVersion)-nightly$(CurrentDate)</Version>
     <Version Condition=" '$(IsNightly)' == '0' Or '$(IsNightly)' == '' ">$(ClientVersion)</Version>
     <FileVersion>$(VersionPrefix)</FileVersion>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -33,11 +33,11 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(SignAssembly)' == 'true' ">
-    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[3.0.0.6-preview,)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[3.0.0.9-preview,)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SignAssembly)' != 'true' ">
-    <PackageReference Include="Microsoft.Azure.Cosmos.Direct.MyGet" Version="[3.0.0.6-preview,)" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct.MyGet" Version="[3.0.0.9-preview,)" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
Bump the direct package to 3.0.0.9 in order to continue the release process.