### PR TITLE
TestReducePageSizeScenario failing on CI

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         }
 
         [TestMethod]
+        [Ignore("Emulator is failing due to socket issues")]
         public async Task TestReducePageSizeScenario()
         {
             int partitionKey = 0;


### PR DESCRIPTION
# Flakey emulator

## Description

Current emulator in CI has socket issues due to a reported bug. This issues make some of our tests fails, particularly `TestReducePageSizeScenario`. This PR disables such test until 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

## Related issues

#289 is tracking the re-enablement of this test once the Emulator fix is done.

