### PR TITLE
Adding specific constructors to PartitionKey

### DIFF
--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -38,12 +38,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="partitionKeyValue">The value to use as partition key.</param>
         public PartitionKey(string partitionKeyValue)
         {
-            if (partitionKeyValue == null)
-            {
-                throw new ArgumentNullException(nameof(partitionKeyValue));
-            }
-
-            this.Value = partitionKeyValue;
+            this.Value = partitionKeyValue ?? throw new ArgumentNullException(nameof(partitionKeyValue));
         }
 
         /// <summary>
@@ -77,7 +72,7 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a new partition key value.
         /// </summary>
         /// <param name="partitionKeyValue">The value to use as partition key.</param>
-        public PartitionKey(object partitionKeyValue)
+        internal PartitionKey(object partitionKeyValue)
         {
             if (partitionKeyValue == null)
             {

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -36,6 +36,47 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a new partition key value.
         /// </summary>
         /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(string partitionKeyValue)
+        {
+            if (partitionKeyValue == null)
+            {
+                throw new ArgumentNullException(nameof(partitionKeyValue));
+            }
+
+            this.Value = partitionKeyValue;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(bool partitionKeyValue)
+        {
+            this.Value = partitionKeyValue;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(double partitionKeyValue)
+        {
+            this.Value = partitionKeyValue;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(Guid partitionKeyValue)
+        {
+            this.Value = partitionKeyValue.ToString();
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
         public PartitionKey(object partitionKeyValue)
         {
             if (partitionKeyValue == null)

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -878,7 +878,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// The Azure Cosmos DB LINQ provider compiles LINQ to SQL statements. Refer to http://azure.microsoft.com/documentation/articles/documentdb-sql-query/#linq-to-documentdb-sql for the list of expressions supported by the Azure Cosmos DB LINQ provider. ToString() on the generated IQueryable returns the translated SQL statement. The Azure Cosmos DB provider translates JSON.NET and DataContract serialization attributes for members to their JSON property names.
         /// </remarks>
-        public abstract IOrderedQueryable<T> CreateItemQuery<T>(object partitionKey = null, bool allowSynchronousQueryExecution = false, QueryRequestOptions requestOptions = null);
+        public abstract IOrderedQueryable<T> CreateItemQuery<T>(PartitionKey partitionKey = null, bool allowSynchronousQueryExecution = false, QueryRequestOptions requestOptions = null);
 
         /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed processing.

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -387,12 +387,12 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions);
         }
 
-        public override IOrderedQueryable<T> CreateItemQuery<T>(object partitionKey = null, bool allowSynchronousQueryExecution = false, QueryRequestOptions requestOptions = null)
+        public override IOrderedQueryable<T> CreateItemQuery<T>(PartitionKey partitionKey = null, bool allowSynchronousQueryExecution = false, QueryRequestOptions requestOptions = null)
         {
             requestOptions = requestOptions != null ? requestOptions : new QueryRequestOptions();
             if (partitionKey != null)
             {
-                requestOptions.PartitionKey = new PartitionKey(partitionKey);
+                requestOptions.PartitionKey = partitionKey;
             }
             else
             {
@@ -602,26 +602,26 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        private object CosmosElementToPartitionKeyObject(CosmosElement cosmosElement)
+        private PartitionKey CosmosElementToPartitionKeyObject(CosmosElement cosmosElement)
         {
             // TODO: Leverage original serialization and avoid re-serialization (bug)
             switch (cosmosElement.Type)
             {
                 case CosmosElementType.String:
                     CosmosString cosmosString = cosmosElement as CosmosString;
-                    return cosmosString.Value;
+                    return new PartitionKey(cosmosString.Value);
 
                 case CosmosElementType.Number:
                     CosmosNumber cosmosNumber = cosmosElement as CosmosNumber;
-                    return cosmosNumber.AsFloatingPoint();
+                    return new PartitionKey(cosmosNumber.AsFloatingPoint());
 
                 case CosmosElementType.Boolean:
                     CosmosBoolean cosmosBool = cosmosElement as CosmosBoolean;
-                    return cosmosBool.Value;
+                    return new PartitionKey(cosmosBool.Value);
 
                 case CosmosElementType.Guid:
                     CosmosGuid cosmosGuid = cosmosElement as CosmosGuid;
-                    return cosmosGuid.Value;
+                    return new PartitionKey(cosmosGuid.Value);
 
                 default:
                     throw new ArgumentException(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1038,12 +1038,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(itemList[1].id, queriable.ToList()[1].id);
 
             //LINQ query execution with wrong partition key.
-            linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: "test", allowSynchronousQueryExecution: true);
+            linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: new Cosmos.PartitionKey("test"), allowSynchronousQueryExecution: true);
             queriable = linqQueryable.Where(item => (item.taskNum < 100));
             Assert.AreEqual(0, queriable.Count());
 
             //LINQ query execution with correct partition key.
-            linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: itemList[1].status, allowSynchronousQueryExecution: true, requestOptions: new QueryRequestOptions { ConsistencyLevel = Cosmos.ConsistencyLevel.Eventual });
+            linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(itemList[1].status), allowSynchronousQueryExecution: true, requestOptions: new QueryRequestOptions { ConsistencyLevel = Cosmos.ConsistencyLevel.Eventual });
             queriable = linqQueryable.Where(item => (item.taskNum < 100));
             Assert.AreEqual(1, queriable.Count());
             Assert.AreEqual(itemList[1].id, queriable.ToList()[0].id);
@@ -1051,7 +1051,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //Creating LINQ query without setting allowSynchronousQueryExecution true.
             try
             {
-                linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: itemList[0].status);
+                linqQueryable = this.Container.CreateItemQuery<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(itemList[0].status));
                 queriable = linqQueryable.Where(item => (item.taskNum < 100));
                 queriable.ToList();
                 Assert.Fail("Should throw NotSupportedException");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -60,13 +60,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                 (Documents.Undefined.Value, "[{}]"),
                 (false, "[false]"),
                 (true, "[true]"),
-                (123, "[123]"),
+                (123, "[123.0]"),
                 (123.456, "[123.456]"),
                 ("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
             };
 
             foreach ((dynamic PkValue, string JsonString) testcase in testcases)
             {
+                Assert.AreEqual(testcase.JsonString, new Documents.PartitionKey(testcase.PkValue).InternalKey.ToJsonString());
                 Assert.AreEqual(testcase.JsonString, new PartitionKey(testcase.PkValue).ToString());
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -10,33 +10,6 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class PartitionKeyTests
     {
-        [TestMethod]
-        public void ValidatePartitionKeySupportedTypes()
-        {
-            Dictionary<dynamic, string> pkValuesToJsonStrings = new Dictionary<dynamic, string>()
-            {
-                {"testString", "[\"testString\"]" },
-                {1234, "[1234.0]" },
-                {42.42, "[42.42]" },
-                {true, "[true]" },
-                {false, "[false]" },
-            };
-
-            foreach(var pkValueToJsonString in pkValuesToJsonStrings)
-            {
-                Documents.PartitionKey v2PK = new Documents.PartitionKey(pkValueToJsonString.Key);
-                PartitionKey pk = new PartitionKey(pkValueToJsonString.Key);
-                Assert.AreEqual(pkValueToJsonString.Value, v2PK.InternalKey.ToJsonString());
-                Assert.AreEqual(pkValueToJsonString.Value, pk.ToString());
-            }
-
-            Guid testGuid = new Guid("228326CF-6B43-46B1-BC86-11701FB06E51");
-            Documents.PartitionKey v2PKGuid = new Documents.PartitionKey(testGuid.ToString());
-            PartitionKey pkGuid = new PartitionKey(testGuid);
-            Assert.AreEqual(v2PKGuid.InternalKey.ToJsonString(), pkGuid.ToString());
-            Assert.AreEqual("[\"228326cf-6b43-46b1-bc86-11701fb06e51\"]", pkGuid.ToString());
-        }
-
         [ExpectedException(typeof(ArgumentNullException))]
         [TestMethod]
         public void NullValue()
@@ -82,18 +55,19 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestPartitionKeyValues()
         {
-            Tuple<object, string>[] testcases =
+            (dynamic PkValue, string JsonString)[] testcases =
             {
-                Tuple.Create<object, string>(Documents.Undefined.Value, "[{}]"),
-                Tuple.Create<object, string>(false, "[false]"),
-                Tuple.Create<object, string>(true, "[true]"),
-                Tuple.Create<object, string>(123.456, "[123.456]"),
-                Tuple.Create<object, string>("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
+                (Documents.Undefined.Value, "[{}]"),
+                (false, "[false]"),
+                (true, "[true]"),
+                (123, "[123]"),
+                (123.456, "[123.456]"),
+                ("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
             };
 
-            foreach (Tuple<object, string> testcase in testcases)
+            foreach ((dynamic PkValue, string JsonString) testcase in testcases)
             {
-                Assert.AreEqual(testcase.Item2, new PartitionKey(testcase.Item1).ToString());
+                Assert.AreEqual(testcase.JsonString, new PartitionKey(testcase.PkValue).ToString());
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -4,11 +4,39 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Collections.Generic;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class PartitionKeyTests
     {
+        [TestMethod]
+        public void ValidatePartitionKeySupportedTypes()
+        {
+            Dictionary<dynamic, string> pkValuesToJsonStrings = new Dictionary<dynamic, string>()
+            {
+                {"testString", "[\"testString\"]" },
+                {1234, "[1234.0]" },
+                {42.42, "[42.42]" },
+                {true, "[true]" },
+                {false, "[false]" },
+            };
+
+            foreach(var pkValueToJsonString in pkValuesToJsonStrings)
+            {
+                Documents.PartitionKey v2PK = new Documents.PartitionKey(pkValueToJsonString.Key);
+                PartitionKey pk = new PartitionKey(pkValueToJsonString.Key);
+                Assert.AreEqual(pkValueToJsonString.Value, v2PK.InternalKey.ToJsonString());
+                Assert.AreEqual(pkValueToJsonString.Value, pk.ToString());
+            }
+
+            Guid testGuid = new Guid("228326CF-6B43-46B1-BC86-11701FB06E51");
+            Documents.PartitionKey v2PKGuid = new Documents.PartitionKey(testGuid.ToString());
+            PartitionKey pkGuid = new PartitionKey(testGuid);
+            Assert.AreEqual(v2PKGuid.InternalKey.ToJsonString(), pkGuid.ToString());
+            Assert.AreEqual("[\"228326cf-6b43-46b1-bc86-11701fb06e51\"]", pkGuid.ToString());
+        }
+
         [ExpectedException(typeof(ArgumentNullException))]
         [TestMethod]
         public void NullValue()


### PR DESCRIPTION
# Pull Request Template

## Description

Partition Key currently takes an object as a parameter for the constructor. This is very confusing to users since only a few primitives are supported.

Adding support for Guid. It will just convert the Guid to a string, but prevent users from needing to .ToString() everywhere.
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


