### PR TITLE
Static code analysis for async

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
 
             PartitionSupervisor supervisor = this.partitionSupervisorFactory.Create(lease);
-            this.ProcessPartition(supervisor, lease).LogException();
+            this.ProcessPartitionAsync(supervisor, lease).LogException();
         }
 
         public override async Task ShutdownAsync()
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
         }
 
-        private async Task ProcessPartition(PartitionSupervisor partitionSupervisor, DocumentServiceLease lease)
+        private async Task ProcessPartitionAsync(PartitionSupervisor partitionSupervisor, DocumentServiceLease lease)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
         public TimeSpan? DispatchPeriod { get; private set; }
 
-        public async Task DispatchEstimation(long estimation, CancellationToken cancellationToken)
+        public async Task DispatchEstimationAsync(long estimation, CancellationToken cancellationToken)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorCore.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                 try
                 {
                     long estimation = await this.remainingWorkEstimator.GetEstimatedRemainingWorkAsync(cancellationToken).ConfigureAwait(false);
-                    await this.dispatcher.DispatchEstimation(estimation, cancellationToken);
+                    await this.dispatcher.DispatchEstimationAsync(estimation, cancellationToken);
                 }
                 catch (TaskCanceledException canceledException)
                 {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                         lastContinuation = response.Headers.Continuation;
                         if (this.resultSetIterator.HasMoreResults)
                         {
-                            await this.DispatchChanges(response, cancellationToken).ConfigureAwait(false);
+                            await this.DispatchChangesAsync(response, cancellationToken).ConfigureAwait(false);
                         }
                     }
                     while (this.resultSetIterator.HasMoreResults && !cancellationToken.IsCancellationRequested);
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             }
         }
 
-        private Task DispatchChanges(CosmosResponseMessage response, CancellationToken cancellationToken)
+        private Task DispatchChangesAsync(CosmosResponseMessage response, CancellationToken cancellationToken)
         {
             ChangeFeedObserverContext context = new ChangeFeedObserverContextCore<T>(this.settings.LeaseToken, response, this.checkpointer);
             Collection<T> asFeedResponse;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                 return suggestedMonitoredRid;
             }
 
-            string containerRid = await ((CosmosContainerCore)monitoredContainer).GetRID(cancellationToken);
-            string databaseRid = await ((CosmosDatabaseCore)((CosmosContainerCore)monitoredContainer).Database).GetRID(cancellationToken);
+            string containerRid = await ((CosmosContainerCore)monitoredContainer).GetRIDAsync(cancellationToken);
+            string databaseRid = await ((CosmosDatabaseCore)((CosmosContainerCore)monitoredContainer).Database).GetRIDAsync(cancellationToken);
             return $"{databaseRid}_{containerRid}";
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/TaskExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/TaskExtensions.cs
@@ -12,19 +12,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
     {
         public static void LogException(this Task task)
         {
+#pragma warning disable VSTHRD110 // Observe result of async calls
             task.ContinueWith(_ => DefaultTrace.TraceException(task.Exception), TaskContinuationOptions.OnlyOnFaulted);
-        }
-
-        public static async Task IgnoreException(this Task task)
-        {
-            try
-            {
-                await task.ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // ignore
-            }
+#pragma warning restore VSTHRD110 // Observe result of async calls
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ClientExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientExtensions.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos
             }
             else
             {
-                throw await GatewayStoreClient.CreateDocumentClientException(responseMessage);
+                throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos
                 }
                 else
                 {
-                    throw await GatewayStoreClient.CreateDocumentClientException(responseMessage);
+                    throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage);
                 }
             }
         }
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Cosmos
             return headers;
         }
 
-        internal static async Task<DocumentClientException> CreateDocumentClientException(HttpResponseMessage responseMessage)
+        internal static async Task<DocumentClientException> CreateDocumentClientExceptionAsync(HttpResponseMessage responseMessage)
         {
             // ensure there is no local ActivityId, since in Gateway mode ActivityId
             // should always come from message headers

--- a/Microsoft.Azure.Cosmos/src/GlobalSuppressions.cs
+++ b/Microsoft.Azure.Cosmos/src/GlobalSuppressions.cs
@@ -34,6 +34,9 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1408:Conditional expressions should declare precedence", Justification = "Code style not enforced")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1139:Use literal suffix notation instead of casting", Justification = "Code style not enforced")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:Parameter should not span multiple lines", Justification = "Code style not enforced")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD105:Avoid method overloads that assume TaskScheduler.Current", Justification = "Code style not enforced")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "Code style not enforced")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD103:Call async methods when in an async method", Justification = "Code style not enforced")]
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces should not be omitted", Justification = "Remove after fixing existing code")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1513:Closing brace should be followed by blank line", Justification = "Remove after fixing existing code")]

--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -14,13 +14,13 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
     internal abstract class AbstractRetryHandler : CosmosRequestHandler
     {
-        internal abstract Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request);
+        internal abstract Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(CosmosRequestMessage request);
 
         public override async Task<CosmosResponseMessage> SendAsync(
             CosmosRequestMessage request, 
             CancellationToken cancellationToken)
         {
-            IDocumentClientRetryPolicy retryPolicyInstance = await this.GetRetryPolicy(request);
+            IDocumentClientRetryPolicy retryPolicyInstance = await this.GetRetryPolicyAsync(request);
 
             try
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/NamedCacheRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/NamedCacheRetryHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             this.client = client;
         }
 
-        internal override async Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
+        internal override async Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(CosmosRequestMessage request)
         {
             return new InvalidPartitionExceptionRetryPolicy(await client.DocumentClient.GetCollectionCacheAsync(), null);
         }

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeGoneRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeGoneRetryHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             this.client = client;
         }
 
