### PR TITLE
Query pipeline is updated to use CosmosQueryRequestOptions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClientWithUriParameters.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClientWithUriParameters.cs
@@ -1580,7 +1580,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException("documentCollectionOrDatabaseUri");
             }
 
-            return this.CreateDocumentQuery<T>(documentCollectionOrDatabaseUri.OriginalString, querySpec, feedOptions);
+            return this.CreateDocumentQuery<T>(documentCollectionOrDatabaseUri.OriginalString, querySpec, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/FeedOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedOptions.cs
@@ -405,14 +405,6 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Helper function to convert back to older type
         /// </summary>
-        public static implicit operator FeedOptions(CosmosQueryRequestOptions requestOptions)
-        {
-            return requestOptions.ToFeedOptions();
-        }
-
-        /// <summary>
-        /// Helper function to convert back to older type
-        /// </summary>
         public static implicit operator CosmosQueryRequestOptions(FeedOptions feedOptions)
         {
             return new CosmosQueryRequestOptions(feedOptions);

--- a/Microsoft.Azure.Cosmos/src/FeedOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedOptions.cs
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         public static explicit operator CosmosQueryRequestOptions(FeedOptions feedOptions)
         {
-            return new CosmosQueryRequestOptions(feedOptions);
+            return feedOptions == null ? new CosmosQueryRequestOptions() : new CosmosQueryRequestOptions(feedOptions);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/FeedOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedOptions.cs
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Helper function to convert back to older type
         /// </summary>
-        public static implicit operator CosmosQueryRequestOptions(FeedOptions feedOptions)
+        public static explicit operator CosmosQueryRequestOptions(FeedOptions feedOptions)
         {
             return new CosmosQueryRequestOptions(feedOptions);
         }

--- a/Microsoft.Azure.Cosmos/src/FeedOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedOptions.cs
@@ -401,5 +401,21 @@ namespace Microsoft.Azure.Cosmos
         internal CosmosSerializationOptions CosmosSerializationOptions { get; set; }
 
         internal IDictionary<string, object> Properties { get; set; }
+
+        /// <summary>
+        /// Helper function to convert back to older type
+        /// </summary>
+        public static implicit operator FeedOptions(CosmosQueryRequestOptions requestOptions)
+        {
+            return requestOptions.ToFeedOptions();
+        }
+
+        /// <summary>
+        /// Helper function to convert back to older type
+        /// </summary>
+        public static implicit operator CosmosQueryRequestOptions(FeedOptions feedOptions)
+        {
+            return new CosmosQueryRequestOptions(feedOptions);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
@@ -3739,7 +3739,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="collectionLink">The link to the parent document collection.</param>
         /// <param name="querySpec">The SqlQuerySpec instance containing the SQL expression.</param>
-        /// <param name="requestOptions">The options for processing the query result feed. </param>
+        /// <param name="queryRequestOptions">The options for processing the query result feed. </param>
         /// <returns>An IQueryable{T} that can evaluate the query.</returns>
         /// <example>
         /// This example below queries for some book documents.
@@ -3807,7 +3807,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>Refer to https://msdn.microsoft.com/en-us/library/azure/dn782250.aspx and http://azure.microsoft.com/documentation/articles/documentdb-sql-query/ for syntax and examples.</remarks>
         /// <seealso cref="Microsoft.Azure.Cosmos.Internal.Document"/>
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
-        IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions requestOptions = null);
+        IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions queryRequestOptions = null);
 
         /// <summary>
         /// Overloaded. This method creates a query for documents under a collection in an Azure Cosmos DB service. It returns IOrderedQueryable{Document}.

--- a/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
@@ -3739,7 +3739,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="collectionLink">The link to the parent document collection.</param>
         /// <param name="querySpec">The SqlQuerySpec instance containing the SQL expression.</param>
-        /// <param name="feedOptions">The options for processing the query result feed. For details, see <see cref="T:Microsoft.Azure.Documents.Client.FeedOptions"/></param>
+        /// <param name="requestOptions">The options for processing the query result feed. </param>
         /// <returns>An IQueryable{T} that can evaluate the query.</returns>
         /// <example>
         /// This example below queries for some book documents.
@@ -3807,7 +3807,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>Refer to https://msdn.microsoft.com/en-us/library/azure/dn782250.aspx and http://azure.microsoft.com/documentation/articles/documentdb-sql-query/ for syntax and examples.</remarks>
         /// <seealso cref="Microsoft.Azure.Cosmos.Internal.Document"/>
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
-        IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null);
+        IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions requestOptions = null);
 
         /// <summary>
         /// Overloaded. This method creates a query for documents under a collection in an Azure Cosmos DB service. It returns IOrderedQueryable{Document}.

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
@@ -637,7 +637,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="collectionLink">The link to the parent document collection.</param>
         /// <param name="querySpec">The SqlQuerySpec instance containing the SQL expression.</param>
-        /// <param name="requestOptions">The options for processing the query result feed.</param>
+        /// <param name="queryRequestOptions">The options for processing the query result feed.</param>
         /// <returns>An IQueryable{T} that can evaluate the query.</returns>
         /// <example>
         /// This example below queries for some book documents.
@@ -705,9 +705,9 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>Refer to https://msdn.microsoft.com/en-us/library/azure/dn782250.aspx and http://azure.microsoft.com/documentation/articles/documentdb-sql-query/ for syntax and examples.</remarks>
         /// <seealso cref="Microsoft.Azure.Cosmos.Internal.Document"/>
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
-        public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions requestOptions = null)
+        public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions queryRequestOptions = null)
         {
-            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, requestOptions).AsSQL<T, T>(querySpec);
+            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, queryRequestOptions).AsSQL<T, T>(querySpec);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
@@ -637,7 +637,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="collectionLink">The link to the parent document collection.</param>
         /// <param name="querySpec">The SqlQuerySpec instance containing the SQL expression.</param>
-        /// <param name="feedOptions">The options for processing the query result feed. For details, see <see cref="T:Microsoft.Azure.Documents.Client.FeedOptions"/></param>
+        /// <param name="requestOptions">The options for processing the query result feed.</param>
         /// <returns>An IQueryable{T} that can evaluate the query.</returns>
         /// <example>
         /// This example below queries for some book documents.
