### PR TITLE
Moving API version initialization to static CTOR

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -69,6 +69,11 @@ namespace Microsoft.Azure.Cosmos
     {
         private Lazy<CosmosOffers> offerSet;
 
+        static CosmosClient()
+        {
+            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
+        }
+
         /// <summary>
         /// Create a new CosmosClient with the connection
         /// </summary>
@@ -137,7 +142,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 throw new ArgumentNullException(nameof(cosmosClientConfiguration));
             }
-            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
+
             DocumentClient documentClient = new DocumentClient(
                 cosmosClientConfiguration.AccountEndPoint,
                 cosmosClientConfiguration.AccountKey,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
@@ -4,20 +4,28 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Collections.ObjectModel;
     using System.Linq;
-    using System.Threading;
-    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.Azure.Cosmos;
-    using Moq;
     using System.Reflection;
-    using System.Diagnostics;
     using Microsoft.Azure.Documents;
 
     [TestClass]
     public class ContractTests
     {
+        [TestMethod]
+        public void ApiVersionTest()
+        {
+            try
+            {
+                new CosmosClient((string)null);
+                Assert.Fail();
+            }
+            catch(ArgumentNullException)
+            { }
+
+            Assert.AreEqual(HttpConstants.Versions.v2018_12_31, HttpConstants.Versions.CurrentVersion);
+        }
+
         [TestMethod]
         public void ClientDllNamespaceTest()
         {


### PR DESCRIPTION
Moving API version initialization to static CTOR.
And related unit-test