### PR TITLE
Add test to verify that EPK option is honored in query pipeline.

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -504,14 +504,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     throughput: 15000);
                 container = containerResponse;
 
-                // Get all the partition key ranges to verify there is a split
+                // Get all the partition key ranges to verify there is more than one partition
                 IRoutingMapProvider routingMapProvider = await this.cosmosClient.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(
                     containerResponse.Resource.ResourceId,
                     new Documents.Routing.Range<string>("00", "FF", isMaxInclusive: true, isMinInclusive: true));
                 
-                // If this fails the RUs of the container need to be increased to ensure at least 2 partitions.
-                Assert.IsTrue(ranges.Count > 1);
+                // If this fails the RUs of the container needs to be increased to ensure at least 2 partitions.
+                Assert.IsTrue(ranges.Count > 1, " RUs of the container needs to be increased to ensure at least 2 partitions.");
 
                 FeedOptions options = new FeedOptions()
                 {
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     collection: containerResponse,
                     feedOptions: options);
 
-                Assert.IsTrue(partitionKeyRanges.Count == 1);
+                Assert.IsTrue(partitionKeyRanges.Count == 1, "Only 1 partition key range should be selected since the EPK option is set.");
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -10,10 +10,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
+    using System.Linq.Expressions;
     using System.Net;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Query;
+    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -480,6 +483,74 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     CosmosResponseMessage deleteResponse = await this.Container.Items.DeleteItemStreamAsync(delete.status, delete.id);
                     deleteResponse.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validate that if the EPK is set in the options that only a single range is selected.
+        /// </summary>
+        [TestMethod]
+        public async Task ItemEpkQueryValidation()
+        {
+            IList<ToDoActivity> deleteList = new List<ToDoActivity>();
+            CosmosContainer container = null;
+            try
+            {
+                // Create a container large enough to have at least 2 partitions
+                var containerResponse = await this.database.Containers.CreateContainerAsync(
+                    id: Guid.NewGuid().ToString(),
+                    partitionKeyPath: "/pk",
+                    throughput: 15000);
+                container = containerResponse;
+
+                // Get all the partition key ranges to verify there is a split
+                IRoutingMapProvider routingMapProvider = await this.cosmosClient.DocumentClient.GetPartitionKeyRangeCacheAsync();
+                IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(
+                    containerResponse.Resource.ResourceId,
+                    new Documents.Routing.Range<string>("00", "FF", isMaxInclusive: true, isMinInclusive: true));
+                
+                // If this fails the RUs of the container need to be increased to ensure at least 2 partitions.
+                Assert.IsTrue(ranges.Count > 1);
+
+                FeedOptions options = new FeedOptions()
+                {
+                    Properties = new Dictionary<string, object>()
+                    {
+                        {"x-ms-effective-partition-key-string", "AA" }
+                    }
+                };
+
+                // Create a bad expression. It will not be called. Expression is not allowed to be null.
+                IQueryable<int> queryable = new List<int>().AsQueryable();
+                Expression expression = queryable.Expression;
+
+                DocumentQueryExecutionContextBase.InitParams inputParams = new DocumentQueryExecutionContextBase.InitParams(
+                    new DocumentQueryClient(this.cosmosClient.DocumentClient),
+                    ResourceType.Document,
+                    typeof(object),
+                    expression,
+                    options,
+                    container.LinkUri.OriginalString,
+                    false,
+                    Guid.NewGuid());
+
+                DefaultDocumentQueryExecutionContext defaultDocumentQueryExecutionContext = new DefaultDocumentQueryExecutionContext(inputParams, true);
+
+                // There should only be one range since the EPK option is set.
+                List<PartitionKeyRange> partitionKeyRanges = await DocumentQueryExecutionContextFactory.GetTargetPartitionKeyRanges(
+                    queryExecutionContext: defaultDocumentQueryExecutionContext,
+                    partitionedQueryExecutionInfo: null,
+                    collection: containerResponse,
+                    feedOptions: options);
+
+                Assert.IsTrue(partitionKeyRanges.Count == 1);
+            }
+            finally
+            {
+                if(container != null)
+                {
+                    await container.DeleteAsync();
                 }
             }
         }


### PR DESCRIPTION
This test verifies that if the EPK option is set that only a single partition key range is selected.