### PR TITLE
Adding Change Feed Processor Unit Tests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Azure.Cosmos
         private CosmosContainer leaseContainer;
         private string InstanceName;
         private DocumentServiceLeaseStoreManager LeaseStoreManager;
-        private string databaseResourceId;
-        private string collectionResourceId;
+        private string monitoredContainerRid;
         private bool isBuilt;
 
         internal ChangeFeedProcessorBuilder(
@@ -205,6 +204,14 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
+        internal virtual ChangeFeedProcessorBuilder WithMonitoredContainerRid(string monitoredContainerRid)
+        {
+            if (monitoredContainerRid != null) throw new ArgumentNullException(nameof(monitoredContainerRid));
+
+            this.monitoredContainerRid = monitoredContainerRid;
+            return this;
+        }
+
         /// <summary>
         /// Builds a new instance of the <see cref="ChangeFeedProcessor"/> with the specified configuration.
         /// </summary>
@@ -232,31 +239,10 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.InitializeDefaultOptions();
-            this.InitializeCollectionPropertiesForBuild();
-
-            this.applyBuilderConfiguration(this.LeaseStoreManager, this.leaseContainer, this.GetLeasePrefix(), this.InstanceName, this.changeFeedLeaseOptions, this.changeFeedProcessorOptions, this.monitoredContainer);
+            this.applyBuilderConfiguration(this.LeaseStoreManager, this.leaseContainer, this.monitoredContainerRid, this.InstanceName, this.changeFeedLeaseOptions, this.changeFeedProcessorOptions, this.monitoredContainer);
 
             this.isBuilt = true;
             return this.changeFeedProcessor;
-        }
-
-        private string GetLeasePrefix()
-        {
-            string optionsPrefix = this.changeFeedLeaseOptions.LeasePrefix ?? string.Empty;
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                "{0}{1}_{2}_{3}",
-                optionsPrefix,
-                this.monitoredContainer.Client.Configuration.AccountEndPoint.Host,
-                this.databaseResourceId,
-                this.collectionResourceId);
-        }
-
-        private void InitializeCollectionPropertiesForBuild()
-        {
-            string[] containerLinkSegments = this.monitoredContainer.LinkUri.OriginalString.Split('/');
-            this.databaseResourceId = containerLinkSegments[2];
-            this.collectionResourceId = containerLinkSegments[4];
         }
 
         private void InitializeDefaultOptions()

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new InvalidOperationException($"Defining the lease store by WithCosmosLeaseContainer or WithInMemoryLeaseContainer is required.");
             }
 
