### PR TITLE
Adding test to cover default serialization behavior

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -64,6 +64,30 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             await mockContainer.DeleteItemAsync<ToDoActivity>(new Cosmos.PartitionKey(testItem.status), testItem.id);
         }
+
+        /// <summary>
+        /// Verify that null attributes do not get serialized by default.
+        /// </summary>
+        [TestMethod]
+        public async Task DefaultNullValueHandling()
+        {
+            ToDoActivity document = new ToDoActivity()
+            {
+                id = Guid.NewGuid().ToString(),
+                description = default(string),
+                status = "TBD",
+                taskNum = 42,
+                cost = double.MaxValue
+            };
+
+            await container.UpsertItemAsync(document);
+
+            CosmosResponseMessage cosmosResponseMessage = await container.ReadItemAsStreamAsync(new PartitionKey(document.status), document.id);
+            StreamReader reader = new StreamReader(cosmosResponseMessage.Content);
+            string text = reader.ReadToEnd();
+
+            Assert.AreEqual(-1, text.IndexOf("description"), "Stored document contains a null attribute");
+        }
         
         private ToDoActivity CreateRandomToDoActivity(string pk = null)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             StreamReader reader = new StreamReader(cosmosResponseMessage.Content);
             string text = reader.ReadToEnd();
 
-            Assert.AreEqual(-1, text.IndexOf("description"), "Stored document contains a null attribute");
+            Assert.AreEqual(-1, text.IndexOf(nameof(document.description)), "Stored document contains a null attribute");
         }
         
         private ToDoActivity CreateRandomToDoActivity(string pk = null)


### PR DESCRIPTION
# Default serialization test

## Description

This PR adds a test to assert the default serialization behavior (`NullValueHandling = NullValueHandling.Ignore`) and make sure we don't regress it in any future change.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Closing issues

This PR closes #350