### PR TITLE
CreateWithResourceId marked as pure internal

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="resourceId">The resource identifier for the container.</param>
         /// <returns>An instance of <see cref="CosmosContainerSettings"/>.</returns>
-        protected internal static CosmosContainerSettings CreateWithResourceId(string resourceId)
+        internal static CosmosContainerSettings CreateWithResourceId(string resourceId)
         {
             if (string.IsNullOrEmpty(resourceId))
             {


### PR DESCRIPTION
CreateWithResourceId marked as pure internal

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

closes #260 