### PR TITLE
Moving IReadOnlyList to IReadOnlyCollection

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Globalization;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
 
@@ -120,21 +119,6 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Sets the start request session continuation token to start looking for changes after.
-        /// </summary>
-        /// <remarks>
-        /// This is only used when lease store is not initialized and is ignored if a lease exists and has continuation token.
-        /// If this is specified, both StartTime and StartFromBeginning are ignored.
-        /// </remarks>
-        /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
-        public virtual ChangeFeedProcessorBuilder WithSessionContinuationToken(string startContinuation)
-        {
-            this.changeFeedProcessorOptions = this.changeFeedProcessorOptions ?? new ChangeFeedProcessorOptions();
-            this.changeFeedProcessorOptions.StartContinuation = startContinuation;
-            return this;
-        }
-
-        /// <summary>
         /// Sets the time (exclusive) to start looking for changes after.
         /// </summary>
         /// <remarks>
@@ -201,6 +185,21 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.LeaseStoreManager = new DocumentServiceLeaseStoreManagerInMemory();
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the start request session continuation token to start looking for changes after.
+        /// </summary>
+        /// <remarks>
+        /// This is only used when lease store is not initialized and is ignored if a lease exists and has continuation token.
+        /// If this is specified, both StartTime and StartFromBeginning are ignored.
+        /// </remarks>
+        /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
+        internal virtual ChangeFeedProcessorBuilder WithSessionContinuationToken(string startContinuation)
+        {
+            this.changeFeedProcessorOptions = this.changeFeedProcessorOptions ?? new ChangeFeedProcessorOptions();
+            this.changeFeedProcessorOptions.StartContinuation = startContinuation;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/AutoCheckpointer.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/AutoCheckpointer.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             return this.observer.CloseAsync(context, reason);
         }
 
-        public override async Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<T> docs, CancellationToken cancellationToken)
+        public override async Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyCollection<T> docs, CancellationToken cancellationToken)
         {
             await this.observer.ProcessChangesAsync(context, docs, cancellationToken).ConfigureAwait(false);
             this.processedDocCount += docs.Count;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserver.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserver.cs
@@ -35,6 +35,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
         /// <param name="docs">The documents changed.</param>
         /// <param name="cancellationToken">Token to signal that the parition processing is going to finish.</param>
         /// <returns>A Task to allow asynchronous execution.</returns>
-        public abstract Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<T> docs, CancellationToken cancellationToken);
+        public abstract Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyCollection<T> docs, CancellationToken cancellationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverBase.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverBase.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
     internal sealed class ChangeFeedObserverBase<T> : ChangeFeedObserver<T>
     {
-        private readonly Func<IReadOnlyList<T>, CancellationToken, Task> onChanges;
+        private readonly Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges;
 
-        public ChangeFeedObserverBase(Func<IReadOnlyList<T>, CancellationToken, Task> onChanges)
+        public ChangeFeedObserverBase(Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges)
         {
             this.onChanges = onChanges;
         }
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             return Task.CompletedTask;
         }
 
-        public override Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<T> docs, CancellationToken cancellationToken)
+        public override Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyCollection<T> docs, CancellationToken cancellationToken)
         {
             return this.onChanges(docs, cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverFactoryCore.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
     internal sealed class ChangeFeedObserverFactoryCore<T>: ChangeFeedObserverFactory<T>
     {
-        private readonly Func<IReadOnlyList<T>, CancellationToken, Task> onChanges;
+        private readonly Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges;
 
-        public ChangeFeedObserverFactoryCore(Func<IReadOnlyList<T>, CancellationToken, Task> onChanges)
+        public ChangeFeedObserverFactoryCore(Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges)
         {
             this.onChanges = onChanges;
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ObserverExceptionWrappingChangeFeedObserverDecorator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ObserverExceptionWrappingChangeFeedObserverDecorator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             }
         }
 
-        public override async Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyList<T> docs, CancellationToken cancellationToken)
+        public override async Task ProcessChangesAsync(ChangeFeedObserverContext context, IReadOnlyCollection<T> docs, CancellationToken cancellationToken)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -797,7 +797,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
             string workflowName, 
-            Func<IReadOnlyList<T>, CancellationToken, Task> onChangesDelegate);
+            Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate);
 
         /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed monitoring.

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
             string workflowName,
-            Func<IReadOnlyList<T>, CancellationToken, Task> onChangesDelegate)
+            Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate)
         {
             if (workflowName == null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task WhenLeasesHaveContinuationTokenNullReturn0()
         {
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task CountPendingDocuments()
         {
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<TestClass> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<TestClass> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyList<dynamic> docs, CancellationToken token) =>
+                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {


### PR DESCRIPTION
`IReadOnlyList` contains an additional index property that `IReadOnlyCollection` does not. The changes are meant to be read in order (use the Enumerator), so moving to `IReadOnlyCollection` enforces this contract.

This PR fixes #172 