### PR TITLE
Replacing CosmosResultSetIterator to CosmosFeedIterator in Documentation.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/CosmosContainer.Conflict.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/CosmosContainer.Conflict.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator conflictIterator = await cosmosContainer.GetConflictsIterator();
+        /// CosmosFeedIterator conflictIterator = await cosmosContainer.GetConflictsIterator();
         /// do
         /// {
         ///     CosmosQueryResponse<CosmosConflict> conflicts = await conflictIterator.FetchNextAsync();
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator conflictIterator = await cosmosContainer.Conflicts.GetConflictsIterator();
+        /// CosmosFeedIterator conflictIterator = await cosmosContainer.Conflicts.GetConflictsIterator();
         /// do
         /// {
         ///     CosmosQueryResponse<CosmosConflict> conflicts = await conflictIterator.FetchNextAsync();

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainers.cs
@@ -216,10 +216,10 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the containers under the database
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator<CosmosContainerSettings> setIterator = this.cosmosDatabase.Containers.GetContainerIterator();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator<CosmosContainerSettings> feedIterator = this.cosmosDatabase.Containers.GetContainerIterator();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(CosmosContainerSettings setting in await setIterator.FetchNextSetAsync())
+        ///     foreach(CosmosContainerSettings setting in await feedIterator.FetchNextSetAsync())
         ///     {
         ///          Console.WriteLine(setting.Id); 
         ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabases.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabases.cs
@@ -90,9 +90,9 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the database under the cosmos account
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator<CosmosDatabaseSettings> setIterator = this.cosmosClient.Databases.GetDatabaseIterator();
+        /// CosmosFeedIterator<CosmosDatabaseSettings> feedIterator = this.cosmosClient.Databases.GetDatabaseIterator();
         /// {
-        ///     foreach (CosmosDatabaseSettings databaseSettings in  await setIterator.FetchNextSetAsync())
+        ///     foreach (CosmosDatabaseSettings databaseSettings in  await feedIterator.FetchNextSetAsync())
         ///     {
         ///         Console.WriteLine(setting.Id); 
         ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -479,10 +479,10 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// CosmosResultSetIterator<ToDoActivity> setIterator = this.cosmosContainer.Items.GetItemIterator<ToDoActivity>();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator<ToDoActivity> feedIterator = this.cosmosContainer.Items.GetItemIterator<ToDoActivity>();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(ToDoActivity item in await setIterator.FetchNextSetAsync())
+        ///     foreach(ToDoActivity item in await feedIterator.FetchNextSetAsync())
         ///     {
         ///          Console.WriteLine(item.id); 
         ///     }
@@ -509,10 +509,10 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// CosmosResultSetIterator setIterator = this.Container.Items.GetItemStreamIterator();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator feedIterator = this.Container.Items.GetItemStreamIterator();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage iterator = await setIterator.FetchNextSetAsync())
+        ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())
         ///     {
         ///         using (StreamReader sr = new StreamReader(iterator.Content))
         ///         {
@@ -552,13 +552,13 @@ namespace Microsoft.Azure.Cosmos
         /// }
         /// 
         /// CosmosSqlQueryDefinition sqlQuery = new CosmosSqlQueryDefinition("select * from ToDos t where t.cost > @expensive").UseParameter("@expensive", 9000);
-        /// CosmosResultSetIterator setIterator = this.Container.Items.CreateItemQueryAsStream(
+        /// CosmosFeedIterator feedIterator = this.Container.Items.CreateItemQueryAsStream(
         ///     sqlQueryDefinition: sqlQuery, 
         ///     partitionKey: "Error");
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage response = await setIterator.FetchNextSetAsync())
+        ///     using (CosmosResponseMessage response = await feedIterator.FetchNextSetAsync())
         ///     {
         ///         using (StreamReader sr = new StreamReader(response.Content))
         ///         using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -601,13 +601,13 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// CosmosResultSetIterator setIterator = this.Container.Items.CreateItemQueryAsStream(