-            if (this.changeFeedLeaseOptions?.LeasePrefix == null)
+            if (this.changeFeedLeaseOptions.LeasePrefix == null)
             {
                 throw new InvalidOperationException("Workflow name was not specified using WithWorkflowName");
             }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -5,6 +5,8 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed
 {
     using System;
+    using System.Globalization;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
@@ -13,13 +15,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using Microsoft.Azure.Cosmos.ChangeFeed.Logging;
     using Microsoft.Azure.Cosmos.ChangeFeed.Monitoring;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
 
     internal sealed class ChangeFeedProcessorCore<T> : ChangeFeedProcessor
     {
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly ChangeFeedObserverFactory<T> observerFactory;
         private CosmosContainer leaseContainer;
-        private string leaseContainerPrefix;
+        private string monitoredContainerRid;
         private string instanceName;
         private CosmosContainer monitoredContainer;
         private PartitionManager partitionManager;
@@ -38,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         public void ApplyBuildConfiguration(
             DocumentServiceLeaseStoreManager customDocumentServiceLeaseStoreManager,
             CosmosContainer leaseContainer,
-            string leaseContainerPrefix,
+            string monitoredContainerRid,
             string instanceName,
             ChangeFeedLeaseOptions changeFeedLeaseOptions,
             ChangeFeedProcessorOptions changeFeedProcessorOptions,
@@ -50,7 +53,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             this.documentServiceLeaseStoreManager = customDocumentServiceLeaseStoreManager;
             this.leaseContainer = leaseContainer;
-            this.leaseContainerPrefix = leaseContainerPrefix;
+            this.monitoredContainerRid = monitoredContainerRid;
             this.instanceName = instanceName;
             this.changeFeedProcessorOptions = changeFeedProcessorOptions;
             this.changeFeedLeaseOptions = changeFeedLeaseOptions;
@@ -78,7 +81,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
         private async Task InitializeAsync()
         {
-            this.documentServiceLeaseStoreManager = await ChangeFeedProcessorCore<T>.InitializeLeaseStoreManagerAsync(this.documentServiceLeaseStoreManager, this.leaseContainer, this.leaseContainerPrefix, this.instanceName).ConfigureAwait(false);
+            string monitoredContainerRid = await this.monitoredContainer.GetMonitoredContainerRidAsync(this.monitoredContainerRid);
+            this.monitoredContainerRid = this.monitoredContainer.GetLeasePrefix(this.changeFeedLeaseOptions, monitoredContainerRid);
+            this.documentServiceLeaseStoreManager = await ChangeFeedProcessorCore<T>.InitializeLeaseStoreManagerAsync(this.documentServiceLeaseStoreManager, this.leaseContainer, this.monitoredContainerRid, this.instanceName).ConfigureAwait(false);
             this.partitionManager = this.BuildPartitionManager();
             this.initialized = true;
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     /// * Distribute load between different instances of <see cref="ChangeFeedProcessor"/>.
     /// * Ensure reliable recovery for cases when an instance of <see cref="ChangeFeedProcessor"/> gets disconnected, hangs or crashes.
     /// </summary>
+    [Serializable]
     internal abstract class DocumentServiceLease
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -4,9 +4,12 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
 {
+    using System.Globalization;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
 
     internal static class CosmosContainerExtensions
     {
@@ -68,6 +71,35 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                         .ConfigureAwait(false);
 
             return response.IsSuccessStatusCode;
+        }
+
+        public static async Task<string> GetMonitoredContainerRidAsync(
+            this CosmosContainer monitoredContainer,
+            string suggestedMonitoredRid,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!string.IsNullOrEmpty(suggestedMonitoredRid))
+            {
+                return suggestedMonitoredRid;
+            }
+
+            string containerRid = await ((CosmosContainerCore)monitoredContainer).GetRID(cancellationToken);
+            string databaseRid = await ((CosmosDatabaseCore)((CosmosContainerCore)monitoredContainer).Database).GetRID(cancellationToken);
+            return $"{databaseRid}_{containerRid}";
+        }
+
+        public static string GetLeasePrefix(
+            this CosmosContainer monitoredContainer,
+            ChangeFeedLeaseOptions changeFeedLeaseOptions,
+            string monitoredContainerRid)
+        {
+            string optionsPrefix = changeFeedLeaseOptions.LeasePrefix ?? string.Empty;
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0}{1}_{2}",
+                optionsPrefix,
+                monitoredContainer.Client.Configuration.AccountEndPoint.Host,
+                monitoredContainerRid);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosIdentifier.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosIdentifier.cs
@@ -24,12 +24,12 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// The Cosmos client that is used for the request
         /// </summary>
-        internal CosmosClient Client { get; private set; }
+        internal virtual CosmosClient Client { get; private set; }
 
         /// <summary>
         /// The Cosmos resource URI
         /// </summary>
-        internal Uri LinkUri { get; private set; }
+        internal virtual Uri LinkUri { get; private set; }
 
         /// <summary>
         /// Initialize the common properties

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class BootstrapperTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping;
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class BootstrapperTests
+    {
+        [TestMethod]
+        public void ValidatesArguments()
+        {
+            Mock<PartitionSynchronizer> synchronizer = new Mock<PartitionSynchronizer>();
+
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(true);
+            TimeSpan lockTime = TimeSpan.FromSeconds(30);
+            TimeSpan sleepTime = TimeSpan.FromSeconds(30);
+
+            Assert.ThrowsException<ArgumentNullException>(() => new BootstrapperCore(null, leaseStore.Object, lockTime, sleepTime));
+            Assert.ThrowsException<ArgumentNullException>(() => new BootstrapperCore(synchronizer.Object, null, lockTime, sleepTime));
+            Assert.ThrowsException<ArgumentException>(() => new BootstrapperCore(synchronizer.Object, leaseStore.Object, TimeSpan.Zero, sleepTime));
+            Assert.ThrowsException<ArgumentException>(() => new BootstrapperCore(synchronizer.Object, leaseStore.Object, lockTime, TimeSpan.Zero));
+
+        }
+
+        [TestMethod]
+        public async Task InitializeAsyncOrderIsCorrect()
+        {
+            List<string> expectedOrderOfEvents = new List<string>()
+            {
+                "IsInitializedAsync",
+                "AcquireInitializationLockAsync",
+                "CreateMissingLeasesAsync",
+                "MarkInitializedAsync",
+                "ReleaseInitializationLockAsync"
+            };
+
+            List<string> events = new List<string>();
+
+            Mock<PartitionSynchronizer> synchronizer = new Mock<PartitionSynchronizer>();
+            synchronizer.Setup(s => s.CreateMissingLeasesAsync()).Returns(() =>
+            {
+                events.Add("CreateMissingLeasesAsync");
+                return Task.CompletedTask;
+            });
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(() =>
+            {
+                events.Add("IsInitializedAsync");
+                return false;
+            });
+            leaseStore.Setup(l => l.AcquireInitializationLockAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() =>
+            {
+                events.Add("AcquireInitializationLockAsync");
+                return true;
+            });
+            leaseStore.Setup(l => l.MarkInitializedAsync()).Returns(() =>
+            {
+                events.Add("MarkInitializedAsync");
+                return Task.CompletedTask;
+            });
+            leaseStore.Setup(l => l.ReleaseInitializationLockAsync()).ReturnsAsync(() =>
+            {
+                events.Add("ReleaseInitializationLockAsync");
+                return true;
+            });
+            TimeSpan lockTime = TimeSpan.FromSeconds(30);
+            TimeSpan sleepTime = TimeSpan.FromSeconds(30);
+
+            BootstrapperCore bootstrapper = new BootstrapperCore(synchronizer.Object, leaseStore.Object, lockTime, sleepTime);
+
+            await bootstrapper.InitializeAsync();
+            CollectionAssert.AreEqual(expectedOrderOfEvents, events);
+        }
+
+        [TestMethod]
+        public async Task IfInitializedDoNotRunAnythingElse()
+        {
+            List<string> expectedOrderOfEvents = new List<string>()
+            {
+                "IsInitializedAsync"
+            };
+
+            List<string> events = new List<string>();
+
+            Mock<PartitionSynchronizer> synchronizer = new Mock<PartitionSynchronizer>();
+            synchronizer.Setup(s => s.CreateMissingLeasesAsync()).Returns(() =>
+            {
+                events.Add("CreateMissingLeasesAsync");
+                return Task.CompletedTask;
+            });
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(() =>
+            {
+                events.Add("IsInitializedAsync");
+                return true;
+            });
+            leaseStore.Setup(l => l.AcquireInitializationLockAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() =>
+            {
+                events.Add("AcquireInitializationLockAsync");
+                return true;
+            });
+            leaseStore.Setup(l => l.MarkInitializedAsync()).Returns(() =>
+            {
+                events.Add("MarkInitializedAsync");
+                return Task.CompletedTask;
+            });
+            leaseStore.Setup(l => l.ReleaseInitializationLockAsync()).ReturnsAsync(() =>
+            {
+                events.Add("ReleaseInitializationLockAsync");
+                return true;
+            });
+            TimeSpan lockTime = TimeSpan.FromSeconds(30);
+            TimeSpan sleepTime = TimeSpan.FromSeconds(30);
+
+            BootstrapperCore bootstrapper = new BootstrapperCore(synchronizer.Object, leaseStore.Object, lockTime, sleepTime);
+
+            await bootstrapper.InitializeAsync();
+            CollectionAssert.AreEqual(expectedOrderOfEvents, events);
+        }
+
+        [TestMethod]
+        public async Task IfCannotAcquireRetry()
+        {
+            // Includes expected retry
+            List<string> expectedOrderOfEvents = new List<string>()
+            {
+                "IsInitializedAsync",
+                "AcquireInitializationLockAsync",
+                "IsInitializedAsync",
+                "AcquireInitializationLockAsync",
+                "CreateMissingLeasesAsync",
+                "MarkInitializedAsync",
+                "ReleaseInitializationLockAsync"
+            };
+
+            int iteration = 1;
+
+            List<string> events = new List<string>();
+
+            Mock<PartitionSynchronizer> synchronizer = new Mock<PartitionSynchronizer>();
+            synchronizer.Setup(s => s.CreateMissingLeasesAsync()).Returns(() =>
+            {
+                events.Add("CreateMissingLeasesAsync");
+                return Task.CompletedTask;
+            });
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(() =>
+            {
+                events.Add("IsInitializedAsync");
+                return false;
+            });
+            leaseStore.Setup(l => l.AcquireInitializationLockAsync(It.IsAny<TimeSpan>())).ReturnsAsync(() =>
+            {
+                events.Add("AcquireInitializationLockAsync");
+                // Only acquire on retry
+                return (iteration++ > 1);
+            });
+            leaseStore.Setup(l => l.MarkInitializedAsync()).Returns(() =>
+            {
+                events.Add("MarkInitializedAsync");
+                return Task.CompletedTask;
+            });
+            leaseStore.Setup(l => l.ReleaseInitializationLockAsync()).ReturnsAsync(() =>
+            {
+                events.Add("ReleaseInitializationLockAsync");
+                return true;
+            });
+            TimeSpan lockTime = TimeSpan.FromSeconds(1);
+            TimeSpan sleepTime = TimeSpan.FromSeconds(1);
+
+            BootstrapperCore bootstrapper = new BootstrapperCore(synchronizer.Object, leaseStore.Object, lockTime, sleepTime);
+
+            await bootstrapper.InitializeAsync();
+            CollectionAssert.AreEqual(expectedOrderOfEvents, events);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/BootstrapperTests.cs
@@ -1,15 +1,17 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping;
-using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class BootstrapperTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.Azure.Cosmos.Client.Core.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class ChangeFeedEstimatorCoreTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void NullDelegateThrows()
+        {
+            ChangeFeedEstimatorCoreTests.CreateEstimator(null, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+        }
+
+        [TestMethod]
+        public void ApplyBuildConfiguration_ValidCustomStore()
+        {
+            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            {
+                return Task.CompletedTask;
+            };
+
+            ChangeFeedEstimatorCore estimator = ChangeFeedEstimatorCoreTests.CreateEstimator(estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+            estimator.ApplyBuildConfiguration(
+                Mock.Of<DocumentServiceLeaseStoreManager>(),
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        public void ApplyBuildConfiguration_ValidContainerStore()
+        {
+            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            {
+                return Task.CompletedTask;
+            };
+
+            ChangeFeedEstimatorCore estimator = ChangeFeedEstimatorCoreTests.CreateEstimator(estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+            estimator.ApplyBuildConfiguration(
+                null,
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("leases"),
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyBuildConfiguration_ValidatesNullStore()
+        {
+            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            {
+                return Task.CompletedTask;
+            };
+
+            ChangeFeedEstimatorCore estimator = ChangeFeedEstimatorCoreTests.CreateEstimator(estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+            estimator.ApplyBuildConfiguration(
+                null,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyBuildConfiguration_ValidatesNullMonitoredContainer()
+        {
+            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            {
+                return Task.CompletedTask;
+            };
+
+            ChangeFeedEstimatorCore estimator = ChangeFeedEstimatorCoreTests.CreateEstimator(estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+            estimator.ApplyBuildConfiguration(
+                null,
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("leases"),
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                null);
+        }
+
+        [TestMethod]
+        public async Task StartAsync_TriggersDelegate()
+        {
+            const long remainingWork = 15;
+            long estimationDelegateValue = 0;
+            bool receivedEstimation = false;
+            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            {
+                estimationDelegateValue = estimation;
+                receivedEstimation = true;
+                return Task.CompletedTask;
+            };
+
+            Mock<DocumentServiceLeaseStoreManager> leaseStoreManager = new Mock<DocumentServiceLeaseStoreManager>();
+            leaseStoreManager.Setup(l => l.LeaseContainer).Returns(Mock.Of<DocumentServiceLeaseContainer>);
+            leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
+            leaseStoreManager.Setup(l => l.LeaseStore).Returns(Mock.Of<DocumentServiceLeaseStore>);
+            leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
+
+            ChangeFeedEstimatorCore estimator = ChangeFeedEstimatorCoreTests.CreateEstimator(estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator);
+            estimator.ApplyBuildConfiguration(
+                leaseStoreManager.Object,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedEstimatorCoreTests.GetMockedContainer("monitored"));
+
+            remainingWorkEstimator.Setup(r => r.GetEstimatedRemainingWorkAsync(It.IsAny<CancellationToken>())).ReturnsAsync(remainingWork);
+
+            await estimator.StartAsync();
+
+            int waitIterations = 0; // Failsafe in case someone breaks the estimator so this does not run forever
+            while (!receivedEstimation && waitIterations++ < 3)
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(10));
+            }
+
+            Assert.AreEqual(remainingWork, estimationDelegateValue);
+        }
+
+        private static ChangeFeedEstimatorCore CreateEstimator(Func<long, CancellationToken, Task> estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator)
+        {
+            remainingWorkEstimator = new Mock<RemainingWorkEstimator>();
+            return new ChangeFeedEstimatorCore(estimationDelegate, TimeSpan.FromSeconds(5), remainingWorkEstimator.Object);
+        }
+
+        private static CosmosContainer GetMockedContainer(string containerName = "myColl")
+        {
+            Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();
+            mockedContainer.Setup(c => c.LinkUri).Returns(new Uri("/dbs/myDb/colls/" + containerName, UriKind.Relative));
+            mockedContainer.Setup(c => c.Client).Returns(ChangeFeedEstimatorCoreTests.GetMockedClient());
+            return mockedContainer.Object;
+        }
+
+        private static CosmosClient GetMockedClient()
+        {
+            return MockDocumentClient.CreateMockCosmosClient();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class ChangeFeedEstimatorCoreTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -1,19 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
-using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
-using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.Azure.Cosmos.Client.Core.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class ChangeFeedEstimatorCoreTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
@@ -1,14 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.Azure.Cosmos.Client.Core.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class ChangeFeedProcessorBuilderTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.Azure.Cosmos.Client.Core.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class ChangeFeedProcessorBuilderTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void WorkFlowName_IsRequired()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder(null,
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void MonitoredContainer_IsRequired()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                null,
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void MonitoredContainer_LeaseStore_IsRequired()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        public void WithLeaseContainerPassesCorrectValues()
+        {
+            CosmosContainer leaseContainerForBuilder = ChangeFeedProcessorBuilderTests.GetMockedContainer("leases");
+
+            Action<DocumentServiceLeaseStoreManager,
+                CosmosContainer,
+                string,
+                string,
+                ChangeFeedLeaseOptions,
+                ChangeFeedProcessorOptions,
+                CosmosContainer> verifier = (DocumentServiceLeaseStoreManager leaseStoreManager,
+                CosmosContainer leaseContainer,
+                string leaseContainerPrefix,
+                string instanceName,
+                ChangeFeedLeaseOptions changeFeedLeaseOptions,
+                ChangeFeedProcessorOptions changeFeedProcessorOptions,
+                CosmosContainer monitoredContainer) =>
+                {
+                    Assert.AreEqual(leaseContainerForBuilder, leaseContainer);
+                };
+            
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                verifier);
+
+            builder.WithCosmosLeaseContainer(leaseContainerForBuilder);
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        public void WithInMemoryLeaseContainerInitializesStoreCorrectly()
+        {
+            Action<DocumentServiceLeaseStoreManager,
+                CosmosContainer,
+                string,
+                string,
+                ChangeFeedLeaseOptions,
+                ChangeFeedProcessorOptions,
+                CosmosContainer> verifier = (DocumentServiceLeaseStoreManager leaseStoreManager,
+                CosmosContainer leaseContainer,
+                string leaseContainerPrefix,
+                string instanceName,
+                ChangeFeedLeaseOptions changeFeedLeaseOptions,
+                ChangeFeedProcessorOptions changeFeedProcessorOptions,
+                CosmosContainer monitoredContainer) =>
+                {
+                    Assert.IsInstanceOfType(leaseStoreManager, typeof(DocumentServiceLeaseStoreManagerInMemory));
+                };
+
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                verifier);
+
+            builder.WithInMemoryLeaseContainer();
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        public void WithInstanceNameCorrectlyPassesParameters()
+        {
+            string myInstance = "myInstance";
+            Action<DocumentServiceLeaseStoreManager,
+                CosmosContainer,
+                string,
+                string,
+                ChangeFeedLeaseOptions,
+                ChangeFeedProcessorOptions,
+                CosmosContainer> verifier = (DocumentServiceLeaseStoreManager leaseStoreManager,
+                CosmosContainer leaseContainer,
+                string leaseContainerPrefix,
+                string instanceName,
+                ChangeFeedLeaseOptions changeFeedLeaseOptions,
+                ChangeFeedProcessorOptions changeFeedProcessorOptions,
+                CosmosContainer monitoredContainer) =>
+                {
+                    Assert.AreEqual(myInstance, instanceName);
+                };
+
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                verifier);
+
+            builder.WithInMemoryLeaseContainer();
+            builder.WithInstanceName(myInstance);
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        public void WithLeaseConfigurationFillsCorrectValues()
+        {
+            TimeSpan acquireInterval = TimeSpan.FromSeconds(1);
+            TimeSpan expirationInterval = TimeSpan.FromSeconds(2);
+            TimeSpan renewInterval = TimeSpan.FromSeconds(3);
+            string workflowName = "workflowName";
+
+
+            Action<DocumentServiceLeaseStoreManager,
+                CosmosContainer,
+                string,
+                string,
+                ChangeFeedLeaseOptions,
+                ChangeFeedProcessorOptions,
+                CosmosContainer> verifier = (DocumentServiceLeaseStoreManager leaseStoreManager,
+                CosmosContainer leaseContainer,
+                string leaseContainerPrefix,
+                string instanceName,
+                ChangeFeedLeaseOptions changeFeedLeaseOptions,
+                ChangeFeedProcessorOptions changeFeedProcessorOptions,
+                CosmosContainer monitoredContainer) =>
+                {
+                    Assert.AreEqual(workflowName, changeFeedLeaseOptions.LeasePrefix);
+                    Assert.AreEqual(acquireInterval, changeFeedLeaseOptions.LeaseAcquireInterval);
+                    Assert.AreEqual(expirationInterval, changeFeedLeaseOptions.LeaseExpirationInterval);
+                    Assert.AreEqual(renewInterval, changeFeedLeaseOptions.LeaseRenewInterval);
+                };
+
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder(workflowName,
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                verifier);
+
+            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+            builder.WithLeaseConfiguration(acquireInterval, expirationInterval, renewInterval);
+
+            builder.Build();
+        }
+
+        [TestMethod]
+        public void CannotBuildTwice()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+
+            // This build should not throw
+            builder.Build();
+
+            // This one should
+            Assert.ThrowsException<InvalidOperationException>(() => builder.Build());
+        }
+
+        private static CosmosContainer GetMockedContainer(string containerName = "myColl")
+        {
+            Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();
+            mockedContainer.Setup(c => c.LinkUri).Returns(new Uri("/dbs/myDb/colls/" + containerName, UriKind.Relative));
+            mockedContainer.Setup(c => c.Client).Returns(ChangeFeedProcessorBuilderTests.GetMockedClient());
+            return mockedContainer.Object;
+        }
+
+        private static CosmosClient GetMockedClient()
+        {
+            return MockDocumentClient.CreateMockCosmosClient();
+        }
+
+        private static ChangeFeedProcessor GetMockedProcessor()
+        {
+            Mock<ChangeFeedProcessor> mockedChangeFeedProcessor = new Mock<ChangeFeedProcessor>();
+            return mockedChangeFeedProcessor.Object;
+        }
+
+        private static Action<DocumentServiceLeaseStoreManager, CosmosContainer, string, string, ChangeFeedLeaseOptions, ChangeFeedProcessorOptions, CosmosContainer> GetEmptyInitialization()
+        {
+            return (DocumentServiceLeaseStoreManager leaseStoreManager, 
+                CosmosContainer leaseContainer, 
+                string leaseContainerPrefix, 
+                string instanceName, 
+                ChangeFeedLeaseOptions changeFeedLeaseOptions,
+                ChangeFeedProcessorOptions changeFeedProcessorOptions,
+                CosmosContainer monitoredContainer) => { };
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class ChangeFeedProcessorBuilderTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
@@ -199,6 +199,32 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.ThrowsException<InvalidOperationException>(() => builder.Build());
         }
 
+        [TestMethod]
+        public void CanBuildWithCosmosLeaseContainer()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+
+            Assert.IsInstanceOfType(builder.Build(), typeof(ChangeFeedProcessor));
+        }
+
+        [TestMethod]
+        public void CanBuildWithInMemoryContainer()
+        {
+            ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorBuilder("workflowName",
+                ChangeFeedProcessorBuilderTests.GetMockedContainer(),
+                ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
+                ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
+
+            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+
+            Assert.IsInstanceOfType(builder.Build(), typeof(ChangeFeedProcessor));
+        }
+
         private static CosmosContainer GetMockedContainer(string containerName = "myColl")
         {
             Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -1,17 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
-using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.Azure.Cosmos.Client.Core.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class ChangeFeedProcessorCoreTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.Azure.Cosmos.Client.Core.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class ChangeFeedProcessorCoreTests
+    {
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyBuildConfiguration_ValidatesNullStore()
+        {
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                null,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyBuildConfiguration_ValidatesNullInstance()
+        {
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                Mock.Of<DocumentServiceLeaseStoreManager>(),
+                null,
+                "something",
+                null,
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void ApplyBuildConfiguration_ValidatesNullMonitoredContainer()
+        {
+            var processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                Mock.Of<DocumentServiceLeaseStoreManager>(),
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                null);
+        }
+
+        [TestMethod]
+        public void ApplyBuildConfiguration_ValidCustomStore()
+        {
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                Mock.Of<DocumentServiceLeaseStoreManager>(),
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        public void ApplyBuildConfiguration_ValidContainerStore()
+        {
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                null,
+                ChangeFeedProcessorCoreTests.GetMockedContainer("leases"),
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+        }
+
+        [TestMethod]
+        public async Task StartAsync()
+        {
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(true);
+
+            Mock<DocumentServiceLeaseContainer> leaseContainer = new Mock<DocumentServiceLeaseContainer>();
+            leaseContainer.Setup(l => l.GetOwnedLeasesAsync()).Returns(Task.FromResult(Enumerable.Empty<DocumentServiceLease>()));
+
+            Mock<DocumentServiceLeaseStoreManager> leaseStoreManager = new Mock<DocumentServiceLeaseStoreManager>();
+            leaseStoreManager.Setup(l => l.LeaseContainer).Returns(leaseContainer.Object);
+            leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
+            leaseStoreManager.Setup(l => l.LeaseStore).Returns(leaseStore.Object);
+            leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                leaseStoreManager.Object,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+
+            await processor.StartAsync();
+            Mock.Get(leaseStore.Object)
+                .Verify(store => store.IsInitializedAsync(), Times.Once);
+            Mock.Get(leaseContainer.Object)
+                .Verify(store => store.GetOwnedLeasesAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ObserverIsCreated()
+        {
+            IEnumerable<DocumentServiceLease> ownedLeases = new List<DocumentServiceLease>()
+            {
+                new DocumentServiceLeaseCore()
+                {
+                    LeaseId = "0",
+                    LeaseToken = "0"
+                }
+            };
+
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(true);
+
+            Mock<DocumentServiceLeaseContainer> leaseContainer = new Mock<DocumentServiceLeaseContainer>();
+            leaseContainer.Setup(l => l.GetOwnedLeasesAsync()).Returns(Task.FromResult(ownedLeases));
+
+            Mock<DocumentServiceLeaseStoreManager> leaseStoreManager = new Mock<DocumentServiceLeaseStoreManager>();
+            leaseStoreManager.Setup(l => l.LeaseContainer).Returns(leaseContainer.Object);
+            leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
+            leaseStoreManager.Setup(l => l.LeaseStore).Returns(leaseStore.Object);
+            leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                leaseStoreManager.Object,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+
+            await processor.StartAsync();
+
+            Mock.Get(factory.Object)
+                .Verify(mock => mock.CreateObserver(), Times.Once);
+
+            Mock.Get(observer.Object)
+                .Verify(mock => mock.OpenAsync(It.Is<ChangeFeedObserverContext>((context)=>context.LeaseToken == ownedLeases.First().CurrentLeaseToken)), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task StopAsync()
+        {
+            Mock<DocumentServiceLeaseStore> leaseStore = new Mock<DocumentServiceLeaseStore>();
+            leaseStore.Setup(l => l.IsInitializedAsync()).ReturnsAsync(true);
+
+            Mock<DocumentServiceLeaseContainer> leaseContainer = new Mock<DocumentServiceLeaseContainer>();
+            leaseContainer.Setup(l => l.GetOwnedLeasesAsync()).Returns(Task.FromResult(Enumerable.Empty<DocumentServiceLease>()));
+            leaseContainer.Setup(l => l.GetAllLeasesAsync()).Returns(Task.FromResult((IReadOnlyList<DocumentServiceLease>)Enumerable.Empty<DocumentServiceLease>()));
+
+            Mock<DocumentServiceLeaseStoreManager> leaseStoreManager = new Mock<DocumentServiceLeaseStoreManager>();
+            leaseStoreManager.Setup(l => l.LeaseContainer).Returns(leaseContainer.Object);
+            leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
+            leaseStoreManager.Setup(l => l.LeaseStore).Returns(leaseStore.Object);
+            leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
+            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+            processor.ApplyBuildConfiguration(
+                leaseStoreManager.Object,
+                null,
+                "something",
+                "instanceName",
+                new ChangeFeedLeaseOptions(),
+                new ChangeFeedProcessorOptions(),
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+
+            await processor.StartAsync();
+
+            await processor.StopAsync();
+            Mock.Get(leaseContainer.Object)
+                .Verify(store => store.GetAllLeasesAsync(), Times.Once);
+        }
+
+
+        private static ChangeFeedProcessorCore<MyDocument> CreateProcessor(
+            out Mock<ChangeFeedObserverFactory<MyDocument>> factory, 
+            out Mock<ChangeFeedObserver<MyDocument>> observer)
+        {
+            factory = new Mock<ChangeFeedObserverFactory<MyDocument>>();
+            observer = new Mock<ChangeFeedObserver<MyDocument>>();
+            factory.Setup(f => f.CreateObserver()).Returns(observer.Object);
+
+            return new ChangeFeedProcessorCore<MyDocument>(factory.Object);
+        }
+
+        public class MyDocument
+        {
+            public string id { get; set; }
+        }
+
+        private static CosmosContainer GetMockedContainer(string containerName = "myColl")
+        {
+            Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();
+            mockedContainer.Setup(c => c.LinkUri).Returns(new Uri("/dbs/myDb/colls/" + containerName, UriKind.Relative));
+            mockedContainer.Setup(c => c.Client).Returns(ChangeFeedProcessorCoreTests.GetMockedClient());
+            return mockedContainer.Object;
+        }
+
+        private static CosmosClient GetMockedClient()
+        {
+            return MockDocumentClient.CreateMockCosmosClient();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class ChangeFeedProcessorCoreTests
     {
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -76,8 +76,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<int>(), 
                 It.IsAny<int?>(), 
                 It.IsAny<string>(), 
-                It.IsAny<CosmosQueryRequestOptions>(), 
-                It.IsAny<CancellationToken>()))
+                It.IsAny<CosmosQueryRequestOptions>()))
                 .Returns(()=>
                 {
                     return mockedQuery.Object;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.Azure.Cosmos.Client.Core.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class DocumentServiceLeaseContainerCosmosTests
+    {
+        private static DocumentServiceLeaseStoreManagerSettings leaseStoreManagerSettings = new DocumentServiceLeaseStoreManagerSettings()
+        {
+            ContainerNamePrefix = "prefix",
+            HostName = "host"
+        };
+
+        private static List<DocumentServiceLeaseCore> allLeases = new List<DocumentServiceLeaseCore>()
+        {
+            new DocumentServiceLeaseCore()
+            {
+                LeaseId = "1",
+                Owner = "someone"
+            },
+            new DocumentServiceLeaseCore()
+            {
+                LeaseId = "2",
+                Owner = "host"
+            }
+        };
+
+        [TestMethod]
+        public async Task GetAllLeasesAsync_ReturnsAllLeaseDocuments()
+        {
+            DocumentServiceLeaseContainerCosmos documentServiceLeaseContainerCosmos = new DocumentServiceLeaseContainerCosmos(
+                DocumentServiceLeaseContainerCosmosTests.GetMockedContainer(),
+                DocumentServiceLeaseContainerCosmosTests.leaseStoreManagerSettings);
+
+            IEnumerable<DocumentServiceLease> readLeases = await documentServiceLeaseContainerCosmos.GetAllLeasesAsync();
+            CollectionAssert.AreEqual(DocumentServiceLeaseContainerCosmosTests.allLeases, readLeases.ToList());
+        }
+
+        [TestMethod]
+        public async Task GetOwnedLeasesAsync_ReturnsOnlyMatched()
+        {
+            DocumentServiceLeaseContainerCosmos documentServiceLeaseContainerCosmos = new DocumentServiceLeaseContainerCosmos(
+                DocumentServiceLeaseContainerCosmosTests.GetMockedContainer(),
+                DocumentServiceLeaseContainerCosmosTests.leaseStoreManagerSettings);
+
+            IEnumerable<DocumentServiceLease> readLeases = await documentServiceLeaseContainerCosmos.GetOwnedLeasesAsync();
+            CollectionAssert.AreEqual(DocumentServiceLeaseContainerCosmosTests.allLeases.Where(l => l.Owner == DocumentServiceLeaseContainerCosmosTests.leaseStoreManagerSettings.HostName).ToList(), readLeases.ToList());
+        }
+
+        private static CosmosContainer GetMockedContainer(string containerName = "myColl")
+        {
+            Mock<CosmosResultSetIterator<DocumentServiceLeaseCore>> mockedQuery = new Mock<CosmosResultSetIterator<DocumentServiceLeaseCore>>();
+            mockedQuery.Setup(q => q.FetchNextSetAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => CosmosQueryResponse<DocumentServiceLeaseCore>.CreateResponse(DocumentServiceLeaseContainerCosmosTests.allLeases, string.Empty, false));
+            mockedQuery.SetupSequence(q => q.HasMoreResults)
+                .Returns(true)
+                .Returns(false);
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.CreateItemQuery<DocumentServiceLeaseCore>(
+                // To make sure the SQL Query gets correctly created
+                It.Is<string>(value => ("SELECT * FROM c WHERE STARTSWITH(c.id, '" + DocumentServiceLeaseContainerCosmosTests.leaseStoreManagerSettings.GetPartitionLeasePrefix() + "')").Equals(value)), 
+                It.IsAny<int>(), 
+                It.IsAny<int?>(), 
+                It.IsAny<string>(), 
+                It.IsAny<CosmosQueryRequestOptions>(), 
+                It.IsAny<CancellationToken>()))
+                .Returns(()=>
+                {
+                    return mockedQuery.Object;
+                });
+
+            Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();
+            mockedContainer.Setup(c => c.LinkUri).Returns(new Uri("/dbs/myDb/colls/" + containerName, UriKind.Relative));
+            mockedContainer.Setup(c => c.Client).Returns(DocumentServiceLeaseContainerCosmosTests.GetMockedClient());
+            mockedContainer.Setup(c => c.Items).Returns(mockedItems.Object);
+            return mockedContainer.Object;
+        }
+
+        private static CosmosClient GetMockedClient()
+        {
+            DocumentClient documentClient = new MockDocumentClient();
+
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
+
+            return cosmosClientBuilder.Build(documentClient);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -1,16 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.Azure.Cosmos.Client.Core.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class DocumentServiceLeaseContainerCosmosTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseContainerCosmosTests
     {
         private static DocumentServiceLeaseStoreManagerSettings leaseStoreManagerSettings = new DocumentServiceLeaseStoreManagerSettings()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class DocumentServiceLeaseContainerInMemoryTests
+    {
+        [TestMethod]
+        public async Task AllLeasesAreOwnedLeases()
+        {
+            List<DocumentServiceLease> expectedLeases = new List<DocumentServiceLease>()
+            {
+                Mock.Of<DocumentServiceLease>()
+            };
+            ConcurrentDictionary<string, DocumentServiceLease> concurrentDictionary = new ConcurrentDictionary<string, DocumentServiceLease>();
+            concurrentDictionary.TryAdd("0", expectedLeases.First());
+            DocumentServiceLeaseContainerInMemory inMemoryContainer = new DocumentServiceLeaseContainerInMemory(concurrentDictionary);
+            IEnumerable<DocumentServiceLease> ownedLeases = await inMemoryContainer.GetOwnedLeasesAsync();
+            IEnumerable<DocumentServiceLease> allLeases = await inMemoryContainer.GetAllLeasesAsync();
+            CollectionAssert.AreEqual(expectedLeases, ownedLeases.ToList());
+            CollectionAssert.AreEqual(allLeases.ToList(), ownedLeases.ToList());
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
@@ -1,15 +1,17 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class DocumentServiceLeaseContainerInMemoryTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerInMemoryTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseContainerInMemoryTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -17,14 +17,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateProperties()
         {
-            var id = "id";
-            var etag = "etag";
-            var partitionId = "0";
-            var owner = "owner";
-            var continuationToken = "continuation";
-            var timestamp = DateTime.Now - TimeSpan.FromSeconds(5);
-            var key = "key";
-            var value = "value";
+            string id = "id";
+            string etag = "etag";
+            string partitionId = "0";
+            string owner = "owner";
+            string continuationToken = "continuation";
+            DateTime timestamp = DateTime.Now - TimeSpan.FromSeconds(5);
+            string key = "key";
+            string value = "value";
 
             DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
             {
@@ -61,10 +61,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Properties = new Dictionary<string, string> { { "key", "value" } }
             };
 
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            byte[] buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalLease);
             var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);
@@ -83,10 +83,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateSerialization_NullFields()
         {
             DocumentServiceLeaseCore originalLease = new DocumentServiceLeaseCore();
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            byte[]buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalLease);
             var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class DocumentServiceLeaseTests
+    {
+        [TestMethod]
+        public void ValidateProperties()
+        {
+            var id = "id";
+            var etag = "etag";
+            var partitionId = "0";
+            var owner = "owner";
+            var continuationToken = "continuation";
+            var timestamp = DateTime.Now - TimeSpan.FromSeconds(5);
+            var key = "key";
+            var value = "value";
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = id,
+                ETag = etag,
+                LeaseToken = partitionId,
+                Owner = owner,
+                ContinuationToken = continuationToken,
+                Timestamp = timestamp,
+                Properties = new Dictionary<string, string> { { "key", "value" } },
+            };
+
+            Assert.AreEqual(id, lease.Id);
+            Assert.AreEqual(etag, lease.ETag);
+            Assert.AreEqual(partitionId, lease.LeaseToken);
+            Assert.AreEqual(owner, lease.Owner);
+            Assert.AreEqual(continuationToken, lease.ContinuationToken);
+            Assert.AreEqual(timestamp, lease.Timestamp);
+            Assert.AreEqual(value, lease.Properties[key]);
+            Assert.AreEqual(etag, lease.ConcurrencyToken);
+        }
+
+        [TestMethod]
+        public void ValidateSerialization_AllFields()
+        {
+            DocumentServiceLeaseCore originalLease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "id",
+                ETag = "etag",
+                LeaseToken = "0",
+                Owner = "owner",
+                ContinuationToken = "continuation",
+                Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
+                Properties = new Dictionary<string, string> { { "key", "value" } }
+            };
+
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalLease);
+            var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);
+
+            Assert.AreEqual(originalLease.Id, lease.Id);
+            Assert.AreEqual(originalLease.ETag, lease.ETag);
+            Assert.AreEqual(originalLease.LeaseToken, lease.LeaseToken);
+            Assert.AreEqual(originalLease.Owner, lease.Owner);
+            Assert.AreEqual(originalLease.ContinuationToken, lease.ContinuationToken);
+            Assert.AreEqual(originalLease.Timestamp, lease.Timestamp);
+            Assert.AreEqual(originalLease.Properties["key"], lease.Properties["key"]);
+        }
+
+        // Make sure that when some fields are not set, serialization is not broken.
+        [TestMethod]
+        public void ValidateSerialization_NullFields()
+        {
+            DocumentServiceLeaseCore originalLease = new DocumentServiceLeaseCore();
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalLease);
+            var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);
+
+            Assert.IsNull(lease.Id);
+            Assert.IsNull(lease.ETag);
+            Assert.IsNull(lease.LeaseToken);
+            Assert.IsNull(lease.Owner);
+            Assert.IsNull(lease.ContinuationToken);
+            Assert.AreEqual(new DocumentServiceLeaseCore().Timestamp, lease.Timestamp);
+            Assert.IsTrue(lease.Properties.Count == 0);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -1,13 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class DocumentServiceLeaseTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.Azure.Cosmos.Client.Core.Tests;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class DocumentServiceLeaseUpdaterCosmosTests
+    {
+        [TestMethod]
+        public async Task UpdatesLease()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return itemResponse.Object;
+                });
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+
+            Assert.AreEqual("newHost", updatedLease.Owner);
+            Mock.Get(mockedItems.Object)
+                .Verify(items => items.ReplaceItemAsync(It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+            Mock.Get(mockedItems.Object)
+                .Verify(items => items.ReadItemAsync<DocumentServiceLeaseCore>(It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task RetriesOnPreconditionFailed()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReadItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return itemResponse.Object;
+                });
+
+            mockedItems.SetupSequence(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Throws(new CosmosException(string.Empty, HttpStatusCode.PreconditionFailed, 0, string.Empty, 0))
+                .Returns(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return Task.FromResult(itemResponse.Object);
+                });
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+
+            Assert.AreEqual("newHost", updatedLease.Owner);
+            Mock.Get(mockedItems.Object)
+                .Verify(items => items.ReplaceItemAsync(It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+            Mock.Get(mockedItems.Object)
+                .Verify(items => items.ReadItemAsync<DocumentServiceLeaseCore>(It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(LeaseLostException))]
+        public async Task ThrowsAfterMaxRetries()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReadItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return itemResponse.Object;
+                });
+
+            mockedItems.Setup(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Throws(new CosmosException(string.Empty, HttpStatusCode.PreconditionFailed, 0, string.Empty, 0));
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(LeaseLostException))]
+        public async Task ThrowsOnConflict()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReadItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return itemResponse.Object;
+                });
+
+            mockedItems.SetupSequence(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Throws(new CosmosException(string.Empty, HttpStatusCode.Conflict, 0, string.Empty, 0))
+                .Returns(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return Task.FromResult(itemResponse.Object);
+                });
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(LeaseLostException))]
+        public async Task ThrowsOnNotFoundReplace()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReadItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return itemResponse.Object;
+                });
+
+            mockedItems.SetupSequence(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.StatusCode).Returns(HttpStatusCode.NotFound);
+                    return Task.FromResult(itemResponse.Object);
+                })
+                .Returns(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return Task.FromResult(itemResponse.Object);
+                });
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(LeaseLostException))]
+        public async Task ThrowsOnNotFoundRead()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+
+            Mock<CosmosItems> mockedItems = new Mock<CosmosItems>();
+            mockedItems.Setup(i => i.ReadItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.StatusCode).Returns(HttpStatusCode.NotFound);
+                    return itemResponse.Object;
+                });
+
+            mockedItems.SetupSequence(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                It.Is<object>((pk) => pk == partitionKey),
+                It.Is<string>((id) => id == itemId),
+                It.Is<DocumentServiceLeaseCore>((lease) => lease == leaseToUpdate),
+                It.IsAny<CosmosItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Throws(new CosmosException(string.Empty, HttpStatusCode.PreconditionFailed, 0, string.Empty, 0))
+                .Returns(() =>
+                {
+                    var itemResponse = new Mock<CosmosItemResponse<DocumentServiceLeaseCore>>();
+                    itemResponse.Setup(i => i.Resource).Returns(leaseToUpdate);
+                    return Task.FromResult(itemResponse.Object);
+                });
+
+            var updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems.Object));
+            var updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+        }
+
+        private static CosmosContainer GetMockedContainer(CosmosItems mockedItems)
+        {
+            Mock<CosmosContainer> mockedContainer = new Mock<CosmosContainer>();
+            mockedContainer.Setup(c => c.LinkUri).Returns(new Uri("/dbs/myDb/colls/myColl", UriKind.Relative));
+            mockedContainer.Setup(c => c.Client).Returns(DocumentServiceLeaseUpdaterCosmosTests.GetMockedClient());
+            mockedContainer.Setup(c => c.Items).Returns(mockedItems);
+            return mockedContainer.Object;
+        }
+
+        private static CosmosClient GetMockedClient()
+        {
+            DocumentClient documentClient = new MockDocumentClient();
+
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
+
+            return cosmosClientBuilder.Build(documentClient);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -1,17 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.Azure.Cosmos.Client.Core.Tests;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class DocumentServiceLeaseUpdaterCosmosTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseUpdaterCosmosTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class DocumentServiceLeaseUpdaterInMemoryTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class DocumentServiceLeaseUpdaterInMemoryTests
+    {
+        delegate bool Updates(out DocumentServiceLease lease);
+
+        [TestMethod]
+        [ExpectedException(typeof(LeaseLostException))]
+        public async Task RetriesIfCannotFind()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            
+            List<KeyValuePair<string, DocumentServiceLease>> state = new List<KeyValuePair<string, DocumentServiceLease>>();
+
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+            ConcurrentDictionary<string, DocumentServiceLease> container = new ConcurrentDictionary<string, DocumentServiceLease>(state);
+
+            DocumentServiceLeaseUpdaterInMemory updater = new DocumentServiceLeaseUpdaterInMemory(container);
+            DocumentServiceLease updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+        }
+
+        [TestMethod]
+        public async Task UpdatesLease()
+        {
+            string itemId = "1";
+            object partitionKey = "1";
+            
+            List<KeyValuePair<string, DocumentServiceLease>> state = new List<KeyValuePair<string, DocumentServiceLease>>()
+            {
+                new KeyValuePair<string, DocumentServiceLease>( itemId, new DocumentServiceLeaseCore() )
+            };
+
+            DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
+            ConcurrentDictionary<string, DocumentServiceLease> container = new ConcurrentDictionary<string, DocumentServiceLease>(state);
+
+            DocumentServiceLeaseUpdaterInMemory updater = new DocumentServiceLeaseUpdaterInMemory(container);
+            DocumentServiceLease updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            {
+                serverLease.Owner = "newHost";
+                return serverLease;
+            });
+
+            Assert.AreEqual("newHost", updatedLease.Owner);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseUpdaterInMemoryTests
     {
         delegate bool Updates(out DocumentServiceLease lease);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
@@ -1,0 +1,215 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+
+    [TestClass]
+    public class EqualPartitionsBalancingStrategyTests
+    {
+        private const string ownerSelf = "self";
+        private const string owner1 = "owner 1";
+        private const string owner2 = "owner 2";
+        private const string ownerNone = null;
+
+        [TestMethod]
+        public void CalculateLeasesToTake_NoLeases_ReturnsEmpty()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var leasesToTake = strategy.SelectLeasesToTake(Enumerable.Empty<DocumentServiceLease>());
+            Assert.IsTrue(leasesToTake.Count() == 0);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_OwnLeasesOnly_ReturnsEmpty()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var leasesToTake = strategy.SelectLeasesToTake(new[] { CreateLease(ownerSelf, "1"), CreateLease(ownerSelf, "2") });
+            Assert.IsTrue(leasesToTake.Count() == 0);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_NotOwnedLeasesOnly_ReturnsAll()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new HashSet<DocumentServiceLease> { CreateLease(ownerNone, "1"), CreateLease(ownerNone, "2") };
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases);
+            CollectionAssert.AreEqual(allLeases.ToList(), (new HashSet<DocumentServiceLease>(leasesToTake)).ToList());
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_ExpiredLeasesOnly_ReturnsAll()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new HashSet<DocumentServiceLease> { CreateExpiredLease(ownerSelf, "1"), CreateExpiredLease(owner1, "2") };
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases);
+            CollectionAssert.AreEqual(allLeases.ToList(), (new HashSet<DocumentServiceLease>(leasesToTake)).ToList());
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_OtherSingleOwnerTwoLeasesOnly_ReturnsOne()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new HashSet<DocumentServiceLease> { CreateLease(owner1, "1"), CreateLease(owner1, "2") };
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 1);
+            CollectionAssert.IsSubsetOf((new HashSet<DocumentServiceLease>(leasesToTake)).ToList(), allLeases.ToList());
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_ExpiredAndOtherOwner_ReturnsExpiredOnly()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            DocumentServiceLease expiredLease = CreateExpiredLease(owner1, "4");
+            var allLeases = new HashSet<DocumentServiceLease>
+            {
+                CreateLease(owner1, "1"),
+                CreateLease(owner1, "2"),
+                CreateLease(owner1, "3"),
+                expiredLease
+            };
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 1);
+            CollectionAssert.Contains(leasesToTake, expiredLease);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_ExpiredAndOtherSingleOwner_ReturnsHalfOfExpiredRoundedUp()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases1 = new List<DocumentServiceLease>();
+            allLeases1.Add(CreateLease(owner1, "0"));
+            allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
+            var allLeases = allLeases1;
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.AreEqual(6, leasesToTake.Count);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_MinPartitionsSet_ReturnsMinCountOfPartitions()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy(minPartitionCount: 7);
+            var allLeases1 = new List<DocumentServiceLease>();
+            allLeases1.Add(CreateLease(owner1, "0"));
+            allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
+            var allLeases = allLeases1;
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.AreEqual(7, leasesToTake.Count);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_MaxPartitionsSet_ReturnsMaxCountOfPartitions()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy(maxPartitionCount: 3);
+            var allLeases1 = new List<DocumentServiceLease>();
+            allLeases1.Add(CreateLease(owner1, "0"));
+            allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
+            var allLeases = allLeases1;
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.AreEqual(3, leasesToTake.Count);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_TwoOwners_ReturnsStolenFromLargerOwner()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner2, "B" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 1);
+            Assert.IsTrue(leasesToTake.First().CurrentLeaseToken.StartsWith("B"));
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_HavingMoreThanOtherOwner_ReturnsEmpty()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 6).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 0);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_HavingEqualThanOtherOwner_ReturnsEmpty()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 0);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_AllOtherOwnersEqualTargetCount_ReturnsEmpty()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 4).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 3).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 0);
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_OtherOwnerGreaterThanTargetCount_ReturnsLease()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 4).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 2).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 1);
+            Assert.IsTrue(leasesToTake.First().CurrentLeaseToken.StartsWith("A"));
+        }
+
+        [TestMethod]
+        public void CalculateLeasesToTake_NeedTwoAndOtherOwnersEqualThanTargetCount_ReturnsLease()
+        {
+            EqualPartitionsBalancingStrategy strategy = CreateStrategy();
+            var allLeases = new List<DocumentServiceLease>();
+            allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner1, "A" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner2, "B" + index.ToString())));
+            allLeases.AddRange(Enumerable.Range(1, 8).Select(index => CreateLease(ownerSelf, "C" + index.ToString())));
+            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            Assert.IsTrue(leasesToTake.Count == 1);
+        }
+
+        private EqualPartitionsBalancingStrategy CreateStrategy(int minPartitionCount = 0, int maxPartitionCount = 0)
+        {
+            TimeSpan leaseExpirationInterval = TimeSpan.FromMinutes(10);
+            return new EqualPartitionsBalancingStrategy(ownerSelf, minPartitionCount, maxPartitionCount, leaseExpirationInterval);
+        }
+
+        private DocumentServiceLease CreateLease(string owner, string partitionId)
+        {
+            return CreateLease(owner, partitionId, DateTime.UtcNow);
+        }
+
+        private DocumentServiceLease CreateExpiredLease(string owner, string partitionId)
+        {
+            return CreateLease(owner, partitionId, DateTime.UtcNow.AddYears(-1));
+        }
+
+        private static DocumentServiceLease CreateLease(string owner, string partitionId, DateTime timestamp)
+        {
+            var lease = Mock.Of<DocumentServiceLease>();
+            Mock.Get(lease).Setup(l => l.Owner).Returns(owner);
+            Mock.Get(lease).Setup(l => l.CurrentLeaseToken).Returns(partitionId);
+            Mock.Get(lease).Setup(l => l.Timestamp).Returns(timestamp);
+            return lease;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_NoLeases_ReturnsEmpty()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var leasesToTake = strategy.SelectLeasesToTake(Enumerable.Empty<DocumentServiceLease>());
+            IEnumerable<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(Enumerable.Empty<DocumentServiceLease>());
             Assert.IsTrue(leasesToTake.Count() == 0);
         }
 
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_OwnLeasesOnly_ReturnsEmpty()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var leasesToTake = strategy.SelectLeasesToTake(new[] { CreateLease(ownerSelf, "1"), CreateLease(ownerSelf, "2") });
+            IEnumerable<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(new[] { CreateLease(ownerSelf, "1"), CreateLease(ownerSelf, "2") });
             Assert.IsTrue(leasesToTake.Count() == 0);
         }
 
