### PR TITLE
Replacing CosmosResultSetIterator & CosmosQueryResponse

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/ContainerManagement/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/ContainerManagement/Program.cs
@@ -179,7 +179,7 @@
         {
             Console.WriteLine("\n5. Reading all CosmosContainer resources for a database");
 
-            CosmosResultSetIterator<CosmosContainerSettings> resultSetIterator = database.Containers.GetContainerIterator();
+            CosmosFeedIterator<CosmosContainerSettings> resultSetIterator = database.Containers.GetContainerIterator();
             while (resultSetIterator.HasMoreResults)
             {
                 foreach (CosmosContainerSettings container in await resultSetIterator.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/DatabaseManagement/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/DatabaseManagement/Program.cs
@@ -90,7 +90,7 @@
             }
 
             Console.WriteLine("\n5. Reading all databases resources for an account");
-            CosmosResultSetIterator<CosmosDatabaseSettings> iterator = client.Databases.GetDatabaseIterator();
+            CosmosFeedIterator<CosmosDatabaseSettings> iterator = client.Databases.GetDatabaseIterator();
             do
             {
                 foreach (CosmosDatabaseSettings db in await iterator.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/Handlers/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/Handlers/Program.cs
@@ -80,11 +80,11 @@
             await container.Items.ReplaceItemAsync<Item>(item.Id, item.Id, item);
 
             // Querying
-            CosmosResultSetIterator<Item> query = container.Items.CreateItemQuery<Item>(new CosmosSqlQueryDefinition("SELECT * FROM c"), maxConcurrency: 1);
+            CosmosFeedIterator<Item> query = container.Items.CreateItemQuery<Item>(new CosmosSqlQueryDefinition("SELECT * FROM c"), maxConcurrency: 1);
             List<Item> results = new List<Item>();
             while (query.HasMoreResults)
             {
-                CosmosQueryResponse<Item> response = await query.FetchNextSetAsync();
+                CosmosFeedResponse<Item> response = await query.FetchNextSetAsync();
 
                 results.AddRange(response.ToList());
             }

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/ItemManagement/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/ItemManagement/Program.cs
@@ -235,7 +235,7 @@
                 "select * from sales s where s.AccountNumber = @AccountInput ")
                 .UseParameter("@AccountInput", "Account1");
 
-            CosmosResultSetIterator<SalesOrder> resultSet = container.Items.CreateItemQuery<SalesOrder>(
+            CosmosFeedIterator<SalesOrder> resultSet = container.Items.CreateItemQuery<SalesOrder>(
                 query,
                 partitionKey: "Account1",
                 maxItemCount: 1);
@@ -251,7 +251,7 @@
             Console.WriteLine($"\n1.4.2 Query found {allSalesForAccount1.Count} items.");
 
             // Use the same query as before but get the cosmos response message to access the stream directly
-            CosmosResultSetIterator streamResultSet = container.Items.CreateItemQueryAsStream(
+            CosmosFeedIterator streamResultSet = container.Items.CreateItemQueryAsStream(
                 query,
                 maxConcurrency: 1,
                 partitionKey: "Account1",
@@ -260,10 +260,10 @@
             List<SalesOrder> allSalesForAccount1FromStream = new List<SalesOrder>();
             while (streamResultSet.HasMoreResults)
             {
-                using (CosmosQueryResponse responseMessage = await streamResultSet.FetchNextSetAsync())
+                using (CosmosResponseMessage responseMessage = await streamResultSet.FetchNextSetAsync())
                 {
                     // Item stream operations do not throw exceptions for better performance
-                    if (responseMessage.IsSuccess)
+                    if (responseMessage.IsSuccessStatusCode)
                     {
                         dynamic streamResponse = FromStream<dynamic>(responseMessage.Content);
                         List<SalesOrder> salesOrders = streamResponse.ToObject<List<SalesOrder>>();

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/NonPartitionContainerMigration/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/NonPartitionContainerMigration/Program.cs
@@ -227,11 +227,11 @@
             // The operation is made in batches to not lose work in case of partial execution
             int resultsFetched = 0;
             CosmosSqlQueryDefinition sql = new CosmosSqlQueryDefinition("select * from r");           
-            CosmosResultSetIterator<DeviceInformationItem> setIterator = container.Items
+            CosmosFeedIterator<DeviceInformationItem> setIterator = container.Items
                 .CreateItemQuery<DeviceInformationItem>(sql, partitionKey: CosmosContainerSettings.NonePartitionKeyValue, maxItemCount: 2);
             while (setIterator.HasMoreResults)
             {
-                CosmosQueryResponse<DeviceInformationItem> queryResponse = await setIterator.FetchNextSetAsync();
+                CosmosFeedResponse<DeviceInformationItem> queryResponse = await setIterator.FetchNextSetAsync();
                 resultsFetched += queryResponse.Count();
 
                 // For the items returned with NonePartitionKeyValue

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/Queries/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/Queries/Program.cs
@@ -96,7 +96,7 @@
             List<Family> families = new List<Family>();
 
             // SQL
-            CosmosResultSetIterator<Family> setIterator = container.Items.GetItemIterator<Family>(maxItemCount: 1);
+            CosmosFeedIterator<Family> setIterator = container.Items.GetItemIterator<Family>(maxItemCount: 1);
             while (setIterator.HasMoreResults)
             {
                 int count = 0;
@@ -115,7 +115,7 @@
             int totalCount = 0;
 
             // SQL
-            CosmosFeedResultSetIterator setIterator = container.Items.GetItemStreamIterator();
+            CosmosFeedIterator setIterator = container.Items.GetItemStreamIterator();
             while (setIterator.HasMoreResults)
             {
                 int count = 0;
@@ -140,7 +140,7 @@
         private static async Task QueryItemsInPartitionAsStreams(CosmosContainer container)
         {
             // SQL
-            CosmosResultSetIterator setIterator = container.Items.CreateItemQueryAsStream(
+            CosmosFeedIterator setIterator = container.Items.CreateItemQueryAsStream(
                 "SELECT F.id, F.LastName, F.IsRegistered FROM Families F",
                 partitionKey: "Anderson",
                 maxConcurrency: 1,
@@ -149,9 +149,9 @@
             int count = 0;
             while (setIterator.HasMoreResults)
             {
-                using (CosmosQueryResponse response = await setIterator.FetchNextSetAsync())
+                using (CosmosResponseMessage response = await setIterator.FetchNextSetAsync())
                 {
-                    Assert("Response failed", response.IsSuccess);
+                    Assert("Response failed", response.IsSuccessStatusCode);
                     count++;
                     using (StreamReader sr = new StreamReader(response.Content))
                     using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -178,7 +178,7 @@
                 .UseParameter("@city", "Seattle");
 
             List<Family> results = new List<Family>();
-            CosmosResultSetIterator<Family> resultSetIterator = container.Items.CreateItemQuery<Family>(query, partitionKey: "Anderson");
+            CosmosFeedIterator<Family> resultSetIterator = container.Items.CreateItemQuery<Family>(query, partitionKey: "Anderson");
             while (resultSetIterator.HasMoreResults)
             {
                 results.AddRange((await resultSetIterator.FetchNextSetAsync()));
@@ -195,7 +195,7 @@
             // 0 maximum parallel tasks, effectively serial execution
             CosmosQueryRequestOptions options = new CosmosQueryRequestOptions() { MaxBufferedItemCount = 100 };
 
-            CosmosResultSetIterator<Family> query = container.Items.CreateItemQuery<Family>(
+            CosmosFeedIterator<Family> query = container.Items.CreateItemQuery<Family>(
                 queryText,
                 maxConcurrency: 0,
                 requestOptions: options);

--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/ServerSideScripts/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/ServerSideScripts/Program.cs
@@ -182,10 +182,10 @@
             // 8. Validate
             int numDocs = 0;
 
-            CosmosResultSetIterator<dynamic> setIterator = container.Items.GetItemIterator<dynamic>();
+            CosmosFeedIterator<dynamic> setIterator = container.Items.GetItemIterator<dynamic>();
             while (setIterator.HasMoreResults)
             {
-                CosmosQueryResponse<dynamic> response = await setIterator.FetchNextSetAsync();
+                CosmosFeedResponse<dynamic> response = await setIterator.FetchNextSetAsync();
                 numDocs += response.Count();
             }
 


### PR DESCRIPTION
Replacing CosmosResultSetIterator & CosmosQueryResponse
# Pull Request Template

## Description

In Cosmos.Samples
Replacing CosmosResultSetIterator with CosmosFeedIterator
Replacing CosmosQueryResponse with CosmosFeedResponse/CosmosResponseMessage

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Assignee

@KalyanChanumolu-MSFT 

