### PR TITLE
Query stream no longer throws on not found.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/CosmosCrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosCrossPartitionQueryExecutionContext.cs
@@ -426,7 +426,6 @@ namespace Microsoft.Azure.Cosmos.Query
             Func<ItemProducerTree, Task> filterCallback,
             CancellationToken token)
         {
-            CollectionCache collectionCache = await this.queryContext.QueryClient.GetCollectionCacheAsync();
             this.TraceInformation(string.Format(
                 CultureInfo.InvariantCulture,
                 "parallel~contextbase.initializeasync, queryspec {0}, maxbuffereditemcount: {1}, target partitionkeyrange count: {2}, maximumconcurrencylevel: {3}, documentproducer initial page size {4}",

--- a/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClient.cs
@@ -17,7 +17,10 @@ namespace Microsoft.Azure.Cosmos
 
     internal abstract class CosmosQueryClient
     {
-        internal abstract Task<CollectionCache> GetCollectionCacheAsync();
+        internal abstract Task<(CosmosContainerSettings settings, QueryResponse failedResponse)> GetContainerSettingsCacheAsync(
+            ResourceType resourceType,
+            Uri resourceLink,
+            CancellationToken cancellation);
 
         internal abstract Task<IRoutingMapProvider> GetRoutingMapProviderAsync();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -1,0 +1,117 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+    [TestClass]
+    public class CosmosNotFoundTests
+    {
+        public const string DoesNotExist = "DoesNotExist-69E1BD04-EC99-449B-9365-34DA9F4D4ECE";
+        private static CosmosClient client = null;
+        private static CosmosJsonSerializer jsonSerializer = new CosmosDefaultJsonSerializer();
+
+        [ClassInitialize]
+        public static void Initialize(TestContext textContext)
+        {
+            CosmosNotFoundTests.client = TestCommon.CreateCosmosClient();
+        }
+
+        [TestMethod]
+        public async Task ValidateDatabaseNotFoundResponse()
+        {
+            CosmosClient client = CosmosNotFoundTests.client;
+
+            CosmosDatabase database = client.Databases[DoesNotExist];
+            this.VerifyNotFoundResponse(await database.ReadStreamAsync());
+            this.VerifyNotFoundResponse(await database.DeleteStreamAsync());
+        }
+
+        [TestMethod]
+        public async Task ValidateContainerNotFoundResponse()
+        {
+            CosmosClient client = CosmosNotFoundTests.client;
+            CosmosDatabase dbDoesNotExist = client.Databases[DoesNotExist];
+            await this.ContainerOperations(database: dbDoesNotExist, dbNotExist: true);
+
+            CosmosDatabase dbExists = await client.Databases.CreateDatabaseAsync("NotFoundTest" + Guid.NewGuid().ToString());
+            await this.ContainerOperations(database: dbExists, dbNotExist: false);
+        }
+
+        private async Task ContainerOperations(CosmosDatabase database, bool dbNotExist)
+        {
+            // Create should fail if the database does not exist
+            if (dbNotExist)
+            {
+                Stream create = jsonSerializer.ToStream<CosmosContainerSettings>(new CosmosContainerSettings(id: DoesNotExist, partitionKeyPath: "/pk"));
+                this.VerifyNotFoundResponse(await database.Containers.CreateContainerStreamAsync(create, throughput: 500));
+            }
+
+            CosmosContainer doesNotExistContainer = database.Containers[DoesNotExist];
+            this.VerifyNotFoundResponse(await doesNotExistContainer.ReadStreamAsync());
+
+            Stream replace = jsonSerializer.ToStream<CosmosContainerSettings>(new CosmosContainerSettings(id: DoesNotExist, partitionKeyPath: "/pk"));
+            this.VerifyNotFoundResponse(await doesNotExistContainer.ReplaceStreamAsync(replace));
+            this.VerifyNotFoundResponse(await doesNotExistContainer.DeleteStreamAsync());
+
+            // Validate Child resources
+            await this.ItemOperations(doesNotExistContainer, true);
+
+            // The database exists create a container and validate it's children
+            if (!dbNotExist)
+            {
+                CosmosContainer containerExists = await database.Containers.CreateContainerAsync(
+                    id: "NotFoundTest" + Guid.NewGuid().ToString(), 
+                    partitionKeyPath: "/pk");
+
+                await this.ItemOperations(containerExists, false);
+            }
+        }
+
+        private async Task ItemOperations(CosmosContainer container, bool containerNotExist)
+        {
+            CosmosItems cosmosItems = container.Items;
+            if (containerNotExist)
+            {
+                dynamic randomItem = new { id = "test", pk = "doesnotexist" };
+                Stream create = jsonSerializer.ToStream<dynamic>(randomItem);
+                this.VerifyNotFoundResponse(await container.Items.CreateItemStreamAsync(randomItem.pk, create));
+
+                FeedIterator queryIterator = cosmosItems.CreateItemQueryAsStream("select * from t where true", maxConcurrency: 2);
+                this.VerifyNotFoundResponse(await queryIterator.FetchNextSetAsync());
+
+                FeedIterator feedIterator = cosmosItems.GetItemStreamIterator();
+                this.VerifyNotFoundResponse(await feedIterator.FetchNextSetAsync());
+
+                dynamic randomUpsertItem = new { id = DoesNotExist, pk = DoesNotExist, status = 42 };
+                Stream upsert = jsonSerializer.ToStream<dynamic>(randomUpsertItem);
+                this.VerifyNotFoundResponse(await cosmosItems.UpsertItemStreamAsync(
+                    partitionKey: randomUpsertItem.pk,
+                    streamPayload: upsert));
+            }
+
+            this.VerifyNotFoundResponse(await cosmosItems.ReadItemStreamAsync(partitionKey: DoesNotExist, id: DoesNotExist));
+            this.VerifyNotFoundResponse(await cosmosItems.DeleteItemStreamAsync(partitionKey: DoesNotExist, id: DoesNotExist));
+
+            dynamic randomReplaceItem = new { id = "test", pk = "doesnotexist", status = 42 };
+            Stream replace = jsonSerializer.ToStream<dynamic>(randomReplaceItem);
+            this.VerifyNotFoundResponse(await cosmosItems.ReplaceItemStreamAsync(
+                partitionKey: randomReplaceItem.pk, 
+                id: randomReplaceItem.id, 
+                streamPayload: replace));
+        }
+
+        private void VerifyNotFoundResponse(CosmosResponseMessage response)
+        {
+            Assert.IsNotNull(response);
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -67,12 +67,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             bool isContinuationExpected = true;
             CancellationTokenSource cancellation = new CancellationTokenSource();
             CancellationToken token = cancellation.Token;
-
-            Mock<CollectionCache> mockCollectionCache = new Mock<CollectionCache>();
-            mockCollectionCache.Setup(x => x.ResolveCollectionAsync(It.IsAny<DocumentServiceRequest>(), token)).Returns(Task.FromResult(new CosmosContainerSettings("mockContainer", "/pk")));
+            Uri resourceLink = new Uri("dbs/mockdb/colls/mockColl", UriKind.Relative);
 
             Mock<CosmosQueryClient> client = new Mock<CosmosQueryClient>();
-            client.Setup(x => x.GetCollectionCacheAsync()).Returns(Task.FromResult(mockCollectionCache.Object));
+            client.Setup(x => x.GetContainerSettingsCacheAsync(ResourceType.Document, resourceLink, token)).Returns(Task.FromResult<(CosmosContainerSettings, QueryResponse)>((new CosmosContainerSettings("mockContainer", "/pk"), null)));
             client.Setup(x => x.ByPassQueryParsing()).Returns(false);
             client.Setup(x => x.GetPartitionedQueryExecutionInfoAsync(
                 sqlQuerySpec,
@@ -89,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 resourceType: typeof(QueryResponse),
                 sqlQuerySpec: sqlQuerySpec,
                 queryRequestOptions: queryRequestOptions,
-                resourceLink: new Uri("dbs/mockdb/colls/mockColl", UriKind.Relative),
+                resourceLink: resourceLink,
                 isContinuationExpected: isContinuationExpected,
                 allowNonValueAggregateQuery: allowNonValueAggregateQuery,
                 correlatedActivityId: new Guid("221FC86C-1825-4284-B10E-A6029652CCA6"));


### PR DESCRIPTION
# Pull Request Template

## Description
1. Moved get container cache logic to query client. Makes it easier to mock and easier to read the query code.
2. Catch and convert exception to a failed query response.
3. Cache the failure and prevent creating the context if the collection does not exist.
4. Add test to verify that all stream methods do not throw when a container or database does not exist.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Closes #256 

## Excluded 
Created #275 to avoid the try catch in the future.
