### PR TITLE
Exception-less Streaming API for non-existing NP container scenarios

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -5,11 +5,12 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
-    using System.Text;
 
     /// <summary>
     /// Provides a client-side logical representation of the Azure Cosmos DB database account.
@@ -202,7 +203,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal CosmosOffers Offers => this.offerSet.Value;
         internal DocumentClient DocumentClient { get; set; }
-        internal CosmosRequestHandler RequestHandler { get; private set; }
+        internal RequestInvokerHandler RequestHandler { get; private set; }
         internal ConsistencyLevel AccountConsistencyLevel { get; private set; }
 
         internal CosmosResponseFactory ResponseFactory =>

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal CosmosRequestHandler PartitionKeyRangeHandler { get; set; }
 
-        public CosmosRequestHandler Build()
+        public RequestInvokerHandler Build()
         {
-            CosmosRequestHandler root = new RequestInvokerHandler(this.client);
+            RequestInvokerHandler root = new RequestInvokerHandler(this.client);
 
             CosmosRequestHandler current = root;
             if (this.CustomHandlers != null && this.CustomHandlers.Any())

--- a/Microsoft.Azure.Cosmos/src/Handler/CosmosRequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/CosmosRequestMessage.cs
@@ -155,8 +155,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 Debug.Assert(this.AssertPartitioningPropertiesAndHeaders());
             }
-#endif
-#if !DEBUG
+#else
             await Task.CompletedTask;
 #endif
         }

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             Object partitionKey,
             Stream streamPayload,
             Action<CosmosRequestMessage> requestEnricher,
