### PR TITLE
Read feed correctly handle 410 gone.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos
             this.partitionKeyRangeGoneRetryHandler = new PartitionKeyRangeGoneRetryHandler(this.client);
             Debug.Assert(this.partitionKeyRangeGoneRetryHandler.InnerHandler == null, "The partitionKeyRangeGoneRetryHandler.InnerHandler must be null to allow other handlers to be linked.");
 
-            this.invalidPartitionExceptionRetryHandler = new NamedCacheRetryHandler(this.client);
+            this.invalidPartitionExceptionRetryHandler = new NamedCacheRetryHandler();
             Debug.Assert(this.invalidPartitionExceptionRetryHandler.InnerHandler == null, "The invalidPartitionExceptionRetryHandler.InnerHandler must be null to allow other handlers to be linked.");
 
             this.PartitionKeyRangeHandler = new PartitionKeyRangeHandler(client);

--- a/Microsoft.Azure.Cosmos/src/Handler/CosmosRequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/CosmosRequestMessage.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal DocumentServiceRequest DocumentServiceRequest { get; set; }
 
-        internal IDocumentClientRetryPolicy DocumentClientRetryPolicy { get; set; }
+        internal Action<DocumentServiceRequest> OnBeforeRequestHandler { get; set; }
 
         internal bool IsPropertiesInitialized => this.properties.IsValueCreated;
 
@@ -191,16 +191,13 @@ namespace Microsoft.Azure.Cosmos
                 this.DocumentServiceRequest = serviceRequest;
             }
 
-            this.OnBeforeRequestHandler(this.DocumentServiceRequest);
+            this.OnBeforeRequestHandlerHelper(this.DocumentServiceRequest);
             return this.DocumentServiceRequest;
         }
 
-        private void OnBeforeRequestHandler(DocumentServiceRequest serviceRequest)
+        private void OnBeforeRequestHandlerHelper(DocumentServiceRequest serviceRequest)
         {
-            if (this.DocumentClientRetryPolicy != null)
-            {
-                this.DocumentClientRetryPolicy.OnBeforeSendRequest(serviceRequest);
-            }
+            this.OnBeforeRequestHandler?.Invoke(serviceRequest);
         }
 
         private bool AssertPartitioningPropertiesAndHeaders()

