### PR TITLE
Ignoring TestLazyIndexAllTerms

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -851,6 +851,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore] // Flaky
         [TestMethod]
         public void TestLazyIndexAllTerms()
         {


### PR DESCRIPTION
Test is flaky and also not a client test