-            CancellationToken cancellation = default)
+            CancellationToken cancellation = default(CancellationToken))
         {
             HttpMethod method = RequestInvokerHandler.GetHttpMethod(operationType);
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Cosmos
         /// 
         /// For non-existing container will throw <see cref="DocumentClientException"/> with 404 as status code
         /// </remarks>
-        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValueAsync(CancellationToken cancellation = default)
+        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValueAsync(CancellationToken cancellation = default(CancellationToken))
         {
             CosmosContainerSettings containerSettings = await this.GetCachedContainerSettingsAsync(cancellation);
             return containerSettings.GetNoneValue();

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Cosmos
         internal async Task<CosmosContainerSettings> GetCachedContainerSettingsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             ClientCollectionCache collectionCache = await this.ClientContext.DocumentClient.GetCollectionCacheAsync();
-            return await collectionCache.GetByNameAsync(HttpConstants.Versions.CurrentVersion, this.LinkUri.OriginalString, cancellationToken);
+            return await collectionCache.ResolveByNameAsync(HttpConstants.Versions.CurrentVersion, this.LinkUri.OriginalString, cancellationToken);
         }
 
         // Name based look-up, needs re-computation and can't be cached
@@ -213,10 +213,12 @@ namespace Microsoft.Azure.Cosmos
         /// The function selects the right partition key constant for inserting documents that don't have
         /// a value for partition key. The constant selection is based on whether the collection is migrated
         /// or user partitioned
+        /// 
+        /// For non-existing container will throw <see cref="DocumentClientException"/> with 404 as status code
         /// </remarks>
-        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValue(CancellationToken cancellationToken = default(CancellationToken))
+        internal async Task<PartitionKeyInternal> GetNonePartitionKeyValueAsync(CancellationToken cancellation = default)
         {
-            CosmosContainerSettings containerSettings = await this.GetCachedContainerSettingsAsync(cancellationToken);
+            CosmosContainerSettings containerSettings = await this.GetCachedContainerSettingsAsync(cancellation);
             return containerSettings.GetNoneValue();
         }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
 
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal abstract CosmosResponseFactory ResponseFactory { get; }
 
-        internal abstract CosmosRequestHandler RequestHandler { get; }
+        internal abstract RequestInvokerHandler RequestHandler { get; }
 
         internal abstract CosmosClientConfiguration ClientConfiguration { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContextCore.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Globalization;
     using System.IO;
     using System.Text;
     using System.Threading;
@@ -95,17 +94,16 @@ namespace Microsoft.Azure.Cosmos
             Action<CosmosRequestMessage> requestEnricher,
             CancellationToken cancellationToken)
         {
-            return ExecUtils.ProcessResourceOperationStreamAsync(
-                requestHandler: this.RequestHandler,
-                cosmosContainerCore: cosmosContainerCore,
+            return this.RequestHandler.SendAsync(
                 resourceUri: resourceUri,
                 resourceType: resourceType,
                 operationType: operationType,
                 requestOptions: requestOptions,
+                cosmosContainerCore: cosmosContainerCore,
                 partitionKey: partitionKey,
                 streamPayload: streamPayload,
                 requestEnricher: requestEnricher,
-                cancellationToken: cancellationToken);
+                cancellation: cancellationToken);
         }
 
         internal override Task<T> ProcessResourceOperationAsync<T>(
@@ -118,10 +116,9 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             Action<CosmosRequestMessage> requestEnricher,
             Func<CosmosResponseMessage, T> responseCreator,
-            CancellationToken cancellationToken)
+            CancellationToken cancellation)
         {
-            return ExecUtils.ProcessResourceOperationAsync<T>(
-                requestHandler: this.RequestHandler,
+            return this.RequestHandler.SendAsync<T>(
                 resourceUri: resourceUri,
                 resourceType: resourceType,
                 operationType: operationType,
@@ -131,7 +128,7 @@ namespace Microsoft.Azure.Cosmos
                 streamPayload: streamPayload,
                 requestEnricher: requestEnricher,
                 responseCreator: responseCreator,
-                cancellationToken: cancellationToken);
+                cancellation: cancellation);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContextCore.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
 
@@ -20,7 +21,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosClientConfiguration clientConfiguration,
             CosmosJsonSerializer cosmosJsonSerializer,
             CosmosResponseFactory cosmosResponseFactory,
-            CosmosRequestHandler requestHandler,
+            RequestInvokerHandler requestHandler,
             DocumentClient documentClient,
             IDocumentQueryClient documentQueryClient)
         {
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal override CosmosResponseFactory ResponseFactory { get; }
 
-        internal override CosmosRequestHandler RequestHandler { get; }
+        internal override RequestInvokerHandler RequestHandler { get; }
 
         internal override CosmosClientConfiguration ClientConfiguration { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                   cancellationToken);
         }
 
-        internal override Task<CosmosContainerSettings> GetByNameAsync(string apiVersion, string resourceAddress, CancellationToken cancellationToken)
+        protected override Task<CosmosContainerSettings> GetByNameAsync(string apiVersion, string resourceAddress, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(this.sessionContainer, this.retryPolicy.GetRequestPolicy());

--- a/Microsoft.Azure.Cosmos/src/Routing/CollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/CollectionCache.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos.Common
 
         protected abstract Task<CosmosContainerSettings> GetByRidAsync(string apiVersion, string collectionRid, CancellationToken cancellationToken);
 
-        internal abstract Task<CosmosContainerSettings> GetByNameAsync(string apiVersion, string resourceAddress, CancellationToken cancellationToken);
+        protected abstract Task<CosmosContainerSettings> GetByNameAsync(string apiVersion, string resourceAddress, CancellationToken cancellationToken);
 
         private async Task<CosmosContainerSettings> ResolveByPartitionKeyRangeIdentityAsync(string apiVersion, PartitionKeyRangeIdentity partitionKeyRangeIdentity, CancellationToken cancellationToken)
         {
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Cosmos.Common
                 cancellationToken);
         }
 
