### PR TITLE
Query issue fix for none partitioned collection

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Common;
-    using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.ParallelQuery;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
     /// Factory class for creating the appropriate DocumentQueryExecutionContext for the provided type of query.
@@ -146,10 +146,6 @@ namespace Microsoft.Azure.Cosmos.Query
                     containerSettings = await collectionCache.ResolveCollectionAsync(request, cancellationToken);
                 }
 
-                if (this.cosmosQueryContext.QueryRequestOptions != null && this.cosmosQueryContext.QueryRequestOptions.PartitionKey != null && this.cosmosQueryContext.QueryRequestOptions.PartitionKey.Equals(PartitionKey.None))
-                {
-                    this.cosmosQueryContext.QueryRequestOptions.PartitionKey = PartitionKey.FromInternalKey(containerSettings.GetNoneValue());
-                }
             }
             else
             {
@@ -350,10 +346,20 @@ namespace Microsoft.Azure.Cosmos.Query
             List<PartitionKeyRange> targetRanges;
             if (queryRequestOptions.PartitionKey != null)
             {
+                PartitionKeyInternal partitionKeyInternal = null;
+                if (Object.ReferenceEquals(queryRequestOptions.PartitionKey, CosmosContainerSettings.NonePartitionKeyValue))
+                {
+                    partitionKeyInternal = collection.GetNoneValue();
+                }
+                else
+                {
+                    partitionKeyInternal = new PartitionKey(queryRequestOptions.PartitionKey).InternalKey;
+                }
+
                 targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkString(
                     resourceLink,
                     collection.ResourceId,
-                    new PartitionKey(queryRequestOptions.PartitionKey).InternalKey.GetEffectivePartitionKeyString(collection.PartitionKey));
+                    partitionKeyInternal.GetEffectivePartitionKeyString(collection.PartitionKey));
             }
             else if (TryGetEpkProperty(queryRequestOptions, out string effectivePartitionKeyString))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -819,7 +819,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         // Read write non partition Container item.
         [TestMethod]
-        [Ignore] //Temporary ignore till we fix emulator issue
         public async Task ReadNonPartitionItemAsync()
         {
             try


### PR DESCRIPTION
Fix for query failing with CosmosContainerSettings.NonePartitionKeyValue on non partitioned container.
Issue fix involve two points
1. We need to check CosmosContainerSettings.NonePartitionKeyValue whenever fetching PartitionKeyInternal
2. Remove setting PartitionKey.FromInternalKey(containerSettings.GetNoneValue()) in code as partition key in case of NonePartitionKeyValue , because we are now checking condition 
    else if (Object.ReferenceEquals(partitionKey, CosmosContainerSettings.NonePartitionKeyValue)) in 
RequestInvokerHandler , which makes it false if we didn't leave it as CosmosContainerSettings.NonePartitionKeyValue


-  Bug fix (non-breaking change which fixes an issue)

#241

## Naveen


## GA


