### PR TITLE
Making Container.NonePartitionKeyValue stateless

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
@@ -52,8 +52,6 @@ namespace Microsoft.Azure.Cosmos
 
         internal DocumentClient DocumentClient { get; private set; }
 
-        private PartitionKeyInternal nonePartitionKeyValue { get; set; }
-
         public override Task<CosmosContainerResponse> ReadAsync(
             CosmosContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -209,21 +207,10 @@ namespace Microsoft.Azure.Cosmos
         /// a value for partition key. The constant selection is based on whether the collection is migrated
         /// or user partitioned
         /// </remarks>
-        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValue()
+        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValue(CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (nonePartitionKeyValue == null)
-            {
-                PartitionKeyDefinition partitionKeyDefinition = await this.GetPartitionKeyDefinitionAsync();
-                if (partitionKeyDefinition.Paths.Count == 0 || partitionKeyDefinition.IsSystemKey)
-                {
-                    nonePartitionKeyValue = PartitionKeyInternal.Empty;
-                }
-                else
-                {
-                    nonePartitionKeyValue = PartitionKeyInternal.Undefined;
-                }
-            }
-            return nonePartitionKeyValue;
+            CosmosContainerSettings containerSettings = await this.GetCachedContainerSettingsAsync(cancellationToken);
+            return containerSettings.GetNoneValue();
         }
 
         internal Task<CollectionRoutingMap> GetRoutingMapAsync(CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Collections.ObjectModel;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -297,6 +298,26 @@ namespace Microsoft.Azure.Cosmos
         /// The partition key path in the collection definition for migrated collections
         /// </summary>
         public static readonly string SystemKeyPath = Microsoft.Azure.Documents.PartitionKey.SystemKeyPath;
+
+        /// <summary>
+        /// The function selects the right partition key constant mapping for <see cref="NonePartitionKeyValue"/>
+        /// </summary>
+        internal PartitionKeyInternal GetNoneValue()
+        {
+            if (this.PartitionKey == null)
+            {
+                throw new ArgumentNullException($"{nameof(this.PartitionKey)}");
+            }
+
+            if (this.PartitionKey.Paths.Count == 0 || (this.PartitionKey.IsSystemKey))
+            {
+                return PartitionKeyInternal.Empty;
+            }
+            else
+            {
+                return PartitionKeyInternal.Undefined;
+            }
+        }
 
         /// <summary>
         /// Gets or sets <see cref="PartitionKeyDefinition"/> object in the Azure Cosmos DB service.


### PR DESCRIPTION
Contianer is caching the None mapping which in-case of container re-create might get stale. 
None values always derived from CosmosContainerSettings. It resutls in one extra call to local cache most of the time. 