### PR TITLE
Indexes support in IncludedPath

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/IncludedPathIndexFluentDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/IncludedPathIndexFluentDefinition.cs
@@ -1,0 +1,104 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Fluent
+{
+    using System;
+    using System.Collections.ObjectModel;
+
+    /// <summary>
+    /// Fluent definition to specify included paths.
+    /// </summary>
+    public class IncludedPathIndexFluentDefinition<T>
+    {
+        private readonly Collection<Index> indexes = new Collection<Index>();
+        private readonly T parent;
+        private readonly string path;
+        private readonly Action<IncludedPath> attachCallback;
+
+        internal IncludedPathIndexFluentDefinition(
+            T parent,
+            string path,
+            Action<IncludedPath> attachCallback)
+        {
+            this.parent = parent;
+            this.path = path;
+            this.attachCallback = attachCallback;
+        }
+
+        /// <summary>
+        /// Adds a range index to the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="dataType">Specifies the target data type for the index path specification.</param>
+        /// <returns>An instance of the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<T> RangeIndex(DataType dataType)
+        {
+            this.indexes.Add(Index.Range(dataType));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a hash index to the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="dataType">Specifies the target data type for the index path specification.</param>
+        /// <returns>An instance of the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<T> HashIndex(DataType dataType)
+        {
+            this.indexes.Add(Index.Hash(dataType));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a hash index to the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="dataType">Specifies the target data type for the index path specification.</param>
+        /// <param name="precision">Specifies the precision to be used for the data type associated with this index.</param>
+        /// <returns>An instance of the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<T> HashIndex(
+            DataType dataType,
+            short precision)
+        {
+            this.indexes.Add(Index.Hash(dataType, precision));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a spatial index to the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="dataType">Specifies the target data type for the index path specification.</param>
+        /// <returns>An instance of the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<T> SpatialIndex(DataType dataType)
+        {
+            this.indexes.Add(Index.Spatial(dataType));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a range index to the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="dataType">Specifies the target data type for the index path specification.</param>
+        /// <param name="precision">Specifies the precision to be used for the data type associated with this index.</param>
+        /// <returns>An instance of the current <see cref="IncludedPathIndexFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<T> RangeIndex(
+            DataType dataType,
+            short precision)
+        {
+            this.indexes.Add(Index.Range(dataType, precision));
+            return this;
+        }
+
+        /// <summary>
+        /// Applies the current definition to the parent.
+        /// </summary>
+        /// <returns>An instance of the parent.</returns>
+        public virtual T Attach()
+        {
+            this.attachCallback(new IncludedPath()
+            {
+                Path = this.path,
+                Indexes = this.indexes
+            });
+            return this.parent;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/IncludedPathsFluentDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/IncludedPathsFluentDefinition.cs
@@ -1,0 +1,62 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Fluent
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Fluent definition to specify included paths.
+    /// </summary>
+    public class IncludedPathsFluentDefinition<T>
+    {
+        private readonly List<IncludedPath> paths = new List<IncludedPath>();
+        private readonly T parent;
+        private readonly Action<IEnumerable<IncludedPath>> attachCallback;
+
+        internal IncludedPathsFluentDefinition(
+            T parent,
+            Action<IEnumerable<IncludedPath>> attachCallback)
+        {
+            this.parent = parent;
+            this.attachCallback = attachCallback;
+        }
+
+        /// <summary>
+        /// Adds a path to the current <see cref="IncludedPathsFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="path">Property path for the current definition. Example: /path/*</param>
+        /// <returns>An instance of the current <see cref="IncludedPathsFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathsFluentDefinition<T> Path(string path)
+        {
+            this.paths.Add(new IncludedPath() { Path = path });
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a path to the current <see cref="IncludedPathsFluentDefinition{T}"/>.
+        /// </summary>
+        /// <param name="path">Property path for the current definition. Example: /path/*</param>
+        /// <returns>An instance of the current <see cref="IncludedPathsFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathIndexFluentDefinition<IncludedPathsFluentDefinition<T>> PathWithIndexes(string path)
+        {
+            return new IncludedPathIndexFluentDefinition<IncludedPathsFluentDefinition<T>>(this, path, this.AddPathWithIndexes);
+        }
+
+        /// <summary>
+        /// Applies the current definition to the parent.
+        /// </summary>
+        /// <returns>An instance of the parent.</returns>
+        public virtual T Attach()
+        {
+            this.attachCallback(this.paths);
+            return this.parent;
+        }
+
+        private void AddPathWithIndexes(IncludedPath includedPath)
+        {
+            this.paths.Add(includedPath);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/IndexingPolicyFluentDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/IndexingPolicyFluentDefinition.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         private readonly IndexingPolicy indexingPolicy = new IndexingPolicy();
         private readonly T parent;
         private readonly Action<IndexingPolicy> attachCallback;
-        private PathsFluentDefinition<IndexingPolicyFluentDefinition<T>> includedPathsBuilder;
+        private IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<T>> includedPathsBuilder;
         private PathsFluentDefinition<IndexingPolicyFluentDefinition<T>> excludedPathsBuilder;
 
         /// <summary>
@@ -62,12 +62,12 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <summary>
         /// Defines the <see cref="CosmosContainer"/>'s <see cref="IndexingPolicy.IncludedPaths"/>.
         /// </summary>
-        /// <returns>An instance of <see cref="PathsFluentDefinition{T}"/>.</returns>
-        public virtual PathsFluentDefinition<IndexingPolicyFluentDefinition<T>> WithIncludedPaths()
+        /// <returns>An instance of <see cref="IncludedPathsFluentDefinition{T}"/>.</returns>
+        public virtual IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<T>> WithIncludedPaths()
         {
             if (this.includedPathsBuilder == null)
             {
-                this.includedPathsBuilder = new PathsFluentDefinition<IndexingPolicyFluentDefinition<T>>(
+                this.includedPathsBuilder = new IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<T>>(
                     this,
                     (paths) => this.AddIncludedPaths(paths));
             }
@@ -133,11 +133,11 @@ namespace Microsoft.Azure.Cosmos.Fluent
             this.indexingPolicy.SpatialIndexes.Add(spatialSpec);
         }
 
-        private void AddIncludedPaths(IEnumerable<string> paths)
+        private void AddIncludedPaths(IEnumerable<IncludedPath> paths)
         {
-            foreach (string path in paths)
+            foreach (IncludedPath path in paths)
             {
-                this.indexingPolicy.IncludedPaths.Add(new IncludedPath() { Path = path });
+                this.indexingPolicy.IncludedPaths.Add(path);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IncludedPathsFluentDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IncludedPathsFluentDefinitionTests.cs
@@ -1,0 +1,71 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Fluent
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class IncludedPathsFluentDefinitionTests
+    {
+        [TestMethod]
+        public void AttachReturnsCorrectResponse()
+        {
+            Mock<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>>();
+            Action<IEnumerable<IncludedPath>> callback = (paths) =>
+            {
+                Assert.AreEqual("/path1", paths.First().Path);
+                Assert.AreEqual("/path2", paths.Last().Path);
+                Assert.AreEqual(2, paths.Count());
+            };
+
+            IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>> pathsFluentDefinitionCore = new IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>>(
+                mockIndexingPolicyDefinition.Object,
+                callback);
+
+            pathsFluentDefinitionCore
+                .Path("/path1")
+                .Path("/path2")
+                .Attach();
+        }
+
+        [TestMethod]
+        public void AttachReturnsCorrectResponseWithIndexes()
+        {
+            Mock<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>>();
+            Action<IEnumerable<IncludedPath>> callback = (paths) =>
+            {
+                IncludedPath first = paths.First();
+                Assert.AreEqual("/path1", first.Path);
+                Assert.AreEqual(3, first.Indexes.Count);
+                Assert.AreEqual(IndexKind.Range, first.Indexes[0].Kind);
+                Assert.AreEqual(DataType.Number, ((RangeIndex)first.Indexes[0]).DataType);
+                Assert.AreEqual((short)20, ((RangeIndex)first.Indexes[0]).Precision);
+                Assert.AreEqual(IndexKind.Hash, first.Indexes[1].Kind);
+                Assert.AreEqual(DataType.Point, ((HashIndex)first.Indexes[1]).DataType);
+                Assert.AreEqual((short)15, ((HashIndex)first.Indexes[1]).Precision);
+                Assert.AreEqual(IndexKind.Spatial, first.Indexes[2].Kind);
+                Assert.AreEqual(DataType.MultiPolygon, ((SpatialIndex)first.Indexes[2]).DataType);
+                Assert.AreEqual(1, paths.Count());
+            };
+
+            IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>> pathsFluentDefinitionCore = new IncludedPathsFluentDefinition<IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>>(
+                mockIndexingPolicyDefinition.Object,
+                callback);
+
+            pathsFluentDefinitionCore
+                .PathWithIndexes("/path1")
+                    .RangeIndex(DataType.Number, 20)
+                    .HashIndex(DataType.Point, 15)
+                    .SpatialIndex(DataType.MultiPolygon)
+                    .Attach()
+                .Attach();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IndexingPolicyFluentDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IndexingPolicyFluentDefinitionTests.cs
@@ -97,6 +97,39 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         }
 
         [TestMethod]
+        public void AttachReturnsCorrectResponse_WithIncludedPathsWithIndexes()
+        {
+            Mock<CosmosContainerFluentDefinitionForCreate> mockContainerPolicyDefinition = new Mock<CosmosContainerFluentDefinitionForCreate>();
+            Action<IndexingPolicy> callback = (policy) =>
+            {
+                Assert.AreEqual(1, policy.IncludedPaths.Count);
+                Assert.AreEqual("/path1", policy.IncludedPaths[0].Path);
+                Assert.AreEqual(3, policy.IncludedPaths[0].Indexes.Count);
+                Assert.AreEqual(IndexKind.Range, policy.IncludedPaths[0].Indexes[0].Kind);
+                Assert.AreEqual(DataType.Number, ((RangeIndex)policy.IncludedPaths[0].Indexes[0]).DataType);
+                Assert.AreEqual((short)20, ((RangeIndex)policy.IncludedPaths[0].Indexes[0]).Precision);
+                Assert.AreEqual(IndexKind.Hash, policy.IncludedPaths[0].Indexes[1].Kind);
+                Assert.AreEqual(DataType.Point, ((HashIndex)policy.IncludedPaths[0].Indexes[1]).DataType);
+                Assert.AreEqual(IndexKind.Spatial, policy.IncludedPaths[0].Indexes[2].Kind);
+                Assert.AreEqual(DataType.MultiPolygon, ((SpatialIndex)policy.IncludedPaths[0].Indexes[2]).DataType);
+            };
+
+            IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate> indexingPolicyFluentDefinitionCore = new IndexingPolicyFluentDefinition<CosmosContainerFluentDefinitionForCreate>(
+                mockContainerPolicyDefinition.Object,
+                callback);
+
+            indexingPolicyFluentDefinitionCore
+                .WithIncludedPaths()
+                    .PathWithIndexes("/path1")
+                        .RangeIndex(DataType.Number, 20)
+                        .HashIndex(DataType.Point)
+                        .SpatialIndex(DataType.MultiPolygon)
+                        .Attach()
+                    .Attach()
+                .Attach();
+        }
+
+        [TestMethod]
         public void AttachReturnsCorrectResponse_WithCompositeIndex()
         {
             Mock<CosmosContainerFluentDefinitionForCreate> mockContainerPolicyDefinition = new Mock<CosmosContainerFluentDefinitionForCreate>();


### PR DESCRIPTION
# Indexes support in IncludedPath

## Description

In the current Fluent API to define Indexing Policies for a Container, Included Paths are missing the optional Indexes.

This PR extends the Fluent API to support them like so:

    .WithIncludedPaths()
        .Path("/pathwithoutindexes")
        .Path("/anotherpathwithoutindexes")
        .PathWithIndexes("/pathwithindexes")
            .RangeIndex(DataType.Number, 20)
            .HashIndex(DataType.Point)
            .SpatialIndex(DataType.MultiPolygon)
            .Attach()
        .Attach()

Which would, in a complete scenario, look like: 

    CosmosContainerResponse container = await database.DefineContainer("TestContainer", "partitionKeyPath")
        .WithIndexingPolicy()
            .WithIndexingMode(IndexingMode.Consistent)
            .WithAutomaticIndexing(false)
            .WithIncludedPaths()
                .Path("/pathwithoutindexes")
                .Path("/anotherpathwithoutindexes")
                .PathWithIndexes("/pathwithindexes")
                    .RangeIndex(DataType.Number, 20)
                    .HashIndex(DataType.Point)
                    .SpatialIndex(DataType.MultiPolygon)
                    .Attach()
                .Attach()
            .WithExcludedPaths()
                .Path("/excludepath1")
                .Path("/excludepath2")
                .Attach()
            .WithCompositeIndex()
                .Path("/root/leaf1")
                .Path("/root/leaf2", CompositePathSortOrder.Descending)
                .Attach()
            .WithCompositeIndex()
                .Path("/root/leaf3")
                .Path("/root/leaf4")
                .Attach()
        .Attach()
    .CreateAsync(5000 /* throughput /*); 


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Closing issues

This PR closes #351 