### PR TITLE
Session Token as promoted property in Headers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/CosmosResponseMessageHeaders.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/CosmosResponseMessageHeaders.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-    using Microsoft.Azure.Cosmos.Internal;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -71,6 +70,15 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.ContentType)]
         public virtual string ContentType { get; internal set; }
+
+        /// <summary>
+        /// Gets the Session Token for the current <see cref="CosmosResponseMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// Session Token is used along with Session Consistency.
+        /// </remarks>
+        [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.SessionToken)]
+        public virtual string Session { get; internal set; }
 
         /// <summary>
         /// Gets the Content Length for the current content in the <see cref="CosmosResponseMessage"/>.

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/ItemResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/ItemResponse.cs
@@ -37,13 +37,5 @@ namespace Microsoft.Azure.Cosmos
                 item)
         {
         }
-
-        /// <summary>
-        /// Gets the token for use with session consistency requests from the Azure Cosmos DB service.
-        /// </summary>
-        /// <value>
-        /// The token for use with session consistency requests.
-        /// </value>
-        public virtual string SessionToken => this.Headers.GetHeaderValue<string>(HttpConstants.HttpHeaders.SessionToken);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1023,6 +1023,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [TestMethod]
+        public async Task VerifySessionTokenPassThrough()
+        {
+            ToDoActivity temp = this.CreateRandomToDoActivity("TBD");
+
+            ItemResponse<ToDoActivity> responseAstype = await this.Container.CreateItemAsync<ToDoActivity>(partitionKey: temp.status, item: temp);
+
+            string sessionToken = responseAstype.Headers.Session;
+            Assert.IsNotNull(sessionToken);
+
+            CosmosResponseMessage readResponse = await this.Container.ReadItemAsStreamAsync(temp.status, temp.id, new ItemRequestOptions() { SessionToken = sessionToken });
+
+            Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+            Assert.IsNotNull(readResponse.Headers.Session);
+            Assert.AreEqual(sessionToken, readResponse.Headers.Session);
+        }
+
         private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)
         {
             Assert.IsFalse(!randomPartitionKey && pkCount > 1);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosResponseMessageHeadersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosResponseMessageHeadersTests.cs
@@ -115,16 +115,20 @@ namespace Microsoft.Azure.Cosmos.Tests
             string value1 = Guid.NewGuid().ToString();
             string value2 = "1002";
             string value3 = "20";
+            string value4 = "someSession";
             var requestHeaders = new CosmosResponseMessageHeaders();
             requestHeaders.CosmosMessageHeaders[HttpConstants.HttpHeaders.Continuation] = value1;
             requestHeaders.CosmosMessageHeaders[WFConstants.BackendHeaders.SubStatus] = value2;
             requestHeaders.CosmosMessageHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds] = value3;
+            requestHeaders.CosmosMessageHeaders[HttpConstants.HttpHeaders.SessionToken] = value4;
             Assert.AreEqual(value1, requestHeaders.Continuation);
             Assert.AreEqual(int.Parse(value2), (int)requestHeaders.SubStatusCode);
             Assert.AreEqual(TimeSpan.FromMilliseconds(20), requestHeaders.RetryAfter);
+            Assert.AreEqual(value4, requestHeaders.Session);
             Assert.AreEqual(value1, requestHeaders[HttpConstants.HttpHeaders.Continuation]);
             Assert.AreEqual(value2, requestHeaders[WFConstants.BackendHeaders.SubStatus]);
             Assert.AreEqual(value3, requestHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds]);
+            Assert.AreEqual(value4, requestHeaders[HttpConstants.HttpHeaders.SessionToken]);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Session Token as promoted property in Headers

## Description

This PR creates a promoted property in the `CosmosResponseMessageHeaders` to access the Session Token easily, both in Stream and Typed operations.

As an example, to obtain the Session Token, both in Typed and Stream operations, the user can do:

    ItemResponse<MyClass> responseAstype = await container.CreateItemAsync<MyClass>(partitionKey: myPK, item: myItem);
    string sessionToken = responseAstype.Headers.Session;

    CosmosResponseMessage readResponse = await container.ReadItemAsStreamAsync(myPK, myItem.id, new ItemRequestOptions() { SessionToken = sessionToken });
    string sessionTokenFromStreamOperation = readResponse.Headers.Session;

## Type of change

- [X ] New feature (non-breaking change which adds functionality)

## Closing issues

This PR closes #269

