### PR TITLE
Update XML doc for continuation token

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedResponse.cs
@@ -284,6 +284,12 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The continuation token to be used for continuing enumeration.
         /// </value>
+        /// <remarks>
+        /// The continuation token only affects the session result set.  It is not
+        /// possible to break out of the original query by tampering with the
+        /// token when continuing the enumeration.  From a security perspective,
+        /// it is safe to pass the token value to a client.
+        /// </remarks>
         public string ResponseContinuation
         {
             get

--- a/Microsoft.Azure.Cosmos/src/FeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedResponse.cs
@@ -284,12 +284,6 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The continuation token to be used for continuing enumeration.
         /// </value>
-        /// <remarks>
-        /// The continuation token only affects the session result set.  It is not
-        /// possible to break out of the original query by tampering with the
-        /// token when continuing the enumeration.  From a security perspective,
-        /// it is safe to pass the token value to a client.
-        /// </remarks>
         public string ResponseContinuation
         {
             get

--- a/Microsoft.Azure.Cosmos/src/Headers/CosmosResponseMessageHeaders.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/CosmosResponseMessageHeaders.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the Continuation Token in the current <see cref="CosmosResponseMessage"/>.
         /// </summary>
+        /// <remarks>
+        /// The continuation token only affects the session result set.  It is not
+        /// possible to break out of the original query by tampering with the
+        /// token when continuing the enumeration.  From a security perspective,
+        /// it is safe to pass the token value to a client.
+        /// </remarks>
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.Continuation)]
         public virtual string Continuation { get; internal set; }
 


### PR DESCRIPTION
This commit will add information in the XML docs for
FeedResponse<T>.ResponseContinuation.  The added information clarifies
that it is safe to return the continuation token to the client; it is
not possible to tamper with the token in an injection attack.

https://github.com/Azure/azure-cosmos-dotnet-v2/issues/697