### PR TITLE
Release branch CosmosContainerSettings.LastModified is now ignored when null

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
@@ -78,11 +78,13 @@ namespace Microsoft.Azure.Cosmos
             this.Id = id;
             if (!string.IsNullOrEmpty(partitionKeyPath))
             {
-                this.PartitionKey = new PartitionKeyDefinition();
-                this.PartitionKey.Paths = new Collection<string>() { partitionKeyPath };
+                this.PartitionKey = new PartitionKeyDefinition
+                {
+                    Paths = new Collection<string>() { partitionKeyPath }
+                };
             }
 
-            ValidateRequiredProperties();
+            this.ValidateRequiredProperties();
         }
 
         /// <summary>
@@ -91,10 +93,7 @@ namespace Microsoft.Azure.Cosmos
         [JsonIgnore]
         public virtual PartitionKeyDefinitionVersion? PartitionKeyDefinitionVersion
         {
-            get
-            {
-                return (Cosmos.PartitionKeyDefinitionVersion?)this.PartitionKey?.Version;
-            }
+            get => (Cosmos.PartitionKeyDefinitionVersion?)this.PartitionKey?.Version;
 
             set
             {
@@ -149,7 +148,10 @@ namespace Microsoft.Azure.Cosmos
 
             set
             {
-                if (value == null) throw new ArgumentNullException($"{nameof(value)}");
+                if (value == null)
+                {
+                    throw new ArgumentNullException($"{nameof(value)}");
+                }
 
                 this.uniqueKeyPolicyInternal = value;
             }
@@ -171,7 +173,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the last modified timestamp associated with <see cref="CosmosContainerSettings" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified timestamp associated with the resource.</value>
-        [JsonProperty(PropertyName = Constants.Properties.LastModified)]
+        [JsonProperty(PropertyName = Constants.Properties.LastModified, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(UnixDateTimeConverter))]
         public virtual DateTime? LastModified { get; private set; }
 
@@ -196,7 +198,10 @@ namespace Microsoft.Azure.Cosmos
 
             set
             {
-                if (value == null) throw new ArgumentNullException($"{nameof(value)}");
+                if (value == null)
+                {
+                    throw new ArgumentNullException($"{nameof(value)}");
+                }
 
                 this.indexingPolicyInternal = value;
             }
@@ -206,13 +211,7 @@ namespace Microsoft.Azure.Cosmos
         /// JSON path used for containers partitioning
         /// </summary>
         [JsonIgnore]
-        public virtual string PartitionKeyPath
-        {
-            get
-            {
-                return this.PartitionKey?.Paths[0];
-            }
-        }
+        public virtual string PartitionKeyPath => this.PartitionKey?.Paths[0];
 
         /// <summary>
         /// Gets or sets the time to live base timestamp property path.
@@ -347,7 +346,7 @@ namespace Microsoft.Azure.Cosmos
             this.Id = id;
             this.PartitionKey = partitionKeyDefinition;
 
-            ValidateRequiredProperties();
+            this.ValidateRequiredProperties();
         }
 
         /// <summary>
@@ -383,17 +382,17 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.Id == null)
             {
-                throw new ArgumentNullException(nameof(Id));
+                throw new ArgumentNullException(nameof(this.Id));
             }
 
             if (this.PartitionKey == null || this.PartitionKey.Paths.Count == 0)
             {
-                throw new ArgumentNullException(nameof(PartitionKey));
+                throw new ArgumentNullException(nameof(this.PartitionKey));
             }
 
             // HACK: Till service can handle the defaults (self-mutation)
             // If indexing mode is not 'none' and not paths are set, set them to the defaults
-            if (this.indexingPolicyInternal != null 
+            if (this.indexingPolicyInternal != null
                 && this.indexingPolicyInternal.IndexingMode != IndexingMode.None
                 && this.indexingPolicyInternal.IncludedPaths.Count == 0
                 && this.indexingPolicyInternal.ExcludedPaths.Count == 0)


### PR DESCRIPTION
# Pull Request Template

## Description

The UnixDateTimeConverter throws if the value is null. Last Modified is a null-able date which causes an exception for compute scenarios. Adding a JSON ignore tag to prevent serializing the null value.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