@@ -41,8 +41,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_NotOwnedLeasesOnly_ReturnsAll()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new HashSet<DocumentServiceLease> { CreateLease(ownerNone, "1"), CreateLease(ownerNone, "2") };
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases);
+            HashSet<DocumentServiceLease> allLeases = new HashSet<DocumentServiceLease> { CreateLease(ownerNone, "1"), CreateLease(ownerNone, "2") };
+            IEnumerable<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases);
             CollectionAssert.AreEqual(allLeases.ToList(), (new HashSet<DocumentServiceLease>(leasesToTake)).ToList());
         }
 
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_ExpiredLeasesOnly_ReturnsAll()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new HashSet<DocumentServiceLease> { CreateExpiredLease(ownerSelf, "1"), CreateExpiredLease(owner1, "2") };
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases);
+            HashSet<DocumentServiceLease> allLeases = new HashSet<DocumentServiceLease> { CreateExpiredLease(ownerSelf, "1"), CreateExpiredLease(owner1, "2") };
+            IEnumerable<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases);
             CollectionAssert.AreEqual(allLeases.ToList(), (new HashSet<DocumentServiceLease>(leasesToTake)).ToList());
         }
 
@@ -59,8 +59,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_OtherSingleOwnerTwoLeasesOnly_ReturnsOne()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new HashSet<DocumentServiceLease> { CreateLease(owner1, "1"), CreateLease(owner1, "2") };
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            HashSet<DocumentServiceLease> allLeases = new HashSet<DocumentServiceLease> { CreateLease(owner1, "1"), CreateLease(owner1, "2") };
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 1);
             CollectionAssert.IsSubsetOf((new HashSet<DocumentServiceLease>(leasesToTake)).ToList(), allLeases.ToList());
         }
