### PR TITLE
Adding Change Feed Processor and Estimator emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -64,7 +64,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             {
                 await this.InitializeAsync().ConfigureAwait(false);
             }
-
+            else
+            {
+                this.shutdownCts = new CancellationTokenSource();
+            }
+            
             Logger.InfoFormat("Starting estimator...");
             this.runAsync = this.feedEstimator.RunAsync(this.shutdownCts.Token);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
         private static readonly ILog Logger = LogProvider.GetCurrentClassLogger();
         private readonly Func<long, CancellationToken, Task> initialEstimateDelegate;
-        private CancellationTokenSource shutdownCts = new CancellationTokenSource();
+        private CancellationTokenSource shutdownCts;
         private CosmosContainer leaseContainer;
         private string leaseContainerPrefix;
         private TimeSpan? estimatorPeriod = null;
@@ -64,11 +64,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             {
                 await this.InitializeAsync().ConfigureAwait(false);
             }
-            else
-            {
-                this.shutdownCts = new CancellationTokenSource();
-            }
-            
+
+            this.shutdownCts = new CancellationTokenSource();
             Logger.InfoFormat("Starting estimator...");
             this.runAsync = this.feedEstimator.RunAsync(this.shutdownCts.Token);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
         private readonly DocumentServiceLeaseManager leaseManager;
         private readonly PartitionSupervisorFactory partitionSupervisorFactory;
         private readonly PartitionSynchronizer synchronizer;