+        /// CosmosFeedIterator feedIterator = this.Container.Items.CreateItemQueryAsStream(
         ///     sqlQueryText: "select * from ToDos t where t.cost > 9000", 
         ///     partitionKey: "Error");
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage response = await setIterator.FetchNextSetAsync())
+        ///     using (CosmosResponseMessage response = await feedIterator.FetchNextSetAsync())
         ///     {
         ///         using (StreamReader sr = new StreamReader(response.Content))
         ///         using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -628,7 +628,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosQueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosFeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="CosmosSqlQueryDefinition"/>.
         /// </summary>
         /// <param name="sqlQueryDefinition">The cosmos SQL query definition.</param>
@@ -647,13 +647,13 @@ namespace Microsoft.Azure.Cosmos
         /// }
         /// 
         /// CosmosSqlQueryDefinition sqlQuery = new CosmosSqlQueryDefinition("select * from ToDos t where t.cost > @expensive").UseParameter("@expensive", 9000);
-        /// CosmosResultSetIterator<ToDoActivity> setIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
+        /// CosmosFeedIterator<ToDoActivity> feedIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
         ///     sqlQueryDefinition: sqlQuery, 
         ///     partitionKey: "Error");
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(var item in await setIterator.FetchNextSetAsync()){
+        ///     foreach(var item in await feedIterator.FetchNextSetAsync()){
         ///     {
         ///         Console.WriteLine(item.cost); 
         ///     }
@@ -669,7 +669,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosQueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosFeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="CosmosSqlQueryDefinition"/>.
         /// </summary>
         /// <param name="sqlQueryText">The cosmos SQL query text.</param>
@@ -687,13 +687,13 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// CosmosResultSetIterator<ToDoActivity> setIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
+        /// CosmosFeedIterator<ToDoActivity> feedIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
         ///     sqlQueryText: "select * from ToDos t where t.cost > 9000", 
         ///     partitionKey: "Error");
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(var item in await setIterator.FetchNextSetAsync()){
+        ///     foreach(var item in await feedIterator.FetchNextSetAsync()){
         ///     {
         ///         Console.WriteLine(item.cost); 
         ///     }
@@ -709,7 +709,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosQueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosFeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="CosmosSqlQueryDefinition"/>.
         /// </summary>
         /// <param name="sqlQueryDefinition">The cosmos SQL query definition.</param>
@@ -728,13 +728,13 @@ namespace Microsoft.Azure.Cosmos
         /// }
         /// 
         /// CosmosSqlQueryDefinition sqlQuery = new CosmosSqlQueryDefinition("select * from ToDos t where t.cost > @expensive").UseParameter("@expensive", 9000);
-        /// CosmosResultSetIterator<ToDoActivity> setIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
+        /// CosmosFeedIterator<ToDoActivity> feedIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
         ///     sqlQuery,
         ///     maxConcurrency: 2);
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(var item in await setIterator.FetchNextSetAsync()){
+        ///     foreach(var item in await feedIterator.FetchNextSetAsync()){
         ///     {
         ///         Console.WriteLine(item.cost); 
         ///     }
@@ -750,7 +750,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosQueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosFeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="CosmosSqlQueryDefinition"/>.
         /// </summary>
         /// <param name="sqlQueryText">The cosmos SQL query text.</param>
@@ -768,13 +768,13 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// CosmosResultSetIterator<ToDoActivity> setIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
+        /// CosmosFeedIterator<ToDoActivity> feedIterator = this.Container.Items.CreateItemQuery<ToDoActivity>(
         ///     "select * from ToDos t where t.cost > 9000",
         ///     maxConcurrency: 2);
         ///     
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(var item in await setIterator.FetchNextSetAsync()){
+        ///     foreach(var item in await feedIterator.FetchNextSetAsync()){
         ///     {
         ///         Console.WriteLine(item.cost); 
         ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosUserDefinedFunctionSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosUserDefinedFunctionSettings.cs
@@ -33,13 +33,13 @@ namespace Microsoft.Azure.Cosmos
     ///     .UseParameter("@expensive", 9000)
     ///     .UseParameter("@status", "Done");
     ///
-    /// CosmosResultSetIterator<double> setIterator = this.container.Items.CreateItemQuery<double>(
+    /// CosmosFeedIterator<double> feedIterator = this.container.Items.CreateItemQuery<double>(
     ///     sqlQueryDefinition: sqlQuery,
     ///     partitionKey: "Done");
     ///
-    /// while (setIterator.HasMoreResults)
+    /// while (feedIterator.HasMoreResults)
     /// {
-    ///     foreach (var tax in await setIterator.FetchNextSetAsync())
+    ///     foreach (var tax in await feedIterator.FetchNextSetAsync())
     ///     {
     ///         Console.WriteLine(tax);
     ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProcedures.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProcedures.cs
@@ -95,10 +95,10 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the stored procedures under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator<CosmosStoredProcedureSettings> setIterator = this.container.StoredProcedures.GetStoredProcedureIterator();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator<CosmosStoredProcedureSettings> feedIterator = this.container.StoredProcedures.GetStoredProcedureIterator();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(CosmosStoredProcedureSettings settings in await setIterator.FetchNextSetAsync())
+        ///     foreach(CosmosStoredProcedureSettings settings in await feedIterator.FetchNextSetAsync())
         ///     {
         ///          Console.WriteLine(settings.Id); 
         ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Trigger/CosmosTriggers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Trigger/CosmosTriggers.cs
@@ -122,10 +122,10 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the triggers under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator<CosmosTriggerSettings> setIterator = this.container.Triggers.GetTriggerIterator();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator<CosmosTriggerSettings> feedIterator = this.container.Triggers.GetTriggerIterator();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(CosmosTriggerSettings settings in await setIterator.FetchNextSetAsync())
+        ///     foreach(CosmosTriggerSettings settings in await feedIterator.FetchNextSetAsync())
         ///     {
         ///          Console.WriteLine(settings.Id); 
         ///     }

--- a/Microsoft.Azure.Cosmos/src/Resource/UserDefinedFunction/CosmosUserDefinedFunctions.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/UserDefinedFunction/CosmosUserDefinedFunctions.cs
@@ -78,13 +78,13 @@ namespace Microsoft.Azure.Cosmos
         ///     .UseParameter("@expensive", 9000)
         ///     .UseParameter("@status", "Done");
         ///
-        /// CosmosResultSetIterator<double> setIterator = this.container.Items.CreateItemQuery<double>(
+        /// CosmosFeedIterator<double> feedIterator = this.container.Items.CreateItemQuery<double>(
         ///     sqlQueryDefinition: sqlQuery,
         ///     partitionKey: "Done");
         ///
-        /// while (setIterator.HasMoreResults)
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach (var tax in await setIterator.FetchNextSetAsync())
+        ///     foreach (var tax in await feedIterator.FetchNextSetAsync())
         ///     {
         ///         Console.WriteLine(tax);
         ///     }
@@ -120,10 +120,10 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the triggers under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// CosmosResultSetIterator<CosmosUserDefinedFunctionSettings> setIterator = this.container.UserDefinedFunctions.GetUserDefinedFunctionIterator();
-        /// while (setIterator.HasMoreResults)
+        /// CosmosFeedIterator<CosmosUserDefinedFunctionSettings> feedIterator = this.container.UserDefinedFunctions.GetUserDefinedFunctionIterator();
+        /// while (feedIterator.HasMoreResults)
         /// {
-        ///     foreach(CosmosUserDefinedFunctionSettings settings in await setIterator.FetchNextSetAsync())
+        ///     foreach(CosmosUserDefinedFunctionSettings settings in await feedIterator.FetchNextSetAsync())
         ///     {
         ///          Console.WriteLine(settings.Id); 
         ///     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -255,12 +255,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     databaseIds.Add(createResponse.Resource.Id);
                 }
 
-                CosmosFeedIterator<CosmosDatabaseSettings> setIterator =
+                CosmosFeedIterator<CosmosDatabaseSettings> feedIterator =
                     this.cosmosClient.Databases.GetDatabaseIterator();
-                while (setIterator.HasMoreResults)
+                while (feedIterator.HasMoreResults)
                 {
                     CosmosFeedResponse<CosmosDatabaseSettings> iterator =
-                        await setIterator.FetchNextSetAsync(this.cancellationToken);
+                        await feedIterator.FetchNextSetAsync(this.cancellationToken);
                     foreach (CosmosDatabaseSettings databaseSettings in iterator)
                     {
                         if (databaseIds.Contains(databaseSettings.Id))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -60,12 +60,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             await this.CreateRandomItems(batchSize, randomPartitionKey: true);
             CosmosItemsCore itemsCore = (CosmosItemsCore)this.Container.Items;
-            CosmosFeedIterator setIterator = itemsCore.GetStandByFeedIterator(requestOptions: new CosmosChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+            CosmosFeedIterator feedIterator = itemsCore.GetStandByFeedIterator(requestOptions: new CosmosChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
                 using (CosmosResponseMessage responseMessage =
-                    await setIterator.FetchNextSetAsync(this.cancellationToken))
+                    await feedIterator.FetchNextSetAsync(this.cancellationToken))
                 {
                     lastcontinuation = responseMessage.Headers.Continuation;
                     List<CompositeContinuationToken> deserializedToken = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(lastcontinuation);
@@ -172,12 +172,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             await this.CreateRandomItems(2, randomPartitionKey: true);
             CosmosItemsCore itemsCore = (CosmosItemsCore)this.Container.Items;
-            CosmosFeedIterator setIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new CosmosChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+            CosmosFeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new CosmosChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
                 using (CosmosResponseMessage responseMessage =
-                    await setIterator.FetchNextSetAsync(this.cancellationToken))
+                    await feedIterator.FetchNextSetAsync(this.cancellationToken))
                 {
                     if (responseMessage.IsSuccessStatusCode)
                     {
@@ -213,9 +213,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 CosmosChangeFeedRequestOptions requestOptions = new CosmosChangeFeedRequestOptions() { StartTime = DateTime.MinValue };
 
-                CosmosFeedIterator setIterator = itemsCore.GetStandByFeedIterator(continuationToken, requestOptions: requestOptions);
+                CosmosFeedIterator feedIterator = itemsCore.GetStandByFeedIterator(continuationToken, requestOptions: requestOptions);
                 using (CosmosResponseMessage responseMessage =
-                    await setIterator.FetchNextSetAsync(this.cancellationToken))
+                    await feedIterator.FetchNextSetAsync(this.cancellationToken))
                 {
                     continuationToken = responseMessage.Headers.Continuation;
                     if (responseMessage.IsSuccessStatusCode)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -209,18 +209,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string lastContinuationToken = null;
             int pageSize = 1;
             CosmosItemRequestOptions requestOptions = new CosmosItemRequestOptions();
-            CosmosFeedIterator setIterator =
+            CosmosFeedIterator feedIterator =
                 this.Container.Items.GetItemStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
 
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
                 if (useStatelessIterator)
                 {
-                    setIterator = this.Container.Items.GetItemStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
+                    feedIterator = this.Container.Items.GetItemStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
                 }
 
                 using (CosmosResponseMessage responseMessage =
-                    await setIterator.FetchNextSetAsync(this.cancellationToken))
+                    await feedIterator.FetchNextSetAsync(this.cancellationToken))
                 {
                     lastContinuationToken = responseMessage.Headers.Continuation;
 
@@ -246,11 +246,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             IList<ToDoActivity> deleteList = await this.CreateRandomItems(3, randomPartitionKey: true);
             HashSet<string> itemIds = deleteList.Select(x => x.id).ToHashSet<string>();
-            CosmosFeedIterator<ToDoActivity> setIterator =
+            CosmosFeedIterator<ToDoActivity> feedIterator =
                 this.Container.Items.GetItemIterator<ToDoActivity>();
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                foreach (ToDoActivity toDoActivity in await setIterator.FetchNextSetAsync(this.cancellationToken))
+                foreach (ToDoActivity toDoActivity in await feedIterator.FetchNextSetAsync(this.cancellationToken))
                 {
                     if (itemIds.Contains(toDoActivity.id))
                     {
@@ -281,13 +281,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             do
             {
                 iterationCount++;
-                CosmosFeedIterator setIterator = this.Container.Items
+                CosmosFeedIterator feedIterator = this.Container.Items
                     .CreateItemQueryAsStream(sql, 1, find.status,
                         maxItemCount: maxItemCount,
                         continuationToken: lastContinuationToken,
                         requestOptions: new CosmosQueryRequestOptions());
 
-                CosmosResponseMessage response = await setIterator.FetchNextSetAsync();
+                CosmosResponseMessage response = await feedIterator.FetchNextSetAsync();
                 lastContinuationToken = response.Headers.Continuation;
                 Trace.TraceInformation($"ContinuationToken: {lastContinuationToken}");
                 JsonSerializer serializer = new JsonSerializer();
@@ -342,11 +342,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseContinuationTokenLimitInKb = 500
             };
 
-            CosmosFeedIterator<ToDoActivity> setIterator =
+            CosmosFeedIterator<ToDoActivity> feedIterator =
                 this.Container.Items.CreateItemQuery<ToDoActivity>(sql, maxConcurrency: 1, maxItemCount: 1, requestOptions: requestOptions);
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                CosmosFeedResponse<ToDoActivity> iter = await setIterator.FetchNextSetAsync();
+                CosmosFeedResponse<ToDoActivity> iter = await feedIterator.FetchNextSetAsync();
                 Assert.AreEqual(1, iter.Count());
                 ToDoActivity response = iter.First();
                 Assert.AreEqual(find.id, response.id);
@@ -371,11 +371,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
-            CosmosFeedIterator setIterator =
+            CosmosFeedIterator feedIterator =
                 this.Container.Items.CreateItemQueryAsStream(sql, maxConcurrency: 5, maxItemCount: 1, requestOptions: requestOptions);
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                CosmosResponseMessage iter = await setIterator.FetchNextSetAsync();
+                CosmosResponseMessage iter = await feedIterator.FetchNextSetAsync();
                 Assert.IsTrue(iter.IsSuccessStatusCode);
                 Assert.IsNull(iter.ErrorMessage);
                 totalRequstCharge += iter.Headers.RequestCharge;
@@ -408,11 +408,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
-            CosmosFeedIterator setIterator =
+            CosmosFeedIterator feedIterator =
                 this.Container.Items.CreateItemQueryAsStream(sql, maxConcurrency: 5, maxItemCount: 5);
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                CosmosResponseMessage iter = await setIterator.FetchNextSetAsync();
+                CosmosResponseMessage iter = await feedIterator.FetchNextSetAsync();
                 Assert.IsTrue(iter.IsSuccessStatusCode);
                 Assert.IsNull(iter.ErrorMessage);
                 totalRequstCharge += iter.Headers.RequestCharge;
@@ -544,11 +544,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
-            CosmosFeedIterator setIterator =
+            CosmosFeedIterator feedIterator =
                 this.Container.Items.CreateItemQueryAsStream(sql, maxConcurrency: 5, maxItemCount: 5, requestOptions: requestOptions);
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                CosmosResponseMessage iter = await setIterator.FetchNextSetAsync();
+                CosmosResponseMessage iter = await feedIterator.FetchNextSetAsync();
                 Assert.IsTrue(iter.IsSuccessStatusCode);
                 Assert.IsNull(iter.ErrorMessage);
                 totalRequstCharge += iter.Headers.RequestCharge;
@@ -588,11 +588,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .UseParameter("@status", toDoActivity.status);
 
             // Test max size at 1
-            CosmosFeedIterator<ToDoActivity> setIterator =
+            CosmosFeedIterator<ToDoActivity> feedIterator =
                 this.Container.Items.CreateItemQuery<ToDoActivity>(sql, toDoActivity.status, maxItemCount: 1);
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                CosmosFeedResponse<ToDoActivity> iter = await setIterator.FetchNextSetAsync();
+                CosmosFeedResponse<ToDoActivity> iter = await feedIterator.FetchNextSetAsync();
                 Assert.AreEqual(1, iter.Count());
             }
 
@@ -770,38 +770,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 //Quering items on fixed container with cross partition enabled.
                 CosmosSqlQueryDefinition sql = new CosmosSqlQueryDefinition("select * from r");
-                CosmosFeedIterator<dynamic> setIterator = fixedContainer.Items
+                CosmosFeedIterator<dynamic> feedIterator = fixedContainer.Items
                     .CreateItemQuery<dynamic>(sql, maxConcurrency: 1,maxItemCount:10, requestOptions: new CosmosQueryRequestOptions { EnableCrossPartitionQuery = true});
-                while (setIterator.HasMoreResults)
+                while (feedIterator.HasMoreResults)
                 {
-                    CosmosFeedResponse<dynamic> queryResponse = await setIterator.FetchNextSetAsync();
+                    CosmosFeedResponse<dynamic> queryResponse = await feedIterator.FetchNextSetAsync();
                     Assert.AreEqual(3, queryResponse.Count());
                 }
 
                 //Reading all items on fixed container.
-                setIterator = fixedContainer.Items
+                feedIterator = fixedContainer.Items
                     .GetItemIterator<dynamic>(maxItemCount: 10);
-                while (setIterator.HasMoreResults)
+                while (feedIterator.HasMoreResults)
                 {
-                    CosmosFeedResponse<dynamic> queryResponse = await setIterator.FetchNextSetAsync();
+                    CosmosFeedResponse<dynamic> queryResponse = await feedIterator.FetchNextSetAsync();
                     Assert.AreEqual(3, queryResponse.Count());
                 }
 
                 //Quering items on fixed container with CosmosContainerSettings.NonePartitionKeyValue.
-                setIterator = fixedContainer.Items
+                feedIterator = fixedContainer.Items
                     .CreateItemQuery<dynamic>(sql, partitionKey: CosmosContainerSettings.NonePartitionKeyValue, maxItemCount: 10);
-                while (setIterator.HasMoreResults)
+                while (feedIterator.HasMoreResults)
                 {
-                    CosmosFeedResponse<dynamic> queryResponse = await setIterator.FetchNextSetAsync();
+                    CosmosFeedResponse<dynamic> queryResponse = await feedIterator.FetchNextSetAsync();
                     Assert.AreEqual(2, queryResponse.Count());
                 }
 
                 //Quering items on fixed container with non-none PK.
-                setIterator = fixedContainer.Items
+                feedIterator = fixedContainer.Items
                     .CreateItemQuery<dynamic>(sql, partitionKey: itemWithPK.status, maxItemCount: 10);
-                while (setIterator.HasMoreResults)
+                while (feedIterator.HasMoreResults)
                 {
-                    CosmosFeedResponse<dynamic> queryResponse = await setIterator.FetchNextSetAsync();
+                    CosmosFeedResponse<dynamic> queryResponse = await feedIterator.FetchNextSetAsync();
                     Assert.AreEqual(1, queryResponse.Count());
                 }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -3584,7 +3584,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         //    int totalReadCount = 0;
 
-        //    CosmosResultSetIterator<dynamic> docQuery = coll.Items.CreateItemQuery<dynamic>(query, feedOptions);
+        //    CosmosFeedIterator<dynamic> docQuery = coll.Items.CreateItemQuery<dynamic>(query, feedOptions);
         //        while (docQuery.HasMoreResults && (maxReadItemCount < 0 || maxReadItemCount > totalReadCount))
         //        {
         //            CosmosFeedResponse<dynamic> response = await docQuery.FetchNextSetAsync();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CustomSerializationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CustomSerializationTests.cs
@@ -300,9 +300,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             AssertEqual(testDocument, replacedResponse.Resource);
 
             CosmosSqlQueryDefinition sql = new CosmosSqlQueryDefinition("select * from r");
-            CosmosFeedIterator<TestDocument> setIterator =
+            CosmosFeedIterator<TestDocument> feedIterator =
                container.Items.CreateItemQuery<TestDocument>(sqlQueryDefinition: sql, partitionKey: testDocument.Name,maxItemCount: 1);
-            CosmosFeedResponse<TestDocument> queryResponse = await setIterator.FetchNextSetAsync();
+            CosmosFeedResponse<TestDocument> queryResponse = await feedIterator.FetchNextSetAsync();
             AssertEqual(testDocument, queryResponse.First());
 
             //Will add LINQ test once it is available with new V3 OM 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -103,14 +103,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                  .UseParameter("@expensive", 9000)
                  .UseParameter("@status", "Done");
             
-             CosmosFeedIterator<dynamic> setIterator = this.container.Items.CreateItemQuery<dynamic>(
+             CosmosFeedIterator<dynamic> feedIterator = this.container.Items.CreateItemQuery<dynamic>(
                  sqlQueryDefinition: sqlQuery,
                  partitionKey: "Done");
 
             HashSet<string> iterIds = new HashSet<string>();
-            while (setIterator.HasMoreResults)
+            while (feedIterator.HasMoreResults)
             {
-                foreach (var response in await setIterator.FetchNextSetAsync())
+                foreach (var response in await feedIterator.FetchNextSetAsync())
                 {
                     Assert.IsTrue(response.cost > 9000);
                     Assert.AreEqual(response.cost * .05, response.total);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             CosmosContainer container = mockClient.Databases["database"].Containers["container"];
             CosmosSqlQueryDefinition sql = new CosmosSqlQueryDefinition("select * from r");
-            CosmosFeedIterator setIterator = container.Items.CreateItemQueryAsStream(
+            CosmosFeedIterator feedIterator = container.Items.CreateItemQueryAsStream(
                 sqlQueryDefinition: sql,
                 maxConcurrency: 1,
                 partitionKey: "pk",
@@ -102,13 +102,13 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             mockClient.RequestHandler.InnerHandler = testHandler;
-            CosmosResponseMessage response = await setIterator.FetchNextSetAsync();
+            CosmosResponseMessage response = await feedIterator.FetchNextSetAsync();
 
             //Test gateway mode
             mockClient = MockCosmosUtil.CreateMockCosmosClient(
                 (cosmosClientBuilder) => cosmosClientBuilder.UseConnectionModeGateway());
             container = mockClient.Databases["database"].Containers["container"];
-            setIterator = container.Items.CreateItemQueryAsStream(
+            feedIterator = container.Items.CreateItemQueryAsStream(
                 sqlQueryDefinition: sql,
                 maxConcurrency: 1,
                 partitionKey: "pk",
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             mockClient.RequestHandler.InnerHandler = testHandler;
-            response = await setIterator.FetchNextSetAsync();
+            response = await feedIterator.FetchNextSetAsync();
         }
 
         [TestMethod]
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 (cosmosClientBuilder) => cosmosClientBuilder.UseConnectionModeDirect());
 
             CosmosContainer container = mockClient.Databases["database"].Containers["container"];
-            CosmosFeedIterator<CosmosConflict> setIterator = container.GetConflictsIterator();
+            CosmosFeedIterator<CosmosConflict> feedIterator = container.GetConflictsIterator();
 
             TestHandler testHandler = new TestHandler((request, cancellationToken) =>
             {
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             mockClient.RequestHandler.InnerHandler = testHandler;
-            CosmosFeedResponse<CosmosConflict> response = await setIterator.FetchNextSetAsync();
+            CosmosFeedResponse<CosmosConflict> response = await feedIterator.FetchNextSetAsync();
 
             Assert.AreEqual(1, response.Count());
 
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 (cosmosClientBuilder) => cosmosClientBuilder.UseConnectionModeDirect());
 
             CosmosContainer container = mockClient.Databases["database"].Containers["container"];
-            CosmosFeedIterator setIterator = container.GetConflictsStreamIterator();
+            CosmosFeedIterator feedIterator = container.GetConflictsStreamIterator();
 
             TestHandler testHandler = new TestHandler((request, cancellationToken) =>
             {
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             mockClient.RequestHandler.InnerHandler = testHandler;
-            CosmosResponseMessage streamResponse = await setIterator.FetchNextSetAsync();
+            CosmosResponseMessage streamResponse = await feedIterator.FetchNextSetAsync();
 
             Collection<CosmosConflict> response = new CosmosDefaultJsonSerializer().FromStream<CosmosFeedResponseUtil<CosmosConflict>>(streamResponse.Content).Data;
 


### PR DESCRIPTION
It will rename CosmosResultSetIterator  to CosmosFeedIterator  in documentation and its sample examples.
Also  changing the object name from setIterator to feedIterator for consistency