@@ -70,14 +70,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
             DocumentServiceLease expiredLease = CreateExpiredLease(owner1, "4");
-            var allLeases = new HashSet<DocumentServiceLease>
+            HashSet<DocumentServiceLease> allLeases = new HashSet<DocumentServiceLease>
             {
                 CreateLease(owner1, "1"),
                 CreateLease(owner1, "2"),
                 CreateLease(owner1, "3"),
                 expiredLease
             };
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 1);
             CollectionAssert.Contains(leasesToTake, expiredLease);
         }
@@ -86,11 +86,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_ExpiredAndOtherSingleOwner_ReturnsHalfOfExpiredRoundedUp()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases1 = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases1 = new List<DocumentServiceLease>();
             allLeases1.Add(CreateLease(owner1, "0"));
             allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
-            var allLeases = allLeases1;
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> allLeases = allLeases1;
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.AreEqual(6, leasesToTake.Count);
         }
 
@@ -98,11 +98,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_MinPartitionsSet_ReturnsMinCountOfPartitions()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy(minPartitionCount: 7);
-            var allLeases1 = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases1 = new List<DocumentServiceLease>();
             allLeases1.Add(CreateLease(owner1, "0"));
             allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
-            var allLeases = allLeases1;
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> allLeases = allLeases1;
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.AreEqual(7, leasesToTake.Count);
         }
 
