### PR TITLE
Adding new system strings

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/JsonBinaryEncoding.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonBinaryEncoding.cs
@@ -85,6 +85,9 @@ namespace Microsoft.Azure.Cosmos.Json
             "properties",
             "type",
             "value",
+            "Feature",
+            "FeatureCollection",
+            "_id",
         };
 
         /// <summary>


### PR DESCRIPTION
Added new system strings.

Tests already exist in:

`JsonWriterTests.cs` and `JsonReaderTests.cs`

SystemStringTest

It uses reflection so it automatically picks up the full set of strings:

```c#
        [TestMethod]
        [Owner("brchon")]
        public void SystemStringTest()
        {
            Type jsonBinaryEncodingType = typeof(JsonBinaryEncoding);
            FieldInfo systemStringsFieldInfo = jsonBinaryEncodingType.GetField("SystemStrings", BindingFlags.NonPublic | BindingFlags.Static);
            string[] systemStrings = (string[])systemStringsFieldInfo.GetValue(null);
            Assert.IsNotNull(systemStrings, "Failed to get system strings using reflection");

            int systemStringId = 0;
            foreach (string systemString in systemStrings)
            {
                string expectedString = "\"" + systemString + "\"";
                byte[] binaryOutput =
                {
                    BinaryFormat,
                    (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + ((int)systemStringId)),
                };

                JsonTokenInfo[] tokensToWrite =
                {
                    JsonTokenInfo.String(systemString)
                };

                this.VerifyWriter(tokensToWrite, expectedString);
                this.VerifyWriter(tokensToWrite, binaryOutput);
                systemStringId++;
            }
        }
```