-        private async Task<CosmosContainerSettings> ResolveByNameAsync(
+        internal virtual async Task<CosmosContainerSettings> ResolveByNameAsync(
             string apiVersion,
             string resourceAddress,
             CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/Util/ExecUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ExecUtils.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.IO;
-    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Handlers;
@@ -160,60 +159,6 @@ namespace Microsoft.Azure.Cosmos
                 requestEnricher);
 
             return responseCreator(response);
-        }
-
-        /// <summary>
-        /// Used internally by friends ensure robust argument and
-        /// exception-less handling
-        /// </summary>
-        internal static Task<T> ProcessResourceOperationAsync<T>(
-            CosmosClient client,
-            Uri resourceUri,
-            ResourceType resourceType,
-            OperationType operationType,
-            CosmosRequestOptions requestOptions,
-            Object partitionKey,
-            Stream streamPayload,
-            Action<CosmosRequestMessage> requestEnricher,
-            Func<CosmosResponseMessage, T> responseCreator,
-            CancellationToken cancellationToken)
-        {
-            return ProcessResourceOperationAsync(
-                requestHandler: client.RequestHandler,
-                resourceUri: resourceUri,
-                resourceType: resourceType,
-                operationType: operationType,
-                requestOptions: requestOptions,
-                cosmosContainerCore: null,
-                partitionKey: partitionKey,
-                streamPayload: streamPayload,
-                requestEnricher: requestEnricher,
-                responseCreator: responseCreator,
-                cancellationToken: cancellationToken);
-        }
-
-        internal static Task<CosmosResponseMessage> ProcessResourceOperationStreamAsync(
-            RequestInvokerHandler requestHandler,
-            Uri resourceUri,
-            ResourceType resourceType,
-            OperationType operationType,
-            CosmosRequestOptions requestOptions,
-            CosmosContainerCore cosmosContainerCore,
-            Object partitionKey,
-            Stream streamPayload,
-            Action<CosmosRequestMessage> requestEnricher,
-            CancellationToken cancellationToken)
-        {
-            return requestHandler.SendAsync(
-                resourceUri,
-                resourceType,
-                operationType,
-                requestOptions,
-                cosmosContainerCore,
-                partitionKey,
-                streamPayload,
-                requestEnricher);
-
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Net;
     using System.Net.Http;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query;
@@ -22,6 +23,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
+    using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.TransportWrapperTests;
     using JsonReader = Json.JsonReader;
     using JsonWriter = Json.JsonWriter;
 
@@ -90,6 +92,108 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             CosmosItemResponse<dynamic> deleteResponse = await this.Container.Items.DeleteItemAsync<dynamic>(partitionKey: "[{}]", id: testItem.id);
             Assert.IsNotNull(deleteResponse);
+        }
+
+        [TestMethod]
+        public async Task ReadCollectionNotExists()
+        {
+            string collectionName = Guid.NewGuid().ToString();
+            CosmosContainer testContainer = this.database.Containers[collectionName];
+            await CosmosItemTests.TestNonePKForNonExistingContainer(testContainer);
+
+            // Item -> Container -> Database contract 
+            string dbName = Guid.NewGuid().ToString();
+            testContainer = this.cosmosClient.Databases[dbName].Containers[collectionName];
+            await CosmosItemTests.TestNonePKForNonExistingContainer(testContainer);
+        }
+
+        [TestMethod]
+        public async Task NonPartitionKeyLookupCacheTest()
+        {
+            int count = 0;
+            CosmosClient client = TestCommon.CreateCosmosClient(builder => 
+                {
+                    builder.UseConnectionModeDirect();
+                    builder.UseSendingRequestEventArgs((sender, e) =>
+                        {
+                            if (e.DocumentServiceRequest != null)
+                            {
+                                Trace.TraceInformation($"{e.DocumentServiceRequest.ToString()}");
+                            }
+
+                            if (e.HttpRequest != null)
+                            {
+                                Trace.TraceInformation($"{e.HttpRequest.ToString()}");
+                            }
+
+                            if (e.IsHttpRequest() 
+                                && e.HttpRequest.RequestUri.AbsolutePath.Contains("/colls/"))
+                            {
+                                count++;
+                            }
+
+                            if (e.IsHttpRequest()
+                                && e.HttpRequest.RequestUri.AbsolutePath.Contains("/pkranges"))
+                            {
+                                Debugger.Break();
+                            }
+                        });
+                });
+
+            string dbName = Guid.NewGuid().ToString();
+            string containerName = Guid.NewGuid().ToString();
+            CosmosContainerCore testContainer = (CosmosContainerCore)client.Databases[dbName].Containers[containerName];
+
+            int loopCount = 2;
+            for (int i = 0; i < loopCount; i++)
+            {
+                try
+                {
+                    await testContainer.GetNonePartitionKeyValueAsync();
+                }
+                catch (DocumentClientException dce) when (dce.StatusCode == HttpStatusCode.NotFound)
+                {
+                }
+            }
+
+            Assert.AreEqual(loopCount, count);
+
+            // Create real container and address 
+            CosmosDatabase db = await client.Databases.CreateDatabaseAsync(dbName);
+            CosmosContainer container = await db.Containers.CreateContainerAsync(containerName, "/id");
+
+            // reset counter
+            count = 0;
+            for (int i = 0; i < loopCount; i++)
+            {
+                await testContainer.GetNonePartitionKeyValueAsync();
+            }
+
+            // expected once post create 
+            Assert.AreEqual(1, count);
+
+            // reset counter
+            count = 0;
+            for (int i = 0; i < loopCount; i++)
+            {
+                await testContainer.GetRID(default(CancellationToken));
+            }
+
+            // Already cached by GetNonePartitionKeyValueAsync before
+            Assert.AreEqual(0, count);
+
+            // reset counter
+            count = 0;
+            int expected = 0;
+            for (int i = 0; i < loopCount; i++)
+            {
+                await testContainer.GetRoutingMapAsync(default(CancellationToken));
+                expected = count;
+            }
+
+            // OkRagnes should be fetched only once. 
+            // Possible to make multiple calls for ranges
+            Assert.AreEqual(expected, count);
         }
 
         [TestMethod]