@@ -705,9 +705,9 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>Refer to https://msdn.microsoft.com/en-us/library/azure/dn782250.aspx and http://azure.microsoft.com/documentation/articles/documentdb-sql-query/ for syntax and examples.</remarks>
         /// <seealso cref="Microsoft.Azure.Cosmos.Internal.Document"/>
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
-        public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
+        public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, CosmosQueryRequestOptions requestOptions = null)
         {
-            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions).AsSQL<T, T>(querySpec);
+            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, requestOptions).AsSQL<T, T>(querySpec);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<CosmosDatabaseSettings> CreateDatabaseQuery(FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosDatabaseSettings>(this, ResourceType.Database, typeof(CosmosDatabaseSettings), Paths.Databases_Root, feedOptions);
+            return new DocumentQuery<CosmosDatabaseSettings>(this, ResourceType.Database, typeof(CosmosDatabaseSettings), Paths.Databases_Root, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateDatabaseQuery(SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosDatabaseSettings>(this, ResourceType.Database, typeof(CosmosDatabaseSettings), Paths.Databases_Root, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<CosmosDatabaseSettings>(this, ResourceType.Database, typeof(CosmosDatabaseSettings), Paths.Databases_Root, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<CosmosContainerSettings> CreateDocumentCollectionQuery(string databaseLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosContainerSettings>(this, ResourceType.Collection, typeof(CosmosContainerSettings), databaseLink, feedOptions);
+            return new DocumentQuery<CosmosContainerSettings>(this, ResourceType.Collection, typeof(CosmosContainerSettings), databaseLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateDocumentCollectionQuery(string databaseLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosContainerSettings>(this, ResourceType.Collection, typeof(CosmosContainerSettings), databaseLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<CosmosContainerSettings>(this, ResourceType.Collection, typeof(CosmosContainerSettings), databaseLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<CosmosStoredProcedureSettings> CreateStoredProcedureQuery(string collectionLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosStoredProcedureSettings>(this, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), collectionLink, feedOptions);
+            return new DocumentQuery<CosmosStoredProcedureSettings>(this, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="CosmosStoredProcedureSettings"/>
         public IQueryable<dynamic> CreateStoredProcedureQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosStoredProcedureSettings>(this, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), collectionLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<CosmosStoredProcedureSettings>(this, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<CosmosTriggerSettings> CreateTriggerQuery(string collectionLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosTriggerSettings>(this, ResourceType.Trigger, typeof(CosmosTriggerSettings), collectionLink, feedOptions);
+            return new DocumentQuery<CosmosTriggerSettings>(this, ResourceType.Trigger, typeof(CosmosTriggerSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateTriggerQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosTriggerSettings>(this, ResourceType.Trigger, typeof(CosmosTriggerSettings), collectionLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<CosmosTriggerSettings>(this, ResourceType.Trigger, typeof(CosmosTriggerSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<CosmosUserDefinedFunctionSettings> CreateUserDefinedFunctionQuery(string collectionLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosUserDefinedFunctionSettings>(this, ResourceType.UserDefinedFunction, typeof(CosmosUserDefinedFunctionSettings), collectionLink, feedOptions);
+            return new DocumentQuery<CosmosUserDefinedFunctionSettings>(this, ResourceType.UserDefinedFunction, typeof(CosmosUserDefinedFunctionSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateUserDefinedFunctionQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosUserDefinedFunctionSettings>(this, ResourceType.UserDefinedFunction, typeof(CosmosUserDefinedFunctionSettings), collectionLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<CosmosUserDefinedFunctionSettings>(this, ResourceType.UserDefinedFunction, typeof(CosmosUserDefinedFunctionSettings), collectionLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -401,7 +401,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<Conflict> CreateConflictQuery(string collectionLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Conflict>(this, ResourceType.Conflict, typeof(Conflict), collectionLink, feedOptions);
+            return new DocumentQuery<Conflict>(this, ResourceType.Conflict, typeof(Conflict), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateConflictQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Conflict>(this, ResourceType.Conflict, typeof(Conflict), collectionLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<Conflict>(this, ResourceType.Conflict, typeof(Conflict), collectionLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -517,7 +517,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<T> CreateDocumentQuery<T>(string collectionLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions);
+            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.Cosmos
                   " Please use the override that does not take a partitionKey parameter.")]
         public IOrderedQueryable<T> CreateDocumentQuery<T>(string documentsFeedOrDatabaseLink, FeedOptions feedOptions, object partitionKey)
         {
-            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), documentsFeedOrDatabaseLink, feedOptions, partitionKey);
+            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), documentsFeedOrDatabaseLink, (CosmosQueryRequestOptions)feedOptions, partitionKey);
         }
 
         /// <summary>
@@ -605,7 +605,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, string sqlExpression, FeedOptions feedOptions = null)
         {
-            return this.CreateDocumentQuery<T>(collectionLink, new SqlQuerySpec(sqlExpression), feedOptions);
+            return this.CreateDocumentQuery<T>(collectionLink, new SqlQuerySpec(sqlExpression), (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -730,7 +730,7 @@ namespace Microsoft.Azure.Cosmos
                   " Please use the override that does not take a partitionKey parameter.")]
         public IQueryable<T> CreateDocumentQuery<T>(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions, object partitionKey)
         {
-            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions, partitionKey).AsSQL<T, T>(querySpec);
+            return new DocumentQuery<T>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions, partitionKey).AsSQL<T, T>(querySpec);
         }
 
         /// <summary>
@@ -758,7 +758,7 @@ namespace Microsoft.Azure.Cosmos
         public IOrderedQueryable<Document> CreateDocumentQuery(string collectionLink, FeedOptions feedOptions = null)
 
         {
-            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions);
+            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -778,7 +778,7 @@ namespace Microsoft.Azure.Cosmos
                   " Please use the override that does not take a partitionKey parameter.")]
         public IOrderedQueryable<Document> CreateDocumentQuery(string collectionLink, FeedOptions feedOptions, object partitionKey)
         {
-            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions, partitionKey);
+            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions, partitionKey);
         }
 
         /// <summary>
@@ -853,7 +853,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateDocumentQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -875,7 +875,7 @@ namespace Microsoft.Azure.Cosmos
                   " Please use the override that does not take a partitionKey parameter.")]
         public IQueryable<dynamic> CreateDocumentQuery(string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions, object partitionKey)
         {
-            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, feedOptions, partitionKey).AsSQL(querySpec);
+            return new DocumentQuery<Document>(this, ResourceType.Document, typeof(Document), collectionLink, (CosmosQueryRequestOptions)feedOptions, partitionKey).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -953,7 +953,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IOrderedQueryable<Offer> CreateOfferQuery(FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, feedOptions);
+            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -980,7 +980,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateOfferQuery(string sqlExpression, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, feedOptions).AsSQL(new SqlQuerySpec(sqlExpression));
+            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, (CosmosQueryRequestOptions)feedOptions).AsSQL(new SqlQuerySpec(sqlExpression));
         }
 
         /// <summary>
@@ -1007,7 +1007,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="Microsoft.Azure.Cosmos.Linq.IDocumentQuery"/>
         public IQueryable<dynamic> CreateOfferQuery(SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<Offer>(this, ResourceType.Offer, typeof(Offer), Paths.Offers_Root, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -1028,7 +1028,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="IDocumentQuery"/>
         internal IOrderedQueryable<UserDefinedType> CreateUserDefinedTypeQuery(string userDefinedTypesLink, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<UserDefinedType>(this, ResourceType.UserDefinedType, typeof(UserDefinedType), userDefinedTypesLink, feedOptions);
+            return new DocumentQuery<UserDefinedType>(this, ResourceType.UserDefinedType, typeof(UserDefinedType), userDefinedTypesLink, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -1079,7 +1079,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="IDocumentQuery"/>
         internal IQueryable<dynamic> CreateUserDefinedTypeQuery(string userDefinedTypesLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<UserDefinedType>(this, ResourceType.UserDefinedType, typeof(UserDefinedType), userDefinedTypesLink, feedOptions).AsSQL(querySpec);
+            return new DocumentQuery<UserDefinedType>(this, ResourceType.UserDefinedType, typeof(UserDefinedType), userDefinedTypesLink, (CosmosQueryRequestOptions)feedOptions).AsSQL(querySpec);
         }
 
         /// <summary>
@@ -1097,7 +1097,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             ValidateChangeFeedOptionsForNotPartitionedResource(feedOptions);
-            return new ChangeFeedQuery<UserDefinedType>(this, ResourceType.UserDefinedType, databaseLink, feedOptions);
+            return new ChangeFeedQuery<UserDefinedType>(this, ResourceType.UserDefinedType, databaseLink,  feedOptions);
         }
         #endregion Query Methods
 

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private readonly ResourceType resourceTypeEnum;
         private readonly Type resourceType;
         private readonly string documentsFeedOrDatabaseLink;
-        private readonly CosmosQueryRequestOptions requestOptions;
+        private readonly CosmosQueryRequestOptions queryRequestOptions;
         private readonly object partitionKey;
 
         private readonly Expression expression;
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             Type resourceType,
             string documentsFeedOrDatabaseLink,
             Expression expression,
-            CosmosQueryRequestOptions requestOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             object partitionKey = null)
         {
             if (client == null)
@@ -60,22 +60,22 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.resourceTypeEnum = resourceTypeEnum;
             this.resourceType = resourceType;
             this.documentsFeedOrDatabaseLink = documentsFeedOrDatabaseLink;
-            this.requestOptions = requestOptions == null ? new CosmosQueryRequestOptions() : requestOptions.Clone();
+            this.queryRequestOptions = queryRequestOptions == null ? new CosmosQueryRequestOptions() : queryRequestOptions.Clone();
 
             // Swapping out negative values in requestOptions for int.MaxValue
-            if (this.requestOptions.MaxBufferedItemCount < 0)
+            if (this.queryRequestOptions.MaxBufferedItemCount < 0)
             {
-                this.requestOptions.MaxBufferedItemCount = int.MaxValue;
+                this.queryRequestOptions.MaxBufferedItemCount = int.MaxValue;
             }
 
-            if (this.requestOptions.MaxConcurrency < 0)
+            if (this.queryRequestOptions.MaxConcurrency < 0)
             {
-                this.requestOptions.MaxConcurrency = int.MaxValue;
+                this.queryRequestOptions.MaxConcurrency = int.MaxValue;
             }
 
-            if (this.requestOptions.MaxItemCount < 0)
+            if (this.queryRequestOptions.MaxItemCount < 0)
             {
-                this.requestOptions.MaxItemCount = int.MaxValue;
+                this.queryRequestOptions.MaxItemCount = int.MaxValue;
             }
 
             this.partitionKey = partitionKey;
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 resourceTypeEnum,
                 resourceType,
                 documentsFeedOrDatabaseLink,
-                requestOptions,
+                queryRequestOptions,
                 partitionKey,
                 this.client.OnExecuteScalarQueryCallback);
             this.executeNextAysncMetrics = new SchedulingStopwatch();
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             ResourceType resourceTypeEnum,
             Type resourceType,
             string documentsFeedOrDatabaseLink,
-            CosmosQueryRequestOptions requestOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             object partitionKey = null) :
             this(
                 client,
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 resourceType,
                 documentsFeedOrDatabaseLink,
                 null,
-                requestOptions,
+                queryRequestOptions,
                 partitionKey)
         {
         }
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     FeedResponse<T> typedFeedResponse = FeedResponseBinder.ConvertCosmosElementFeed<T>(
                         feedResponse, 
                         this.resourceTypeEnum,
-                        this.requestOptions.JsonSerializerSettings);
+                        this.queryRequestOptions.JsonSerializerSettings);
                     foreach (T item in typedFeedResponse)
                     {
                         yield return item;
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceTypeEnum,
                 this.resourceType,
                 this.expression,
-                this.requestOptions,
+                this.queryRequestOptions,
                 this.documentsFeedOrDatabaseLink,
                 isContinuationExpected,
                 cancellationToken,
@@ -377,7 +377,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             FeedResponse<CosmosElement> response = await this.queryExecutionContext.ExecuteNextAsync(cancellationToken);
             CosmosQueryResponse typedFeedResponse = FeedResponseBinder.ConvertToCosmosQueryResponse(
                        response,
-                       this.requestOptions.CosmosSerializationOptions);
+                       this.queryRequestOptions.CosmosSerializationOptions);
 
             if (!this.HasMoreResults && !tracedLastExecution)
             {
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             FeedResponse<TResponse> typedFeedResponse = FeedResponseBinder.ConvertCosmosElementFeed<TResponse>(
                 response, 
                 this.resourceTypeEnum,
-                this.requestOptions.JsonSerializerSettings);
+                this.queryRequestOptions.JsonSerializerSettings);
 
             if (!this.HasMoreResults && !tracedLastExecution)
             {

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private readonly ResourceType resourceTypeEnum;
         private readonly Type resourceType;
         private readonly string documentsFeedOrDatabaseLink;
-        private readonly FeedOptions feedOptions;
+        private readonly CosmosQueryRequestOptions queryRequestOptions;
         private readonly object partitionKey;
         private readonly Action<IQueryable> onExecuteScalarQueryCallback;
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             ResourceType resourceTypeEnum,
             Type resourceType,
             string documentsFeedOrDatabaseLink,
-            FeedOptions feedOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             object partitionKey = null,
             Action<IQueryable> onExecuteScalarQueryCallback = null)
         {
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.resourceTypeEnum = resourceTypeEnum;
             this.resourceType = resourceType;
             this.documentsFeedOrDatabaseLink = documentsFeedOrDatabaseLink;
-            this.feedOptions = feedOptions;
+            this.queryRequestOptions = queryRequestOptions;
             this.partitionKey = partitionKey;
             this.onExecuteScalarQueryCallback = onExecuteScalarQueryCallback;
         }
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceType,
                 this.documentsFeedOrDatabaseLink,
                 expression,
-                this.feedOptions,
+                this.queryRequestOptions,
                 this.partitionKey);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceType,
                 this.documentsFeedOrDatabaseLink,
                 expression,
-                this.feedOptions,
+                this.queryRequestOptions,
                 this.partitionKey);
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceType,
                 this.documentsFeedOrDatabaseLink,
                 expression,
-                this.feedOptions,
+                this.queryRequestOptions,
                 this.partitionKey);
             this.onExecuteScalarQueryCallback?.Invoke(documentQuery);
 
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceType,
                 this.documentsFeedOrDatabaseLink,
                 expression,
-                this.feedOptions,
+                this.queryRequestOptions,
                 this.partitionKey);
             this.onExecuteScalarQueryCallback?.Invoke(documentQuery);
 
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.resourceType,
                 this.documentsFeedOrDatabaseLink,
                 expression,
-                this.feedOptions,
+                this.queryRequestOptions,
                 this.partitionKey);
             this.onExecuteScalarQueryCallback?.Invoke(documentQuery);
 

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryableExtension.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryableExtension.cs
@@ -525,12 +525,12 @@
 
         internal static IOrderedQueryable<Document> CreateDocumentQuery(this IDocumentQueryClient client, string collectionLink, FeedOptions feedOptions = null, object partitionKey = null)
         {
-            return new DocumentQuery<Document>(client, ResourceType.Document, typeof (Document), collectionLink, feedOptions, partitionKey);
+            return new DocumentQuery<Document>(client, ResourceType.Document, typeof (Document), collectionLink, (CosmosQueryRequestOptions)feedOptions, partitionKey);
         }
 
         internal static IQueryable<dynamic> CreateDocumentQuery(this IDocumentQueryClient client, string collectionLink, SqlQuerySpec querySpec, FeedOptions feedOptions = null, object partitionKey = null)
         {
-            return new DocumentQuery<Document>(client, ResourceType.Document, typeof (Document), collectionLink, feedOptions, partitionKey).AsSQL(querySpec);
+            return new DocumentQuery<Document>(client, ResourceType.Document, typeof (Document), collectionLink, (CosmosQueryRequestOptions)feedOptions, partitionKey).AsSQL(querySpec);
         }
 
         private static MethodInfo GetMethodInfoOf<T>(Expression<Func<T>> expression)

--- a/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
@@ -444,7 +444,7 @@ namespace Microsoft.Azure.Cosmos.Query
                             pkRange,
                             collectionRid);
                     },
-                    this.ExecuteRequestLazyAsync,
+                    this.ExecuteRequestAsync,
                     //// Retry policy callback
                     () => new NonRetriableInvalidPartitionExceptionRetryPolicy(collectionCache, this.Client.ResetSessionTokenRetryPolicy.GetRequestPolicy()),
                     this.OnDocumentProducerTreeCompleteFetching,

--- a/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
             this.documentProducerForest = new PriorityQueue<DocumentProducerTree>(moveNextComparer, isSynchronized: true);
             this.fetchPrioirtyFunction = fetchPrioirtyFunction;
-            this.comparableTaskScheduler = new ComparableTaskScheduler(initParams.FeedOptions.MaxDegreeOfParallelism);
+            this.comparableTaskScheduler = new ComparableTaskScheduler(initParams.RequestOptions.MaxConcurrency);
             this.equalityComparer = equalityComparer;
             this.requestChargeTracker = new RequestChargeTracker();
             this.partitionedQueryMetrics = new ConcurrentBag<Tuple<string, QueryMetrics>>();
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Cosmos.Query
             CancellationToken token)
         {
             CollectionCache collectionCache = await this.Client.GetCollectionCacheAsync();
-            INameValueCollection requestHeaders = await this.CreateCommonHeadersAsync(this.GetFeedOptions(null));
+            INameValueCollection requestHeaders = await this.CreateCommonHeadersAsync(this.GetRequestOptions(null));
 
             this.TraceInformation(string.Format(
                 CultureInfo.InvariantCulture,

--- a/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Cosmos.Query
         private async Task<DocumentServiceRequest> CreateRequestAsync()
         {
             INameValueCollection requestHeaders = await this.CreateCommonHeadersAsync(
-                    this.GetFeedOptions(this.ContinuationToken));
+                    this.GetRequestOptions(this.ContinuationToken));
 
             requestHeaders[HttpConstants.HttpHeaders.IsContinuationExpected] = isContinuationExpected.ToString();
 

--- a/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
                 request.RouteTo(new PartitionKeyRangeIdentity(collection.ResourceId, queryRoutingInfo.Item1.ResolvedRange.Id));
 
-                FeedResponse<CosmosElement> response = await this.ExecuteRequestLazyAsync(request, cancellationToken);
+                FeedResponse<CosmosElement> response = await this.ExecuteRequestAsync(request, cancellationToken);
 
                 if (!await this.partitionRoutingHelper.TryAddPartitionKeyRangeToContinuationTokenAsync(
                     response.Headers,

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextBase.cs
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Cosmos.Query
             ConsistencyLevel defaultConsistencyLevel = await this.client.GetDefaultConsistencyLevelAsync();
             ConsistencyLevel? desiredConsistencyLevel = await this.client.GetDesiredConsistencyLevelAsync();
 
-            return queryRequestOptions.CreateCommonHeadersAsync(
+            return this.queryRequestOptions.CreateCommonHeadersAsync(
                 queryRequestOptions,
                 defaultConsistencyLevel,
                 desiredConsistencyLevel,

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
         private static bool TryGetEpkProperty(FeedOptions feedOptions, out string effectivePartitionKeyString)
         {
-            if (feedOptions?.Properties == null && feedOptions.Properties.TryGetValue(
+            if (feedOptions?.Properties != null && feedOptions.Properties.TryGetValue(
                    WFConstants.BackendHeaders.EffectivePartitionKeyString, out object effectivePartitionKeyStringObject))
             {
                 effectivePartitionKeyString = effectivePartitionKeyStringObject as string;

--- a/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Query
         private readonly ResourceType resourceTypeEnum;
         private readonly Type resourceType;
         private readonly Expression expression;
-        private readonly FeedOptions feedOptions;
+        private readonly CosmosQueryRequestOptions requestOptions;
         private readonly string resourceLink;
 
         private readonly CosmosContainerSettings collection;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Query
             ResourceType resourceTypeEnum,
             Type resourceType,
             Expression expression,
-            FeedOptions feedOptions,
+            CosmosQueryRequestOptions requestOptions,
             string resourceLink,
             CosmosContainerSettings collection,
             bool isContinuationExpected,
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.Query
             this.resourceTypeEnum = resourceTypeEnum;
             this.resourceType = resourceType;
             this.expression = expression;
-            this.feedOptions = feedOptions;
+            this.requestOptions = requestOptions;
             this.resourceLink = resourceLink;
 
             this.collection = collection;
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Query
             ResourceType resourceTypeEnum,
             Type resourceType,
             Expression expression,
-            FeedOptions feedOptions,
+            CosmosQueryRequestOptions feedOptions,
             string resourceLink,
             CancellationToken token,
             CosmosContainerSettings collection,
@@ -83,15 +83,17 @@ namespace Microsoft.Azure.Cosmos.Query
             IDocumentQueryExecutionContext innerExecutionContext =
              new DefaultDocumentQueryExecutionContext(constructorParams, isContinuationExpected);
 
-            return new ProxyDocumentQueryExecutionContext(innerExecutionContext, client,
-                resourceTypeEnum,
-                resourceType,
-                expression,
-                feedOptions,
-                resourceLink,
-                collection, 
-                isContinuationExpected,
-                correlatedActivityId);
+            return new ProxyDocumentQueryExecutionContext(
+                innerExecutionContext: innerExecutionContext,
+                client: client,
+                resourceTypeEnum: resourceTypeEnum,
+                resourceType: resourceType,
+                expression: expression,
+                requestOptions: feedOptions,
+                resourceLink: resourceLink,
+                collection: collection,
+                isContinuationExpected: isContinuationExpected,
+                correlatedActivityId: correlatedActivityId);
         }
 
         public bool IsDone
@@ -138,7 +140,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     queryExecutionContext.GetTargetPartitionKeyRanges(collection.ResourceId,
                         partitionedQueryExecutionInfo.QueryRanges);
 
-            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(this.client, this.resourceTypeEnum, this.resourceType, this.expression, this.feedOptions, this.resourceLink, false, correlatedActivityId);
+            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(this.client, this.resourceTypeEnum, this.resourceType, this.expression, this.requestOptions, this.resourceLink, false, correlatedActivityId);
             this.innerExecutionContext = await DocumentQueryExecutionContextFactory.CreateSpecializedDocumentQueryExecutionContext(
                 constructorParams,
                 partitionedQueryExecutionInfo,

--- a/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Query
         private readonly ResourceType resourceTypeEnum;
         private readonly Type resourceType;
         private readonly Expression expression;
-        private readonly CosmosQueryRequestOptions requestOptions;
+        private readonly CosmosQueryRequestOptions queryRequestOptions;
         private readonly string resourceLink;
 
         private readonly CosmosContainerSettings collection;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Query
             ResourceType resourceTypeEnum,
             Type resourceType,
             Expression expression,
-            CosmosQueryRequestOptions requestOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             string resourceLink,
             CosmosContainerSettings collection,
             bool isContinuationExpected,
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.Query
             this.resourceTypeEnum = resourceTypeEnum;
             this.resourceType = resourceType;
             this.expression = expression;
-            this.requestOptions = requestOptions;
+            this.queryRequestOptions = queryRequestOptions;
             this.resourceLink = resourceLink;
 
             this.collection = collection;
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Query
             ResourceType resourceTypeEnum,
             Type resourceType,
             Expression expression,
-            CosmosQueryRequestOptions feedOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             string resourceLink,
             CancellationToken token,
             CosmosContainerSettings collection,
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.Query
             Guid correlatedActivityId)
         {
             token.ThrowIfCancellationRequested();
-            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(client, resourceTypeEnum, resourceType, expression, feedOptions, resourceLink, false, correlatedActivityId);
+            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(client, resourceTypeEnum, resourceType, expression, queryRequestOptions, resourceLink, false, correlatedActivityId);
             IDocumentQueryExecutionContext innerExecutionContext =
              new DefaultDocumentQueryExecutionContext(constructorParams, isContinuationExpected);
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 resourceTypeEnum: resourceTypeEnum,
                 resourceType: resourceType,
                 expression: expression,
-                requestOptions: feedOptions,
+                queryRequestOptions: queryRequestOptions,
                 resourceLink: resourceLink,
                 collection: collection,
                 isContinuationExpected: isContinuationExpected,
@@ -140,7 +140,16 @@ namespace Microsoft.Azure.Cosmos.Query
                     queryExecutionContext.GetTargetPartitionKeyRanges(collection.ResourceId,
                         partitionedQueryExecutionInfo.QueryRanges);
 
-            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(this.client, this.resourceTypeEnum, this.resourceType, this.expression, this.requestOptions, this.resourceLink, false, correlatedActivityId);
+            DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(
+                client: this.client,
+                resourceTypeEnum: this.resourceTypeEnum,
+                resourceType: this.resourceType,
+                expression: this.expression,
+                queryRequestOptions: this.queryRequestOptions,
+                resourceLink: this.resourceLink,
+                getLazyFeedResponse: false,
+                correlatedActivityId: correlatedActivityId);
+
             this.innerExecutionContext = await DocumentQueryExecutionContextFactory.CreateSpecializedDocumentQueryExecutionContext(
                 constructorParams,
                 partitionedQueryExecutionInfo,

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (feedOptions != null)
             {
-                this.RequestContinuation = this.RequestContinuation;
+                this.RequestContinuation = feedOptions.RequestContinuation;
                 this.MaxItemCount = feedOptions.MaxItemCount;
                 this.ResponseContinuationTokenLimitInKb = feedOptions.ResponseContinuationTokenLimitInKb;
                 this.EnableScanInQuery = feedOptions.EnableScanInQuery;

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -246,14 +246,14 @@ namespace Microsoft.Azure.Cosmos
         /// DEVNOTE: This will be converted to use CosmosRequestMessage in next PR
         /// </summary>
         internal INameValueCollection CreateCommonHeadersAsync(
-            FeedOptions feedOptions,
+            CosmosQueryRequestOptions queryRequestOptions,
             ConsistencyLevel defaultConsistencyLevel,
             ConsistencyLevel? desiredConsistencyLevel,
             ResourceType resourceType)
         {
             INameValueCollection requestHeaders = new StringKeyValueCollection();
 
-            if (!string.IsNullOrEmpty(feedOptions.SessionToken) && !ReplicatedResourceClient.IsReadingFromMaster(resourceType, OperationType.ReadFeed))
+            if (!string.IsNullOrEmpty(queryRequestOptions.SessionToken) && !ReplicatedResourceClient.IsReadingFromMaster(resourceType, OperationType.ReadFeed))
             {
                 if (defaultConsistencyLevel == Microsoft.Azure.Cosmos.ConsistencyLevel.Session ||
                     (desiredConsistencyLevel.HasValue && desiredConsistencyLevel.Value == Microsoft.Azure.Cosmos.ConsistencyLevel.Session))
@@ -267,22 +267,22 @@ namespace Microsoft.Azure.Cosmos
                     // irrespective of the chosen replica.
                     // For server resources, which don't span partitions, specify the session token 
                     // for correct replica to be chosen for servicing the query result.
-                    requestHeaders[HttpConstants.HttpHeaders.SessionToken] = feedOptions.SessionToken;
+                    requestHeaders[HttpConstants.HttpHeaders.SessionToken] = queryRequestOptions.SessionToken;
                 }
             }
 
-            requestHeaders[HttpConstants.HttpHeaders.Continuation] = feedOptions.RequestContinuation;
+            requestHeaders[HttpConstants.HttpHeaders.Continuation] = queryRequestOptions.RequestContinuation;
             requestHeaders[HttpConstants.HttpHeaders.IsQuery] = bool.TrueString;
 
             // Flow the pageSize only when we are not doing client eval
-            if (feedOptions.MaxItemCount.HasValue)
+            if (queryRequestOptions.MaxItemCount.HasValue)
             {
-                requestHeaders[HttpConstants.HttpHeaders.PageSize] = feedOptions.MaxItemCount.ToString();
+                requestHeaders[HttpConstants.HttpHeaders.PageSize] = queryRequestOptions.MaxItemCount.ToString();
             }
 
-            requestHeaders[HttpConstants.HttpHeaders.EnableCrossPartitionQuery] = feedOptions.EnableCrossPartitionQuery.ToString();
+            requestHeaders[HttpConstants.HttpHeaders.EnableCrossPartitionQuery] = queryRequestOptions.EnableCrossPartitionQuery.ToString();
 
-            if (feedOptions.MaxDegreeOfParallelism != 0)
+            if (queryRequestOptions.MaxConcurrency != 0)
             {
                 requestHeaders[HttpConstants.HttpHeaders.ParallelizeCrossPartitionQuery] = bool.TrueString;
             }

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public class CosmosQueryRequestOptions : CosmosRequestOptions
     {
-        private readonly FeedOptions feedOptions = null;
+        private readonly FeedOptions feedOptions;
 
         /// <summary>
         /// The default empty constructor
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Cosmos
         internal string PartitionKeyRangeId => this.feedOptions == null ? null : this.feedOptions.PartitionKeyRangeId;
 
         /// <summary>
-        /// DEVNOTE: This exists to keep compatability with FeedOptions. Support for JsonSerializerSettings is now obsolete. Please use CosmosJsonSerializer.
+        /// DEVNOTE: This exists to keep compatibility with FeedOptions. Support for JsonSerializerSettings is now obsolete. Please use CosmosJsonSerializer.
         /// Gets the <see cref="JsonSerializerSettings"/> for the current request used to deserialize the document.
         /// If null, uses the default serializer settings set up in the DocumentClient.
         /// </summary>
@@ -292,19 +292,9 @@ namespace Microsoft.Azure.Cosmos
                 requestHeaders[HttpConstants.HttpHeaders.EnableScanInQuery] = this.EnableScanInQuery.ToString();
             }
 
-            if (this.feedOptions.EmitVerboseTracesInQuery != null)
-            {
-                requestHeaders[HttpConstants.HttpHeaders.EmitVerboseTracesInQuery] = this.feedOptions.EmitVerboseTracesInQuery.ToString();
-            }
-
             if (this.EnableLowPrecisionOrderBy != null)
             {
                 requestHeaders[HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy] = this.EnableLowPrecisionOrderBy.ToString();
-            }
-
-            if (!string.IsNullOrEmpty(this.feedOptions.FilterBySchemaResourceId))
-            {
-                requestHeaders[HttpConstants.HttpHeaders.FilterBySchemaResourceId] = this.feedOptions.FilterBySchemaResourceId;
             }
 
             if (this.ResponseContinuationTokenLimitInKb != null)
@@ -321,53 +311,67 @@ namespace Microsoft.Azure.Cosmos
                 requestHeaders.Set(HttpConstants.HttpHeaders.ConsistencyLevel, desiredConsistencyLevel.Value.ToString());
             }
 
-            if (this.feedOptions.EnumerationDirection.HasValue)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.EnumerationDirection, this.feedOptions.EnumerationDirection.Value.ToString());
-            }
-
-            if (this.feedOptions.ReadFeedKeyType.HasValue)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.ReadFeedKeyType, this.feedOptions.ReadFeedKeyType.Value.ToString());
-            }
-
-            if (this.feedOptions.StartId != null)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.StartId, this.feedOptions.StartId);
-            }
-
-            if (this.feedOptions.EndId != null)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.EndId, this.feedOptions.EndId);
-            }
-
-            if (this.feedOptions.StartEpk != null)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.StartEpk, this.feedOptions.StartEpk);
-            }
-
-            if (this.feedOptions.EndEpk != null)
-            {
-                requestHeaders.Set(HttpConstants.HttpHeaders.EndEpk, this.feedOptions.EndEpk);
-            }
-
-            if (this.feedOptions.PopulateQueryMetrics)
-            {
-                requestHeaders[HttpConstants.HttpHeaders.PopulateQueryMetrics] = bool.TrueString;
-            }
-
-            if (this.feedOptions.ForceQueryScan)
-            {
-                requestHeaders[HttpConstants.HttpHeaders.ForceQueryScan] = bool.TrueString;
-            }
-
             if (this.CosmosSerializationOptions != null)
             {
                 requestHeaders[HttpConstants.HttpHeaders.ContentSerializationFormat] = this.CosmosSerializationOptions.ContentSerializationFormat;
             }
-            else if (this.feedOptions.ContentSerializationFormat.HasValue)
+            else if (this.feedOptions != null && this.feedOptions.ContentSerializationFormat.HasValue)
             {
                 requestHeaders[HttpConstants.HttpHeaders.ContentSerializationFormat] = this.feedOptions.ContentSerializationFormat.Value.ToString();
+            }
+
+            if (this.feedOptions != null)
+            {
+
+                if (!string.IsNullOrEmpty(this.feedOptions.FilterBySchemaResourceId))
+                {
+                    requestHeaders[HttpConstants.HttpHeaders.FilterBySchemaResourceId] = this.feedOptions.FilterBySchemaResourceId;
+                }
+
+                if (this.feedOptions.EmitVerboseTracesInQuery != null)
+                {
+                    requestHeaders[HttpConstants.HttpHeaders.EmitVerboseTracesInQuery] = this.feedOptions.EmitVerboseTracesInQuery.ToString();
+                }
+
+                if (this.feedOptions.EnumerationDirection.HasValue)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.EnumerationDirection, this.feedOptions.EnumerationDirection.Value.ToString());
+                }
+
+                if (this.feedOptions.ReadFeedKeyType.HasValue)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.ReadFeedKeyType, this.feedOptions.ReadFeedKeyType.Value.ToString());
+                }
+
+                if (this.feedOptions.StartId != null)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.StartId, this.feedOptions.StartId);
+                }
+
+                if (this.feedOptions.EndId != null)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.EndId, this.feedOptions.EndId);
+                }
+
+                if (this.feedOptions.StartEpk != null)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.StartEpk, this.feedOptions.StartEpk);
+                }
+
+                if (this.feedOptions.EndEpk != null)
+                {
+                    requestHeaders.Set(HttpConstants.HttpHeaders.EndEpk, this.feedOptions.EndEpk);
+                }
+
+                if (this.feedOptions.PopulateQueryMetrics)
+                {
+                    requestHeaders[HttpConstants.HttpHeaders.PopulateQueryMetrics] = bool.TrueString;
+                }
+
+                if (this.feedOptions.ForceQueryScan)
+                {
+                    requestHeaders[HttpConstants.HttpHeaders.ForceQueryScan] = bool.TrueString;
+                }
             }
 
             return requestHeaders;

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -4,19 +4,49 @@
 
 namespace Microsoft.Azure.Cosmos
 {
-    using System;
     using System.Globalization;
-    using System.IO;
-    using System.Net.Http;
+    using Microsoft.Azure.Cosmos.Collections;
     using Microsoft.Azure.Cosmos.Internal;
-    using Microsoft.Azure.Cosmos.Json;
+    using Newtonsoft.Json;
     using static Microsoft.Azure.Cosmos.Internal.RuntimeConstants;
-    
+
     /// <summary>
     /// The Cosmos query request options
     /// </summary>
     public class CosmosQueryRequestOptions : CosmosRequestOptions
     {
+        private readonly FeedOptions feedOptions = null;
+
+        /// <summary>
+        /// The default empty constructor
+        /// </summary>
+        public CosmosQueryRequestOptions() : base() { }
+
+        /// <summary>
+        /// This allows easy conversion from feed options to CosmosQueryRequestOptions.
+        /// DEVNOTE: This can be removed once query is completely on new v3 handler pipeline.
+        /// </summary>
+        internal CosmosQueryRequestOptions(FeedOptions feedOptions)
+        {
+            if (feedOptions != null)
+            {
+                this.RequestContinuation = this.RequestContinuation;
+                this.MaxItemCount = feedOptions.MaxItemCount;
+                this.ResponseContinuationTokenLimitInKb = feedOptions.ResponseContinuationTokenLimitInKb;
+                this.EnableScanInQuery = feedOptions.EnableScanInQuery;
+                this.EnableLowPrecisionOrderBy = feedOptions.EnableLowPrecisionOrderBy;
+                this.MaxBufferedItemCount = feedOptions.MaxBufferedItemCount;
+                this.SessionToken = feedOptions.SessionToken;
+                this.ConsistencyLevel = feedOptions.ConsistencyLevel;
+                this.MaxConcurrency = feedOptions.MaxDegreeOfParallelism;
+                this.PartitionKey = feedOptions.PartitionKey;
+                this.EnableCrossPartitionQuery = feedOptions.EnableCrossPartitionQuery;
+                this.CosmosSerializationOptions = feedOptions.CosmosSerializationOptions;
+                this.Properties = feedOptions.Properties;
+                this.feedOptions = new FeedOptions(feedOptions);
+            }
+        }
+
         /// <summary>
         ///  Gets or sets the <see cref="ResponseContinuationTokenLimitInKb"/> request option for document query requests in the Azure Cosmos DB service.
         /// </summary>
@@ -106,6 +136,48 @@ namespace Microsoft.Azure.Cosmos
         public virtual ConsistencyLevel? ConsistencyLevel { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of items to be returned in the enumeration operation in the Azure Cosmos DB service.
+        /// </summary>
+        /// <value>
+        /// The maximum number of items to be returned in the enumeration operation.
+        /// </value> 
+        /// <remarks>
+        /// Used for query pagination.
+        /// '-1' Used for dynamic page size.
+        /// </remarks>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// // Fetch query results 10 at a time.
+        /// using (var queryable = client.CreateDocumentQuery<Book>(collectionLink, new FeedOptions { MaxItemCount = 10 }))
+        /// {
+        ///     while (queryable.HasResults)
+        ///     {
+        ///         FeedResponse<Book> response = await queryable.ExecuteNext<Book>();
+        ///     }
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        public virtual int? MaxItemCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request continuation token in the Azure Cosmos DB service.
+        /// </summary>
+        /// <value>
+        /// The request continuation token.
+        /// </value>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// // Resume query execution using the continuation from the previous query
+        /// var queryable = client.CreateDocumentQuery<Book>(collectionLink, new FeedOptions { RequestContinuation = prevQuery.ResponseContinuation });
+        /// ]]>
+        /// </code>
+        /// </example>
+        public virtual string RequestContinuation { get; set; }
+
+        /// <summary>
         /// Gets or sets the number of concurrent operations run client side during 
         /// parallel query execution in the Azure Cosmos DB service. 
         /// A positive property value limits the number of 
@@ -116,16 +188,35 @@ namespace Microsoft.Azure.Cosmos
         /// The maximum number of concurrent operations during parallel execution. 
         /// Defaults will be executed serially with no-parallelism
         /// </value> 
-        internal int maxConcurrency { get; set; }
+        internal int MaxConcurrency { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="PartitionKey"/> for the current request in the Azure Cosmos DB service.
         /// </summary>
         internal PartitionKey PartitionKey { get; set; }
 
-        internal bool EnableCrossPartitionQuery {get; set;}
+        internal bool EnableCrossPartitionQuery { get; set; }
 
         internal CosmosSerializationOptions CosmosSerializationOptions { get; set; }
+
+        /// <summary>
+        /// DEVNOTE: This exists to keep compatability with FeedOptions
+        /// Gets the partition key range id for the current request.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// ReadFeed requests can use this to forward request to specific range.
+        /// This is usefull in case of bulk export scenarios.
+        /// </para>
+        /// </remarks>
+        internal string PartitionKeyRangeId => this.feedOptions == null ? null : this.feedOptions.PartitionKeyRangeId;
+
+        /// <summary>
+        /// DEVNOTE: This exists to keep compatability with FeedOptions. Support for JsonSerializerSettings is now obsolete. Please use CosmosJsonSerializer.
+        /// Gets the <see cref="JsonSerializerSettings"/> for the current request used to deserialize the document.
+        /// If null, uses the default serializer settings set up in the DocumentClient.
+        /// </summary>
+        internal JsonSerializerSettings JsonSerializerSettings => this.feedOptions == null ? null : this.feedOptions.JsonSerializerSettings;
 
         /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties
@@ -151,24 +242,191 @@ namespace Microsoft.Azure.Cosmos
             base.FillRequestOptions(request);
         }
 
-        internal FeedOptions ToFeedOptions()
+        /// <summary>
+        /// DEVNOTE: This will be converted to use CosmosRequestMessage in next PR
+        /// </summary>
+        internal INameValueCollection CreateCommonHeadersAsync(
+            FeedOptions feedOptions,
+            ConsistencyLevel defaultConsistencyLevel,
+            ConsistencyLevel? desiredConsistencyLevel,
+            ResourceType resourceType)
         {
-            return new FeedOptions()
+            INameValueCollection requestHeaders = new StringKeyValueCollection();
+
+            if (!string.IsNullOrEmpty(feedOptions.SessionToken) && !ReplicatedResourceClient.IsReadingFromMaster(resourceType, OperationType.ReadFeed))
             {
-                EnableCrossPartitionQuery = this.EnableCrossPartitionQuery,
-                MaxDegreeOfParallelism = this.maxConcurrency,
-                PartitionKey = this.PartitionKey,
+                if (defaultConsistencyLevel == Microsoft.Azure.Cosmos.ConsistencyLevel.Session ||
+                    (desiredConsistencyLevel.HasValue && desiredConsistencyLevel.Value == Microsoft.Azure.Cosmos.ConsistencyLevel.Session))
+                {
+                    // Query across partitions is not supported today. Master resources (for e.g., database) 
+                    // can span across partitions, whereas server resources (viz: collection, document and attachment)
+                    // don't span across partitions. Hence, session token returned by one partition should not be used 
+                    // when quering resources from another partition. 
+                    // Since master resources can span across partitions, don't send session token to the backend.
+                    // As master resources are sync replicated, we should always get consistent query result for master resources,
+                    // irrespective of the chosen replica.
+                    // For server resources, which don't span partitions, specify the session token 
+                    // for correct replica to be chosen for servicing the query result.
+                    requestHeaders[HttpConstants.HttpHeaders.SessionToken] = feedOptions.SessionToken;
+                }
+            }
+
+            requestHeaders[HttpConstants.HttpHeaders.Continuation] = feedOptions.RequestContinuation;
+            requestHeaders[HttpConstants.HttpHeaders.IsQuery] = bool.TrueString;
+
+            // Flow the pageSize only when we are not doing client eval
+            if (feedOptions.MaxItemCount.HasValue)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.PageSize] = feedOptions.MaxItemCount.ToString();
+            }
+
+            requestHeaders[HttpConstants.HttpHeaders.EnableCrossPartitionQuery] = feedOptions.EnableCrossPartitionQuery.ToString();
+
+            if (feedOptions.MaxDegreeOfParallelism != 0)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.ParallelizeCrossPartitionQuery] = bool.TrueString;
+            }
+
+            if (this.EnableScanInQuery != null)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.EnableScanInQuery] = this.EnableScanInQuery.ToString();
+            }
+
+            if (this.feedOptions.EmitVerboseTracesInQuery != null)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.EmitVerboseTracesInQuery] = this.feedOptions.EmitVerboseTracesInQuery.ToString();
+            }
+
+            if (this.EnableLowPrecisionOrderBy != null)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy] = this.EnableLowPrecisionOrderBy.ToString();
+            }
+
+            if (!string.IsNullOrEmpty(this.feedOptions.FilterBySchemaResourceId))
+            {
+                requestHeaders[HttpConstants.HttpHeaders.FilterBySchemaResourceId] = this.feedOptions.FilterBySchemaResourceId;
+            }
+
+            if (this.ResponseContinuationTokenLimitInKb != null)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.ResponseContinuationTokenLimitInKB] = this.ResponseContinuationTokenLimitInKb.ToString();
+            }
+
+            if (this.ConsistencyLevel.HasValue)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.ConsistencyLevel, this.ConsistencyLevel.Value.ToString());
+            }
+            else if (desiredConsistencyLevel.HasValue)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.ConsistencyLevel, desiredConsistencyLevel.Value.ToString());
+            }
+
+            if (this.feedOptions.EnumerationDirection.HasValue)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.EnumerationDirection, this.feedOptions.EnumerationDirection.Value.ToString());
+            }
+
+            if (this.feedOptions.ReadFeedKeyType.HasValue)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.ReadFeedKeyType, this.feedOptions.ReadFeedKeyType.Value.ToString());
+            }
+
+            if (this.feedOptions.StartId != null)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.StartId, this.feedOptions.StartId);
+            }
+
+            if (this.feedOptions.EndId != null)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.EndId, this.feedOptions.EndId);
+            }
+
+            if (this.feedOptions.StartEpk != null)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.StartEpk, this.feedOptions.StartEpk);
+            }
+
+            if (this.feedOptions.EndEpk != null)
+            {
+                requestHeaders.Set(HttpConstants.HttpHeaders.EndEpk, this.feedOptions.EndEpk);
+            }
+
+            if (this.feedOptions.PopulateQueryMetrics)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.PopulateQueryMetrics] = bool.TrueString;
+            }
+
+            if (this.feedOptions.ForceQueryScan)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.ForceQueryScan] = bool.TrueString;
+            }
+
+            if (this.CosmosSerializationOptions != null)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.ContentSerializationFormat] = this.CosmosSerializationOptions.ContentSerializationFormat;
+            }
+            else if (this.feedOptions.ContentSerializationFormat.HasValue)
+            {
+                requestHeaders[HttpConstants.HttpHeaders.ContentSerializationFormat] = this.feedOptions.ContentSerializationFormat.Value.ToString();
+            }
+
+            return requestHeaders;
+        }
+
+        internal CosmosQueryRequestOptions Clone()
+        {
+            return new CosmosQueryRequestOptions(this.feedOptions)
+            {
+                AccessCondition = this.AccessCondition,
+                RequestContinuation = this.RequestContinuation,
+                MaxItemCount = this.MaxItemCount,
                 ResponseContinuationTokenLimitInKb = this.ResponseContinuationTokenLimitInKb,
                 EnableScanInQuery = this.EnableScanInQuery,
                 EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy,
                 MaxBufferedItemCount = this.MaxBufferedItemCount,
+                SessionToken = this.SessionToken,
+                ConsistencyLevel = this.ConsistencyLevel,
+                MaxConcurrency = this.MaxConcurrency,
+                PartitionKey = this.PartitionKey,
+                EnableCrossPartitionQuery = this.EnableCrossPartitionQuery,
                 CosmosSerializationOptions = this.CosmosSerializationOptions,
                 Properties = this.Properties,
             };
         }
 
