### PR TITLE
ExecuteStoredProcedure with Streams support

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.IO;
     using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Scripts;

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
@@ -93,19 +93,6 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
-        internal Task<StoredProcedureExecuteResponse<Stream>> CreateStoredProcedureExecuteResponseAsStreamAsync(Task<CosmosResponseMessage> cosmosResponseMessageTask)
-        {
-            return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
-            {
-                Stream item = this.ToStreamTnternal(cosmosResponseMessage);
-
-                return new StoredProcedureExecuteResponse<Stream>(
-                    cosmosResponseMessage.StatusCode,
-                    cosmosResponseMessage.Headers,
-                    item);
-            });
-        }
-
         internal Task<StoredProcedureResponse> CreateStoredProcedureResponseAsync(Task<CosmosResponseMessage> cosmosResponseMessageTask)
         {
             return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
@@ -168,29 +155,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return jsonSerializer.FromStream<T>(cosmosResponseMessage.Content);
-        }
-
-        internal Stream ToStreamTnternal(CosmosResponseMessage cosmosResponseMessage)
-        {
-            // Not finding something is part of a normal work-flow and should not be an exception.
-            // This prevents the unnecessary overhead of an exception
-            if (cosmosResponseMessage.StatusCode == HttpStatusCode.NotFound)
-            {
-                return default(Stream);
-            }
-
-            //Throw the exception
-            cosmosResponseMessage.EnsureSuccessStatusCode();
-
-            if (cosmosResponseMessage.Content == null)
-            {
-                return default(Stream);
-            }
-
-            MemoryStream clonedStream = new MemoryStream();
-            cosmosResponseMessage.Content.CopyTo(clonedStream);
-            clonedStream.Position = 0;
-            return clonedStream;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -281,10 +281,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <summary>
         /// Executes a stored procedure against a container as an asynchronous operation in the Azure Cosmos service and obtains a Stream as response.
         /// </summary>
-        /// <typeparam name="TInput">The input type that is JSON serializable.</typeparam>
         /// <param name="partitionKey">The partition key for the item. <see cref="Microsoft.Azure.Documents.PartitionKey"/></param>
         /// <param name="id">The identifier of the Stored Procedure to execute.</param>
-        /// <param name="input">The JSON serializable input parameters.</param>
+        /// <param name="input">The stream representing the input for the stored procedure.</param>
         /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
@@ -319,8 +318,8 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         body: sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, "Item as a string: ");
-        /// using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
+        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, input: stream);
+        /// using (StreamReader sr = new StreamReader(sprocResponse.Content))
         /// {
         ///     string stringResponse = await sr.ReadToEndAsync();
         ///     Console.WriteLine(stringResponse);
