### PR TITLE
Estimator to provide detailed information 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
@@ -18,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     {
         private const string EstimatorDefaultHostName = "Estimator";
 
-        private readonly Func<long, CancellationToken, Task> initialEstimateDelegate;
+        private readonly Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> initialEstimateDelegate;
         private CancellationTokenSource shutdownCts;
         private CosmosContainerCore leaseContainer;
         private string monitoredContainerRid;
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         private Task runAsync;
 
         public ChangeFeedEstimatorCore(
-            Func<long, CancellationToken, Task> initialEstimateDelegate, 
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> initialEstimateDelegate, 
             TimeSpan? estimatorPeriod)
         {
             if (initialEstimateDelegate == null) throw new ArgumentNullException(nameof(initialEstimateDelegate));
@@ -44,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         }
 
         internal ChangeFeedEstimatorCore(
-            Func<long, CancellationToken, Task> initialEstimateDelegate,
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> initialEstimateDelegate,
             TimeSpan? estimatorPeriod,
             RemainingWorkEstimator remainingWorkEstimator)
             : this(initialEstimateDelegate, estimatorPeriod)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/RemainingLeaseTokenWork.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/RemainingLeaseTokenWork.cs
@@ -2,21 +2,21 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
+namespace Microsoft.Azure.Cosmos
 {
     using System;
 
     /// <summary>
     /// Remaing estimated work on the lease token
     /// </summary>
-    internal class RemainingLeaseTokenWork
+    public class RemainingLeaseTokenWork
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RemainingLeaseTokenWork"/> class.
         /// </summary>
         /// <param name="leaseToken">The lease token for which the remaining work is calculated</param>
         /// <param name="remainingWork">The amount of documents remaining to be processed</param>
-        public RemainingLeaseTokenWork(string leaseToken, long remainingWork)
+        internal RemainingLeaseTokenWork(string leaseToken, long remainingWork)
         {
             if (string.IsNullOrEmpty(leaseToken)) throw new ArgumentNullException(nameof(leaseToken));
 
@@ -27,11 +27,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
         /// <summary>
         /// Gets the lease token for which the remaining work is calculated
         /// </summary>
-        public string LeaseToken { get; }
+        public virtual string LeaseToken { get; }
 
         /// <summary>
-        /// Gets the ammount of documents remaining to be processed.
+        /// Gets the amount of documents remaining to be processed on this particular lease.
         /// </summary>
-        public long RemainingWork { get; }
+        public virtual long RemainingWork { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/RemainingWorkEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/RemainingWorkEstimatorCore.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
 
     internal sealed class RemainingWorkEstimatorCore : RemainingWorkEstimator
     {
+        private const string NoLeases = "NoLeases";
         private const char PKRangeIdSeparator = ':';
         private const char SegmentSeparator = '#';
         private const string LSNPropertyName = "_lsn";
@@ -66,7 +67,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             IReadOnlyList<DocumentServiceLease> leases = await this.leaseContainer.GetAllLeasesAsync().ConfigureAwait(false);
             if (leases == null || leases.Count == 0)
             {
-                return new List<RemainingLeaseTokenWork>().AsReadOnly();
+                // Maintain compatibility with GetEstimatedRemainingWorkAsync : No leases, should return 1. 
+                return new List<RemainingLeaseTokenWork>() { new RemainingLeaseTokenWork(RemainingWorkEstimatorCore.NoLeases, 1) }.AsReadOnly();
             }
 
             IEnumerable<Task<List<RemainingLeaseTokenWork>>> tasks = Partitioner.Create(leases)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
@@ -5,15 +5,18 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
 
     internal sealed class ChangeFeedEstimatorDispatcher
     {
-        private readonly Func<long, CancellationToken, Task> dispatchEstimation;
+        private readonly Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> dispatchEstimation;
 
-        public ChangeFeedEstimatorDispatcher(Func<long, CancellationToken, Task> dispatchEstimation, TimeSpan? estimationPeriod = null)
+        public ChangeFeedEstimatorDispatcher(
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> dispatchEstimation, 
+            TimeSpan? estimationPeriod = null)
         {
             this.dispatchEstimation = dispatchEstimation;
             this.DispatchPeriod = estimationPeriod;
@@ -21,7 +24,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
         public TimeSpan? DispatchPeriod { get; private set; }
 
-        public async Task DispatchEstimationAsync(long estimation, CancellationToken cancellationToken)
+        public async Task DispatchEstimationAsync(
+            IReadOnlyList<RemainingLeaseTokenWork> estimation, 
+            CancellationToken cancellationToken)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorCore.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
@@ -32,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
                 try
                 {
-                    long estimation = await this.remainingWorkEstimator.GetEstimatedRemainingWorkAsync(cancellationToken).ConfigureAwait(false);
+                    IReadOnlyList<RemainingLeaseTokenWork> estimation = await this.remainingWorkEstimator.GetEstimatedRemainingWorkPerLeaseTokenAsync(cancellationToken).ConfigureAwait(false);
                     await this.dispatcher.DispatchEstimationAsync(estimation, cancellationToken);
                 }
                 catch (TaskCanceledException canceledException)

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -819,7 +819,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>An instace of <see cref="ChangeFeedProcessorBuilder"/></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string workflowName, 
-            Func<long, CancellationToken, Task> estimationDelegate, 
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate, 
             TimeSpan? estimationPeriod = null);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string workflowName,
-            Func<long, CancellationToken, Task> estimationDelegate,
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate,
             TimeSpan? estimationPeriod = null)
         {
             if (workflowName == null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         {
             long? receivedEstimation = 0;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
                 {
-                    receivedEstimation = estimation;
+                    receivedEstimation = estimation.Sum(e=> e.RemainingWork);
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
                 .WithCosmosLeaseContainer(this.LeaseContainer).Build();
@@ -67,9 +67,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
                 {
-                    receivedEstimation = estimation;
+                    receivedEstimation = estimation.Sum(e => e.RemainingWork);
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
                 .WithCosmosLeaseContainer(this.LeaseContainer).Build();
@@ -111,9 +111,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .CreateChangeFeedEstimatorBuilder("test", (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
                 {
-                    receivedEstimation = estimation;
+                    receivedEstimation = estimation.Sum(e => e.RemainingWork);
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
                 .WithCosmosLeaseContainer(this.LeaseContainer).Build();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -5,6 +5,8 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
@@ -28,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ApplyBuildConfiguration_ValidCustomStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate = (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -47,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ApplyBuildConfiguration_ValidContainerStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate = (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -67,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ApplyBuildConfiguration_ValidatesNullStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate = (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -87,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ApplyBuildConfiguration_ValidatesNullMonitoredContainer()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate = (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -109,9 +111,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             const long remainingWork = 15;
             long estimationDelegateValue = 0;
             bool receivedEstimation = false;
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate = (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
             {
-                estimationDelegateValue = estimation;
+                estimationDelegateValue = estimation.Sum(e => e.RemainingWork);
                 receivedEstimation = true;
                 return Task.CompletedTask;
             };
@@ -145,7 +147,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(remainingWork, estimationDelegateValue);
         }
 
-        private static ChangeFeedEstimatorCore CreateEstimator(Func<long, CancellationToken, Task> estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator)
+        private static ChangeFeedEstimatorCore CreateEstimator(Func<IReadOnlyList<RemainingLeaseTokenWork>, CancellationToken, Task> estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator)
         {
             remainingWorkEstimator = new Mock<RemainingWorkEstimator>();
             return new ChangeFeedEstimatorCore(estimationDelegate, TimeSpan.FromSeconds(5), remainingWorkEstimator.Object);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -134,7 +134,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 new ChangeFeedProcessorOptions(),
                 ChangeFeedEstimatorCoreTests.GetMockedContainer("monitored"));
 
-            remainingWorkEstimator.Setup(r => r.GetEstimatedRemainingWorkAsync(It.IsAny<CancellationToken>())).ReturnsAsync(remainingWork);
+            IReadOnlyList<RemainingLeaseTokenWork> estimationList = new List<RemainingLeaseTokenWork>()
+            {
+                new RemainingLeaseTokenWork(Guid.NewGuid().ToString(), remainingWork / 3),
+                new RemainingLeaseTokenWork(Guid.NewGuid().ToString(), remainingWork / 3),
+                new RemainingLeaseTokenWork(Guid.NewGuid().ToString(), remainingWork / 3)
+            };
+
+            remainingWorkEstimator.Setup(r => r.GetEstimatedRemainingWorkPerLeaseTokenAsync(It.IsAny<CancellationToken>())).ReturnsAsync(estimationList);
 
             await estimator.StartAsync();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedEstimatorCoreTests.cs
@@ -5,6 +5,8 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
@@ -22,9 +24,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             const long estimation = 10;
             bool detectedEstimationCorrectly = false;
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(5000);
-            ChangeFeedEstimatorDispatcher estimatorDispatcher = new ChangeFeedEstimatorDispatcher((long detectedEstimation, CancellationToken token) =>
+            ChangeFeedEstimatorDispatcher estimatorDispatcher = new ChangeFeedEstimatorDispatcher((IReadOnlyList<RemainingLeaseTokenWork> detectedEstimation, CancellationToken token) =>
             {
-                detectedEstimationCorrectly = estimation == detectedEstimation;
+                detectedEstimationCorrectly = estimation == detectedEstimation.Sum(e => e.RemainingWork);
 
                 return Task.CompletedTask;
             },  TimeSpan.FromSeconds(1));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedEstimatorCoreTests.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task FeedEstimatorCore_ReceivesEstimation()
         {
             const long estimation = 10;
+            IReadOnlyList<RemainingLeaseTokenWork> estimationList = new List<RemainingLeaseTokenWork>()
+            {
+                new RemainingLeaseTokenWork(Guid.NewGuid().ToString(), estimation / 2),
+                new RemainingLeaseTokenWork(Guid.NewGuid().ToString(), estimation / 2)
+            };
             bool detectedEstimationCorrectly = false;
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(5000);
             ChangeFeedEstimatorDispatcher estimatorDispatcher = new ChangeFeedEstimatorDispatcher((IReadOnlyList<RemainingLeaseTokenWork> detectedEstimation, CancellationToken token) =>
@@ -32,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             },  TimeSpan.FromSeconds(1));
 
             Mock<RemainingWorkEstimator> mockedEstimator = new Mock<RemainingWorkEstimator>();
-            mockedEstimator.Setup(e => e.GetEstimatedRemainingWorkAsync(It.IsAny<CancellationToken>())).ReturnsAsync(estimation);
+            mockedEstimator.Setup(e => e.GetEstimatedRemainingWorkPerLeaseTokenAsync(It.IsAny<CancellationToken>())).ReturnsAsync(estimationList);
 
             FeedEstimatorCore estimatorCore = new FeedEstimatorCore(estimatorDispatcher, mockedEstimator.Object);
 


### PR DESCRIPTION
# Estimator to provide detailed information 

## Description

Currently, the Change Feed Estimator returns a number representing the sum of pending work across all leases. This hides potential information to troubleshoot if a particular host might be stuck or having difficulties to process items (issues in the machine, resources, etc.).

Currently, in order to use the Estimator, a user can create it like so:

    ChangeFeedProcessor estimator = this.Container
        .CreateChangeFeedEstimatorBuilder("myWorkFlow", (long estimation, CancellationToken token) =>
        {
            Console.WriteLine($"Pending work to be done across all leases: {estimation}");
            return Task.CompletedTask;
        }, TimeSpan.FromSeconds(1))
        .WithCosmosLeaseContainer(this.LeaseContainer).Build();

With the new public signature, it can be:

    ChangeFeedProcessor estimator = this.Container
        .CreateChangeFeedEstimatorBuilder("myWorkFlow", (IReadOnlyList<RemainingLeaseTokenWork> estimation, CancellationToken token) =>
        {
            long receivedEstimation = estimation.Sum(e=> e.RemainingWork);
            Console.WriteLine($"Pending work to be done across all leases: {receivedEstimation}");
            foreach(RemainingLeaseTokenWork leaseEstimation in estimation)
            {
                Console.WriteLine($"Pending work for lease with Token {leaseEstimation.LeaseToken}: {leaseEstimation.RemainingWork}");
            }
            return Task.CompletedTask;
        }, TimeSpan.FromSeconds(1))
        .WithCosmosLeaseContainer(this.LeaseContainer).Build();

Thus allowing both scenarios:
* Getting the complete estimation
* Getting partial estimation per lease

## Type of change

Please delete options that are not relevant.

- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

This PR fixes #322