-        private readonly CancellationTokenSource shutdownCts = new CancellationTokenSource();
+        private CancellationTokenSource shutdownCts;
 
         public PartitionControllerCore(
             DocumentServiceLeaseContainer leaseContainer,
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
 
         public override async Task InitializeAsync()
         {
+            shutdownCts = new CancellationTokenSource();
             await this.LoadLeasesAsync().ConfigureAwait(false);
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionLoadBalancerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionLoadBalancerCore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
         private readonly DocumentServiceLeaseContainer leaseContainer;
         private readonly LoadBalancingStrategy partitionLoadBalancingStrategy;
         private readonly TimeSpan leaseAcquireInterval;
-        private readonly CancellationTokenSource cancellationTokenSource;
+        private CancellationTokenSource cancellationTokenSource;
         private Task runTask;
 
         public PartitionLoadBalancerCore(
@@ -35,16 +35,16 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             this.leaseContainer = leaseContainer;
             this.partitionLoadBalancingStrategy = partitionLoadBalancingStrategy;
             this.leaseAcquireInterval = leaseAcquireInterval;
-            this.cancellationTokenSource = new CancellationTokenSource();
         }
 
         public override void Start()
         {
-            if (this.runTask != null)
+            if (this.runTask != null && !this.runTask.IsCompleted)
             {
                 throw new InvalidOperationException("Already started");
             }
 
+            this.cancellationTokenSource = new CancellationTokenSource();
             this.runTask = this.RunAsync();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -1,0 +1,36 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
+
+    public class BaseChangeFeedClientHelper : BaseCosmosClientHelper
+    {
+        public static int ChangeFeedSetupTime = 1000;
+        public static int ChangeFeedCleanupTime = 5000;
+
+        public CosmosContainer Container = null;
+        public CosmosContainer LeaseContainer = null;
+
+        public async Task ChangeFeedTestInit()
+        {
+            await base.TestInit();
+            string PartitionKey = "/id";
+            CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+            this.Container = response;
+
+
+            response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: "leases", partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+
+            this.LeaseContainer = response;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             await base.TestInit();
             string PartitionKey = "/id";
             CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
-                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerSettings(id: "monitored", partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             this.Container = response;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -1,0 +1,128 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class DynamicTests : BaseChangeFeedClientHelper
+    {
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await base.ChangeFeedTestInit();
+
+            string PartitionKey = "/pk";
+            CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                throughput: 10000,
+                cancellationToken: this.cancellationToken);
+            this.Container = response;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            await base.TestCleanup();
+        }
+
+        [TestMethod]
+        public async Task TestWithRunningProcessor()
+        {
+            int partitionKey = 0;
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
+
+            int processedDocCount = 0;
+            string accumulator = string.Empty;
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    processedDocCount += docs.Count;
+                    foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
+                    if (processedDocCount == 10) allDocsProcessed.Set();
+
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            // Start the processor, insert 1 document to generate a checkpoint
+            await processor.StartAsync();
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            foreach (int id in Enumerable.Range(0, 10))
+            {
+                await this.Container.Items.CreateItemAsync<dynamic>(partitionKey, new { id = id.ToString(), pk = partitionKey });
+            }
+
+            var isStartOk = allDocsProcessed.WaitOne(10 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
+            Assert.AreEqual("0.1.2.3.4.5.6.7.8.9.", accumulator);
+        }
+
+        [TestMethod]
+        public async Task TestReducePageSizeScenario()
+        {
+            int partitionKey = 0;
+            // Create some docs to make sure that one separate response is returned for 1st execute of query before retries.
+            // These are to make sure continuation token is passed along during retries.
+            string sprocId = "createTwoDocs";
+            string sprocBody = @"function(startIndex) { for (var i = 0; i < 2; ++i) __.createDocument(
+                            __.getSelfLink(),
+                            { id: 'doc' + (i + startIndex).toString(), value: 'y'.repeat(1500000), pk:0 },
+                            err => { if (err) throw err;}
+                        );}";
+
+            CosmosStoredProcedureResponse storedProcedureResponse =
+                await this.Container.StoredProcedures.CreateStoredProcedureAsync(sprocId, sprocBody);
+
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
+
+            int processedDocCount = 0;
+            string accumulator = string.Empty;
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    processedDocCount += docs.Count;
+                    foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
+                    if (processedDocCount == 6) allDocsProcessed.Set();
+
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            // Start the processor, insert 1 document to generate a checkpoint
+            await processor.StartAsync();
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await this.Container.Items.CreateItemAsync(partitionKey, new { id="doc10", pk=0 });
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
+            await processor.StopAsync();
+
+            // Generate the payload
+            await storedProcedureResponse.StoredProcedure.ExecuteAsync<int, object>(partitionKey, 0);
+            // Create 3 docs each 1.5MB. All 3 do not fit into MAX_RESPONSE_SIZE (4 MB). 2nd and 3rd are in same transaction.
+            var content = string.Format("{{\"id\": \"doc2\", \"value\": \"{0}\", \"pk\": 0}}", new string('x', 1500000));
+            await this.Container.Items.CreateItemAsync(partitionKey, JsonConvert.DeserializeObject<dynamic>(content));
+
+            await storedProcedureResponse.StoredProcedure.ExecuteAsync<int, object>(partitionKey, 3);
+
+            await processor.StartAsync();
+            // Letting processor initialize and pickup changes
+            var isStartOk = allDocsProcessed.WaitOne(10 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
+            Assert.AreEqual("doc10.doc0.doc1.doc2.doc3.doc4.", accumulator);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count;
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count;
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -1,0 +1,150 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class EstimatorTests : BaseCosmosClientHelper
+    {
+        private CosmosContainer Container = null;
+        private CosmosContainer LeaseContainer = null;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await base.TestInit();
+            string PartitionKey = "/id";
+            CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+            this.Container = response;
+
+
+            response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: "leases", partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+
+            this.LeaseContainer = response;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            await base.TestCleanup();
+        }
+
+        [TestMethod]
+        public async Task WhenNoLeasesExistReturn1()
+        {
+            long? receivedEstimation = 0;
+            ChangeFeedProcessor estimator = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("noleases", (long estimation, CancellationToken token) =>
+                {
+                    receivedEstimation = estimation;
+                    return Task.CompletedTask;
+                }, TimeSpan.FromSeconds(1))
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            await estimator.StartAsync();
+            await Task.Delay(1000);
+            await estimator.StopAsync();
+            Assert.IsTrue(receivedEstimation.HasValue);
+            Assert.AreEqual(1, receivedEstimation);
+        }
+
+        /// <summary>
+        /// This test checks that when the ContinuationToken is null, we send the StartFromBeginning flag, but since there is no documents, it returns 0
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task WhenLeasesHaveContinuationTokenNullReturn0()
+        {
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("continuationnull", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            await processor.StartAsync();
+            await processor.StopAsync();
+
+            long? receivedEstimation = null;
+            ChangeFeedProcessor estimator = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("continuationnull", (long estimation, CancellationToken token) =>
+                {
+                    receivedEstimation = estimation;
+                    return Task.CompletedTask;
+                }, TimeSpan.FromSeconds(1))
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            await estimator.StartAsync();
+            await Task.Delay(1000);
+            await estimator.StopAsync();
+            Assert.IsTrue(receivedEstimation.HasValue);
+            Assert.AreEqual(0, receivedEstimation);
+        }
+
+        /// <summary>
+        /// This test checks that when the ContinuationToken is null, we send the StartFromBeginning flag, but since there is no documents, it returns 0
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task CountPendingDocuments()
+        {
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("counting", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            await processor.StartAsync();
+            // Letting processor initialize
+            await Task.Delay(1000);
+            // Inserting documents
+            foreach (int id in Enumerable.Range(0, 10))
+            {
+                await this.Container.Items.CreateItemAsync<dynamic>(id.ToString(), new { id = id.ToString() });
+            }
+
+            // Waiting on all notifications to finish
+            await Task.Delay(5000);
+            await processor.StopAsync();
+
+            long? receivedEstimation = null;
+            ChangeFeedProcessor estimator = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("counting", (long estimation, CancellationToken token) =>
+                {
+                    receivedEstimation = estimation;
+                    return Task.CompletedTask;
+                }, TimeSpan.FromSeconds(1))
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            
+            // Inserting more documents
+            foreach (int id in Enumerable.Range(11, 10))
+            {
+                await this.Container.Items.CreateItemAsync<dynamic>(id.ToString(), new { id = id.ToString() });
+            }
+
+            await estimator.StartAsync();
+            await Task.Delay(1000); // Let the estimator delegate fire at least once
+            await estimator.StopAsync();
+            Assert.IsTrue(receivedEstimation.HasValue);
+            Assert.AreEqual(10, receivedEstimation);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         {
             long? receivedEstimation = 0;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("noleases", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task WhenLeasesHaveContinuationTokenNullReturn0()
         {
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("continuationnull", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("continuationnull", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task CountPendingDocuments()
         {
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("counting", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("counting", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             await estimator.StartAsync();
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await estimator.StopAsync();
             Assert.IsTrue(receivedEstimation.HasValue);
             Assert.AreEqual(10, receivedEstimation);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -4,37 +4,20 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     [TestCategory("ChangeFeed")]
-    public class SmokeTests : BaseCosmosClientHelper
+    public class SmokeTests : BaseChangeFeedClientHelper
     {
-        private CosmosContainer Container = null;
-        private CosmosContainer LeaseContainer = null;
-
         [TestInitialize]
         public async Task TestInitialize()
         {
-            await base.TestInit();
-            string PartitionKey = "/id";
-            CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
-                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
-                cancellationToken: this.cancellationToken);
-            this.Container = response;
-
-
-            response = await this.database.Containers.CreateContainerAsync(
-                new CosmosContainerSettings(id: "leases", partitionKeyPath: PartitionKey),
-                cancellationToken: this.cancellationToken);
-
-            this.LeaseContainer = response;
+            await base.ChangeFeedTestInit();
         }
 
         [TestCleanup]
@@ -63,15 +46,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             await processor.StartAsync();
             // Letting processor initialize
-            await Task.Delay(5000);
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
             // Inserting documents
-            foreach(int id in expectedIds)
+            foreach (int id in expectedIds)
             {
                 await this.Container.Items.CreateItemAsync<dynamic>(id.ToString(), new { id = id.ToString() });
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(5000);
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
@@ -97,7 +80,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             await processor.StartAsync();
             // Letting processor initialize
-            await Task.Delay(5000);
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
             // Inserting documents
             foreach (int id in expectedIds)
             {
@@ -105,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(5000);
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("withinmemorycontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -1,0 +1,114 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class SmokeTests : BaseCosmosClientHelper
+    {
+        private CosmosContainer Container = null;
+        private CosmosContainer LeaseContainer = null;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await base.TestInit();
+            string PartitionKey = "/id";
+            CosmosContainerResponse response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+            this.Container = response;
+
+
+            response = await this.database.Containers.CreateContainerAsync(
+                new CosmosContainerSettings(id: "leases", partitionKeyPath: PartitionKey),
+                cancellationToken: this.cancellationToken);
+
+            this.LeaseContainer = response;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            await base.TestCleanup();
+        }
+
+        [TestMethod]
+        public async Task WritesTriggerDelegate_WithLeaseContainer()
+        {
+            IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
+            List<int> receivedIds = new List<int>();
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("withleasecontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    foreach (dynamic doc in docs)
+                    {
+                        receivedIds.Add(int.Parse(doc.id));
+                    }
+
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+
+            await processor.StartAsync();
+            // Letting processor initialize
+            await Task.Delay(5000);
+            // Inserting documents
+            foreach(int id in expectedIds)
+            {
+                await this.Container.Items.CreateItemAsync<dynamic>(id.ToString(), new { id = id.ToString() });
+            }
+
+            // Waiting on all notifications to finish
+            await Task.Delay(5000);
+            await processor.StopAsync();
+            // Verify that we maintain order
+            CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
+        }
+
+        [TestMethod]
+        public async Task WritesTriggerDelegate_WithInMemoryContainer()
+        {
+            IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
+            List<int> receivedIds = new List<int>();
+            ChangeFeedProcessor processor = this.Container.Items
+                .CreateChangeFeedProcessorBuilder("withinmemorycontainer", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                {
+                    foreach (dynamic doc in docs)
+                    {
+                        receivedIds.Add(int.Parse(doc.id));
+                    }
+
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithInMemoryLeaseContainer().Build();
+
+            await processor.StartAsync();
+            // Letting processor initialize
+            await Task.Delay(5000);
+            // Inserting documents
+            foreach (int id in expectedIds)
+            {
+                await this.Container.Items.CreateItemAsync<dynamic>(id.ToString(), new { id = id.ToString() });
+            }
+
+            // Waiting on all notifications to finish
+            await Task.Delay(5000);
+            await processor.StopAsync();
+            // Verify that we maintain order
+            CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds Emulator tests covering different scenarios both for Change Feed Processor and Change Feed Estimator.

All tests have a defined Category in case we want to turn the on/off.

Additionally, some changes were made so it is now possible to Start, Stop and then Start again a Processor and Estimator. Originally they were left in a non Start-able state after a Stop.