@@ -110,11 +110,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_MaxPartitionsSet_ReturnsMaxCountOfPartitions()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy(maxPartitionCount: 3);
-            var allLeases1 = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases1 = new List<DocumentServiceLease>();
             allLeases1.Add(CreateLease(owner1, "0"));
             allLeases1.AddRange(Enumerable.Range(1, 10).Select(index => CreateExpiredLease(owner1, index.ToString())));
-            var allLeases = allLeases1;
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> allLeases = allLeases1;
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.AreEqual(3, leasesToTake.Count);
         }
 
@@ -122,10 +122,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_TwoOwners_ReturnsStolenFromLargerOwner()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner2, "B" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 1);
             Assert.IsTrue(leasesToTake.First().CurrentLeaseToken.StartsWith("B"));
         }
@@ -134,10 +134,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_HavingMoreThanOtherOwner_ReturnsEmpty()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 6).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 0);
         }
 
@@ -145,10 +145,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_HavingEqualThanOtherOwner_ReturnsEmpty()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 5).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 0);
         }
 
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             var allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 4).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 3).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 0);
         }
 
@@ -167,10 +167,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_OtherOwnerGreaterThanTargetCount_ReturnsLease()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 4).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 2).Select(index => CreateLease(ownerSelf, "B" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 1);
             Assert.IsTrue(leasesToTake.First().CurrentLeaseToken.StartsWith("A"));
         }
@@ -179,11 +179,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void CalculateLeasesToTake_NeedTwoAndOtherOwnersEqualThanTargetCount_ReturnsLease()
         {
             EqualPartitionsBalancingStrategy strategy = CreateStrategy();
-            var allLeases = new List<DocumentServiceLease>();
+            List<DocumentServiceLease> allLeases = new List<DocumentServiceLease>();
             allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner1, "A" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 10).Select(index => CreateLease(owner2, "B" + index.ToString())));
             allLeases.AddRange(Enumerable.Range(1, 8).Select(index => CreateLease(ownerSelf, "C" + index.ToString())));