--- a/Microsoft.Azure.Cosmos/src/Handler/NamedCacheRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/NamedCacheRetryHandler.cs
@@ -14,21 +14,11 @@ namespace Microsoft.Azure.Cosmos.Handlers
     /// </summary>
     internal class NamedCacheRetryHandler : AbstractRetryHandler
     {
-        private readonly CosmosClient client;
-
-        public NamedCacheRetryHandler(CosmosClient client)
+        internal override Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
         {
-            if (client == null)
-            {
-                throw new ArgumentNullException(nameof(client));
-            }
-
-            this.client = client;
-        }
-
-        internal override async Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
-        {
-            return new InvalidPartitionExceptionRetryPolicy(await client.DocumentClient.GetCollectionCacheAsync(), null);
+            IDocumentClientRetryPolicy retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(null);
+            request.OnBeforeRequestHandler += retryPolicyInstance.OnBeforeSendRequest;
+            return Task.FromResult<IDocumentClientRetryPolicy>(retryPolicyInstance);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -83,8 +83,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 PartitionKeyRangeCache routingMapProvider = await this.client.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 CollectionCache collectionCache = await this.client.DocumentClient.GetCollectionCacheAsync();
-                CosmosContainerSettings collectionFromCache =
-                    await collectionCache.ResolveByNameAsync(apiVersion: null, serviceRequest.ResourceAddress, cancellationToken);
+                CosmosContainerSettings collectionFromCache = await collectionCache.ResolveByNameAsync(
+                    apiVersion: null, 
+                    resourceAddress: serviceRequest.ResourceAddress, 
+                    cancellationToken: cancellationToken);
 
                 List<CompositeContinuationToken> suppliedTokens;
                 //direction is not expected to change  between continuations.

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 PartitionKeyRangeCache routingMapProvider = await this.client.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 CollectionCache collectionCache = await this.client.DocumentClient.GetCollectionCacheAsync();
                 CosmosContainerSettings collectionFromCache =
-                    await collectionCache.ResolveCollectionAsync(serviceRequest, CancellationToken.None);
+                    await collectionCache.ResolveByNameAsync(apiVersion: null, serviceRequest.ResourceAddress, cancellationToken);
 
                 List<CompositeContinuationToken> suppliedTokens;
                 //direction is not expected to change  between continuations.

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -83,10 +83,9 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 PartitionKeyRangeCache routingMapProvider = await this.client.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 CollectionCache collectionCache = await this.client.DocumentClient.GetCollectionCacheAsync();
-                CosmosContainerSettings collectionFromCache = await collectionCache.ResolveByNameAsync(
-                    apiVersion: null, 
-                    resourceAddress: serviceRequest.ResourceAddress, 
-                    cancellationToken: cancellationToken);
+                CosmosContainerSettings collectionFromCache = await collectionCache.ResolveCollectionAsync(
+                        request: serviceRequest,
+                        cancellationToken: cancellationToken);
 
                 List<CompositeContinuationToken> suppliedTokens;
                 //direction is not expected to change  between continuations.

--- a/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
         internal override Task<IDocumentClientRetryPolicy> GetRetryPolicy(CosmosRequestMessage request)
         {
-            IDocumentClientRetryPolicy retryPolicyInstance = retryPolicyFactory.GetRequestPolicy();
-            request.DocumentClientRetryPolicy = retryPolicyInstance;
+            IDocumentClientRetryPolicy retryPolicyInstance = this.retryPolicyFactory.GetRequestPolicy();
+            request.OnBeforeRequestHandler += retryPolicyInstance.OnBeforeSendRequest;
             return Task.FromResult(retryPolicyInstance);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosGatewayQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosGatewayQueryExecutionContext.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos.Query
             CollectionCache collectionCache = await this.queryContext.QueryClient.GetCollectionCacheAsync();
             PartitionKeyRangeCache partitionKeyRangeCache = await this.queryContext.QueryClient.GetPartitionKeyRangeCache();
             IDocumentClientRetryPolicy retryPolicyInstance = this.queryContext.QueryClient.GetRetryPolicy();
-            retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(collectionCache, retryPolicyInstance);
+            retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(retryPolicyInstance);
             if (this.queryContext.ResourceTypeEnum.IsPartitioned())
             {
                 retryPolicyInstance = new PartitionKeyRangeGoneRetryPolicy(

--- a/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DefaultDocumentQueryExecutionContext.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.Query
             CollectionCache collectionCache = await this.Client.GetCollectionCacheAsync();
             PartitionKeyRangeCache partitionKeyRangeCache = await this.Client.GetPartitionKeyRangeCache();
             IDocumentClientRetryPolicy retryPolicyInstance = this.Client.ResetSessionTokenRetryPolicy.GetRequestPolicy();
-            retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(collectionCache, retryPolicyInstance);
+            retryPolicyInstance = new InvalidPartitionExceptionRetryPolicy(retryPolicyInstance);
             if (base.ResourceTypeEnum.IsPartitioned())
             {
                 retryPolicyInstance = new PartitionKeyRangeGoneRetryPolicy(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
@@ -32,60 +32,60 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             this.Init();
         }
 
-        public MockDocumentClient(Uri serviceEndpoint, SecureString authKey, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        public MockDocumentClient(Uri serviceEndpoint, SecureString authKey, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, authKey, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
-        public MockDocumentClient(Uri serviceEndpoint, string authKeyOrResourceToken, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        public MockDocumentClient(Uri serviceEndpoint, string authKeyOrResourceToken, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, authKeyOrResourceToken, (HttpMessageHandler)null, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
-        public MockDocumentClient(Uri serviceEndpoint, IList<Permission> permissionFeed, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        public MockDocumentClient(Uri serviceEndpoint, IList<Permission> permissionFeed, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, permissionFeed, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
-        public MockDocumentClient(Uri serviceEndpoint, SecureString authKey, JsonSerializerSettings serializerSettings, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        public MockDocumentClient(Uri serviceEndpoint, SecureString authKey, JsonSerializerSettings serializerSettings, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, authKey, serializerSettings, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
-        public MockDocumentClient(Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        public MockDocumentClient(Uri serviceEndpoint, string authKeyOrResourceToken, JsonSerializerSettings serializerSettings, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, authKeyOrResourceToken, serializerSettings, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
-        internal MockDocumentClient(Uri serviceEndpoint, IList<ResourceToken> resourceTokens, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null) 
+        internal MockDocumentClient(Uri serviceEndpoint, IList<ResourceToken> resourceTokens, ConnectionPolicy connectionPolicy = null, Documents.ConsistencyLevel? desiredConsistencyLevel = null)
             : base(serviceEndpoint, resourceTokens, connectionPolicy, desiredConsistencyLevel)
         {
             this.Init();
         }
 
         internal MockDocumentClient(
-            Uri serviceEndpoint, 
-            string authKeyOrResourceToken, 
-            EventHandler<SendingRequestEventArgs> sendingRequestEventArgs, 
-            ConnectionPolicy connectionPolicy = null, 
+            Uri serviceEndpoint,
+            string authKeyOrResourceToken,
+            EventHandler<SendingRequestEventArgs> sendingRequestEventArgs,
+            ConnectionPolicy connectionPolicy = null,
             Documents.ConsistencyLevel? desiredConsistencyLevel = null,
             JsonSerializerSettings serializerSettings = null,
             ApiType apitype = ApiType.None,
             EventHandler<ReceivedResponseEventArgs> receivedResponseEventArgs = null,
-            Func<TransportClient, TransportClient> transportClientHandlerFactory = null) 
-            : base(serviceEndpoint, 
-                  authKeyOrResourceToken, 
-                  sendingRequestEventArgs, 
-                  connectionPolicy, 
-                  desiredConsistencyLevel, 
-                  serializerSettings, 
-                  apitype, 
-                  receivedResponseEventArgs, 
+            Func<TransportClient, TransportClient> transportClientHandlerFactory = null)
+            : base(serviceEndpoint,
+                  authKeyOrResourceToken,
+                  sendingRequestEventArgs,
+                  connectionPolicy,
+                  desiredConsistencyLevel,
+                  serializerSettings,
+                  apitype,
+                  receivedResponseEventArgs,
                   null,
                   null,
                   true,
@@ -130,6 +130,15 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
                     (m =>
                         m.ResolveCollectionAsync(
                         It.IsAny<DocumentServiceRequest>(),
+                        It.IsAny<CancellationToken>()
+                    )
+                ).Returns(Task.FromResult(CosmosContainerSettings.CreateWithResourceId("test")));
+
+            this.collectionCache.Setup
+                    (m =>
+                        m.ResolveByNameAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
                         It.IsAny<CancellationToken>()
                     )
                 ).Returns(Task.FromResult(CosmosContainerSettings.CreateWithResourceId("test")));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -563,7 +563,6 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
         [TestMethod]
         public async Task InvalidPartitionRetryPolicyWithNextRetryPolicy()
         {
-            Mock<CollectionCache> cacheMock = new Mock<CollectionCache>();
             Mock<IDocumentClientRetryPolicy> nextRetryPolicyMock = new Mock<IDocumentClientRetryPolicy>();
 
             nextRetryPolicyMock
@@ -576,7 +575,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
                 .Returns(() => Task.FromResult<ShouldRetryResult>(ShouldRetryResult.RetryAfter(TimeSpan.FromDays(1))))
                 .Verifiable();
 
-            InvalidPartitionExceptionRetryPolicy retryPolicyMock = new InvalidPartitionExceptionRetryPolicy(cacheMock.Object, nextRetryPolicyMock.Object);
+            InvalidPartitionExceptionRetryPolicy retryPolicyMock = new InvalidPartitionExceptionRetryPolicy(nextRetryPolicyMock.Object);
 
             ShouldRetryResult exceptionResult = await retryPolicyMock.ShouldRetryAsync(new Exception("", null), CancellationToken.None);
             Assert.IsNotNull(exceptionResult);
@@ -592,10 +591,7 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
         [TestMethod]
         public async Task InvalidPartitionRetryPolicyWithoutNextRetryPolicy()
         {
-            Mock<CollectionCache> cacheMock = new Mock<CollectionCache>();
-
-            CollectionCache cache = cacheMock.Object;
-            InvalidPartitionExceptionRetryPolicy retryPolicyMock = new InvalidPartitionExceptionRetryPolicy(cache, null);
+            InvalidPartitionExceptionRetryPolicy retryPolicyMock = new InvalidPartitionExceptionRetryPolicy(null);
 
             ShouldRetryResult exceptionResult = await retryPolicyMock.ShouldRetryAsync(new Exception("", null), CancellationToken.None);
             Assert.IsNotNull(exceptionResult);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            NamedCacheRetryHandler retryHandler = new NamedCacheRetryHandler(client);
+            NamedCacheRetryHandler retryHandler = new NamedCacheRetryHandler();
             int handlerCalls = 0;
             int expectedHandlerCalls = 1;
             TestHandler testHandler = new TestHandler((request, cancellationToken) => {
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            NamedCacheRetryHandler retryHandler = new NamedCacheRetryHandler(client);
+            NamedCacheRetryHandler retryHandler = new NamedCacheRetryHandler();
             int handlerCalls = 0;
             int expectedHandlerCalls = 2;
             TestHandler testHandler = new TestHandler((request, cancellationToken) => {


### PR DESCRIPTION
# Pull Request Template

## Description
This fixes the issue where the collection recreate causes a 410 exception to be returned to users.

InvalidPartitionExceptionRetryPolicy refreshes the name collection cache, but no the RID based Collection Cache. The PartitionKeyRangeHandler does a collection cache lookup based on rid which always gets the stale value. Updated PartitionKeyRangeHandler to use name cache lookup to match the other retry policies.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

