### PR TITLE
CosmosContainerSettings.LastModified is now ignored if null

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
@@ -81,11 +81,13 @@ namespace Microsoft.Azure.Cosmos
             this.Id = id;
             if (!string.IsNullOrEmpty(partitionKeyPath))
             {
-                this.PartitionKey = new PartitionKeyDefinition();
-                this.PartitionKey.Paths = new Collection<string>() { partitionKeyPath };
+                this.PartitionKey = new PartitionKeyDefinition
+                {
+                    Paths = new Collection<string>() { partitionKeyPath }
+                };
             }
 
-            ValidateRequiredProperties();
+            this.ValidateRequiredProperties();
         }
 
         /// <summary>
@@ -94,10 +96,7 @@ namespace Microsoft.Azure.Cosmos
         [JsonIgnore]
         public virtual PartitionKeyDefinitionVersion? PartitionKeyDefinitionVersion
         {
-            get
-            {
-                return (Cosmos.PartitionKeyDefinitionVersion?)this.PartitionKey?.Version;
-            }
+            get => (Cosmos.PartitionKeyDefinitionVersion?)this.PartitionKey?.Version;
 
             set
             {
@@ -126,10 +125,7 @@ namespace Microsoft.Azure.Cosmos
                 return this.conflictResolutionInternal;
             }
 
-            set
-            {
-                this.conflictResolutionInternal = value ?? throw new ArgumentNullException($"{nameof(value)}");
-            }
+            set => this.conflictResolutionInternal = value ?? throw new ArgumentNullException($"{nameof(value)}");
         }
 
         /// <summary>
@@ -174,7 +170,10 @@ namespace Microsoft.Azure.Cosmos
 
             set
             {
-                if (value == null) throw new ArgumentNullException($"{nameof(value)}");
+                if (value == null)
+                {
+                    throw new ArgumentNullException($"{nameof(value)}");
+                }
 
                 this.uniqueKeyPolicyInternal = value;
             }
@@ -196,7 +195,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the last modified timestamp associated with <see cref="CosmosContainerSettings" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified timestamp associated with the resource.</value>
-        [JsonProperty(PropertyName = Constants.Properties.LastModified)]
+        [JsonProperty(PropertyName = Constants.Properties.LastModified, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(UnixDateTimeConverter))]
         public virtual DateTime? LastModified { get; private set; }
 
@@ -221,7 +220,10 @@ namespace Microsoft.Azure.Cosmos
 
             set
             {
-                if (value == null) throw new ArgumentNullException($"{nameof(value)}");
+                if (value == null)
+                {
+                    throw new ArgumentNullException($"{nameof(value)}");
+                }
 
                 this.indexingPolicyInternal = value;
             }
@@ -231,13 +233,7 @@ namespace Microsoft.Azure.Cosmos
         /// JSON path used for containers partitioning
         /// </summary>
         [JsonIgnore]
-        public virtual string PartitionKeyPath
-        {
-            get
-            {
-                return this.PartitionKey?.Paths[0];
-            }
-        }
+        public virtual string PartitionKeyPath => this.PartitionKey?.Paths[0];
 
         /// <summary>
         /// Gets or sets the time to live base timestamp property path.
@@ -372,7 +368,7 @@ namespace Microsoft.Azure.Cosmos
             this.Id = id;
             this.PartitionKey = partitionKeyDefinition;
 
-            ValidateRequiredProperties();
+            this.ValidateRequiredProperties();
         }
 
         /// <summary>
@@ -408,12 +404,12 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.Id == null)
             {
-                throw new ArgumentNullException(nameof(Id));
+                throw new ArgumentNullException(nameof(this.Id));
             }
 
             if (this.PartitionKey == null || this.PartitionKey.Paths.Count == 0)
             {
-                throw new ArgumentNullException(nameof(PartitionKey));
+                throw new ArgumentNullException(nameof(this.PartitionKey));
             }
 
             // HACK: Till service can handle the defaults (self-mutation)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -4,10 +4,9 @@
 
 namespace Microsoft.Azure.Cosmos
 {
-    using System;
+    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
-    using System.Collections.ObjectModel;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -35,6 +34,17 @@ namespace Microsoft.Azure.Cosmos
         }
 
         [TestMethod]
+        public void ValidateSerialization()
+        {
+            CosmosDefaultJsonSerializer jsonSerializer = new CosmosDefaultJsonSerializer();
+            CosmosContainerSettings containerSettings = new CosmosContainerSettings("TestContainer", "/partitionKey");
+            Stream basic = jsonSerializer.ToStream<CosmosContainerSettings>(containerSettings);
+            CosmosContainerSettings response = jsonSerializer.FromStream<CosmosContainerSettings>(basic);
+            Assert.AreEqual(containerSettings.Id, response.Id);
+            Assert.AreEqual(containerSettings.PartitionKeyPath, response.PartitionKeyPath);
+        }
+
+        [TestMethod]
         public void DefaultIncludesShouldNotBePopulated()
         {
             CosmosContainerSettings containerSettings = new CosmosContainerSettings("TestContainer", "/partitionKey");
@@ -49,8 +59,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(0, containerSettings.IndexingPolicy.IncludedPaths.Count);
 
             // None indexing mode should not auto-generate the default indexing 
-            containerSettings.IndexingPolicy = new IndexingPolicy();
-            containerSettings.IndexingPolicy.IndexingMode = IndexingMode.None;
+            containerSettings.IndexingPolicy = new IndexingPolicy
+            {
+                IndexingMode = IndexingMode.None
+            };
 
             Assert.AreEqual(0, containerSettings.IndexingPolicy.IncludedPaths.Count);
             containerSettings.ValidateRequiredProperties();
@@ -79,8 +91,10 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void DefaultIndexingPolicySameAsDocumentCollection()
         {
-            CosmosContainerSettings containerSettings = new CosmosContainerSettings("TestContainer", "/partitionKey");
-            containerSettings.IndexingPolicy = new IndexingPolicy();
+            CosmosContainerSettings containerSettings = new CosmosContainerSettings("TestContainer", "/partitionKey")
+            {
+                IndexingPolicy = new IndexingPolicy()
+            };
 
             DocumentCollection dc = new DocumentCollection()
             {
@@ -114,7 +128,7 @@ namespace Microsoft.Azure.Cosmos
 
         private static void AssertSerializedPayloads(CosmosContainerSettings settings, DocumentCollection documentCollection)
         {
-            var jsonSettings = new JsonSerializerSettings
+            JsonSerializerSettings jsonSettings = new JsonSerializerSettings
             {
                 NullValueHandling = NullValueHandling.Ignore
             };
@@ -133,17 +147,19 @@ namespace Microsoft.Azure.Cosmos
 
         private static JObject OrderProeprties(JObject input)
         {
-            var props = input.Properties().ToList();
-            foreach (var prop in props)
+            System.Collections.Generic.List<JProperty> props = input.Properties().ToList();
+            foreach (JProperty prop in props)
             {
                 prop.Remove();
             }
 
-            foreach (var prop in props.OrderBy(p => p.Name))
+            foreach (JProperty prop in props.OrderBy(p => p.Name))
             {
                 input.Add(prop);
                 if (prop.Value is JObject)
+                {
                     OrderProeprties((JObject)prop.Value);
+                }
             }
 
             return input;


### PR DESCRIPTION
# Pull Request Template

## Description

The UnixDateTimeConverter throws if the value is null. Last Modified is a null-able date which causes an exception for compute scenarios. Adding a JSON ignore tag to prevent serializing the null value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