-            var leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
+            List<DocumentServiceLease> leasesToTake = strategy.SelectLeasesToTake(allLeases).ToList();
             Assert.IsTrue(leasesToTake.Count == 1);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/EqualPartitionsBalancingStrategyTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class EqualPartitionsBalancingStrategyTests
     {
         private const string ownerSelf = "self";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class LeaseLostExceptionTests
+    {
+        [TestMethod]
+        public void ValidateRecommendedConstructors()
+        {
+            // Default ctor.
+            var ex = new LeaseLostException();
+            Assert.IsNotNull(ex.Message);
+
+            // ctor(message).
+            string message = "message";
+            ex = new LeaseLostException(message);
+            Assert.AreEqual(message, ex.Message);
+
+            // ctor()
+            Exception innerException = new Exception();
+            ex = new LeaseLostException(message, innerException);
+            Assert.AreEqual(message, ex.Message);
+            Assert.AreEqual(innerException, ex.InnerException);
+        }
+
+        [TestMethod]
+        public void ValidateLeaseContructor()
+        {
+            var lease = Mock.Of<DocumentServiceLease>();
+            var ex = new LeaseLostException(lease);
+            Assert.AreEqual(lease, ex.Lease);
+            Assert.IsNotNull(ex.Message);
+        }
+
+        [TestMethod]
+        public void ValidateIsGoneConstructor()
+        {
+            var lease = Mock.Of<DocumentServiceLease>();
+            var innerException = new Exception();
+            var ex = new LeaseLostException(lease, innerException, true);
+
+            Assert.IsNotNull(ex.Message);
+            Assert.AreEqual(lease, ex.Lease);
+            Assert.AreEqual(innerException, ex.InnerException);
+            Assert.IsTrue(ex.IsGone);
+        }
+
+        // Tests the GetObjectData method and the serialization ctor.
+        [TestMethod]
+        public void ValidateSerialization_AllFields()
+        {
+            var lease = new DocumentServiceLeaseCore() { LeaseId = "id" };
+            var originalException = new LeaseLostException(lease, new Exception("foo"), true);
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalException);
+            var deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+
+            Assert.AreEqual(originalException.Message, deserializedException.Message);
+            Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
+            Assert.AreEqual(originalException.Lease.Id, deserializedException.Lease.Id);
+            Assert.AreEqual(originalException.IsGone, deserializedException.IsGone);
+        }
+
+        // Make sure that when some fields are not set, serialization is not broken.
+        [TestMethod]
+        public void ValidateSerialization_NullFields()
+        {
+            var originalException = new LeaseLostException("message");
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalException);
+            var deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+
+            Assert.AreEqual(originalException.Message, deserializedException.Message);
+            Assert.IsNull(deserializedException.InnerException);
+            Assert.IsNull(deserializedException.Lease);
+            Assert.IsFalse(deserializedException.IsGone);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
@@ -1,13 +1,17 @@
-﻿using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class LeaseLostExceptionTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class LeaseLostExceptionTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateRecommendedConstructors()
         {
             // Default ctor.
-            var ex = new LeaseLostException();
+            LeaseLostException ex = new LeaseLostException();
             Assert.IsNotNull(ex.Message);
 
             // ctor(message).
@@ -37,8 +37,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateLeaseContructor()
         {
-            var lease = Mock.Of<DocumentServiceLease>();
-            var ex = new LeaseLostException(lease);
+            DocumentServiceLease lease = Mock.Of<DocumentServiceLease>();
+            LeaseLostException ex = new LeaseLostException(lease);
             Assert.AreEqual(lease, ex.Lease);
             Assert.IsNotNull(ex.Message);
         }
@@ -46,9 +46,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateIsGoneConstructor()
         {
-            var lease = Mock.Of<DocumentServiceLease>();
-            var innerException = new Exception();
-            var ex = new LeaseLostException(lease, innerException, true);
+            DocumentServiceLease lease = Mock.Of<DocumentServiceLease>();
+            Exception innerException = new Exception();
+            LeaseLostException ex = new LeaseLostException(lease, innerException, true);
 
             Assert.IsNotNull(ex.Message);
             Assert.AreEqual(lease, ex.Lease);
@@ -60,15 +60,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateSerialization_AllFields()
         {
-            var lease = new DocumentServiceLeaseCore() { LeaseId = "id" };
-            var originalException = new LeaseLostException(lease, new Exception("foo"), true);
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore() { LeaseId = "id" };
+            LeaseLostException originalException = new LeaseLostException(lease, new Exception("foo"), true);
+            byte[] buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalException);
-            var deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+            LeaseLostException deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
@@ -80,14 +80,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateSerialization_NullFields()
         {
-            var originalException = new LeaseLostException("message");
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            LeaseLostException originalException = new LeaseLostException("message");
+            byte[] buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalException);
-            var deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+            LeaseLostException deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.IsNull(deserializedException.InnerException);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class ObserverExceptionTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateConstructor()
         {
             Exception exception = new Exception("randomMessage");
-            var ex = new ObserverException(exception);
+            ObserverException ex = new ObserverException(exception);
             Assert.AreEqual(exception.Message, ex.InnerException.Message);
             Assert.AreEqual(exception, ex.InnerException);
         }
@@ -27,14 +27,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateSerialization_AllFields()
         {
             Exception exception = new Exception("randomMessage");
-            var originalException = new ObserverException(exception);
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            ObserverException originalException = new ObserverException(exception);
+            byte[] buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalException);
-            var deserializedException = (ObserverException)formatter.Deserialize(stream2);
+            ObserverException deserializedException = (ObserverException)formatter.Deserialize(stream2);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
@@ -44,14 +44,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ValidateSerialization_NullFields()
         {
-            var originalException = new ObserverException(null);
-            var buffer = new byte[4096];
-            var formatter = new BinaryFormatter();
-            var stream1 = new MemoryStream(buffer);
-            var stream2 = new MemoryStream(buffer);
+            ObserverException originalException = new ObserverException(null);
+            byte[] buffer = new byte[4096];
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream stream1 = new MemoryStream(buffer);
+            MemoryStream stream2 = new MemoryStream(buffer);
 
             formatter.Serialize(stream1, originalException);
-            var deserializedException = (ObserverException)formatter.Deserialize(stream2);
+            ObserverException deserializedException = (ObserverException)formatter.Deserialize(stream2);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.IsNull(deserializedException.InnerException);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
@@ -1,11 +1,15 @@
-﻿using System;
-using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
     [TestClass]
     public class ObserverExceptionTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization.Formatters.Binary;
+using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class ObserverExceptionTests
+    {
+        [TestMethod]
+        public void ValidateConstructor()
+        {
+            Exception exception = new Exception("randomMessage");
+            var ex = new ObserverException(exception);
+            Assert.AreEqual(exception.Message, ex.InnerException.Message);
+            Assert.AreEqual(exception, ex.InnerException);
+        }
+
+        // Tests the GetObjectData method and the serialization ctor.
+        [TestMethod]
+        public void ValidateSerialization_AllFields()
+        {
+            Exception exception = new Exception("randomMessage");
+            var originalException = new ObserverException(exception);
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalException);
+            var deserializedException = (ObserverException)formatter.Deserialize(stream2);
+
+            Assert.AreEqual(originalException.Message, deserializedException.Message);
+            Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
+        }
+
+        // Make sure that when some fields are not set, serialization is not broken.
+        [TestMethod]
+        public void ValidateSerialization_NullFields()
+        {
+            var originalException = new ObserverException(null);
+            var buffer = new byte[4096];
+            var formatter = new BinaryFormatter();
+            var stream1 = new MemoryStream(buffer);
+            var stream2 = new MemoryStream(buffer);
+
+            formatter.Serialize(stream1, originalException);
+            var deserializedException = (ObserverException)formatter.Deserialize(stream2);
+
+            Assert.AreEqual(originalException.Message, deserializedException.Message);
+            Assert.IsNull(deserializedException.InnerException);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/HealthinessMonitorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/HealthinessMonitorTests.cs
@@ -1,0 +1,47 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Monitoring;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class HealthinessMonitorTests
+    {
+        [TestMethod]
+        public async Task AcquireLease_ShouldReportHealthy_IfNoIssues()
+        {
+            var monitor = new Mock<HealthMonitor>();
+            var sut = new HealthMonitoringPartitionControllerDecorator(Mock.Of<PartitionController>(), monitor.Object);
+            var lease = Mock.Of<DocumentServiceLease>();
+            await sut.AddOrUpdateLeaseAsync(lease);
+
+            monitor.Verify(m => m.InspectAsync(It.Is<HealthMonitoringRecord>(r => r.Severity == HealthSeverity.Informational && r.Lease == lease && r.Operation == MonitoredOperation.AcquireLease && r.Exception == null)));
+        }
+
+        [TestMethod]
+        public async Task AcquireLease_ShouldReportFailure_IfSystemIssue()
+        {
+            var lease = Mock.Of<DocumentServiceLease>();
+            var monitor = new Mock<HealthMonitor>();
+            var controller = new Mock<PartitionController>();
+
+            Exception exception = new InvalidOperationException();
+            controller
+                .Setup(c => c.AddOrUpdateLeaseAsync(lease))
+                .Returns(Task.FromException(exception));
+
+            var sut = new HealthMonitoringPartitionControllerDecorator(controller.Object, monitor.Object);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => sut.AddOrUpdateLeaseAsync(lease));
+
+            monitor.Verify(m => m.InspectAsync(It.Is<HealthMonitoringRecord>(r => r.Severity == HealthSeverity.Error && r.Lease == lease && r.Operation == MonitoredOperation.AcquireLease && r.Exception == exception)));
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/HealthinessMonitorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/HealthinessMonitorTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class HealthinessMonitorTests
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
@@ -1,17 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
-using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
     [TestClass]
     public class ObserverExceptionWrappingChangeFeedObserverDecoratorTests
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class ObserverExceptionWrappingChangeFeedObserverDecoratorTests
+    {
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private readonly Mock<ChangeFeedObserver<MyDocument>> observer;
+        private readonly ChangeFeedObserverContext changeFeedObserverContext;
+        private readonly FeedProcessing.ObserverExceptionWrappingChangeFeedObserverDecorator<MyDocument> observerWrapper;
+        private readonly List<MyDocument> documents;
+
+        public ObserverExceptionWrappingChangeFeedObserverDecoratorTests()
+        {
+            this.observer = new Mock<ChangeFeedObserver<MyDocument>>();
+            this.changeFeedObserverContext = Mock.Of<ChangeFeedObserverContext>();
+            this.observerWrapper = new FeedProcessing.ObserverExceptionWrappingChangeFeedObserverDecorator<MyDocument>(this.observer.Object);
+
+            var document = new MyDocument();
+            documents = new List<MyDocument> { document };
+        }
+
+        [TestMethod]
+        public async Task OpenAsync_ShouldCallOpenAsync()
+        {
+            await observerWrapper.OpenAsync(this.changeFeedObserverContext);
+
+            Mock.Get(this.observer.Object)
+                .Verify(feedObserver => feedObserver.OpenAsync(It.IsAny<ChangeFeedObserverContext>()),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task CloseAsync_ShouldCallCloseAsync()
+        {
+            await observerWrapper.CloseAsync(this.changeFeedObserverContext, ChangeFeedObserverCloseReason.Shutdown);
+
+            Mock.Get(this.observer.Object)
+                .Verify(feedObserver => feedObserver
+                        .CloseAsync(It.IsAny<ChangeFeedObserverContext>(),
+                        It.Is<ChangeFeedObserverCloseReason>(reason => reason == ChangeFeedObserverCloseReason.Shutdown)),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ProcessChangesAsync_ShouldPassDocumentsToProcessChangesAsync()
+        {
+            await observerWrapper.ProcessChangesAsync(this.changeFeedObserverContext, this.documents, cancellationTokenSource.Token);
+
+            Mock.Get(this.observer.Object)
+                .Verify(feedObserver => feedObserver
+                        .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(),
+                            It.Is<IReadOnlyList<MyDocument>>(list => this.documents.SequenceEqual(list)),
+                            It.IsAny<CancellationToken>()
+                        ),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ProcessChangesAsync_ShouldThrow_IfObserverThrows()
+        {
+            Mock.Get(this.observer.Object)
+                .SetupSequence(feedObserver => feedObserver
+                    .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<MyDocument>>(), It.IsAny<CancellationToken>()))
+                .Throws(new Exception());
+
+            try
+            {
+                await observerWrapper.ProcessChangesAsync(this.changeFeedObserverContext, this.documents, cancellationTokenSource.Token);
+                Assert.Fail("Should had thrown");
+            }
+            catch (ObserverException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(Exception));
+            }
+
+            Mock.Get(this.observer.Object)
+                .Verify(feedObserver => feedObserver
+                        .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(),
+                            It.Is<IReadOnlyList<MyDocument>>(list => this.documents.SequenceEqual(list)),
+                            It.IsAny<CancellationToken>()
+                        ),
+                    Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ProcessChangesAsync_ShouldThrow_IfObserverThrowsDocumentClientException()
+        {
+            Mock.Get(this.observer.Object)
+                .SetupSequence(feedObserver => feedObserver
+                    .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<MyDocument>>(), It.IsAny<CancellationToken>()))
+                .Throws(new Documents.DocumentClientException("Some message", (HttpStatusCode) 429, Documents.SubStatusCodes.Unknown));
+
+            try
+            {
+                await observerWrapper.ProcessChangesAsync(this.changeFeedObserverContext, this.documents, cancellationTokenSource.Token);
+                Assert.Fail("Should had thrown");
+            }
+            catch (ObserverException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(Documents.DocumentClientException));
+            }
+
+            Mock.Get(this.observer.Object)
+                .Verify(feedObserver => feedObserver
+                        .ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(),
+                            It.Is<IReadOnlyList<MyDocument>>(list => this.documents.SequenceEqual(list)),
+                            It.IsAny<CancellationToken>()
+                        ),
+                    Times.Once);
+        }
+
+        public class MyDocument
+        {
+            public string id { get; set; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ObserverExceptionWrappingChangeFeedObserverDecoratorTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class ObserverExceptionWrappingChangeFeedObserverDecoratorTests
     {
         private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class PartitionControllerSplitTests
     {
         private const string LastContinuationToken = "lastContinuation";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
@@ -1,0 +1,279 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class PartitionControllerSplitTests
+    {
+        private const string LastContinuationToken = "lastContinuation";
+        private const string InitialContinuationToken = "initial token";
+        private const string PartitionId = "partitionId";
+
+        [TestMethod]
+        public async Task Controller_ShouldSignalSynchronizerSplitPartition_IfPartitionSplitHappened()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(lease))
+                .ReturnsAsync(new[] { CreateMockLease(), CreateMockLease() });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(synchronizer).VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldPassLastKnownContinuationTokenToSynchronizer_IfPartitionSplitHappened()
+        {
+            //arrange
+            var lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == InitialContinuationToken);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
+                .ReturnsAsync(new[] { CreateMockLease(), CreateMockLease() });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(synchronizer).VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldCopyParentLeaseProperties_IfPartitionSplitHappened()
+        {
+            //arrange
+            var customProperties = new Dictionary<string, string> { { "key", "value" } };
+            var lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.Properties == customProperties);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease leaseChild1 = CreateMockLease();
+            DocumentServiceLease leaseChild2 = CreateMockLease();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
+                .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            await sut.ShutdownAsync().ConfigureAwait(false);
+            Mock.Get(leaseChild1)
+                    .VerifySet(l => l.Properties = customProperties, Times.Once);
+            Mock.Get(leaseChild2)
+                .VerifySet(l => l.Properties = customProperties, Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldKeepParentLease_IfSplitThrows()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>(s => s.SplitPartitionAsync(lease) == Task.FromException<IEnumerable<DocumentServiceLease>>(new InvalidOperationException()));
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>();
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager).Verify(manager => manager.DeleteAsync(lease), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldRunProcessingOnChildPartitions_IfHappyPath()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease leaseChild1 = CreateMockLease();
+            DocumentServiceLease leaseChild2 = CreateMockLease();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
+                .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisor1 = Mock.Of<PartitionSupervisor>();
+            Mock.Get(partitionSupervisor1).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
+            var partitionSupervisor2 = Mock.Of<PartitionSupervisor>();
+            Mock.Get(partitionSupervisor2).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
+
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
+                f.Create(lease) == partitionSupervisor && f.Create(leaseChild1) == partitionSupervisor1 && f.Create(leaseChild2) == partitionSupervisor2);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager).Verify(manager => manager.AcquireAsync(leaseChild1), Times.Once);
+            Mock.Get(leaseManager).Verify(manager => manager.AcquireAsync(leaseChild2), Times.Once);
+
+            Mock.Get(partitionSupervisorFactory).Verify(f => f.Create(leaseChild1), Times.Once);
+            Mock.Get(partitionSupervisorFactory).Verify(f => f.Create(leaseChild2), Times.Once);
+
+            Mock.Get(partitionSupervisor1).Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+            Mock.Get(partitionSupervisor2).Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldIgnoreProcessingChildPartition_IfPartitionAlreadyAdded()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease leaseChild1 = CreateMockLease();
+            DocumentServiceLease leaseChild2 = CreateMockLease();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
+                .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisor1 = Mock.Of<PartitionSupervisor>();
+            Mock.Get(partitionSupervisor1).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
+            var partitionSupervisor2 = Mock.Of<PartitionSupervisor>();
+            Mock.Get(partitionSupervisor2).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
+
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
+                f.Create(lease) == partitionSupervisor && f.Create(leaseChild1) == partitionSupervisor1 && f.Create(leaseChild2) == partitionSupervisor2);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.AcquireAsync(leaseChild2), Times.Once);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.UpdatePropertiesAsync(leaseChild2), Times.Exactly(5));
+
+            Mock.Get(partitionSupervisorFactory)
+                .Verify(f => f.Create(leaseChild2), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldDeleteParentLease_IfChildLeasesCreatedByAnotherHost()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(lease))
+                .ReturnsAsync(new DocumentServiceLease[] { });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
+                manager.AcquireAsync(lease) == Task.FromResult(lease)
+            );
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager).Verify(manager => manager.DeleteAsync(lease), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldDeleteParentLease_IfChildLeaseAcquireThrows()
+        {
+            //arrange
+            var lease = CreateMockLease(PartitionId);
+            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease leaseChild2 = CreateMockLease();
+            Mock.Get(synchronizer)
+                .Setup(s => s.SplitPartitionAsync(lease))
+                .ReturnsAsync(new[] { CreateMockLease(), leaseChild2 });
+
+            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
+                manager.AcquireAsync(lease) == Task.FromResult(lease) &&
+                manager.AcquireAsync(leaseChild2) == Task.FromException<DocumentServiceLease>(new LeaseLostException())
+                );
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            //act
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            //assert
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager).Verify(manager => manager.DeleteAsync(lease), Times.Once);
+        }
+
+        private DocumentServiceLease CreateMockLease(string partitionId = null)
+        {
+            partitionId = partitionId ?? Guid.NewGuid().ToString();
+            return Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == partitionId);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
@@ -25,18 +25,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldSignalSynchronizerSplitPartition_IfPartitionSplitHappened()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(lease))
                 .ReturnsAsync(new[] { CreateMockLease(), CreateMockLease() });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -51,18 +51,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldPassLastKnownContinuationTokenToSynchronizer_IfPartitionSplitHappened()
         {
             //arrange
-            var lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == InitialContinuationToken);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == InitialContinuationToken);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
                 .ReturnsAsync(new[] { CreateMockLease(), CreateMockLease() });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -78,20 +78,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         {
             //arrange
             var customProperties = new Dictionary<string, string> { { "key", "value" } };
-            var lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.Properties == customProperties);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = Mock.Of<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.Properties == customProperties);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             DocumentServiceLease leaseChild1 = CreateMockLease();
             DocumentServiceLease leaseChild2 = CreateMockLease();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
                 .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -107,14 +107,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldKeepParentLease_IfSplitThrows()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>(s => s.SplitPartitionAsync(lease) == Task.FromException<IEnumerable<DocumentServiceLease>>(new InvalidOperationException()));
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>();
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>(s => s.SplitPartitionAsync(lease) == Task.FromException<IEnumerable<DocumentServiceLease>>(new InvalidOperationException()));
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>();
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -129,26 +129,26 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldRunProcessingOnChildPartitions_IfHappyPath()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             DocumentServiceLease leaseChild1 = CreateMockLease();
             DocumentServiceLease leaseChild2 = CreateMockLease();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
                 .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
             var partitionSupervisor1 = Mock.Of<PartitionSupervisor>();
             Mock.Get(partitionSupervisor1).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
             var partitionSupervisor2 = Mock.Of<PartitionSupervisor>();
             Mock.Get(partitionSupervisor2).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
 
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
                 f.Create(lease) == partitionSupervisor && f.Create(leaseChild1) == partitionSupervisor1 && f.Create(leaseChild2) == partitionSupervisor2);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -170,26 +170,26 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldIgnoreProcessingChildPartition_IfPartitionAlreadyAdded()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             DocumentServiceLease leaseChild1 = CreateMockLease();
             DocumentServiceLease leaseChild2 = CreateMockLease();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(It.Is<DocumentServiceLease>(l => l.CurrentLeaseToken == PartitionId && l.ContinuationToken == LastContinuationToken)))
                 .ReturnsAsync(new[] { leaseChild1, leaseChild2 });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
             var partitionSupervisor1 = Mock.Of<PartitionSupervisor>();
             Mock.Get(partitionSupervisor1).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
             var partitionSupervisor2 = Mock.Of<PartitionSupervisor>();
             Mock.Get(partitionSupervisor2).Setup(o => o.RunAsync(It.IsAny<CancellationToken>())).Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
 
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f =>
                 f.Create(lease) == partitionSupervisor && f.Create(leaseChild1) == partitionSupervisor1 && f.Create(leaseChild2) == partitionSupervisor2);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager => manager.AcquireAsync(lease) == Task.FromResult(lease));
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -216,20 +216,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldDeleteParentLease_IfChildLeasesCreatedByAnotherHost()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(lease))
                 .ReturnsAsync(new DocumentServiceLease[] { });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
                 manager.AcquireAsync(lease) == Task.FromResult(lease)
             );
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -244,22 +244,22 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task Controller_ShouldDeleteParentLease_IfChildLeaseAcquireThrows()
         {
             //arrange
-            var lease = CreateMockLease(PartitionId);
-            var synchronizer = Mock.Of<PartitionSynchronizer>();
+            DocumentServiceLease lease = CreateMockLease(PartitionId);
+            PartitionSynchronizer synchronizer = Mock.Of<PartitionSynchronizer>();
             DocumentServiceLease leaseChild2 = CreateMockLease();
             Mock.Get(synchronizer)
                 .Setup(s => s.SplitPartitionAsync(lease))
                 .ReturnsAsync(new[] { CreateMockLease(), leaseChild2 });
 
-            var partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
-            var partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
-            var leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
+            PartitionSupervisor partitionSupervisor = Mock.Of<PartitionSupervisor>(o => o.RunAsync(It.IsAny<CancellationToken>()) == Task.FromException(new FeedSplitException("message", LastContinuationToken)));
+            PartitionSupervisorFactory partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == partitionSupervisor);
+            DocumentServiceLeaseManager leaseManager = Mock.Of<DocumentServiceLeaseManager>(manager =>
                 manager.AcquireAsync(lease) == Task.FromResult(lease) &&
                 manager.AcquireAsync(leaseChild2) == Task.FromException<DocumentServiceLease>(new LeaseLostException())
                 );