@@ -1023,6 +1127,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 taskNum = 42,
                 cost = double.MaxValue
             };
+        }
+
+        private static async Task TestNonePKForNonExistingContainer(CosmosContainer cosmosContainer)
+        {
+            // Stream implementation should not throw
+            CosmosResponseMessage response = await cosmosContainer.Items.ReadItemStreamAsync(CosmosContainerSettings.NonePartitionKeyValue, "id1");
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            Assert.IsNotNull(response.Headers.ActivityId);
+            Assert.IsNotNull(response.ErrorMessage);
+
+            // FOr typed also its not error
+            var typedResponse = await cosmosContainer.Items.ReadItemAsync<string>(CosmosContainerSettings.NonePartitionKeyValue, "id1");
+            Assert.AreEqual(HttpStatusCode.NotFound, typedResponse.StatusCode);
+            Assert.IsNotNull(typedResponse.Headers.ActivityId);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 try
                 {
                     await testContainer.GetNonePartitionKeyValueAsync();
+                    Assert.Fail();
                 }
                 catch (DocumentClientException dce) when (dce.StatusCode == HttpStatusCode.NotFound)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             public string id { get; set; }
         }
 
-        private class TransportClientWrapper : TransportClient
+        internal class TransportClientWrapper : TransportClient
         {
             private readonly TransportClient baseClient;
             private readonly Action<Uri, ResourceOperation, DocumentServiceRequest> interceptor;


### PR DESCRIPTION
# Pull Request Template

## Description
CreateItemStreamAsync targeting a NP collection with NonePartitionKeyValue should not throw exception. Expected to return status code. 

Currently for partitioned collection its returning 404 and will return the same. 
For GA we should make it 424 (Dependency failure) instead for dis-disambiguate it. 

## Type of change
- ExecUtils moved to the path of deprecation. Related changes moved to RequestInvokerHandler
- RequestInvokerHandler made primary entry contract for client
- Fixed a bug introduced with FI from master, where cached ContainerSettings are not used. 

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #233 
