### PR TITLE
Release branch name cache fix

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Cosmos
                 this.RetryAfter = this.Headers?.RetryAfter;
                 this.RequestCharge = this.Headers == null ? 0 : this.Headers.GetHeaderValue<double>(HttpConstants.HttpHeaders.RequestCharge);
                 this.SubStatusCode = (int)this.Headers.SubStatusCode;
+                this.ResourceAddress = cosmosResponseMessage.GetResourceAddress();
                 this.Error = error;
                 if (cosmosResponseMessage.Headers.ContentLengthAsLong > 0)
                 {
@@ -97,6 +98,8 @@ namespace Microsoft.Azure.Cosmos
         internal TimeSpan? RetryAfter { get; }
 
         internal CosmosResponseMessageHeaders Headers { get; }
+
+        internal string ResourceAddress { get; set; }
 
         /// <summary>
         /// Try to get a header from the cosmos response message

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             var crossPartitionQueryIterator = container.Items.CreateItemQueryAsStream("select * from t where true", maxConcurrency: 2);
             var queryResponse = await crossPartitionQueryIterator.FetchNextSetAsync();
             Assert.IsNotNull(queryResponse);
-            Assert.AreEqual(HttpStatusCode.Gone, queryResponse.StatusCode);
+            Assert.AreEqual(HttpStatusCode.NotFound, queryResponse.StatusCode);
 
             var queryIterator = container.Items.CreateItemQueryAsStream("select * from t where true", maxConcurrency: 1, partitionKey: "testpk");
             this.VerifyQueryNotFoundResponse(await queryIterator.FetchNextSetAsync());


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a bug which causes a 410 exception to be returned to users. The retry policy was updated to handle CosmosException type instead of DocumentClientExceptions.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