-            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+            DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
-            var sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+            PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
+            await sut.InitializeAsync().ConfigureAwait(false);
+
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
 
@@ -64,6 +66,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            await sut.InitializeAsync().ConfigureAwait(false);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -94,6 +98,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
+            await sut.InitializeAsync().ConfigureAwait(false);
+
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
 
@@ -116,6 +122,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            await sut.InitializeAsync().ConfigureAwait(false);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -150,6 +158,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            await sut.InitializeAsync().ConfigureAwait(false);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
@@ -192,6 +202,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
+            await sut.InitializeAsync().ConfigureAwait(false);
+
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
             await sut.AddOrUpdateLeaseAsync(leaseChild2).ConfigureAwait(false);
@@ -232,6 +244,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
 
+            await sut.InitializeAsync().ConfigureAwait(false);
+
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
 
@@ -261,6 +275,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
 
             PartitionControllerCore sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+
+            await sut.InitializeAsync().ConfigureAwait(false);
 
             //act
             await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
         }
 
+        [TestInitialize]
+        public async Task Setup()
+        {
+            await sut.InitializeAsync().ConfigureAwait(false);
+        }
+
         [TestCleanup]
         public async Task CleanUp()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -1,0 +1,319 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class PartitionControllerTests
+    {
+        private readonly DocumentServiceLease lease;
+        private readonly DocumentServiceLeaseManager leaseManager;
+        private readonly FeedProcessor partitionProcessor;
+        private readonly LeaseRenewer leaseRenewer;
+        private readonly ChangeFeedObserver<MyDocument> observer;
+        private readonly PartitionSynchronizer synchronizer;
+        private readonly PartitionController sut;
+        private readonly PartitionSupervisorFactory partitionSupervisorFactory;
+
+        public PartitionControllerTests()
+        {
+            lease = Mock.Of<DocumentServiceLease>();
+            Mock.Get(lease)
+                .Setup(l => l.CurrentLeaseToken)
+                .Returns("partitionId");
+
+            partitionProcessor = MockPartitionProcessor();
+            leaseRenewer = MockRenewer();
+            observer = MockObserver();
+            partitionSupervisorFactory = Mock.Of<PartitionSupervisorFactory>(f => f.Create(lease) == new PartitionSupervisorCore<MyDocument>(lease, observer, partitionProcessor, leaseRenewer));
+
+            leaseManager = Mock.Of<DocumentServiceLeaseManager>();
+            Mock.Get(leaseManager).Reset(); // Reset implicit/by default setup of properties.
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.AcquireAsync(lease))
+                .ReturnsAsync(lease);
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.ReleaseAsync(lease))
+                .Returns(Task.CompletedTask);
+            var leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+
+            synchronizer = Mock.Of<PartitionSynchronizer>();
+            sut = new PartitionControllerCore(leaseContainer, leaseManager, partitionSupervisorFactory, synchronizer);
+        }
+
+        [TestCleanup]
+        public async Task CleanUp()
+        {
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .VerifyAll();
+
+            Mock.Get(partitionProcessor)
+                .VerifyAll();
+
+            Mock.Get(synchronizer)
+                .VerifyAll();
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldAcquireLease_WhenCalled()
+        {
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.AcquireAsync(lease), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldRunObserver_WhenCalled()
+        {
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            Mock.Get(partitionProcessor)
+                .Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldntReleaseLease_WhenCalled()
+        {
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            Mock.Get(partitionProcessor)
+                .Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldIgnorePartitionObserving_IfDuplicateLease()
+        {
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            FeedProcessor processorDuplicate = MockPartitionProcessor();
+            Mock.Get(partitionSupervisorFactory)
+                .Setup(f => f.Create(lease))
+                .Returns(new PartitionSupervisorCore<MyDocument>(lease, observer, processorDuplicate, leaseRenewer));
+
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.AcquireAsync(lease), Times.Once);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.UpdatePropertiesAsync(lease), Times.Once);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.ReleaseAsync(It.IsAny<DocumentServiceLease>()), Times.Never);
+
+            Mock.Get(partitionProcessor)
+                .Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+            Mock.Get(processorDuplicate)
+                .Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldNotRelease_IfUpdateLeasePropertiesThrows()
+        {
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.UpdatePropertiesAsync(lease))
+                .Throws(new NullReferenceException());
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.ReleaseAsync(lease))
+                .Returns(Task.CompletedTask);
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => sut.AddOrUpdateLeaseAsync(lease)).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.ReleaseAsync(It.IsAny<DocumentServiceLease>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldAcquireLease_IfSecondLeaseAdded()
+        {
+            var lease2 = Mock.Of<DocumentServiceLease>();
+            Mock.Get(lease2)
+                .Setup(l => l.CurrentLeaseToken)
+                .Returns("partitionId2");
+
+            Mock.Get(partitionSupervisorFactory)
+                .Setup(f => f.Create(lease2))
+                .Returns(new PartitionSupervisorCore<MyDocument>(lease2, observer, MockPartitionProcessor(), leaseRenewer));
+
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(lease2).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.AcquireAsync(lease2), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldRunObserver_IfSecondAdded()
+        {
+            var lease2 = Mock.Of<DocumentServiceLease>();
+            Mock.Get(lease2)
+                .Setup(l => l.CurrentLeaseToken)
+                .Returns("partitionId2");
+
+            FeedProcessor partitionProcessor2 = MockPartitionProcessor();
+            Mock.Get(partitionSupervisorFactory)
+                .Setup(f => f.Create(lease2))
+                .Returns(new PartitionSupervisorCore<MyDocument>(lease2, observer, partitionProcessor2, leaseRenewer));
+
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+            await sut.AddOrUpdateLeaseAsync(lease2).ConfigureAwait(false);
+
+            Mock.Get(partitionProcessor2)
+                .Verify(p => p.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task Shutdown_ShouldWork_WithoutLeases()
+        {
+            Mock.Get(leaseManager)
+                .Reset();
+
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            await sut.ShutdownAsync().ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.ReleaseAsync(It.IsAny<DocumentServiceLease>()), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task Controller_ShouldReleasesLease_IfObserverExits()
+        {
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            Mock.Get(partitionSupervisorFactory)
+                .Setup(f => f.Create(lease))
+                .Returns(new PartitionSupervisorCore<MyDocument>(lease, observer, partitionProcessor, leaseRenewer));
+
+            await sut.AddOrUpdateLeaseAsync(lease).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.ReleaseAsync(It.IsAny<DocumentServiceLease>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldFail_IfLeaseAcquireThrows()
+        {
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.AcquireAsync(lease))
+                .Throws(new NullReferenceException());
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.ReleaseAsync(lease))
+                .Returns(Task.CompletedTask);
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => sut.AddOrUpdateLeaseAsync(lease)).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldReleaseLease_IfLeaseAcquireThrows()
+        {
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.AcquireAsync(lease))
+                .Throws(new NullReferenceException());
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.ReleaseAsync(lease))
+                .Returns(Task.CompletedTask);
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => sut.AddOrUpdateLeaseAsync(lease)).ConfigureAwait(false);
+
+            Mock.Get(leaseManager)
+                .Verify(manager => manager.ReleaseAsync(It.IsAny<DocumentServiceLease>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldntRunObserver_IfLeaseAcquireThrows()
+        {
+            Mock.Get(partitionProcessor)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Reset();
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.AcquireAsync(lease))
+                .Throws(new NullReferenceException());
+
+            Mock.Get(leaseManager)
+                .Setup(manager => manager.ReleaseAsync(lease))
+                .Returns(Task.CompletedTask);
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => sut.AddOrUpdateLeaseAsync(lease)).ConfigureAwait(false);
+
+            Mock.Get(partitionProcessor)
+                .Verify(processor => processor.RunAsync(It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        public Task InitializeAsync()
+        {
+            return Task.FromResult(false);
+        }
+
+        private static FeedProcessor MockPartitionProcessor()
+        {
+            var mock = new Mock<FeedProcessor>();
+            mock
+                .Setup(p => p.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromHours(1), token));
+            return mock.Object;
+        }
+
+        private static LeaseRenewer MockRenewer()
+        {
+            var mock = new Mock<LeaseRenewer>();
+            mock
+                .Setup(renewer => renewer.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => Task.Delay(TimeSpan.FromMinutes(1), token));
+            return mock.Object;
+        }
+
+        private static ChangeFeedObserver<MyDocument> MockObserver()
+        {
+            var mock = new Mock<ChangeFeedObserver<MyDocument>>();
+            return mock.Object;
+        }
+
+        public class MyDocument
+        {
+            public string id { get; set; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class PartitionControllerTests
     {
         private readonly DocumentServiceLease lease;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public async Task AddLease_ShouldAcquireLease_IfSecondLeaseAdded()
         {
-            var lease2 = Mock.Of<DocumentServiceLease>();
+            DocumentServiceLease lease2 = Mock.Of<DocumentServiceLease>();
             Mock.Get(lease2)
                 .Setup(l => l.CurrentLeaseToken)
                 .Returns("partitionId2");
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public async Task AddLease_ShouldRunObserver_IfSecondAdded()
         {
-            var lease2 = Mock.Of<DocumentServiceLease>();
+            DocumentServiceLease lease2 = Mock.Of<DocumentServiceLease>();
             Mock.Get(lease2)
                 .Setup(l => l.CurrentLeaseToken)
                 .Returns("partitionId2");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
@@ -1,0 +1,71 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class PartitionLoadBalancerTests
+    {
+        private readonly DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
+        private readonly LoadBalancingStrategy strategy = Mock.Of<LoadBalancingStrategy>();
+
+        [TestMethod]
+        public async Task AddLease_ThrowsException_LeaseAddingContinues()
+        {
+            FailingPartitionController controller = new FailingPartitionController();
+
+            // long acquire interval to ensure that only 1 load balancing iteration is performed in a test run
+            var leaseAcquireInterval = TimeSpan.FromHours(1);
+            var loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval);
+
+            Mock.Get(this.strategy)
+                .Setup(s => s.SelectLeasesToTake(It.IsAny<IEnumerable<DocumentServiceLease>>()))
+                .Returns(new[] { Mock.Of<DocumentServiceLease>(), Mock.Of<DocumentServiceLease>() });
+
+            Mock.Get(this.leaseContainer)
+                .Setup(m => m.GetAllLeasesAsync())
+                .ReturnsAsync(new[] { Mock.Of<DocumentServiceLease>(), Mock.Of<DocumentServiceLease>() });
+
+            loadBalancer.Start();
+            await loadBalancer.StopAsync();
+
+            Mock.Get(this.strategy)
+                .Verify(s => s.SelectLeasesToTake(It.IsAny<IEnumerable<DocumentServiceLease>>()), Times.Once);
+
+            Mock.Get(this.leaseContainer)
+                .Verify(m => m.GetAllLeasesAsync(), Times.Once);
+
+            Assert.AreEqual(2, controller.HitCount);
+        }
+
+        private class FailingPartitionController : PartitionController
+        {
+            public int HitCount { get; private set; }
+
+            public override Task AddOrUpdateLeaseAsync(DocumentServiceLease lease)
+            {
+                this.HitCount++;
+                throw new ArgumentException();
+            }
+
+            public override Task InitializeAsync()
+            {
+                return Task.CompletedTask;
+            }
+
+            public override Task ShutdownAsync()
+            {
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             FailingPartitionController controller = new FailingPartitionController();
 
             // long acquire interval to ensure that only 1 load balancing iteration is performed in a test run
-            var leaseAcquireInterval = TimeSpan.FromHours(1);
-            var loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval);
+            TimeSpan leaseAcquireInterval = TimeSpan.FromHours(1);
+            PartitionLoadBalancerCore loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval);
 
             Mock.Get(this.strategy)
                 .Setup(s => s.SelectLeasesToTake(It.IsAny<IEnumerable<DocumentServiceLease>>()))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class PartitionLoadBalancerTests
     {
         private readonly DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSupervisorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSupervisorTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Moq;
 
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class PartitionSupervisorTests : IDisposable
     {
         private readonly DocumentServiceLease lease;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSupervisorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSupervisorTests.cs
@@ -1,0 +1,164 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class PartitionSupervisorTests : IDisposable
+    {
+        private readonly DocumentServiceLease lease;
+        private readonly LeaseRenewer leaseRenewer;
+        private readonly FeedProcessor partitionProcessor;
+        private readonly ChangeFeedObserver<dynamic> observer;
+        private readonly CancellationTokenSource shutdownToken = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        private readonly PartitionSupervisor sut;
+
+        public PartitionSupervisorTests()
+        {
+            lease = Mock.Of<DocumentServiceLease>();
+            Mock.Get(lease)
+                .Setup(l => l.CurrentLeaseToken)
+                .Returns("partitionId");
+
+            leaseRenewer = Mock.Of<LeaseRenewer>();
+            partitionProcessor = Mock.Of<FeedProcessor>();
+            observer = Mock.Of<ChangeFeedObserver<dynamic>>();
+
+            sut = new PartitionSupervisorCore<dynamic>(lease, observer, partitionProcessor, leaseRenewer);
+        }
+
+        [TestMethod]
+        public async Task RunObserver_ShouldCancelTasks_WhenTokenCanceled()
+        {
+            Task renewerTask = Task.FromResult(false);
+            Mock.Get(leaseRenewer)
+                .Setup(renewer => renewer.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => renewerTask = Task.Delay(TimeSpan.FromMinutes(1), token));
+
+            Task processorTask = Task.FromResult(false);
+            Mock.Get(partitionProcessor)
+                .Setup(processor => processor.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => processorTask = Task.Delay(TimeSpan.FromMinutes(1), token));
+
+            Task supervisorTask = sut.RunAsync(shutdownToken.Token);
+
+            Task delay = Task.Delay(TimeSpan.FromMilliseconds(100));
+            Task finished = await Task.WhenAny(supervisorTask, delay).ConfigureAwait(false);
+            Assert.AreEqual(delay, finished);
+
+            shutdownToken.Cancel();
+            await supervisorTask.ConfigureAwait(false);
+
+            Assert.IsTrue(renewerTask.IsCanceled);
+            Assert.IsTrue(processorTask.IsCanceled);
+            Mock.Get(partitionProcessor)
+                .Verify(processor => processor.RunAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+            Mock.Get(observer)
+                .Verify(feedObserver => feedObserver
+                    .CloseAsync(It.Is<ChangeFeedObserverContext>(context => context.LeaseToken == lease.CurrentLeaseToken),
+                        ChangeFeedObserverCloseReason.Shutdown));
+        }
+
+        [TestMethod]
+        public async Task RunObserver_ShouldCancelProcessor_IfRenewerFailed()
+        {
+            Task processorTask = Task.FromResult(false);
+            Mock.Get(leaseRenewer)
+                .Setup(renewer => renewer.RunAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new LeaseLostException());
+
+            Mock.Get(partitionProcessor)
+                .Setup(processor => processor.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => processorTask = Task.Delay(TimeSpan.FromMinutes(1), token));
+
+            await Assert.ThrowsExceptionAsync<LeaseLostException>(() => sut.RunAsync(shutdownToken.Token)).ConfigureAwait(false);
+            Assert.IsTrue(processorTask.IsCanceled);
+
+            Mock.Get(observer)
+                .Verify(feedObserver => feedObserver
+                    .CloseAsync(It.Is<ChangeFeedObserverContext>(context => context.LeaseToken == lease.CurrentLeaseToken),
+                        ChangeFeedObserverCloseReason.LeaseLost));
+        }
+
+        [TestMethod]
+        public async Task RunObserver_ShouldCancelRenewer_IfProcessorFailed()
+        {
+            Task renewerTask = Task.FromResult(false);
+            Mock.Get(leaseRenewer)
+                .Setup(renewer => renewer.RunAsync(It.IsAny<CancellationToken>()))
+                .Returns<CancellationToken>(token => renewerTask = Task.Delay(TimeSpan.FromMinutes(1), token));
+
+            Mock.Get(partitionProcessor)
+                .Setup(processor => processor.RunAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("processorException"));
+
+            await Assert.ThrowsExceptionAsync<Exception>(() => sut.RunAsync(shutdownToken.Token)).ConfigureAwait(false);
+            Assert.IsTrue(renewerTask.IsCanceled);
+
+            Mock.Get(observer)
+                .Verify(feedObserver => feedObserver
+                    .CloseAsync(It.Is<ChangeFeedObserverContext>(context => context.LeaseToken == lease.CurrentLeaseToken),
+                        ChangeFeedObserverCloseReason.Unknown));
+        }
+
+        [TestMethod]
+        public async Task RunObserver_ShouldCloseWithObserverError_IfObserverFailed()
+        {
+            Mock.Get(partitionProcessor)
+                .Setup(processor => processor.RunAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ObserverException(new Exception()));
+
+            await Assert.ThrowsExceptionAsync<ObserverException>(() => sut.RunAsync(shutdownToken.Token)).ConfigureAwait(false);
+
+            Mock.Get(observer)
+                .Verify(feedObserver => feedObserver
+                    .CloseAsync(It.Is<ChangeFeedObserverContext>(context => context.LeaseToken == lease.CurrentLeaseToken),
+                        ChangeFeedObserverCloseReason.ObserverError));
+        }
+
+        [TestMethod]
+        public async Task RunObserver_ShouldPassPartitionToObserver_WhenExecuted()
+        {
+            Mock.Get(observer)
+                .Setup(feedObserver => feedObserver.ProcessChangesAsync(It.IsAny<ChangeFeedObserverContext>(), It.IsAny<IReadOnlyList<dynamic>>(), It.IsAny<CancellationToken>()))
+                .Callback(() => shutdownToken.Cancel());
+
+            await sut.RunAsync(shutdownToken.Token).ConfigureAwait(false);
+            Mock.Get(observer)
+                .Verify(feedObserver => feedObserver
+                    .OpenAsync(It.Is<ChangeFeedObserverContext>(context => context.LeaseToken == lease.CurrentLeaseToken)));
+        }
+
+        [TestMethod]
+        public void Dispose_ShouldWork_WithoutRun()
+        {
+            try
+            {
+                sut.Dispose();
+            }
+            catch (Exception)
+            {
+                Assert.Fail();
+            }
+        }
+
+        public void Dispose()
+        {
+            sut.Dispose();
+            shutdownToken.Dispose();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     [TestClass]
+    [TestCategory("ChangeFeed")]
     public class RemainingWorkEstimatorTests
     {
         // TODO: Add more tests when Feed Read goes through OM

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    [TestClass]
+    public class RemainingWorkEstimatorTests
+    {
+        // TODO: Add more tests when Feed Read goes through OM
+
+        [TestMethod]
+        public void ExtractLsnFromSessionToken_ShouldParseOldSessionToken()
+        {
+            string oldToken = "0:12345";
+            string expectedLsn = "12345";
+            Assert.AreEqual(expectedLsn, RemainingWorkEstimatorCore.ExtractLsnFromSessionToken(oldToken));
+        }
+
+        [TestMethod]
+        public void ExtractLsnFromSessionToken_ShouldParseNewSessionToken()
+        {
+            string newToken = "0:-1#12345";
+            string expectedLsn = "12345";
+            Assert.AreEqual(expectedLsn, RemainingWorkEstimatorCore.ExtractLsnFromSessionToken(newToken));
+        }
+
+        [TestMethod]
+        public void ExtractLsnFromSessionToken_ShouldParseNewSessionTokenWithMultipleRegionalLsn()
+        {
+            string newTokenWithRegionalLsn = "0:-1#12345#Region1=1#Region2=2";
+            string expectedLsn = "12345";
+            Assert.AreEqual(expectedLsn, RemainingWorkEstimatorCore.ExtractLsnFromSessionToken(newTokenWithRegionalLsn));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds 100+ unit tests covering the Change Feed Processor / Estimator. Some where ported from the current CFP SDK repo and refactored for our new class distribution, others are entirely new based on our new Builder.

Some fixes to current files:
* `DocumentServiceLease` should've been `Serializable`
* Added `internal` constructor to `ChangeFeedEstimatorCore` for mocking purposes
* Added `internal` `WithMonitoredContainerRid` builder extension to be able to specify the ContainerRid for the leases so the Builder does not have to do a `GetRID` call (which would fail in a mocked scenario).
* `DocumentServiceLeaseUpdaterCosmos` was incorrectly detecting `NotFound` status through exceptions
* `CosmosIdentifier` got some attributes marked as `virtual` although this will be refactored once @j82w merges #117 
