### PR TITLE
Rename all iterators to be plural

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos
     ///
     /// Note: all these operations make calls against a fixed budget.
     /// You should design your system such that these calls scale sub-linearly with your application.
-    /// For instance, do not call `containers.GetContainerIterator()` before every single `item.read()` call, to ensure the container exists;
+    /// For instance, do not call `containers.GetContainersIterator()` before every single `item.read()` call, to ensure the container exists;
     /// do this once on application start up.
     /// </summary>
     public abstract class CosmosContainers
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the containers under the database
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<CosmosContainerSettings> feedIterator = this.cosmosDatabase.Containers.GetContainerIterator();
+        /// FeedIterator<CosmosContainerSettings> feedIterator = this.cosmosDatabase.Containers.GetContainersIterator();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(CosmosContainerSettings setting in await feedIterator.FetchNextSetAsync())
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract FeedIterator<CosmosContainerSettings> GetContainerIterator(
+        public abstract FeedIterator<CosmosContainerSettings> GetContainersIterator(
             int? maxItemCount = null,
             string continuationToken = null);
 
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="maxItemCount">(Optional) The max item count to return as part of the query</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
-        public abstract FeedIterator GetContainerStreamIterator(
+        public abstract FeedIterator GetContainersStreamIterator(
             int? maxItemCount = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null);

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainersCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainersCore.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Cosmos
             return this.CreateContainerIfNotExistsAsync(settings, throughput, requestOptions, cancellationToken);
         }
 
-        public override FeedIterator<CosmosContainerSettings> GetContainerIterator(
+        public override FeedIterator<CosmosContainerSettings> GetContainersIterator(
             int? maxItemCount = null,
             string continuationToken = null)
         {
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
-        public override FeedIterator GetContainerStreamIterator(
+        public override FeedIterator GetContainersStreamIterator(
             int? maxItemCount = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabases.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabases.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the database under the cosmos account
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<CosmosDatabaseSettings> feedIterator = this.cosmosClient.Databases.GetDatabaseIterator();
+        /// FeedIterator<CosmosDatabaseSettings> feedIterator = this.cosmosClient.Databases.GetDatabasesIterator();
         /// {
         ///     foreach (CosmosDatabaseSettings databaseSettings in  await feedIterator.FetchNextSetAsync())
         ///     {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract FeedIterator<CosmosDatabaseSettings> GetDatabaseIterator(
+        public abstract FeedIterator<CosmosDatabaseSettings> GetDatabasesIterator(
             int? maxItemCount = null,
             string continuationToken = null);
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabasesCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabasesCore.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos
             return await database.ReadAsync(cancellationToken: cancellationToken);
         }
 
-        public override FeedIterator<CosmosDatabaseSettings> GetDatabaseIterator(
+        public override FeedIterator<CosmosDatabaseSettings> GetDatabasesIterator(
             int? maxItemCount = null,
             string continuationToken = null)
         {

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// FeedIterator<ToDoActivity> feedIterator = this.cosmosContainer.Items.GetItemIterator<ToDoActivity>();
+        /// FeedIterator<ToDoActivity> feedIterator = this.cosmosContainer.Items.GetItemsIterator<ToDoActivity>();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(ToDoActivity item in await feedIterator.FetchNextSetAsync())
@@ -490,7 +490,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract FeedIterator<T> GetItemIterator<T>(
+        public abstract FeedIterator<T> GetItemsIterator<T>(
             int? maxItemCount = null,
             string continuationToken = null);
 
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// FeedIterator feedIterator = this.Container.Items.GetItemStreamIterator();
+        /// FeedIterator feedIterator = this.Container.Items.GetItemsStreamIterator();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract FeedIterator GetItemStreamIterator(
+        public abstract FeedIterator GetItemsStreamIterator(
             int? maxItemCount = null,
             string continuationToken = null,
             ItemRequestOptions requestOptions = null);

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Cosmos
             return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
         }
 
-        public override FeedIterator<T> GetItemIterator<T>(
+        public override FeedIterator<T> GetItemsIterator<T>(
             int? maxItemCount = null,
             string continuationToken = null)
         {
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Cosmos
                 this.ItemFeedRequestExecutor<T>);
         }
 
-        public override FeedIterator GetItemStreamIterator(
+        public override FeedIterator GetItemsStreamIterator(
             int? maxItemCount = null,
             string continuationToken = null,
             ItemRequestOptions requestOptions = null)

--- a/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProcedures.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProcedures.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the stored procedures under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<CosmosStoredProcedureSettings> feedIterator = this.container.StoredProcedures.GetStoredProcedureIterator();
+        /// FeedIterator<CosmosStoredProcedureSettings> feedIterator = this.container.StoredProcedures.GetStoredProceduresIterator();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(CosmosStoredProcedureSettings settings in await feedIterator.FetchNextSetAsync())
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract FeedIterator<CosmosStoredProcedureSettings> GetStoredProcedureIterator(
+        public abstract FeedIterator<CosmosStoredProcedureSettings> GetStoredProceduresIterator(
             int? maxItemCount = null,
             string continuationToken = null);
 

--- a/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProceduresCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/StoredProcedure/CosmosStoredProceduresCore.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos
             return this.clientContext.ResponseFactory.CreateStoredProcedureResponse(this[id], response);
         }
 
-        public override FeedIterator<CosmosStoredProcedureSettings> GetStoredProcedureIterator(
+        public override FeedIterator<CosmosStoredProcedureSettings> GetStoredProceduresIterator(
             int? maxItemCount = null,
             string continuationToken = null)
         {

--- a/Microsoft.Azure.Cosmos/src/Resource/Trigger/CosmosTriggers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Trigger/CosmosTriggers.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the triggers under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<CosmosTriggerSettings> feedIterator = this.container.Triggers.GetTriggerIterator();
+        /// FeedIterator<CosmosTriggerSettings> feedIterator = this.container.Triggers.GetTriggersIterator();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(CosmosTriggerSettings settings in await feedIterator.FetchNextSetAsync())
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public FeedIterator<CosmosTriggerSettings> GetTriggerIterator(
+        public FeedIterator<CosmosTriggerSettings> GetTriggersIterator(
             int? maxItemCount = null,
             string continuationToken = null)
         {

--- a/Microsoft.Azure.Cosmos/src/Resource/UserDefinedFunction/CosmosUserDefinedFunctions.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/UserDefinedFunction/CosmosUserDefinedFunctions.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos
         /// Get an iterator for all the triggers under the cosmos container
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<CosmosUserDefinedFunctionSettings> feedIterator = this.container.UserDefinedFunctions.GetUserDefinedFunctionIterator();
+        /// FeedIterator<CosmosUserDefinedFunctionSettings> feedIterator = this.container.UserDefinedFunctions.GetUserDefinedFunctionsIterator();
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(CosmosUserDefinedFunctionSettings settings in await feedIterator.FetchNextSetAsync())
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public FeedIterator<CosmosUserDefinedFunctionSettings> GetUserDefinedFunctionIterator(
+        public FeedIterator<CosmosUserDefinedFunctionSettings> GetUserDefinedFunctionsIterator(
             int? maxItemCount = null,
             string continuationToken = null)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(partitionKeyPath, containerResponse.Resource.PartitionKey.Paths.First());
 
             HashSet<string> containerIds = new HashSet<string>();
-            FeedIterator<CosmosContainerSettings> resultSet = this.cosmosDatabase.Containers.GetContainerIterator();
+            FeedIterator<CosmosContainerSettings> resultSet = this.cosmosDatabase.Containers.GetContainersIterator();
             while (resultSet.HasMoreResults)
             {
                 foreach (CosmosContainerSettings setting in await resultSet.FetchNextSetAsync())
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(partitionKeyPath, containerResponse.Resource.PartitionKey.Paths.First());
 
             HashSet<string> containerIds = new HashSet<string>();
-            FeedIterator resultSet = this.cosmosDatabase.Containers.GetContainerStreamIterator(
+            FeedIterator resultSet = this.cosmosDatabase.Containers.GetContainersStreamIterator(
                     maxItemCount:1,
                     requestOptions: new QueryRequestOptions());
             while (resultSet.HasMoreResults)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
 
                 FeedIterator<CosmosDatabaseSettings> feedIterator =
-                    this.cosmosClient.Databases.GetDatabaseIterator();
+                    this.cosmosClient.Databases.GetDatabasesIterator();
                 while (feedIterator.HasMoreResults)
                 {
                     FeedResponse<CosmosDatabaseSettings> iterator =

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -315,13 +315,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             int pageSize = 1;
             ItemRequestOptions requestOptions = new ItemRequestOptions();
             FeedIterator feedIterator =
-                this.Container.Items.GetItemStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
+                this.Container.Items.GetItemsStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
 
             while (feedIterator.HasMoreResults)
             {
                 if (useStatelessIterator)
                 {
-                    feedIterator = this.Container.Items.GetItemStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
+                    feedIterator = this.Container.Items.GetItemsStreamIterator(maxItemCount: pageSize, continuationToken: lastContinuationToken, requestOptions: requestOptions);
                 }
 
                 using (CosmosResponseMessage responseMessage =
@@ -352,7 +352,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IList<ToDoActivity> deleteList = await this.CreateRandomItems(3, randomPartitionKey: true);
             HashSet<string> itemIds = deleteList.Select(x => x.id).ToHashSet<string>();
             FeedIterator<ToDoActivity> feedIterator =
-                this.Container.Items.GetItemIterator<ToDoActivity>();
+                this.Container.Items.GetItemsIterator<ToDoActivity>();
             while (feedIterator.HasMoreResults)
             {
                 foreach (ToDoActivity toDoActivity in await feedIterator.FetchNextSetAsync(this.cancellationToken))
@@ -860,7 +860,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 //Reading all items on fixed container.
                 feedIterator = fixedContainer.Items
-                    .GetItemIterator<dynamic>(maxItemCount: 10);
+                    .GetItemsIterator<dynamic>(maxItemCount: 10);
                 while (feedIterator.HasMoreResults)
                 {
                     FeedResponse<dynamic> queryResponse = await feedIterator.FetchNextSetAsync();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             string lastKnownContinuationToken = null;
             FeedIterator iter = this.Container.Database.Containers[this.Container.Id].Items
-                                .GetItemStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken);
+                                .GetItemsStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken);
             int count = 0;
             List<string> forwardOrder = new List<string>();
             while (iter.HasMoreResults)
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 if (useStatelessIteration)
                 {
                     iter = this.Container.Database.Containers[this.Container.Id].Items
-                                        .GetItemStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken);
+                                        .GetItemsStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken);
                 }
 
                 using (CosmosResponseMessage response = await iter.FetchNextSetAsync())
@@ -114,13 +114,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             lastKnownContinuationToken = null;
             iter = this.Container.Database.Containers[this.Container.Id].Items
-                    .GetItemStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
+                    .GetItemsStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
             while (iter.HasMoreResults)
             {
                 if (useStatelessIteration)
                 {
                     iter = this.Container.Database.Containers[this.Container.Id].Items
-                            .GetItemStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
+                            .GetItemsStreamIterator(maxItemCount, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
                 }
 
                 using (CosmosResponseMessage response = await iter.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.OnePartition.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.OnePartition.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private async Task CleanUp()
         {
-            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabaseIterator();
+            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabasesIterator();
 
             while (allDatabases.HasMoreResults)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private async Task CleanUp()
         {
-            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabaseIterator();
+            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabasesIterator();
 
             while (allDatabases.HasMoreResults)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTestsNp.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTestsNp.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private async Task CleanUp()
         {
-            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabaseIterator();
+            FeedIterator<CosmosDatabaseSettings> allDatabases = this.Client.Databases.GetDatabasesIterator();
 
             while (allDatabases.HasMoreResults)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 container = await container.ReadAsync();
 
                 // read documentCollection feed.
-                FeedIterator<CosmosContainerSettings> rr = database.Containers.GetContainerIterator();
+                FeedIterator<CosmosContainerSettings> rr = database.Containers.GetContainersIterator();
                 List<CosmosContainerSettings> settings = new List<CosmosContainerSettings>();
                 while (rr.HasMoreResults)
                 {
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     doc3 = await container.Items.DeleteItemAsync<Document>(partitionKey: resourceRandomId, id: resourceRandomId);
 
                     // read databaseCollection feed.
-                    FeedIterator<dynamic> itemIterator = container.Items.GetItemIterator<dynamic>();
+                    FeedIterator<dynamic> itemIterator = container.Items.GetItemsIterator<dynamic>();
                     int count = 0;
                     while (itemIterator.HasMoreResults)
                     {
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     // 
                     // read databaseCollection feed.
-                    FeedIterator<CosmosStoredProcedureSettings> storedProcedureIter = container.StoredProcedures.GetStoredProcedureIterator();
+                    FeedIterator<CosmosStoredProcedureSettings> storedProcedureIter = container.StoredProcedures.GetStoredProceduresIterator();
                     List<CosmosStoredProcedureSettings> storedProcedures = new List<CosmosStoredProcedureSettings>();
                     while (storedProcedureIter.HasMoreResults)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             List<string> readSprocIds = new List<string>();
-            FeedIterator<CosmosStoredProcedureSettings> iter = this.container.StoredProcedures.GetStoredProcedureIterator();
+            FeedIterator<CosmosStoredProcedureSettings> iter = this.container.StoredProcedures.GetStoredProceduresIterator();
             while (iter.HasMoreResults)
             {
                 FeedResponse<CosmosStoredProcedureSettings> currentResultSet = await iter.FetchNextSetAsync();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosTrigger cosmosTrigger = await this.CreateRandomTrigger();
 
             HashSet<string> settings = new HashSet<string>();
-            FeedIterator<CosmosTriggerSettings> iter = this.container.Triggers.GetTriggerIterator(); ;
+            FeedIterator<CosmosTriggerSettings> iter = this.container.Triggers.GetTriggersIterator(); ;
             while (iter.HasMoreResults)
             {
                 foreach (CosmosTriggerSettings storedProcedureSettingsEntry in await iter.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosUserDefinedFunction cosmosUserDefinedFunction = await CreateRandomUdf();
 
             HashSet<string> settings = new HashSet<string>();
-            FeedIterator<CosmosUserDefinedFunctionSettings> iter = this.container.UserDefinedFunctions.GetUserDefinedFunctionIterator(); ;
+            FeedIterator<CosmosUserDefinedFunctionSettings> iter = this.container.UserDefinedFunctions.GetUserDefinedFunctionsIterator(); ;
             while (iter.HasMoreResults)
             {
                 foreach (CosmosUserDefinedFunctionSettings storedProcedureSettingsEntry in await iter.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -1383,7 +1383,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             IList<CosmosDatabase> databases = new List<CosmosDatabase>();
 
-            FeedIterator<CosmosDatabaseSettings> resultSetIterator = client.Databases.GetDatabaseIterator(maxItemCount: 10);
+            FeedIterator<CosmosDatabaseSettings> resultSetIterator = client.Databases.GetDatabasesIterator(maxItemCount: 10);
             List<Task> deleteTasks = new List<Task>(10); //Delete in chunks of 10
             int totalCount = 0;
             while (resultSetIterator.HasMoreResults)
@@ -1411,7 +1411,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public static async Task DeleteDatabaseCollectionAsync(CosmosClient client, CosmosDatabase database)
         {
             //Delete them in chunks of 10.
-            FeedIterator<CosmosContainerSettings> resultSetIterator = database.Containers.GetContainerIterator(maxItemCount: 10);
+            FeedIterator<CosmosContainerSettings> resultSetIterator = database.Containers.GetContainersIterator(maxItemCount: 10);
             while (resultSetIterator.HasMoreResults)
             {
                 List<Task> deleteCollectionTasks = new List<Task>(10);


### PR DESCRIPTION
# Pull Request Template

## Description

Based on feed back rename all iterators to be plural.

Get{Resource}Iterator -> Get{Resource}sIterator 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Closing issues

closes #270 

