### PR TITLE
Change Feed Estimator public API

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -806,7 +806,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="estimationDelegate">Delegate to receive estimation.</param>
         /// <param name="estimationPeriod">Time interval on which to report the estimation.</param>
         /// <returns></returns>
-        public abstract ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder(
+        public abstract ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string workflowName, 
             Func<long, CancellationToken, Task> estimationDelegate, 
             TimeSpan? estimationPeriod = null);

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Cosmos
                 applyBuilderConfiguration: changeFeedProcessor.ApplyBuildConfiguration);
         }
 
-        public override ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder(
+        public override ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string workflowName,
             Func<long, CancellationToken, Task> estimationDelegate,
             TimeSpan? estimationPeriod = null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         {
             long? receivedEstimation = 0;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container.Items
-                .CreateChangeFeedProcessorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;


### PR DESCRIPTION
Renaming `CreateChangeFeedProcessorBuilder` to `CreateChangeFeedEstimatorBuilder` for estimation purposes.