### PR TITLE
V2 SDK: Add the JsonSerializerSettings parameter to Upsert/Replace document calls

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -3112,7 +3112,8 @@ namespace Microsoft.Azure.Cosmos
                 ResourceType.Document,
                 AuthorizationTokenType.PrimaryMasterKey,
                 headers,
-                SerializationFormattingPolicy.None))
+                SerializationFormattingPolicy.None,
+                this.GetSerializerSettingsForRequest(options)))
             {
                 await this.AddPartitionKeyInformationAsync(request, document, options);
                 request.SerializerSettings = this.GetSerializerSettingsForRequest(options);
@@ -5502,7 +5503,8 @@ namespace Microsoft.Azure.Cosmos
                 ResourceType.Document,
                 AuthorizationTokenType.PrimaryMasterKey,
                 headers,
-                SerializationFormattingPolicy.None))
+                SerializationFormattingPolicy.None,
+                this.GetSerializerSettingsForRequest(options)))
             {
                 await this.AddPartitionKeyInformationAsync(request, typedDocument, options);
                 request.SerializerSettings = this.GetSerializerSettingsForRequest(options);


### PR DESCRIPTION
This fixes the bug where the Create Document honors the JsonSerializerSettings used to initialize the DocumentClient, but Upsert/Replace Document does not.