-        internal override async Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
+        internal override async Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(CosmosRequestMessage request)
         {
             return new PartitionKeyRangeGoneRetryPolicy(
                 await client.DocumentClient.GetCollectionCacheAsync(),

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                     this.partitionRoutingHelper.ExtractPartitionKeyRangeFromContinuationToken(serviceRequest.Headers, out suppliedTokens);
 
                 ResolvedRangeInfo resolvedRangeInfo =
-                    await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+                    await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                         providedPartitionKeyRanges: providedRanges,
                         routingMapProvider: routingMapProvider,
                         collectionRid: collectionFromCache.ResourceId,
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 {
                     serviceRequest.ForceNameCacheRefresh = true;
                     collectionFromCache = await collectionCache.ResolveCollectionAsync(serviceRequest, CancellationToken.None);
-                    resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+                    resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                         providedPartitionKeyRanges: providedRanges,
                         routingMapProvider: routingMapProvider,
                         collectionRid: collectionFromCache.ResourceId,

--- a/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             this.retryPolicyFactory = retryPolicyFactory;
         }
 
-        internal override Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
+        internal override Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(CosmosRequestMessage request)
         {
             IDocumentClientRetryPolicy retryPolicyInstance = retryPolicyFactory.GetRequestPolicy();
             request.DocumentClientRetryPolicy = retryPolicyInstance;

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
@@ -252,11 +252,15 @@ namespace Microsoft.Azure.Cosmos.Linq
         public IEnumerator<T> GetEnumerator()
         {
             using (IDocumentQueryExecutionContext localQueryExecutionContext =
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                 TaskHelper.InlineIfPossible(() => this.CreateDocumentQueryExecutionContextAsync(false, CancellationToken.None), null).Result)
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             {
                 while (!localQueryExecutionContext.IsDone)
                 {
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
                     DocumentFeedResponse<CosmosElement> feedResponse = TaskHelper.InlineIfPossible(() => localQueryExecutionContext.ExecuteNextFeedResponseAsync(CancellationToken.None), null).Result;
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
                     DocumentFeedResponse<T> typedFeedResponse = FeedResponseBinder.ConvertCosmosElementFeed<T>(
                         feedResponse, 
                         this.resourceTypeEnum,

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup Condition=" '$(SignAssembly)' == 'true' ">

--- a/Microsoft.Azure.Cosmos/src/Query/CompletedTask.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CompletedTask.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        public static Task<T> SetException<T>(Exception exception)
+        public static Task<T> SetExceptionAsync<T>(Exception exception)
         {
             TaskCompletionSource<T> completionSource = new TaskCompletionSource<T>();
             completionSource.SetException(exception);

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosCrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosCrossPartitionQueryExecutionContext.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 if (!deferFirstPage)
                 {
-                    (bool successfullyMovedNext, QueryResponse failureResponse) response = await itemProducerTree.MoveNextIfNotSplit(token);
+                    (bool successfullyMovedNext, QueryResponse failureResponse) response = await itemProducerTree.MoveNextIfNotSplitAsync(token);
                     if (response.failureResponse != null)
                     {
                         // Set the failure so on drain it can be returned.
@@ -882,7 +882,7 @@ namespace Microsoft.Azure.Cosmos.Query
             /// <returns>A task to await on.</returns>
             public override Task StartAsync(CancellationToken token)
             {
-                return this.producer.BufferMoreDocuments(token);
+                return this.producer.BufferMoreDocumentsAsync(token);
             }
 
             /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     cancellationToken);
             }
 
-            List<PartitionKeyRange> targetRanges = await GetTargetPartitionKeyRanges(
+            List<PartitionKeyRange> targetRanges = await GetTargetPartitionKeyRangesAsync(
                    this.cosmosQueryContext.QueryClient,
                    this.cosmosQueryContext.ResourceLink.OriginalString,
                    partitionedQueryExecutionInfo,
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 rewrittenComosQueryContext = this.cosmosQueryContext;
             }
 
-            return await CreateSpecializedDocumentQueryExecutionContext(
+            return await CreateSpecializedDocumentQueryExecutionContextAsync(
                 rewrittenComosQueryContext,
                 partitionedQueryExecutionInfo,
                 targetRanges,
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 cancellationToken);
         }
 
-        public static async Task<CosmosQueryExecutionContext> CreateSpecializedDocumentQueryExecutionContext(
+        public static async Task<CosmosQueryExecutionContext> CreateSpecializedDocumentQueryExecutionContextAsync(
             CosmosQueryContext cosmosQueryContext,
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
             List<PartitionKeyRange> targetRanges,
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// 3. Check the effective partition key
         /// 4. Get the range from the PartitionedQueryExecutionInfo
         /// </summary>
-        internal static async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRanges(
+        internal static async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(
             CosmosQueryClient queryClient,
             string resourceLink,
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
@@ -357,21 +357,21 @@ namespace Microsoft.Azure.Cosmos.Query
                     partitionKeyInternal = new PartitionKey(queryRequestOptions.PartitionKey).InternalKey;
                 }
 
-                targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkString(
+                targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkStringAsync(
                     resourceLink,
                     collection.ResourceId,
                     partitionKeyInternal.GetEffectivePartitionKeyString(collection.PartitionKey));
             }
             else if (TryGetEpkProperty(queryRequestOptions, out string effectivePartitionKeyString))
             {
-                targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkString(
+                targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkStringAsync(
                     resourceLink,
                     collection.ResourceId,
                     effectivePartitionKeyString);
             }
             else
             {
-                targetRanges = await queryClient.GetTargetPartitionKeyRanges(
+                targetRanges = await queryClient.GetTargetPartitionKeyRangesAsync(
                     resourceLink,
                     collection.ResourceId,
                     partitionedQueryExecutionInfo.QueryRanges);

--- a/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CrossPartitionQueryExecutionContext.cs
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 if (!deferFirstPage)
                 {
-                    await documentProducerTree.MoveNextIfNotSplit(token);
+                    await documentProducerTree.MoveNextIfNotSplitAsync(token);
                 }
 
                 if (filterCallback != null)
@@ -885,7 +885,7 @@ namespace Microsoft.Azure.Cosmos.Query
             /// <returns>A task to await on.</returns>
             public override Task StartAsync(CancellationToken token)
             {
-                return this.producer.BufferMoreDocuments(token);
+                return this.producer.BufferMoreDocumentsAsync(token);
             }
 
             /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos.Query
         protected override async Task<DocumentFeedResponse<CosmosElement>> ExecuteInternalAsync(CancellationToken token)
         {
             CollectionCache collectionCache = await this.Client.GetCollectionCacheAsync();
-            PartitionKeyRangeCache partitionKeyRangeCache = await this.Client.GetPartitionKeyRangeCache();
+            PartitionKeyRangeCache partitionKeyRangeCache = await this.Client.GetPartitionKeyRangeCacheAsync();
             IDocumentClientRetryPolicy retryPolicyInstance = this.Client.ResetSessionTokenRetryPolicy.GetRequestPolicy();
             retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(collectionCache, retryPolicyInstance);
             if (base.ResourceTypeEnum.IsPartitioned())
@@ -348,7 +348,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 this.providedRangesCache[collection.ResourceId] = providedRanges;
             }
 
-            PartitionRoutingHelper.ResolvedRangeInfo resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            PartitionRoutingHelper.ResolvedRangeInfo resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                     providedRanges,
                     routingMapProvider,
                     collection.ResourceId,

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentProducerTree.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentProducerTree.cs
@@ -430,8 +430,8 @@ namespace Microsoft.Azure.Cosmos.Query
         /// <remarks>This function is split proofed.</remarks>
         public async Task<bool> MoveNextAsync(CancellationToken token)
         {
-            return await this.ExecuteWithSplitProofing(
-                function: this.MoveNextAsyncImplementation,
+            return await this.ExecuteWithSplitProofingAsync(
+                function: this.MoveNextAsyncImplementationAsync,
                 functionNeedsBeReexecuted: false,
                 cancellationToken: token);
         }
@@ -442,10 +442,10 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on which in turn returns whether or not we moved next.</returns>
-        public async Task<bool> MoveNextIfNotSplit(CancellationToken token)
+        public async Task<bool> MoveNextIfNotSplitAsync(CancellationToken token)
         {
-            return await this.ExecuteWithSplitProofing(
-                function: this.MoveNextIfNotSplitAsyncImplementation,
+            return await this.ExecuteWithSplitProofingAsync(
+                function: this.MoveNextIfNotSplitAsyncImplementationAsync,
                 functionNeedsBeReexecuted: false,
                 cancellationToken: token);
         }
@@ -455,10 +455,10 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        public Task BufferMoreDocuments(CancellationToken token)
+        public Task BufferMoreDocumentsAsync(CancellationToken token)
         {
-            return this.ExecuteWithSplitProofing(
-                function: this.BufferMoreDocumentsImplementation,
+            return this.ExecuteWithSplitProofingAsync(
+                function: this.BufferMoreDocumentsImplementationAsync,
                 functionNeedsBeReexecuted: true,
                 cancellationToken: token);
         }
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task with whether or not move next succeeded.</returns>
-        private async Task<dynamic> MoveNextAsyncImplementation(CancellationToken token)
+        private async Task<dynamic> MoveNextAsyncImplementationAsync(CancellationToken token)
         {
             if (!this.HasMoreResults)
             {
@@ -607,14 +607,14 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on which in turn return whether we successfully moved next.</returns>
-        private Task<dynamic> MoveNextIfNotSplitAsyncImplementation(CancellationToken token)
+        private Task<dynamic> MoveNextIfNotSplitAsyncImplementationAsync(CancellationToken token)
         {
             if (this.HasSplit)
             {
                 return Task.FromResult<dynamic>(false);
             }
 
-            return this.MoveNextAsyncImplementation(token);
+            return this.MoveNextAsyncImplementationAsync(token);
         }
 
         /// <summary>
@@ -622,7 +622,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        private async Task<object> BufferMoreDocumentsImplementation(CancellationToken token)
+        private async Task<object> BufferMoreDocumentsImplementationAsync(CancellationToken token)
         {
             if (this.CurrentDocumentProducerTree == this)
             {
@@ -632,11 +632,11 @@ namespace Microsoft.Azure.Cosmos.Query
                     return null;
                 }
 
-                await this.root.BufferMoreDocuments(token);
+                await this.root.BufferMoreDocumentsAsync(token);
             }
             else
             {
-                await this.CurrentDocumentProducerTree.BufferMoreDocuments(token);
+                await this.CurrentDocumentProducerTree.BufferMoreDocumentsAsync(token);
             }
 
             return null;
@@ -667,7 +667,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </para>
         /// </remarks>
         /// <returns>The result of the function would have returned as if there were no splits.</returns>
-        private async Task<dynamic> ExecuteWithSplitProofing(
+        private async Task<dynamic> ExecuteWithSplitProofingAsync(
             Func<CancellationToken, Task<dynamic>> function,
             bool functionNeedsBeReexecuted,
             CancellationToken cancellationToken)
@@ -693,7 +693,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     }
 
                     // Repair the execution context: Get the replacement documentproducers and add them to the tree.
-                    List<PartitionKeyRange> replacementRanges = await this.GetReplacementRanges(splitDocumentProducerTree.PartitionKeyRange, this.collectionRid);
+                    List<PartitionKeyRange> replacementRanges = await this.GetReplacementRangesAsync(splitDocumentProducerTree.PartitionKeyRange, this.collectionRid);
                     foreach (PartitionKeyRange replacementRange in replacementRanges)
                     {
                         DocumentProducerTree replacementDocumentProducerTree = this.createDocumentProducerTreeCallback(replacementRange, splitDocumentProducerTree.root.BackendContinuationToken);
@@ -732,7 +732,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// <param name="targetRange">The target range that got split.</param>
         /// <param name="collectionRid">The collection rid.</param>
         /// <returns>The replacement ranges for the target range that got split.</returns>
-        private async Task<List<PartitionKeyRange>> GetReplacementRanges(PartitionKeyRange targetRange, string collectionRid)
+        private async Task<List<PartitionKeyRange>> GetReplacementRangesAsync(PartitionKeyRange targetRange, string collectionRid)
         {
             IRoutingMapProvider routingMapProvider = await this.client.GetRoutingMapProviderAsync();
             List<PartitionKeyRange> replacementRanges = (

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryClient.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 if (this.queryPartitionProvider == null)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    this.queryPartitionProvider = new QueryPartitionProvider(await this.innerClient.GetQueryEngineConfiguration());
+                    this.queryPartitionProvider = new QueryPartitionProvider(await this.innerClient.GetQueryEngineConfigurationAsync());
                 }
 
                 this.semaphore.Release();
@@ -128,13 +128,13 @@ namespace Microsoft.Azure.Cosmos.Query
             return this.innerClient.GetDesiredConsistencyLevelAsync();
         }
 
-        public Task EnsureValidOverwrite(ConsistencyLevel requestedConsistencyLevel)
+        public Task EnsureValidOverwriteAsync(ConsistencyLevel requestedConsistencyLevel)
         {
             this.innerClient.EnsureValidOverwrite(requestedConsistencyLevel);
             return CompletedTask.Instance;
         }
 
-        public Task<PartitionKeyRangeCache> GetPartitionKeyRangeCache()
+        public Task<PartitionKeyRangeCache> GetPartitionKeyRangeCacheAsync()
         {
             return this.innerClient.GetPartitionKeyRangeCacheAsync();
         }

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextBase.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
             if (this.feedOptions.ConsistencyLevel.HasValue)
             {
-                await this.client.EnsureValidOverwrite((Documents.ConsistencyLevel)feedOptions.ConsistencyLevel.Value);
+                await this.client.EnsureValidOverwriteAsync((Documents.ConsistencyLevel)feedOptions.ConsistencyLevel.Value);
                 requestHeaders.Set(HttpConstants.HttpHeaders.ConsistencyLevel, this.feedOptions.ConsistencyLevel.Value.ToString());
             }
             else if (desiredConsistencyLevel.HasValue)
@@ -418,7 +418,7 @@ namespace Microsoft.Azure.Cosmos.Query
             }
         }
 
-        public async Task<PartitionKeyRange> GetTargetPartitionKeyRangeById(string collectionResourceId, string partitionKeyRangeId)
+        public async Task<PartitionKeyRange> GetTargetPartitionKeyRangeByIdAsync(string collectionResourceId, string partitionKeyRangeId)
         {
             IRoutingMapProvider routingMapProvider = await this.client.GetRoutingMapProviderAsync();
 
@@ -442,16 +442,16 @@ namespace Microsoft.Azure.Cosmos.Query
             return range;
         }
 
-        internal Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkString(string collectionResourceId, string effectivePartitionKeyString)
+        internal Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkStringAsync(string collectionResourceId, string effectivePartitionKeyString)
         {
-            return this.GetTargetPartitionKeyRanges(collectionResourceId,
+            return this.GetTargetPartitionKeyRangesAsync(collectionResourceId,
                 new List<Range<string>>
                 {
                     Range<string>.GetPointRange(effectivePartitionKeyString)
                 });
         }
 
-        internal async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRanges(string collectionResourceId, List<Range<string>> providedRanges)
+        internal async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(string collectionResourceId, List<Range<string>> providedRanges)
         {
             if (string.IsNullOrEmpty(nameof(collectionResourceId)))
             {
@@ -489,7 +489,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
         protected abstract Task<DocumentFeedResponse<CosmosElement>> ExecuteInternalAsync(CancellationToken cancellationToken);
 
-        protected async Task<List<PartitionKeyRange>> GetReplacementRanges(PartitionKeyRange targetRange, string collectionRid)
+        protected async Task<List<PartitionKeyRange>> GetReplacementRangesAsync(PartitionKeyRange targetRange, string collectionRid)
         {
             IRoutingMapProvider routingMapProvider = await this.client.GetRoutingMapProviderAsync();
             List<PartitionKeyRange> replacementRanges = (await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, targetRange.ToRange(), true)).ToList();

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 // which will be used to send the query to Gateway and on getting 400(bad request) with 1004(cross partition query not servable), we initialize it with
                 // PipelinedDocumentQueryExecutionContext by providing the partition query execution info that's needed(which we get from the exception returned from Gateway).
                 ProxyDocumentQueryExecutionContext proxyQueryExecutionContext =
-                    ProxyDocumentQueryExecutionContext.CreateAsync(
+                    ProxyDocumentQueryExecutionContext.Create(
                         client,
                         resourceTypeEnum,
                         resourceType,
@@ -115,13 +115,13 @@ namespace Microsoft.Azure.Cosmos.Query
                         collection.PartitionKey,
                         isContinuationExpected))
                 {
-                    List<PartitionKeyRange> targetRanges = await GetTargetPartitionKeyRanges(
+                    List<PartitionKeyRange> targetRanges = await GetTargetPartitionKeyRangesAsync(
                         queryExecutionContext,
                         partitionedQueryExecutionInfo,
                         collection,
                         feedOptions);
 
-                    return await CreateSpecializedDocumentQueryExecutionContext(
+                    return await CreateSpecializedDocumentQueryExecutionContextAsync(
                         constructorParams,
                         partitionedQueryExecutionInfo,
                         targetRanges,
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.Query
             return queryExecutionContext;
         }
 
-        public static async Task<IDocumentQueryExecutionContext> CreateSpecializedDocumentQueryExecutionContext(
+        public static async Task<IDocumentQueryExecutionContext> CreateSpecializedDocumentQueryExecutionContextAsync(
             DocumentQueryExecutionContextBase.InitParams constructorParams,
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
             List<PartitionKeyRange> targetRanges,
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// 3. Check the effective partition key
         /// 4. Get the range from the PartitionedQueryExecutionInfo
         /// </summary>
-        internal static async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRanges(
+        internal static async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(
             DefaultDocumentQueryExecutionContext queryExecutionContext,
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
             CosmosContainerSettings collection,
@@ -219,26 +219,26 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 targetRanges = new List<PartitionKeyRange>()
                 {
-                    await queryExecutionContext.GetTargetPartitionKeyRangeById(
+                    await queryExecutionContext.GetTargetPartitionKeyRangeByIdAsync(
                                     collection.ResourceId,
                                     feedOptions.PartitionKeyRangeId)
                 };
             }
             else if (feedOptions.PartitionKey != null)
             {
-                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRangesByEpkString(
+                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRangesByEpkStringAsync(
                     collection.ResourceId,
                     feedOptions.PartitionKey.InternalKey.GetEffectivePartitionKeyString(collection.PartitionKey));
             }
             else if (TryGetEpkProperty(feedOptions, out string effectivePartitionKeyString))
             {
-                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRangesByEpkString(
+                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRangesByEpkStringAsync(
                     collection.ResourceId,
                     effectivePartitionKeyString);
             }
             else
             {
-                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRanges(
+                targetRanges = await queryExecutionContext.GetTargetPartitionKeyRangesAsync(
                     collection.ResourceId,
                     partitionedQueryExecutionInfo.QueryRanges);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/IDocumentQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/IDocumentQueryClient.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Azure.Cosmos.Query
 
         Task<Documents.ConsistencyLevel?> GetDesiredConsistencyLevelAsync();
 
-        Task EnsureValidOverwrite(Documents.ConsistencyLevel desiredConsistencyLevel);
+        Task EnsureValidOverwriteAsync(Documents.ConsistencyLevel desiredConsistencyLevel);
 
-        Task<PartitionKeyRangeCache> GetPartitionKeyRangeCache();
+        Task<PartitionKeyRangeCache> GetPartitionKeyRangeCacheAsync();
     }
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/DocumentProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/DocumentProducer.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Cosmos.Query
             token.ThrowIfCancellationRequested();
 
             CosmosElement originalCurrent = this.current;
-            bool movedNext = await this.MoveNextAsyncImplementation(token);
+            bool movedNext = await this.MoveNextAsyncImplementationAsync(token);
             if (!movedNext || (originalCurrent != null && !this.equalityComparer.Equals(originalCurrent, this.current)))
             {
                 this.isActive = false;
@@ -410,13 +410,13 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        public async Task BufferMoreIfEmpty(CancellationToken token)
+        public async Task BufferMoreIfEmptyAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
             if (this.bufferedPages.Count == 0)
             {
-                await this.BufferMoreDocuments(token);
+                await this.BufferMoreDocumentsAsync(token);
             }
         }
 
@@ -425,7 +425,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        public async Task BufferMoreDocuments(CancellationToken token)
+        public async Task BufferMoreDocumentsAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Whether or not we successfully moved to the next document in the producer.</returns>
-        private async Task<bool> MoveNextAsyncImplementation(CancellationToken token)
+        private async Task<bool> MoveNextAsyncImplementationAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -560,13 +560,13 @@ namespace Microsoft.Azure.Cosmos.Query
                 return false;
             }
 
-            await this.BufferMoreIfEmpty(token);
+            await this.BufferMoreIfEmptyAsync(token);
 
             if (!this.hasInitialized)
             {
                 // First time calling move next async so we are just going to call movenextpage to get the ball rolling
                 this.hasInitialized = true;
-                if (await this.MoveNextPage(token))
+                if (await this.MoveNextPageAsync(token))
                 {
                     return true;
                 }
@@ -590,7 +590,7 @@ namespace Microsoft.Azure.Cosmos.Query
             else
             {
                 // We might be at a continuation boundary so we need to move to the next page
-                if (await this.MoveNextPage(token))
+                if (await this.MoveNextPageAsync(token))
                 {
                     return true;
                 }
@@ -622,7 +622,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Whether the operation was successful.</returns>
-        private async Task<bool> MoveNextPage(CancellationToken token)
+        private async Task<bool> MoveNextPageAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 

--- a/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/ItemProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/ItemProducer.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Cosmos.Query
             token.ThrowIfCancellationRequested();
 
             CosmosElement originalCurrent = this.Current;
-            (bool successfullyMovedNext, QueryResponse failureResponse) movedNext = await this.MoveNextAsyncImplementation(token);
+            (bool successfullyMovedNext, QueryResponse failureResponse) movedNext = await this.MoveNextAsyncImplementationAsync(token);
             if (!movedNext.successfullyMovedNext || (originalCurrent != null && !this.equalityComparer.Equals(originalCurrent, this.Current)))
             {
                 this.IsActive = false;
@@ -275,13 +275,13 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        public async Task BufferMoreIfEmpty(CancellationToken token)
+        public async Task BufferMoreIfEmptyAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
             if (this.bufferedPages.Count == 0)
             {
-                await this.BufferMoreDocuments(token);
+                await this.BufferMoreDocumentsAsync(token);
             }
         }
 
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on.</returns>
-        public async Task BufferMoreDocuments(CancellationToken token)
+        public async Task BufferMoreDocumentsAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Whether or not we successfully moved to the next document in the producer.</returns>
-        private async Task<(bool successfullyMovedNext, QueryResponse failureResponse)> MoveNextAsyncImplementation(CancellationToken token)
+        private async Task<(bool successfullyMovedNext, QueryResponse failureResponse)> MoveNextAsyncImplementationAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 
@@ -428,13 +428,13 @@ namespace Microsoft.Azure.Cosmos.Query
                 return ItemProducer.IsDoneResponse;
             }
 
-            await this.BufferMoreIfEmpty(token);
+            await this.BufferMoreIfEmptyAsync(token);
 
             if (!this.hasInitialized)
             {
                 // First time calling move next async so we are just going to call movenextpage to get the ball rolling
                 this.hasInitialized = true;
-                (bool successfullyMovedNext, QueryResponse failureResponse) response = await this.TryMoveNextPage(token);
+                (bool successfullyMovedNext, QueryResponse failureResponse) response = await this.TryMoveNextPageAsync(token);
                 if (!response.successfullyMovedNext)
                 {
                     this.HasMoreResults = false;
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Cosmos.Query
             else
             {
                 // We might be at a continuation boundary so we need to move to the next page
-                (bool successfullyMovedNext, QueryResponse failureResponse) response = await this.TryMoveNextPage(token);
+                (bool successfullyMovedNext, QueryResponse failureResponse) response = await this.TryMoveNextPageAsync(token);
                 if (!response.successfullyMovedNext)
                 {
                     this.HasMoreResults = false;
@@ -486,7 +486,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         /// <param name="token">The cancellation token.</param>
         /// <returns>Whether the operation was successful.</returns>
-        private async Task<(bool successfullyMovedNext, QueryResponse failureResponse)> TryMoveNextPage(CancellationToken token)
+        private async Task<(bool successfullyMovedNext, QueryResponse failureResponse)> TryMoveNextPageAsync(CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
 

--- a/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ProxyDocumentQueryExecutionContext.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos.Query
             this.correlatedActivityId = correlatedActivityId;
         }
 
-        public static ProxyDocumentQueryExecutionContext CreateAsync(
+        public static ProxyDocumentQueryExecutionContext Create(
             IDocumentQueryClient client,
             ResourceType resourceTypeEnum,
             Type resourceType,
@@ -134,11 +134,11 @@ namespace Microsoft.Azure.Cosmos.Query
 
             List<PartitionKeyRange> partitionKeyRanges =
                 await
-                    queryExecutionContext.GetTargetPartitionKeyRanges(collection.ResourceId,
+                    queryExecutionContext.GetTargetPartitionKeyRangesAsync(collection.ResourceId,
                         partitionedQueryExecutionInfo.QueryRanges);
 
             DocumentQueryExecutionContextBase.InitParams constructorParams = new DocumentQueryExecutionContextBase.InitParams(this.client, this.resourceTypeEnum, this.resourceType, this.expression, this.feedOptions, this.resourceLink, false, correlatedActivityId);
-            this.innerExecutionContext = await DocumentQueryExecutionContextFactory.CreateSpecializedDocumentQueryExecutionContext(
+            this.innerExecutionContext = await DocumentQueryExecutionContextFactory.CreateSpecializedDocumentQueryExecutionContextAsync(
                 constructorParams,
                 partitionedQueryExecutionInfo,
                 partitionKeyRanges,

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos
             this.queryClient = queryClient;
         }
 
-        public async Task<PartitionedQueryExecutionInfo> GetQueryPlan(
+        public async Task<PartitionedQueryExecutionInfo> GetQueryPlanAsync(
             SqlQuerySpec sqlQuerySpec,
             PartitionKeyDefinition partitionKeyDefinition,
             QueryFeatures supportedQueryFeatures,

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Query
         {
             QueryPlanHandler queryPlanHandler = new QueryPlanHandler(queryClient);
 
-            return queryPlanHandler.GetQueryPlan(
+            return queryPlanHandler.GetQueryPlanAsync(
                     sqlQuerySpec,
                     partitionKeyDefinition,
                     SupportedQueryFeatures,

--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/CosmosConflictsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/CosmosConflictsCore.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 null,
-                this.ConflictsFeedRequestExecutor);
+                this.ConflictsFeedRequestExecutorAsync);
         }
 
         public override FeedIterator GetConflictsStreamIterator(
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 null,
-                this.ConflictsFeedStreamRequestExecutor);
+                this.ConflictsFeedStreamRequestExecutorAsync);
         }
 
         public override async Task<ItemResponse<T>> ReadCurrentAsync<T>(
@@ -104,8 +104,8 @@ namespace Microsoft.Azure.Cosmos
 
             // SourceResourceId is RID based on Conflicts, so we need to obtain the db and container rid
             CosmosDatabaseCore databaseCore = (CosmosDatabaseCore)this.container.Database;
-            string databaseResourceId = await databaseCore.GetRID(cancellationToken);
-            string containerResourceId = await this.container.GetRID(cancellationToken);
+            string databaseResourceId = await databaseCore.GetRIDAsync(cancellationToken);
+            string containerResourceId = await this.container.GetRIDAsync(cancellationToken);
 
             Uri dbLink = this.clientContext.CreateLink(
                 parentLink: string.Empty,
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos
                 requestEnricher: null,
                 cancellationToken: cancellationToken);
 
-            return await this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return await this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override T ReadConflictContent<T>(CosmosConflictSettings cosmosConflict)
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Cosmos
             return default(T);
         }
 
-        private Task<CosmosResponseMessage> ConflictsFeedStreamRequestExecutor(
+        private Task<CosmosResponseMessage> ConflictsFeedStreamRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<CosmosConflictSettings>> ConflictsFeedRequestExecutor(
+        private Task<FeedResponse<CosmosConflictSettings>> ConflictsFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateContainerResponse(this, response);
+            return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response);
         }
 
         public override Task<ContainerResponse> ReplaceAsync(
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateContainerResponse(this, response);
+            return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response);
         }
 
         public override Task<ContainerResponse> DeleteAsync(
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateContainerResponse(this, response);
+            return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response);
         }
 
         public override async Task<int?> ReadProvisionedThroughputAsync(
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Cosmos
         internal Task<CosmosOfferResult> ReadProvisionedThroughputIfExistsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRID(cancellationToken)
+            return this.GetRIDAsync(cancellationToken)
                 .ContinueWith(task => task.Result == null ?
                     Task.FromResult(new CosmosOfferResult(
                         statusCode: HttpStatusCode.Found,
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Cosmos
             int targetThroughput,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRID(cancellationToken)
+            return this.GetRIDAsync(cancellationToken)
                  .ContinueWith(task => this.ClientContext.Client.Offers.ReplaceThroughputIfExistsAsync(task.Result, targetThroughput, cancellationToken), cancellationToken)
                  .Unwrap();
         }
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         // Name based look-up, needs re-computation and can't be cached
-        internal Task<string> GetRID(CancellationToken cancellationToken)
+        internal Task<string> GetRIDAsync(CancellationToken cancellationToken)
         {
             return this.GetCachedContainerSettingsAsync(cancellationToken)
                             .ContinueWith(containerSettingsTask => containerSettingsTask.Result?.ResourceId, cancellationToken);
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Cosmos
         internal Task<CollectionRoutingMap> GetRoutingMapAsync(CancellationToken cancellationToken)
         {
             string collectionRID = null;
-            return this.GetRID(cancellationToken)
+            return this.GetRIDAsync(cancellationToken)
                 .ContinueWith(ridTask =>
                 {
                     collectionRID = ridTask.Result;

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainersCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainersCore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateContainerResponse(this[containerSettings.Id], response);
+            return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this[containerSettings.Id], response);
         }
         
         public override Task<ContainerResponse> CreateContainerAsync(
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 null,
-                this.ContainerFeedRequestExecutor);
+                this.ContainerFeedRequestExecutorAsync);
         }
         
         public override CosmosContainer this[string id] =>
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 requestOptions,
-                this.ContainerStreamFeedRequestExecutor);
+                this.ContainerStreamFeedRequestExecutorAsync);
         }
 
         public override CosmosContainerFluentDefinitionForCreate DefineContainer(
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos
                cancellationToken: cancellationToken);
         }
 
-        private Task<CosmosResponseMessage> ContainerStreamFeedRequestExecutor(
+        private Task<CosmosResponseMessage> ContainerStreamFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions requestOptions,
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Cosmos
                cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<CosmosContainerSettings>> ContainerFeedRequestExecutor(
+        private Task<FeedResponse<CosmosContainerSettings>> ContainerFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Azure.Cosmos
                 this.jsonSerializer);
         }
 
-        internal Task<ItemResponse<T>> CreateItemResponse<T>(
+        internal Task<ItemResponse<T>> CreateItemResponseAsync<T>(
             Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 T item = this.ToObjectInternal<T>(cosmosResponseMessage);
                 return new ItemResponse<T>(
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<ContainerResponse> CreateContainerResponse(
+        internal Task<ContainerResponse> CreateContainerResponseAsync(
             CosmosContainer container,
             Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 CosmosContainerSettings settings = this.ToObjectInternal<CosmosContainerSettings>(cosmosResponseMessage);
                 return new ContainerResponse(
@@ -57,11 +57,11 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<DatabaseResponse> CreateDatabaseResponse(
+        internal Task<DatabaseResponse> CreateDatabaseResponseAsync(
             CosmosDatabase database,
             Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 CosmosDatabaseSettings settings = this.ToObjectInternal<CosmosDatabaseSettings>(cosmosResponseMessage);
                 return new DatabaseResponse(
@@ -72,9 +72,9 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<StoredProcedureExecuteResponse<T>> CreateStoredProcedureExecuteResponse<T>(Task<CosmosResponseMessage> cosmosResponseMessageTask)
+        internal Task<StoredProcedureExecuteResponse<T>> CreateStoredProcedureExecuteResponseAsync<T>(Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 T item = this.ToObjectInternal<T>(cosmosResponseMessage);
                 return new StoredProcedureExecuteResponse<T>(
@@ -84,9 +84,9 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<StoredProcedureResponse> CreateStoredProcedureResponse(Task<CosmosResponseMessage> cosmosResponseMessageTask)
+        internal Task<StoredProcedureResponse> CreateStoredProcedureResponseAsync(Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 CosmosStoredProcedureSettings cosmosStoredProcedure = this.ToObjectInternal<CosmosStoredProcedureSettings>(cosmosResponseMessage);
                 return new StoredProcedureResponse(
@@ -96,9 +96,9 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<TriggerResponse> CreateTriggerResponse(Task<CosmosResponseMessage> cosmosResponseMessageTask)
+        internal Task<TriggerResponse> CreateTriggerResponseAsync(Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 CosmosTriggerSettings settings = this.ToObjectInternal<CosmosTriggerSettings>(cosmosResponseMessage);
                 return new TriggerResponse(
@@ -108,9 +108,9 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<UserDefinedFunctionResponse> CreateUserDefinedFunctionResponse(Task<CosmosResponseMessage> cosmosResponseMessageTask)
+        internal Task<UserDefinedFunctionResponse> CreateUserDefinedFunctionResponseAsync(Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
-            return this.MessageHelper(cosmosResponseMessageTask, (cosmosResponseMessage) =>
+            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
                 CosmosUserDefinedFunctionSettings settings = this.ToObjectInternal<CosmosUserDefinedFunctionSettings>(cosmosResponseMessage);
                 return new UserDefinedFunctionResponse(
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<T> MessageHelper<T>(Task<CosmosResponseMessage> cosmosResponseTask, Func<CosmosResponseMessage, T> createResponse)
+        internal Task<T> ProcessMessageAsync<T>(Task<CosmosResponseMessage> cosmosResponseTask, Func<CosmosResponseMessage, T> createResponse)
         {
             return cosmosResponseTask.ContinueWith((action) =>
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabaseCore.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
                         requestOptions: requestOptions,
                         cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateDatabaseResponse(this, response);
+            return this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this, response);
         }
 
         public override Task<DatabaseResponse> DeleteAsync(
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
                         requestOptions: requestOptions,
                         cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateDatabaseResponse(this, response);
+            return this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this, response);
         }
 
         public override async Task<int?> ReadProvisionedThroughputAsync(
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos
         internal Task<CosmosOfferResult> ReadProvisionedThroughputIfExistsAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetRID(cancellationToken)
+            return this.GetRIDAsync(cancellationToken)
                 .ContinueWith(task => this.ClientContext.Client.Offers.ReadProvisionedThroughputIfExistsAsync(task.Result, cancellationToken), cancellationToken)
                 .Unwrap();
         }
@@ -123,12 +123,12 @@ namespace Microsoft.Azure.Cosmos
             int targetThroughput,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Task<string> rid = this.GetRID(cancellationToken);
+            Task<string> rid = this.GetRIDAsync(cancellationToken);
             return rid.ContinueWith(task => this.ClientContext.Client.Offers.ReplaceThroughputIfExistsAsync(task.Result, targetThroughput, cancellationToken), cancellationToken)
                 .Unwrap();
         }
 
-        internal virtual Task<string> GetRID(CancellationToken cancellationToken = default(CancellationToken))
+        internal virtual Task<string> GetRIDAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ReadAsync(cancellationToken: cancellationToken)
                 .ContinueWith(task =>

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabasesCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/CosmosDatabasesCore.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 options: null,
-                nextDelegate: this.DatabaseFeedRequestExecutor);
+                nextDelegate: this.DatabaseFeedRequestExecutorAsync);
         }
 
         public override CosmosDatabase this[string id] =>
@@ -134,10 +134,10 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreateDatabaseResponse(this[databaseSettings.Id], response);
+            return this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this[databaseSettings.Id], response);
         }
 
-        private Task<FeedResponse<CosmosDatabaseSettings>> DatabaseFeedRequestExecutor(
+        private Task<FeedResponse<CosmosDatabaseSettings>> DatabaseFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override Task<CosmosResponseMessage> ReadItemStreamAsync(
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override Task<CosmosResponseMessage> UpsertItemStreamAsync(
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override Task<CosmosResponseMessage> ReplaceItemStreamAsync(
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Cosmos
                requestOptions: requestOptions,
                cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override Task<CosmosResponseMessage> DeleteItemStreamAsync(
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Cosmos
                requestOptions: requestOptions,
                cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateItemResponse<T>(response);
+            return this.clientContext.ResponseFactory.CreateItemResponseAsync<T>(response);
         }
 
         public override FeedIterator<T> GetItemsIterator<T>(
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 null,
-                this.ItemFeedRequestExecutor<T>);
+                this.ItemFeedRequestExecutorAsync<T>);
         }
 
         public override FeedIterator GetItemsStreamIterator(
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             ItemRequestOptions requestOptions = null)
         {
-            return new FeedIteratorCore(maxItemCount, continuationToken, requestOptions, this.ItemStreamFeedRequestExecutor);
+            return new FeedIteratorCore(maxItemCount, continuationToken, requestOptions, this.ItemStreamFeedRequestExecutorAsync);
         }
 
         public override FeedIterator CreateItemQueryAsStream(
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Cosmos
                 maxItemCount,
                 continuationToken,
                 requestOptions,
-                this.QueryRequestExecutor,
+                this.QueryRequestExecutorAsync,
                 cosmosQueryExecution);
         }
 
@@ -468,7 +468,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken);
         }
 
-        private Task<CosmosResponseMessage> ItemStreamFeedRequestExecutor(
+        private Task<CosmosResponseMessage> ItemStreamFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
@@ -493,7 +493,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<T>> ItemFeedRequestExecutor<T>(
+        private Task<FeedResponse<T>> ItemFeedRequestExecutorAsync<T>(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
@@ -518,7 +518,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
-        private async Task<CosmosResponseMessage> QueryRequestExecutor(
+        private async Task<CosmosResponseMessage> QueryRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,

--- a/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClient.cs
@@ -50,16 +50,16 @@ namespace Microsoft.Azure.Cosmos
 
         internal abstract Task<Documents.ConsistencyLevel?> GetDesiredConsistencyLevelAsync();
 
-        internal abstract Task EnsureValidOverwrite(Documents.ConsistencyLevel desiredConsistencyLevel);
+        internal abstract Task EnsureValidOverwriteAsync(Documents.ConsistencyLevel desiredConsistencyLevel);
 
-        internal abstract Task<PartitionKeyRangeCache> GetPartitionKeyRangeCache();
+        internal abstract Task<PartitionKeyRangeCache> GetPartitionKeyRangeCacheAsync();
 
-        internal abstract Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkString(
+        internal abstract Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkStringAsync(
             string resourceLink,
             string collectionResourceId,
             string effectivePartitionKeyString);
 
-        internal abstract Task<List<PartitionKeyRange>> GetTargetPartitionKeyRanges(
+        internal abstract Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(
             string resourceLink,
             string collectionResourceId,
             List<Range<string>> providedRanges);

--- a/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Query/CosmosQueryClientCore.cs
@@ -123,22 +123,22 @@ namespace Microsoft.Azure.Cosmos
             return this.DocumentQueryClient.GetDesiredConsistencyLevelAsync();
         }
 
-        internal override Task EnsureValidOverwrite(Documents.ConsistencyLevel desiredConsistencyLevel)
+        internal override Task EnsureValidOverwriteAsync(Documents.ConsistencyLevel desiredConsistencyLevel)
         {
-            return this.DocumentQueryClient.EnsureValidOverwrite(desiredConsistencyLevel);
+            return this.DocumentQueryClient.EnsureValidOverwriteAsync(desiredConsistencyLevel);
         }
 
-        internal override Task<PartitionKeyRangeCache> GetPartitionKeyRangeCache()
+        internal override Task<PartitionKeyRangeCache> GetPartitionKeyRangeCacheAsync()
         {
-            return this.DocumentQueryClient.GetPartitionKeyRangeCache();
+            return this.DocumentQueryClient.GetPartitionKeyRangeCacheAsync();
         }
 
-        internal override Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkString(
+        internal override Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesByEpkStringAsync(
             string resourceLink,
             string collectionResourceId,
             string effectivePartitionKeyString)
         {
-            return this.GetTargetPartitionKeyRanges(
+            return this.GetTargetPartitionKeyRangesAsync(
                 resourceLink,
                 collectionResourceId,
                 new List<Range<string>>
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos
                 });
         }
 
-        internal override async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRanges(
+        internal override async Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(
             string resourceLink,
             string collectionResourceId,
             List<Range<string>> providedRanges)

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return this.NextResultSetDelegate(this.continuationToken, this.partitionKeyRangeId, this.MaxItemCount, this.changeFeedOptions, cancellationToken)
+            return this.NextResultSetDelegateAsync(this.continuationToken, this.partitionKeyRangeId, this.MaxItemCount, this.changeFeedOptions, cancellationToken)
                 .ContinueWith(task =>
                 {
                     CosmosResponseMessage response = task.Result;
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos
                 }, cancellationToken);
         }
 
-        private Task<CosmosResponseMessage> NextResultSetDelegate(
+        private Task<CosmosResponseMessage> NextResultSetDelegateAsync(
             string continuationToken,
             string partitionKeyRangeId,
             int? maxItemCount,

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos
             if (this.compositeContinuationToken == null)
             {
                 PartitionKeyRangeCache pkRangeCache = await this.clientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
-                this.containerRid = await this.cosmosContainer.GetRID(cancellationToken);
+                this.containerRid = await this.cosmosContainer.GetRIDAsync(cancellationToken);
                 this.compositeContinuationToken = await StandByFeedContinuationToken.CreateAsync(this.containerRid, this.continuationToken, pkRangeCache.TryGetOverlappingRangesAsync);
             }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos
             this.partitionKeyRangeId = rangeId;
             this.continuationToken = currentRangeToken.Token;
 
-            CosmosResponseMessage response = await this.NextResultSetDelegate(this.continuationToken, this.partitionKeyRangeId, this.maxItemCount, this.changeFeedOptions, cancellationToken);
+            CosmosResponseMessage response = await this.NextResultSetDelegateAsync(this.continuationToken, this.partitionKeyRangeId, this.maxItemCount, this.changeFeedOptions, cancellationToken);
             if (await this.ShouldRetryFailureAsync(response, cancellationToken))
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
                 currentRangeToken = currentRangeTokenForRetry;
                 this.partitionKeyRangeId = rangeIdForRetry;
                 this.continuationToken = currentRangeToken.Token;
-                response = await this.NextResultSetDelegate(this.continuationToken, this.partitionKeyRangeId, this.maxItemCount, this.changeFeedOptions, cancellationToken);
+                response = await this.NextResultSetDelegateAsync(this.continuationToken, this.partitionKeyRangeId, this.maxItemCount, this.changeFeedOptions, cancellationToken);
             }
 
             // Change Feed read uses Etag for continuation
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos
             return false;
         }
 
-        internal virtual Task<CosmosResponseMessage> NextResultSetDelegate(
+        internal virtual Task<CosmosResponseMessage> NextResultSetDelegateAsync(
             string continuationToken,
             string partitionKeyRangeId,
             int? maxItemCount,

--- a/Microsoft.Azure.Cosmos/src/ResourceFeedReader.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceFeedReader.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The response from a single call to ReadFeed for the specified resource.</returns>
         public Task<DocumentFeedResponse<T>> ExecuteNextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.InlineIfPossible(() => this.ExecuteNextAsyncInternal(cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossible(() => this.InternalExecuteNextAsync(cancellationToken), null, cancellationToken);
         }
 
-        private async Task<DocumentFeedResponse<T>> ExecuteNextAsyncInternal(CancellationToken cancellationToken)
+        private async Task<DocumentFeedResponse<T>> InternalExecuteNextAsync(CancellationToken cancellationToken)
         {
             return await this.documentQuery.ExecuteNextAsync<T>(cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Cosmos
                 //     3. Requests which target specific partition of an existing collection will use x-ms-documentdb-partitionkeyrangeid header
                 //        to send request to specific partition and will not set request.ServiceIdentity
                 ServiceIdentity identity = request.ServiceIdentity;
-                PartitionAddressInformation addresses = await this.addressCache.TryGetAddresses(request, null, identity, forceRefreshPartitionAddresses, cancellationToken);
+                PartitionAddressInformation addresses = await this.addressCache.TryGetAddressesAsync(request, null, identity, forceRefreshPartitionAddresses, cancellationToken);
                 if (addresses == null)
                 {
                     DefaultTrace.TraceInformation("Could not get addresses for explicitly specified ServiceIdentity {0}", identity);
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Cosmos
                 }
                 ServiceIdentity serviceIdentity = this.masterServiceIdentityProvider?.MasterServiceIdentity;
                 PartitionKeyRangeIdentity partitionKeyRangeIdentity = this.masterPartitionKeyRangeIdentity;
-                PartitionAddressInformation addresses = await this.addressCache.TryGetAddresses(
+                PartitionAddressInformation addresses = await this.addressCache.TryGetAddressesAsync(
                     request,
                     partitionKeyRangeIdentity,
                     serviceIdentity,
@@ -477,7 +477,7 @@ namespace Microsoft.Azure.Cosmos
 
             ServiceIdentity serviceIdentity = routingMap.TryGetInfoByPartitionKeyRangeId(range.Id);
 
-            PartitionAddressInformation addresses = await this.addressCache.TryGetAddresses(
+            PartitionAddressInformation addresses = await this.addressCache.TryGetAddressesAsync(
                 request,
                 new PartitionKeyRangeIdentity(collection.ResourceId, range.Id),
                 serviceIdentity,
@@ -570,7 +570,7 @@ namespace Microsoft.Azure.Cosmos
 
             ServiceIdentity identity = routingMap.TryGetInfoByPartitionKeyRangeId(request.PartitionKeyRangeIdentity.PartitionKeyRangeId);
 
-            PartitionAddressInformation addresses = await this.addressCache.TryGetAddresses(
+            PartitionAddressInformation addresses = await this.addressCache.TryGetAddressesAsync(
                 request,
                 new PartitionKeyRangeIdentity(collection.ResourceId, request.PartitionKeyRangeIdentity.PartitionKeyRangeId),
                 identity,

--- a/Microsoft.Azure.Cosmos/src/Routing/AsyncCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AsyncCache.cs
@@ -48,7 +48,9 @@ namespace Microsoft.Azure.Cosmos.Common
             AsyncLazy<TValue> lazyValue = new AsyncLazy<TValue>(() => value, CancellationToken.None);
 
             // Access it to mark as created+completed, so that further calls to getasync do not overwrite.
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             TValue x = lazyValue.Value.Result;
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 
             this.values.AddOrUpdate(key, lazyValue, (k, existingValue) =>
             {

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        public async Task<PartitionAddressInformation> TryGetAddresses(
+        public async Task<PartitionAddressInformation> TryGetAddressesAsync(
             DocumentServiceRequest request,
             PartitionKeyRangeIdentity partitionKeyRangeIdentity,
             ServiceIdentity serviceIdentity,
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                     addresses = await this.serverPartitionAddressCache.GetAsync(
                         partitionKeyRangeIdentity,
                         null,
-                        () => this.GetAddressesForRangeId(
+                        () => this.GetAddressesForRangeIdAsync(
                             request,
                             partitionKeyRangeIdentity.CollectionRid,
                             partitionKeyRangeIdentity.PartitionKeyRangeId,
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                     addresses = await this.serverPartitionAddressCache.GetAsync(
                         partitionKeyRangeIdentity,
                         null,
-                        () => this.GetAddressesForRangeId(
+                        () => this.GetAddressesForRangeIdAsync(
                             request,
                             partitionKeyRangeIdentity.CollectionRid,
                             partitionKeyRangeIdentity.PartitionKeyRangeId,
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             return masterAddressAndRange;
         }
 
-        private async Task<PartitionAddressInformation> GetAddressesForRangeId(
+        private async Task<PartitionAddressInformation> GetAddressesForRangeIdAsync(
             DocumentServiceRequest request,
             string collectionRid,
             string partitionKeyRangeId,

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                     this.locationCache.OnDatabaseAccountRead(databaseAccount);
                 }
 
-                this.StartRefreshLocationTimerAsync();
+                this.StartRefreshLocationTimer();
             }
             else
             {
@@ -229,8 +229,9 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        [SuppressMessage("", "AsyncFixer03", Justification = "Async start is by-design")]
-        private async void StartRefreshLocationTimerAsync()
+#pragma warning disable VSTHRD100 // Avoid async void methods
+        private async void StartRefreshLocationTimer()
+#pragma warning restore VSTHRD100 // Avoid async void methods
         {
             if (this.cancellationTokenSource.IsCancellationRequested)
             {
@@ -256,7 +257,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                 DefaultTrace.TraceCritical("StartRefreshLocationTimerAsync() - Unable to refresh database account from any location. Exception: {0}", ex.ToString());
 
-                this.StartRefreshLocationTimerAsync();
+                this.StartRefreshLocationTimer();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/IAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IAddressCache.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Common
         /// <param name="forceRefreshPartitionAddresses">Whether addresses need to be refreshed as previously resolved addresses were determined to be outdated.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Physical addresses.</returns>
-        Task<PartitionAddressInformation> TryGetAddresses(
+        Task<PartitionAddressInformation> TryGetAddressesAsync(
             DocumentServiceRequest request,
             PartitionKeyRangeIdentity partitionKeyRangeIdentity,
             ServiceIdentity serviceIdentity,

--- a/Microsoft.Azure.Cosmos/src/Routing/IRoutingMapProviderExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IRoutingMapProviderExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
             return true;
         }
 
-        public static async Task<PartitionKeyRange> TryGetRangeByEffectivePartitionKey(
+        public static async Task<PartitionKeyRange> TryGetRangeByEffectivePartitionKeyAsync(
             this IRoutingMapProvider routingMapProvider,
             string collectionResourceId,
             string effectivePartitionKey)

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        public async Task<PartitionKeyRange> TryGetRangeByPartitionKeyRangeId(string collectionRid, string partitionKeyRangeId)
+        public async Task<PartitionKeyRange> TryGetRangeByPartitionKeyRangeIdAsync(string collectionRid, string partitionKeyRangeId)
         {
             try
             {
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                 RetryOptions retryOptions = new RetryOptions();
                 using (DocumentServiceResponse response = await BackoffRetryUtility<DocumentServiceResponse>.ExecuteAsync(
-                    () => ExecutePartitionKeyRangeReadChangeFeed(collectionRid, headers),
+                    () => ExecutePartitionKeyRangeReadChangeFeedAsync(collectionRid, headers),
                     new ResourceThrottleRetryPolicy(retryOptions.MaxRetryAttemptsOnThrottledRequests, retryOptions.MaxRetryWaitTimeInSeconds),
                     cancellationToken))
                 {
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             return routingMap;
         }
 
-        private async Task<DocumentServiceResponse> ExecutePartitionKeyRangeReadChangeFeed(string collectionRid, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> ExecutePartitionKeyRangeReadChangeFeedAsync(string collectionRid, INameValueCollection headers)
         {
             using (DocumentServiceRequest request = DocumentServiceRequest.Create(
                 OperationType.ReadFeed,

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         /// that collection was resolved to outdated Rid by name. Also null can be returned if <paramref name="rangeFromContinuationToken"/>
         /// is not found - this means it was split.
         /// </returns>
-        public virtual async Task<ResolvedRangeInfo> TryGetTargetRangeFromContinuationTokenRange(
+        public virtual async Task<ResolvedRangeInfo> TryGetTargetRangeFromContinuationTokenRangeAsync(
             IReadOnlyList<Range<string>> providedPartitionKeyRanges,
             IRoutingMapProvider routingMapProvider,
             string collectionRid,
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             if (providedPartitionKeyRanges.Count == 0)
             {
                 return new ResolvedRangeInfo(
-                    await routingMapProvider.TryGetRangeByEffectivePartitionKey(
+                    await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(
                         collectionRid,
                         PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey),
                     suppliedTokens);
@@ -191,11 +191,11 @@ namespace Microsoft.Azure.Cosmos.Routing
                 Range<string>.MinComparer.Instance);
 
                 return new ResolvedRangeInfo(
-                    await routingMapProvider.TryGetRangeByEffectivePartitionKey(collectionRid, minimumRange.Min),
+                    await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(collectionRid, minimumRange.Min),
                     suppliedTokens);
             }
 
-            PartitionKeyRange targetPartitionKeyRange = await routingMapProvider.TryGetRangeByEffectivePartitionKey(collectionRid, rangeFromContinuationToken.Min);
+            PartitionKeyRange targetPartitionKeyRange = await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(collectionRid, rangeFromContinuationToken.Min);
 
             if (targetPartitionKeyRange == null)
             {
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             return new ResolvedRangeInfo(targetPartitionKeyRange, suppliedTokens);
         }
 
-        public static async Task<List<PartitionKeyRange>> GetReplacementRanges(PartitionKeyRange targetRange, IRoutingMapProvider routingMapProvider, string collectionRid)
+        public static async Task<List<PartitionKeyRange>> GetReplacementRangesAsync(PartitionKeyRange targetRange, IRoutingMapProvider routingMapProvider, string collectionRid)
         {
             return (await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, targetRange.ToRange(), true)).ToList();
         }
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                             return true;
                         }
 
-                        PartitionKeyRange nextRange = await routingMapProvider.TryGetRangeByEffectivePartitionKey(collectionRid, max);
+                        PartitionKeyRange nextRange = await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(collectionRid, max);
                         if (nextRange == null)
                         {
                             return false;

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 maxItemCount,
                 continuationToken,
                 null,
-                this.StoredProcedureFeedRequestExecutor);
+                this.StoredProcedureFeedRequestExecutorAsync);
         }
 
         public override Task<StoredProcedureResponse> ReadStoredProcedureAsync(
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateStoredProcedureExecuteResponse<TOutput>(response);
+            return this.clientContext.ResponseFactory.CreateStoredProcedureExecuteResponseAsync<TOutput>(response);
         }
 
         public override Task<TriggerResponse> CreateTriggerAsync(
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 maxItemCount,
                 continuationToken,
                 null,
-                this.ContainerFeedRequestExecutor);
+                this.ContainerFeedRequestExecutorAsync);
         }
 
         public override Task<TriggerResponse> ReadTriggerAsync(
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 maxItemCount,
                 continuationToken,
                 null,
-                this.UserDefinedFunctionFeedRequestExecutor);
+                this.UserDefinedFunctionFeedRequestExecutorAsync);
         }
 
         public override Task<UserDefinedFunctionResponse> ReadUserDefinedFunctionAsync(
@@ -344,14 +344,14 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<CosmosTriggerSettings>> ContainerFeedRequestExecutor(
+        private Task<FeedResponse<CosmosTriggerSettings>> ContainerFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
             object state,
             CancellationToken cancellationToken)
         {
-            return this.GetIterator<CosmosTriggerSettings>(
+            return this.GetIteratorAsync<CosmosTriggerSettings>(
                 maxItemCount: maxItemCount,
                 continuationToken: continuationToken,
                 state: state,
@@ -360,14 +360,14 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<CosmosStoredProcedureSettings>> StoredProcedureFeedRequestExecutor(
+        private Task<FeedResponse<CosmosStoredProcedureSettings>> StoredProcedureFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
             object state,
             CancellationToken cancellationToken)
         {
-            return this.GetIterator<CosmosStoredProcedureSettings>(
+            return this.GetIteratorAsync<CosmosStoredProcedureSettings>(
                 maxItemCount: maxItemCount,
                 continuationToken: continuationToken,
                 state: state,
@@ -376,14 +376,14 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        private Task<FeedResponse<CosmosUserDefinedFunctionSettings>> UserDefinedFunctionFeedRequestExecutor(
+        private Task<FeedResponse<CosmosUserDefinedFunctionSettings>> UserDefinedFunctionFeedRequestExecutorAsync(
             int? maxItemCount,
             string continuationToken,
             RequestOptions options,
             object state,
             CancellationToken cancellationToken)
         {
-            return this.GetIterator<CosmosUserDefinedFunctionSettings>(
+            return this.GetIteratorAsync<CosmosUserDefinedFunctionSettings>(
                 maxItemCount: maxItemCount,
                 continuationToken: continuationToken,
                 state: state,
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 streamPayload: streamPayload,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateStoredProcedureResponse(response);
+            return this.clientContext.ResponseFactory.CreateStoredProcedureResponseAsync(response);
         }
 
         private Task<TriggerResponse> ProcessTriggerOperationAsync(
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 streamPayload: streamPayload,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateTriggerResponse(response);
+            return this.clientContext.ResponseFactory.CreateTriggerResponseAsync(response);
         }
 
         private Task<CosmosResponseMessage> ProcessStreamOperationAsync(
@@ -527,10 +527,10 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 streamPayload: streamPayload,
                 cancellationToken: cancellationToken);
 
-            return this.clientContext.ResponseFactory.CreateUserDefinedFunctionResponse(response);
+            return this.clientContext.ResponseFactory.CreateUserDefinedFunctionResponseAsync(response);
         }
 
-        private Task<FeedResponse<T>> GetIterator<T>(
+        private Task<FeedResponse<T>> GetIteratorAsync<T>(
             int? maxItemCount,
             string continuationToken,
             ResourceType resourceType,

--- a/Microsoft.Azure.Cosmos/src/TaskHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/TaskHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal static class TaskHelper
     {
-        static public Task InlineIfPossible(Func<Task> function, IRetryPolicy retryPolicy, CancellationToken cancellationToken = default(CancellationToken))
+        static public Task InlineIfPossibleAsync(Func<Task> function, IRetryPolicy retryPolicy, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (SynchronizationContext.Current == null)
             {
@@ -50,7 +50,9 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
+#pragma warning disable VSTHRD200 // Use "Async" suffix for async methods
         static public Task<TResult> InlineIfPossible<TResult>(Func<Task<TResult>> function, IRetryPolicy retryPolicy, CancellationToken cancellationToken = default(CancellationToken))
+#pragma warning restore VSTHRD200 // Use "Async" suffix for async methods
         {
             if (SynchronizationContext.Current == null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }).Result;
             }
 
-            internal override Task<CosmosResponseMessage> NextResultSetDelegate(
+            internal override Task<CosmosResponseMessage> NextResultSetDelegateAsync(
                 string continuationToken,
                 string partitionKeyRangeId,
                 int? maxItemCount,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             count = 0;
             for (int i = 0; i < loopCount; i++)
             {
-                await testContainer.GetRID(default(CancellationToken));
+                await testContainer.GetRIDAsync(default(CancellationToken));
             }
 
             // Already cached by GetNonePartitionKeyValueAsync before
@@ -629,7 +629,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 };
 
                 // There should only be one range since the EPK option is set.
-                List<PartitionKeyRange> partitionKeyRanges = await CosmosQueryExecutionContextFactory.GetTargetPartitionKeyRanges(
+                List<PartitionKeyRange> partitionKeyRanges = await CosmosQueryExecutionContextFactory.GetTargetPartitionKeyRangesAsync(
                     queryClient: new CosmosQueryClientCore(container.ClientContext, container),
                     resourceLink: container.LinkUri.OriginalString,
                     partitionedQueryExecutionInfo: null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.NetFramework.Tests/Routing/PartitionRoutingHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.NetFramework.Tests/Routing/PartitionRoutingHelperTest.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         }
 
         /// <summary>
-        /// Tests for <see cref="PartitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange"/> method.
+        /// Tests for <see cref="PartitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync"/> method.
         /// </summary>
         [TestMethod]
         public async Task TestGetPartitionRoutingInfo()
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                         for (Range<string> currentRange = startRange; currentRange != null;)
                         {
                             RoutingMapProvider routingMapProvider = new RoutingMapProvider(routingMap);
-                            PartitionRoutingHelper.ResolvedRangeInfo resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(testCase.ProvidedRanges, routingMapProvider, string.Empty, currentRange, null);
+                            PartitionRoutingHelper.ResolvedRangeInfo resolvedRangeInfo = await this.partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(testCase.ProvidedRanges, routingMapProvider, string.Empty, currentRange, null);
                             actualPartitionKeyRangeIds.Add(resolvedRangeInfo.ResolvedRange.Id);
                             INameValueCollection headers = new StringKeyValueCollection();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemProducerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemProducerUnitTests.cs
@@ -71,14 +71,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                 initialPageSize: 50);
 
             // Buffer to success responses
-            await itemProducerTree.BufferMoreDocuments(cancellationTokenSource.Token);
-            await itemProducerTree.BufferMoreDocuments(cancellationTokenSource.Token);
+            await itemProducerTree.BufferMoreDocumentsAsync(cancellationTokenSource.Token);
+            await itemProducerTree.BufferMoreDocumentsAsync(cancellationTokenSource.Token);
 
             // Buffer a failure
             mockQueryContext.Setup(x => x.ExecuteQueryAsync(sqlQuerySpec, cancellationTokenSource.Token, It.IsAny<Action<CosmosRequestMessage>>())).Returns(
                 Task.FromResult(QueryResponse.CreateFailure(headers, HttpStatusCode.InternalServerError, null, "Error message", null)));
 
-            await itemProducerTree.BufferMoreDocuments(cancellationTokenSource.Token);
+            await itemProducerTree.BufferMoreDocumentsAsync(cancellationTokenSource.Token);
 
             // First item should be a success
             var result = await itemProducerTree.MoveNextAsync(cancellationTokenSource.Token);
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockQueryContext.Setup(x => x.ExecuteQueryAsync(sqlQuerySpec, cancellationTokenSource.Token, It.IsAny<Action<CosmosRequestMessage>>())).
                 Throws(new Exception("Previous buffer failed. Operation should return original failure and not try again"));
 
-            await itemProducerTree.BufferMoreDocuments(cancellationTokenSource.Token);
+            await itemProducerTree.BufferMoreDocumentsAsync(cancellationTokenSource.Token);
             Assert.IsFalse(result.successfullyMovedNext);
             Assert.IsNotNull(result.failureResponse);
             Assert.IsFalse(itemProducerTree.HasMoreResults);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockCosmosUtil.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             Uri link = new Uri($"/dbs/{dbName}", UriKind.Relative);
             Mock<CosmosDatabaseCore> mockDB = new Mock<CosmosDatabaseCore>();
             mockDB.Setup(x => x.LinkUri).Returns(link);
-            mockDB.Setup(x => x.GetRID(It.IsAny<CancellationToken>())).Returns(Task.FromResult(dbName));
+            mockDB.Setup(x => x.GetRIDAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(dbName));
             return mockDB;
         }
 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             partitionRoutingHelperMock.Setup(
                 m => m.ExtractPartitionKeyRangeFromContinuationToken(It.IsAny<INameValueCollection>(), out It.Ref<List<CompositeContinuationToken>>.IsAny
             )).Returns(new Range<string>("A", "B", true, false));
-            partitionRoutingHelperMock.Setup(m => m.TryGetTargetRangeFromContinuationTokenRange(
+            partitionRoutingHelperMock.Setup(m => m.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 It.IsAny<IReadOnlyList<Range<string>>>(),
                 It.IsAny<IRoutingMapProvider>(),
                 It.IsAny<string>(),

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
 
             //Reverse
             PartitionRoutingHelper partitionRoutingHelper = new PartitionRoutingHelper();
-            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 providedRanges, 
                 routingMapProvider.Object, 
                 CollectionId, 
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
                 It.Is<Range<string>>(x => x.Min == range.Min),
                 It.IsAny<bool>()
             )).Returns(Task.FromResult((IReadOnlyList<PartitionKeyRange>)overlappingRanges.Take(1).ToList())).Verifiable();
-            resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 providedRanges,
                 routingMapProvider.Object,
                 CollectionId,
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
 
             //Reverse
             PartitionRoutingHelper partitionRoutingHelper = new PartitionRoutingHelper();
-            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 providedRanges,
                 routingMapProvider.Object,
                 CollectionId,
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
 
             //Reverse
             PartitionRoutingHelper partitionRoutingHelper = new PartitionRoutingHelper();
-            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            ResolvedRangeInfo resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 providedRanges,
                 routingMapProvider.Object,
                 CollectionId,
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
 
             //Forward
             partitionRoutingHelper = new PartitionRoutingHelper();
-            resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRange(
+            resolvedRangeInfo = await partitionRoutingHelper.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 providedRanges,
                 routingMapProvider.Object,
                 CollectionId,
@@ -612,7 +612,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             partitionRoutingHelperMock.Setup(
                 m => m.ExtractPartitionKeyRangeFromContinuationToken(It.IsAny<INameValueCollection>(), out It.Ref<List<CompositeContinuationToken>>.IsAny
             )).Returns(new Range<string>("A", "B", true, false));
-            partitionRoutingHelperMock.Setup(m => m.TryGetTargetRangeFromContinuationTokenRange(
+            partitionRoutingHelperMock.Setup(m => m.TryGetTargetRangeFromContinuationTokenRangeAsync(
                 It.IsAny<IReadOnlyList<Range<string>>>(),
                 It.IsAny<IRoutingMapProvider>(),
                 It.IsAny<string>(),


### PR DESCRIPTION
# Static code analysis for async

## Description

This PR adds static code analysis for C# Async scenarios. The idea is to catch common pitfall scenarios in future PRs and enforce naming rules.

There are 3 rules that are suppressed:

* VSTHRD105:Avoid method overloads that assume TaskScheduler.Current
* VSTHRD003:Avoid awaiting foreign Tasks
* VSTHRD103:Call async methods when in an async method
    * This particular rule is targeting scenarios where we use ContinueWith, which is tied to #288

Inline suppressing of other rules has been done when it made sense and to avoid major code refactor (mainly on old files like DocumentClient or DocumentQueryClient).

## Type of change

Please delete options that are not relevant.

- [ X] New feature (non-breaking change which adds functionality)

## Closing issues

This PR fixes #274 