@@ -329,10 +328,10 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync<TInput>(
+        public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(
             PartitionKey partitionKey,
             string id,
-            TInput input,
+            Stream input,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureAsStreamAsync<TInput>(
+        public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync<TInput>(
             PartitionKey partitionKey,
             string id,
             TInput input,

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="partitionKey">The partition key for the item. <see cref="Microsoft.Azure.Documents.PartitionKey"/></param>
         /// <param name="id">The identifier of the Stored Procedure to execute.</param>
-        /// <param name="input">The stream representing the input for the stored procedure.</param>
+        /// <param name="streamPayload">The stream representing the input for the stored procedure.</param>
         /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         body: sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureStreamAsync(testPartitionId, input: stream);
+        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureStreamAsync(testPartitionId, streamPayload: stream);
         /// using (StreamReader sr = new StreamReader(sprocResponse.Content))
         /// {
         ///     string stringResponse = await sr.ReadToEndAsync();
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(
             PartitionKey partitionKey,
             string id,
-            Stream input,
+            Stream streamPayload,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -319,8 +319,8 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         body: sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// StoredProcedureExecuteResponse<Stream> sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, "Item as a string: ");
-        /// using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Resource))
+        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, "Item as a string: ");
+        /// using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
         /// {
         ///     string stringResponse = sr.ReadToEnd();
         ///     Console.WriteLine(stringResponse);
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<StoredProcedureExecuteResponse<Stream>> ExecuteStoredProcedureAsStreamAsync<TInput>(
+        public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureAsStreamAsync<TInput>(
             PartitionKey partitionKey,
             string id,
             TInput input,

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         body: sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, input: stream);
+        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureStreamAsync(testPartitionId, input: stream);
         /// using (StreamReader sr = new StreamReader(sprocResponse.Content))
         /// {
         ///     string stringResponse = await sr.ReadToEndAsync();

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -230,12 +230,12 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <typeparam name="TInput">The input type that is JSON serializable.</typeparam>
         /// <typeparam name="TOutput">The return type that is JSON serializable.</typeparam>
         /// <param name="partitionKey">The partition key for the item. <see cref="Microsoft.Azure.Documents.PartitionKey"/></param>
-        /// <param name="id">The identifier of the Stored Procedure to execute.</param>
+        /// <param name="storedProcedureId">The identifier of the Stored Procedure to execute.</param>
         /// <param name="input">The JSON serializable input parameters.</param>
         /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="id"/> or <paramref name="partitionKey"/>  are not set.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="storedProcedureId"/> or <paramref name="partitionKey"/>  are not set.</exception>
         /// <example>
         ///  This creates and executes a stored procedure that appends a string to the first item returned from the query.
         /// <code language="c#">
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </example>
         public abstract Task<StoredProcedureExecuteResponse<TOutput>> ExecuteStoredProcedureAsync<TInput, TOutput>(
             PartitionKey partitionKey,
-            string id,
+            string storedProcedureId,
             TInput input,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -282,12 +282,12 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Executes a stored procedure against a container as an asynchronous operation in the Azure Cosmos service and obtains a Stream as response.
         /// </summary>
         /// <param name="partitionKey">The partition key for the item. <see cref="Microsoft.Azure.Documents.PartitionKey"/></param>
-        /// <param name="id">The identifier of the Stored Procedure to execute.</param>
+        /// <param name="storedProcedureId">The identifier of the Stored Procedure to execute.</param>
         /// <param name="streamPayload">The stream representing the input for the stored procedure.</param>
         /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="id"/> or <paramref name="partitionKey"/>  are not set.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="storedProcedureId"/> or <paramref name="partitionKey"/>  are not set.</exception>
         /// <example>
         ///  This creates and executes a stored procedure that appends a string to the first item returned from the query.
         /// <code language="c#">
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </example>
         public abstract Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(
             PartitionKey partitionKey,
-            string id,
+            string storedProcedureId,
             Stream streamPayload,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -322,7 +322,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureAsStreamAsync<string>(testPartitionId, "Item as a string: ");
         /// using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
         /// {
-        ///     string stringResponse = sr.ReadToEnd();
+        ///     string stringResponse = await sr.ReadToEndAsync();
         ///     Console.WriteLine(stringResponse);
         ///  }
         /// 

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScripts.cs
@@ -266,8 +266,8 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         body: sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// StoredProcedureExecuteResponse<string> sprocResponse = await scripts.ExecuteAsync<string, string>(testPartitionId, "Item as a string: ");
-        /// Console.WriteLine("sprocResponse.Resource");
+        /// StoredProcedureExecuteResponse<string> sprocResponse = await scripts.ExecuteStoredProcedureAsync<string, string>(testPartitionId, "Item as a string: ");
+        /// Console.WriteLine(sprocResponse.Resource);
         /// /// ]]>
         /// </code>
         /// </example>

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
@@ -114,21 +114,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
             return this.clientContext.ResponseFactory.CreateStoredProcedureExecuteResponseAsync<TOutput>(response);
         }
 
-        public override Task<StoredProcedureExecuteResponse<Stream>> ExecuteStoredProcedureAsStreamAsync<TInput>(
+        public override Task<CosmosResponseMessage> ExecuteStoredProcedureAsStreamAsync<TInput>(
             Cosmos.PartitionKey partitionKey,
             string id,
             TInput input,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Task<CosmosResponseMessage> response = this.ValidateAndProcessExecuteStoredProcedureAsync<TInput>(
+            return this.ValidateAndProcessExecuteStoredProcedureAsync<TInput>(
                 partitionKey: partitionKey,
                 id: id,
                 input: input,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
-
-            return this.clientContext.ResponseFactory.CreateStoredProcedureExecuteResponseAsStreamAsync(response);
         }
 
         public override Task<TriggerResponse> CreateTriggerAsync(

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             return this.clientContext.ResponseFactory.CreateStoredProcedureExecuteResponseAsync<TOutput>(response);
         }
 
-        public override Task<CosmosResponseMessage> ExecuteStoredProcedureAsStreamAsync<TInput>(
+        public override Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync<TInput>(
             Cosmos.PartitionKey partitionKey,
             string id,
             TInput input,

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         public override Task<StoredProcedureExecuteResponse<TOutput>> ExecuteStoredProcedureAsync<TInput, TOutput>(
             Cosmos.PartitionKey partitionKey,
-            string id,
+            string storedProcedureId,
             TInput input,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
             Task<CosmosResponseMessage> response = this.ExecuteStoredProcedureStreamAsync(
                 partitionKey: partitionKey,
-                id: id,
+                storedProcedureId: storedProcedureId,
                 streamPayload: parametersStream,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
@@ -126,14 +126,14 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         public override Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(
             Cosmos.PartitionKey partitionKey,
-            string id,
+            string storedProcedureId,
             Stream streamPayload,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (string.IsNullOrEmpty(id))
+            if (string.IsNullOrEmpty(storedProcedureId))
             {
-                throw new ArgumentNullException(nameof(id));
+                throw new ArgumentNullException(nameof(storedProcedureId));
             }
 
             CosmosContainerCore.ValidatePartitionKey(partitionKey, requestOptions);
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             Uri linkUri = this.clientContext.CreateLink(
                 parentLink: this.container.LinkUri.OriginalString,
                 uriPathSegment: Paths.StoredProceduresPathSegment,
-                id: id);
+                id: storedProcedureId);
 
             return this.ProcessStreamOperationAsync(
                 resourceUri: linkUri,

--- a/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Scripts/CosmosScriptsCore.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             Task<CosmosResponseMessage> response = this.ExecuteStoredProcedureStreamAsync(
                 partitionKey: partitionKey,
                 id: id,
-                input: parametersStream,
+                streamPayload: parametersStream,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         public override Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(
             Cosmos.PartitionKey partitionKey,
             string id,
-            Stream input,
+            Stream streamPayload,
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                 resourceType: ResourceType.StoredProcedure,
                 operationType: OperationType.ExecuteJavaScript,
                 partitionKey: partitionKey,
-                streamPayload: input,
+                streamPayload: streamPayload,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -1404,7 +1404,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //Script cannot timeout.
             CosmosScripts cosmosScripts = collection.GetScripts();
             CosmosStoredProcedureSettings storedProcedure = await cosmosScripts.CreateStoredProcedureAsync(new CosmosStoredProcedureSettings("scriptId", script));
-            string result = await cosmosScripts.ExecuteStoredProcedureAsync<object ,string >(id : "scriptId", partitionKey : new Cosmos.PartitionKey(documentDefinition.Id), input : null);
+            string result = await cosmosScripts.ExecuteStoredProcedureAsync<object ,string >(storedProcedureId : "scriptId", partitionKey : new Cosmos.PartitionKey(documentDefinition.Id), input : null);
             await database.DeleteAsync();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1740,7 +1740,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 CosmosStoredProcedureSettings storedProcedure = await scripts.CreateStoredProcedureAsync(new CosmosStoredProcedureSettings("sproc1", "function() {return 1}"));
                 for (int i = 0; i < 10; i++)
                 {
-                    await scripts.ExecuteStoredProcedureAsync<object, object>(partitionKey: new Cosmos.PartitionKey(i), id: "sproc1", input: null);
+                    await scripts.ExecuteStoredProcedureAsync<object, object>(partitionKey: new Cosmos.PartitionKey(i), storedProcedureId: "sproc1", input: null);
                 }
             }
             finally

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             StoredProcedureTests.ValidateStoredProcedureSettings(sprocId, sprocBody, storedProcedureResponse);
 
             CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
-            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(
                 new Cosmos.PartitionKey(testPartitionId),
                 sprocId,
                 Guid.NewGuid().ToString(),
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 });
 
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
-            Assert.AreEqual(testLogsText, sprocResponse.ScriptLog);
+            Assert.AreEqual(testLogsText, Uri.UnescapeDataString(sprocResponse.Headers["x-ms-documentdb-script-log-results"]));
         }
 
         [TestMethod]
@@ -260,10 +260,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
 
             CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
-            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<object>(new Cosmos.PartitionKey(testPartitionId), sprocId, null);
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<object>(new Cosmos.PartitionKey(testPartitionId), sprocId, null);
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
 
-            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Resource))
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
             {
                 string stringResponse = sr.ReadToEnd();
                 JArray jArray = JArray.Parse(stringResponse);
@@ -362,10 +362,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<dynamic> createItemResponse = await this.container.CreateItemAsync<dynamic>(payload);
             Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
 
-            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string[]>(new Cosmos.PartitionKey(testPartitionId), sprocId, new string[] { "one" });
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string[]>(new Cosmos.PartitionKey(testPartitionId), sprocId, new string[] { "one" });
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
 
-            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Resource))
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
             {
                 string stringResponse = sr.ReadToEnd();
                 Assert.IsNotNull(stringResponse);
@@ -373,10 +373,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual("\"one\"", stringResponse);
             }
 
-            StoredProcedureExecuteResponse<Stream> sprocResponse2 = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(new Cosmos.PartitionKey(testPartitionId), sprocId, "one");
+            CosmosResponseMessage sprocResponse2 = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(new Cosmos.PartitionKey(testPartitionId), sprocId, "one");
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse2.StatusCode);
 
-            using (StreamReader sr = new System.IO.StreamReader(sprocResponse2.Resource))
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse2.Content))
             {
                 string stringResponse2 = sr.ReadToEnd();
                 Assert.IsNotNull(stringResponse2);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             StoredProcedureTests.ValidateStoredProcedureSettings(sprocId, sprocBody, storedProcedureResponse);
 
             CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
-            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureStreamAsync<string>(
                 new Cosmos.PartitionKey(testPartitionId),
                 sprocId,
                 Guid.NewGuid().ToString(),
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
 
             CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
-            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<object>(new Cosmos.PartitionKey(testPartitionId), sprocId, null);
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureStreamAsync<object>(new Cosmos.PartitionKey(testPartitionId), sprocId, null);
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
 
             using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<dynamic> createItemResponse = await this.container.CreateItemAsync<dynamic>(payload);
             Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
 
-            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string[]>(new Cosmos.PartitionKey(testPartitionId), sprocId, new string[] { "one" });
+            CosmosResponseMessage sprocResponse = await this.scripts.ExecuteStoredProcedureStreamAsync<string[]>(new Cosmos.PartitionKey(testPartitionId), sprocId, new string[] { "one" });
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
 
             using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Content))
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual("\"one\"", stringResponse);
             }
 
-            CosmosResponseMessage sprocResponse2 = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(new Cosmos.PartitionKey(testPartitionId), sprocId, "one");
+            CosmosResponseMessage sprocResponse2 = await this.scripts.ExecuteStoredProcedureStreamAsync<string>(new Cosmos.PartitionKey(testPartitionId), sprocId, "one");
             Assert.AreEqual(HttpStatusCode.OK, sprocResponse2.StatusCode);
 
             using (StreamReader sr = new System.IO.StreamReader(sprocResponse2.Content))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -6,8 +6,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Net;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Cosmos.Scripts;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json.Linq;
@@ -125,6 +127,35 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task ExecutionLogsAsStreamTests()
+        {
+            const string testLogsText = "this is a test";
+            const string testPartitionId = "1";
+            string sprocId = Guid.NewGuid().ToString();
+            string sprocBody = @"function(name) { var context = getContext(); console.log('" + testLogsText + "'); var response = context.getResponse(); response.setBody('hello there ' + name); }";
+
+            StoredProcedureResponse storedProcedureResponse =
+                await this.scripts.CreateStoredProcedureAsync(new CosmosStoredProcedureSettings(sprocId, sprocBody));
+            double requestCharge = storedProcedureResponse.RequestCharge;
+            Assert.IsTrue(requestCharge > 0);
+            Assert.AreEqual(HttpStatusCode.Created, storedProcedureResponse.StatusCode);
+            StoredProcedureTests.ValidateStoredProcedureSettings(sprocId, sprocBody, storedProcedureResponse);
+
+            CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
+            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(
+                new Cosmos.PartitionKey(testPartitionId),
+                sprocId,
+                Guid.NewGuid().ToString(),
+                new StoredProcedureRequestOptions()
+                {
+                    EnableScriptLogging = true
+                });
+
+            Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
+            Assert.AreEqual(testLogsText, sprocResponse.ScriptLog);
+        }
+
+        [TestMethod]
         public async Task IteratorTest()
         {
             string sprocBody = "function() { { var x = 42; } }";
@@ -199,6 +230,51 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task ExecuteTestAsStream()
+        {
+            string sprocId = Guid.NewGuid().ToString();
+            string sprocBody = @"function() {
+                var context = getContext();
+                var response = context.getResponse();
+                var collection = context.getCollection();
+                var collectionLink = collection.getSelfLink();
+
+                var filterQuery = 'SELECT * FROM c';
+
+                collection.queryDocuments(collectionLink, filterQuery, { },
+                    function(err, documents) {
+                        response.setBody(documents);
+                    }
+                );
+            }";
+
+            StoredProcedureResponse storedProcedureResponse =
+                await this.scripts.CreateStoredProcedureAsync(new CosmosStoredProcedureSettings(sprocId, sprocBody));
+            Assert.AreEqual(HttpStatusCode.Created, storedProcedureResponse.StatusCode);
+            StoredProcedureTests.ValidateStoredProcedureSettings(sprocId, sprocBody, storedProcedureResponse);
+
+            // Insert document and then query
+            string testPartitionId = Guid.NewGuid().ToString();
+            var payload = new { id = testPartitionId, user = testPartitionId };
+            ItemResponse<dynamic> createItemResponse = await this.container.CreateItemAsync<dynamic>(payload);
+            Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
+
+            CosmosStoredProcedureSettings storedProcedure = storedProcedureResponse;
+            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<object>(new Cosmos.PartitionKey(testPartitionId), sprocId, null);
+            Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
+
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Resource))
+            {
+                string stringResponse = sr.ReadToEnd();
+                JArray jArray = JArray.Parse(stringResponse);
+                Assert.AreEqual(1, jArray.Count);
+            }
+
+            StoredProcedureResponse deleteResponse = await this.scripts.DeleteStoredProcedureAsync(sprocId);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+        }
+
+        [TestMethod]
         public async Task DeleteNonExistingTest()
         {
             string sprocId = Guid.NewGuid().ToString();
@@ -263,6 +339,53 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             StoredProcedureResponse deleteResponse = await this.scripts.DeleteStoredProcedureAsync(sprocId);
             Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task ExecuteTestWithStream()
+        {
+            string sprocId = Guid.NewGuid().ToString();
+            string sprocBody = @"function(param1) {
+                var context = getContext();
+                var response = context.getResponse();
+                response.setBody(param1);
+            }";
+
+            StoredProcedureResponse storedProcedureResponse =
+                await this.scripts.CreateStoredProcedureAsync(new CosmosStoredProcedureSettings(sprocId, sprocBody));
+            Assert.AreEqual(HttpStatusCode.Created, storedProcedureResponse.StatusCode);
+            StoredProcedureTests.ValidateStoredProcedureSettings(sprocId, sprocBody, storedProcedureResponse);
+
+            // Insert document and then query
+            string testPartitionId = Guid.NewGuid().ToString();
+            var payload = new { id = testPartitionId, user = testPartitionId };
+            ItemResponse<dynamic> createItemResponse = await this.container.CreateItemAsync<dynamic>(payload);
+            Assert.AreEqual(HttpStatusCode.Created, createItemResponse.StatusCode);
+
+            StoredProcedureExecuteResponse<Stream> sprocResponse = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string[]>(new Cosmos.PartitionKey(testPartitionId), sprocId, new string[] { "one" });
+            Assert.AreEqual(HttpStatusCode.OK, sprocResponse.StatusCode);
+
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse.Resource))
+            {
+                string stringResponse = sr.ReadToEnd();
+                Assert.IsNotNull(stringResponse);
+                // When working as streams, strings include quotes
+                Assert.AreEqual("\"one\"", stringResponse);
+            }
+
+            StoredProcedureExecuteResponse<Stream> sprocResponse2 = await this.scripts.ExecuteStoredProcedureAsStreamAsync<string>(new Cosmos.PartitionKey(testPartitionId), sprocId, "one");
+            Assert.AreEqual(HttpStatusCode.OK, sprocResponse2.StatusCode);
+
+            using (StreamReader sr = new System.IO.StreamReader(sprocResponse2.Resource))
+            {
+                string stringResponse2 = sr.ReadToEnd();
+                Assert.IsNotNull(stringResponse2);
+                // When working as streams, strings include quotes
+                Assert.AreEqual("\"one\"", stringResponse2);
+            }
+            StoredProcedureResponse deleteResponse = await this.scripts.DeleteStoredProcedureAsync(sprocId);
+            Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
         }
 
         private static void ValidateStoredProcedureSettings(string id, string body, StoredProcedureResponse cosmosResponse)


### PR DESCRIPTION
# ExecuteStoredProcedure with Streams support

## Description

This PR adds the possibility of executing a Stored Procedure and receive the response as a Stream instead of a particular Type and to send a Stream as the payload directly.

The signature of the method in the `CosmosScripts` group is:

`public Task<CosmosResponseMessage> ExecuteStoredProcedureStreamAsync(Stream)`

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Closing issues

This PR closes #362
This PR closes #201