### PR TITLE
Escaping non ascii characters in query continuation tokens

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/CosmosOrderByItemQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosOrderByItemQueryExecutionContext.cs
@@ -123,7 +123,10 @@ namespace Microsoft.Azure.Cosmos.Query
                         this.ShouldIncrementSkipCount(itemProducer) ? this.skipCount + 1 : 0,
                         filter);
                 }),
-                DefaultJsonSerializationSettings.Value) : null;
+                new JsonSerializerSettings()
+                {
+                    StringEscapeHandling = StringEscapeHandling.EscapeNonAscii,
+                }) : null;
             }
         }
 


### PR DESCRIPTION
This PR escapes non ascii characters in query continuation tokens.

For cross partition queries with ORDER BY we generate a continuation token that serializes the state of the query. That state includes the order by item. The problem happens when a user tries to resume that query from the continuation token and we put that continuation token in an HTTP header. The gateway rejects the header and we get back some HTML file explaining that the request was invalid. The problem is when we try to parse that HTML page as JSON we get a serialization exception and the user sees: "Unexpected character encountered while parsing value: (value is lt). Path '', line 0, position 0.". Which is basically saying that the "<" character in "<HTML>" is not valid JSON.

The solution was to escape all non ascii character, so that they can safely be added to headers.