+        /// <summary>
+        /// Copy the internal feed options and update all the properties that might have changed.
+        /// </summary>
+        /// <returns></returns>
+        internal FeedOptions ToFeedOptions()
+        {
+            FeedOptions feedOptions = null;
+            if (this.feedOptions != null)
+            {
+                feedOptions = new FeedOptions(this.feedOptions);
+            }
+            else
+            {
+                feedOptions = new FeedOptions();
+            }
+
+            feedOptions.MaxItemCount = this.MaxItemCount;
+            feedOptions.EnableCrossPartitionQuery = this.EnableCrossPartitionQuery;
+            feedOptions.MaxDegreeOfParallelism = this.MaxConcurrency;
+            feedOptions.PartitionKey = this.PartitionKey;
+            feedOptions.RequestContinuation = this.RequestContinuation;
+            feedOptions.ResponseContinuationTokenLimitInKb = this.ResponseContinuationTokenLimitInKb;
+            feedOptions.EnableScanInQuery = this.EnableScanInQuery;
+            feedOptions.EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy;
+            feedOptions.MaxBufferedItemCount = this.MaxBufferedItemCount;
+            feedOptions.CosmosSerializationOptions = this.CosmosSerializationOptions;
+            feedOptions.Properties = this.Properties;
+
+            return feedOptions;
+        }
+
         internal static void FillContinuationToken(
-            CosmosRequestMessage request, 
+            CosmosRequestMessage request,
             string continuationToken)
         {
             if (!string.IsNullOrWhiteSpace(continuationToken))

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/CosmosQueryRequestOptions.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Globalization;
     using Microsoft.Azure.Cosmos.Collections;
     using Microsoft.Azure.Cosmos.Internal;
@@ -28,23 +29,25 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal CosmosQueryRequestOptions(FeedOptions feedOptions)
         {
-            if (feedOptions != null)
+            if(feedOptions == null)
             {
-                this.RequestContinuation = feedOptions.RequestContinuation;
-                this.MaxItemCount = feedOptions.MaxItemCount;
-                this.ResponseContinuationTokenLimitInKb = feedOptions.ResponseContinuationTokenLimitInKb;
-                this.EnableScanInQuery = feedOptions.EnableScanInQuery;
-                this.EnableLowPrecisionOrderBy = feedOptions.EnableLowPrecisionOrderBy;
-                this.MaxBufferedItemCount = feedOptions.MaxBufferedItemCount;
-                this.SessionToken = feedOptions.SessionToken;
-                this.ConsistencyLevel = feedOptions.ConsistencyLevel;
-                this.MaxConcurrency = feedOptions.MaxDegreeOfParallelism;
-                this.PartitionKey = feedOptions.PartitionKey;
-                this.EnableCrossPartitionQuery = feedOptions.EnableCrossPartitionQuery;
-                this.CosmosSerializationOptions = feedOptions.CosmosSerializationOptions;
-                this.Properties = feedOptions.Properties;
-                this.feedOptions = new FeedOptions(feedOptions);
+                throw new ArgumentNullException(nameof(feedOptions));
             }
+
+            this.RequestContinuation = feedOptions.RequestContinuation;
+            this.MaxItemCount = feedOptions.MaxItemCount;
+            this.ResponseContinuationTokenLimitInKb = feedOptions.ResponseContinuationTokenLimitInKb;
+            this.EnableScanInQuery = feedOptions.EnableScanInQuery;
+            this.EnableLowPrecisionOrderBy = feedOptions.EnableLowPrecisionOrderBy;
+            this.MaxBufferedItemCount = feedOptions.MaxBufferedItemCount;
+            this.SessionToken = feedOptions.SessionToken;
+            this.ConsistencyLevel = feedOptions.ConsistencyLevel;
+            this.MaxConcurrency = feedOptions.MaxDegreeOfParallelism;
+            this.PartitionKey = feedOptions.PartitionKey;
+            this.EnableCrossPartitionQuery = feedOptions.EnableCrossPartitionQuery;
+            this.CosmosSerializationOptions = feedOptions.CosmosSerializationOptions;
+            this.Properties = feedOptions.Properties;
+            this.feedOptions = new FeedOptions(feedOptions);
         }
 
         /// <summary>
@@ -379,23 +382,24 @@ namespace Microsoft.Azure.Cosmos
 
         internal CosmosQueryRequestOptions Clone()
         {
-            return new CosmosQueryRequestOptions(this.feedOptions)
-            {
-                AccessCondition = this.AccessCondition,
-                RequestContinuation = this.RequestContinuation,
-                MaxItemCount = this.MaxItemCount,
-                ResponseContinuationTokenLimitInKb = this.ResponseContinuationTokenLimitInKb,
-                EnableScanInQuery = this.EnableScanInQuery,
-                EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy,
-                MaxBufferedItemCount = this.MaxBufferedItemCount,
-                SessionToken = this.SessionToken,
-                ConsistencyLevel = this.ConsistencyLevel,
-                MaxConcurrency = this.MaxConcurrency,
-                PartitionKey = this.PartitionKey,
-                EnableCrossPartitionQuery = this.EnableCrossPartitionQuery,
-                CosmosSerializationOptions = this.CosmosSerializationOptions,
-                Properties = this.Properties,
-            };
+            CosmosQueryRequestOptions queryRequestOptions = this.feedOptions == null ?
+                new CosmosQueryRequestOptions() : new CosmosQueryRequestOptions(this.feedOptions);
+
+            queryRequestOptions.AccessCondition = this.AccessCondition;
+            queryRequestOptions.RequestContinuation = this.RequestContinuation;
+            queryRequestOptions.MaxItemCount = this.MaxItemCount;
+            queryRequestOptions.ResponseContinuationTokenLimitInKb = this.ResponseContinuationTokenLimitInKb;
+            queryRequestOptions.EnableScanInQuery = this.EnableScanInQuery;
+            queryRequestOptions.EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy;
+            queryRequestOptions.MaxBufferedItemCount = this.MaxBufferedItemCount;
+            queryRequestOptions.SessionToken = this.SessionToken;
+            queryRequestOptions.ConsistencyLevel = this.ConsistencyLevel;
+            queryRequestOptions.MaxConcurrency = this.MaxConcurrency;
+            queryRequestOptions.PartitionKey = this.PartitionKey;
+            queryRequestOptions.EnableCrossPartitionQuery = this.EnableCrossPartitionQuery;
+            queryRequestOptions.CosmosSerializationOptions = this.CosmosSerializationOptions;
+            queryRequestOptions.Properties = this.Properties;
+            return queryRequestOptions;
         }
 
         /// <summary>
@@ -404,15 +408,8 @@ namespace Microsoft.Azure.Cosmos
         /// <returns></returns>
         internal FeedOptions ToFeedOptions()
         {
-            FeedOptions feedOptions = null;
-            if (this.feedOptions != null)
-            {
-                feedOptions = new FeedOptions(this.feedOptions);
-            }
-            else
-            {
-                feedOptions = new FeedOptions();
-            }
+            FeedOptions feedOptions = this.feedOptions != null ?
+                new FeedOptions(this.feedOptions) : new FeedOptions();
 
             feedOptions.MaxItemCount = this.MaxItemCount;
             feedOptions.EnableCrossPartitionQuery = this.EnableCrossPartitionQuery;

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -754,21 +754,19 @@ namespace Microsoft.Azure.Cosmos
             CosmosQueryRequestOptions requestOptions = null)
         {
             requestOptions = requestOptions ?? new CosmosQueryRequestOptions();
-            requestOptions.maxConcurrency = maxConcurrency;
+            requestOptions.MaxConcurrency = maxConcurrency;
             requestOptions.EnableCrossPartitionQuery = true;
-
-            FeedOptions feedOptions = requestOptions.ToFeedOptions();
-            feedOptions.RequestContinuation = continuationToken;
-            feedOptions.MaxItemCount = maxItemCount;
+            requestOptions.MaxItemCount = maxItemCount;
+            requestOptions.RequestContinuation = continuationToken;
             if (partitionKey != null)
             {
                 PartitionKey pk = new PartitionKey(partitionKey);
-                feedOptions.PartitionKey = pk;
+                requestOptions.PartitionKey = pk;
             }
 
             DocumentQuery<CosmosQueryResponse> documentQuery = (DocumentQuery<CosmosQueryResponse>)this.client.DocumentClient.CreateDocumentQuery<CosmosQueryResponse>(
                 collectionLink: this.container.Link,
-                feedOptions: feedOptions,
+                requestOptions: requestOptions,
                 querySpec: sqlQueryDefinition.ToSqlQuerySpec());
 
             return new CosmosResultSetIteratorCore(
@@ -987,7 +985,7 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosQueryRequestOptions options = requestOptions ?? new CosmosQueryRequestOptions();
-            options.maxConcurrency = maxConcurrency;
+            options.MaxConcurrency = maxConcurrency;
             options.EnableCrossPartitionQuery = true;
 
             return new CosmosDefaultResultSetIterator<T>(
@@ -1057,13 +1055,12 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken)
         {
             CosmosQueryRequestOptions cosmosQueryRequestOptions = options as CosmosQueryRequestOptions ?? new CosmosQueryRequestOptions();
-            FeedOptions feedOptions = cosmosQueryRequestOptions.ToFeedOptions();
-            feedOptions.RequestContinuation = continuationToken;
-            feedOptions.MaxItemCount = maxItemCount;
+            cosmosQueryRequestOptions.RequestContinuation = continuationToken;
+            cosmosQueryRequestOptions.MaxItemCount = maxItemCount;
 
             IDocumentQuery<T> documentClientResult = this.client.DocumentClient.CreateDocumentQuery<T>(
                 collectionLink: this.container.Link,
-                feedOptions: feedOptions,
+                requestOptions: cosmosQueryRequestOptions,
                 querySpec: state as SqlQuerySpec).AsDocumentQuery();
 
             try

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -766,7 +766,7 @@ namespace Microsoft.Azure.Cosmos
 
             DocumentQuery<CosmosQueryResponse> documentQuery = (DocumentQuery<CosmosQueryResponse>)this.client.DocumentClient.CreateDocumentQuery<CosmosQueryResponse>(
                 collectionLink: this.container.Link,
-                requestOptions: requestOptions,
+                queryRequestOptions: requestOptions,
                 querySpec: sqlQueryDefinition.ToSqlQuerySpec());
 
             return new CosmosResultSetIteratorCore(
@@ -1060,7 +1060,7 @@ namespace Microsoft.Azure.Cosmos
 
             IDocumentQuery<T> documentClientResult = this.client.DocumentClient.CreateDocumentQuery<T>(
                 collectionLink: this.container.Link,
-                requestOptions: cosmosQueryRequestOptions,
+                queryRequestOptions: cosmosQueryRequestOptions,
                 querySpec: state as SqlQuerySpec).AsDocumentQuery();
 
             try

--- a/Microsoft.Azure.Cosmos/src/ResourceFeedReader.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceFeedReader.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal ResourceFeedReader(DocumentClient client, ResourceType resourceType, FeedOptions options, string resourceLink, object partitionKey = null)
         {
-            this.documentQuery = new DocumentQuery<T>(client, resourceType, typeof(T), resourceLink, options, partitionKey);
+            this.documentQuery = new DocumentQuery<T>(client, resourceType, typeof(T), resourceLink, (CosmosQueryRequestOptions)options, partitionKey);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -2864,7 +2864,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                                             IDocumentQuery<Document> query = Client.CreateDocumentQuery<Document>(
                                                 collection.AltLink,
                                                 querySpec,
-                                                feedOptions).AsDocumentQuery();
+                                                (CosmosQueryRequestOptions)feedOptions).AsDocumentQuery();
 
                                             while (query.HasMoreResults)
                                             {
@@ -2880,7 +2880,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                                             IQueryable<Document> query = Client.CreateDocumentQuery<Document>(
                                                 collection.AltLink,
                                                 querySpec,
-                                                feedOptions);
+                                                (CosmosQueryRequestOptions)feedOptions);
 
                                             actualDocuments = query.ToList();
                                         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientLinkSwitchExtension.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientLinkSwitchExtension.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
         /// <returns>the query result set.</returns>
         public static IOrderedQueryable<CosmosContainerSettings> CreateDocumentCollectionQuery(this DocumentClient client, CosmosDatabaseSettings owner,  FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosContainerSettings>(client, ResourceType.Collection, typeof(CosmosDatabaseSettings), owner.GetLink(), feedOptions);
+            return new DocumentQuery<CosmosContainerSettings>(client, ResourceType.Collection, typeof(CosmosDatabaseSettings), owner.GetLink(), (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -606,7 +606,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
         /// <returns>the query result set.</returns>
         public static IOrderedQueryable<CosmosStoredProcedureSettings> CreateStoredProcedureQuery(this DocumentClient client, CosmosContainerSettings owner, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosStoredProcedureSettings>(client, ResourceType.StoredProcedure, typeof(CosmosContainerSettings), owner.GetLink(), feedOptions);
+            return new DocumentQuery<CosmosStoredProcedureSettings>(client, ResourceType.StoredProcedure, typeof(CosmosContainerSettings), owner.GetLink(), (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -787,7 +787,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
         /// <returns>the query result set.</returns>
         public static IQueryable<T> CreateDocumentQuery<T>(this DocumentClient client, CosmosContainerSettings owner, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return client.CreateDocumentQuery<T>(owner.GetLink(), querySpec, feedOptions);
+            return client.CreateDocumentQuery<T>(owner.GetLink(), querySpec, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DocumentClientLinkSwitchExtension.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DocumentClientLinkSwitchExtension.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// <returns>the query result set.</returns>
         public static IOrderedQueryable<CosmosContainerSettings> CreateDocumentCollectionQuery(this DocumentClient client, CosmosDatabaseSettings owner,  FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosContainerSettings>(client, ResourceType.Collection, typeof(CosmosContainerSettings), owner.GetLink(), feedOptions);
+            return new DocumentQuery<CosmosContainerSettings>(client, ResourceType.Collection, typeof(CosmosContainerSettings), owner.GetLink(), (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -606,7 +606,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// <returns>the query result set.</returns>
         public static IOrderedQueryable<CosmosStoredProcedureSettings> CreateStoredProcedureQuery(this DocumentClient client, CosmosContainerSettings owner, FeedOptions feedOptions = null)
         {
-            return new DocumentQuery<CosmosStoredProcedureSettings>(client, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), owner.GetLink(), feedOptions);
+            return new DocumentQuery<CosmosStoredProcedureSettings>(client, ResourceType.StoredProcedure, typeof(CosmosStoredProcedureSettings), owner.GetLink(), (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>
@@ -787,7 +787,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// <returns>the query result set.</returns>
         public static IQueryable<T> CreateDocumentQuery<T>(this DocumentClient client, CosmosContainerSettings owner, SqlQuerySpec querySpec, FeedOptions feedOptions = null)
         {
-            return client.CreateDocumentQuery<T>(owner.GetLink(), querySpec, feedOptions);
+            return client.CreateDocumentQuery<T>(owner.GetLink(), querySpec, (CosmosQueryRequestOptions)feedOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.NetFramework.Tests/Query/FeedOptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.NetFramework.Tests/Query/FeedOptionTests.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Azure.Cosmos.Query
 
             dcClient.Setup(e => e.GetDefaultConsistencyLevelAsync()).Returns(Task.FromResult(ConsistencyLevel.BoundedStaleness));
 
-            INameValueCollection headers = await cxt.CreateCommonHeadersAsync(fo);
+            INameValueCollection headers = await cxt.CreateCommonHeadersAsync((CosmosQueryRequestOptions)fo);
             Assert.AreEqual(null, headers[HttpConstants.HttpHeaders.ConsistencyLevel]);
 
             fo.ConsistencyLevel = ConsistencyLevel.Eventual;
-            headers = await cxt.CreateCommonHeadersAsync(fo);
+            headers = await cxt.CreateCommonHeadersAsync((CosmosQueryRequestOptions)fo);
             Assert.AreEqual(ConsistencyLevel.Eventual.ToString(), headers[HttpConstants.HttpHeaders.ConsistencyLevel]);
         }
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     resourceTypeEnum,
                     resourceType,
                     expression,
-                    feedOptions,
+                    (CosmosQueryRequestOptions)feedOptions,
                     resourceLink,
                     getLazyFeedResponse,
                     correlatedActivityId))


### PR DESCRIPTION
Refactored the query pipeline to use CosmosQueryRequestOptions instead of FeedOptions
1. Implicit operator was added between FeedOptions and CosmosQueryRequestOptions. This keeps back compatibility and prevent breaking all existing tests.
2. Refactored all the ExecutionContext classes to use the new request options
3. Added the ability to clone the request options since it is required for parallel requests
4. Updated the document client interface to use new request options. This ensures that the v3 calls always use the new request options instead of feed options.
5. FeedOptions will eventually be removed once all the tests are updated to target the new v3 API