### PR TITLE
Cosmos Status Code draft

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosStatusCodes.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosStatusCodes.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Client hit an unknown error
         /// </summary>
-        ClientError = 900,
+        ClientError = 9000000,
 
         /// <summary>
         /// Client side hit a socket error

--- a/Microsoft.Azure.Cosmos/src/CosmosStatusCodes.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosStatusCodes.cs
@@ -1,0 +1,46 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos
+{
+    /// <summary>
+    /// Represents the cosmos status codes
+    /// </summary>
+    /// <remarks>
+    /// Format is (HttpStatus)(substatus) (xxx)(xxxx)
+    /// HttpStatusCode.NotFound(404) SubStatusCode.Unknown(0) == 4040000
+    /// HttpStatusCode.NotFound(404) SubStatusCode.NameCacheIsStale(1001) == 4041001
+    /// </remarks>
+    public enum CosmosStatusCodes
+    {
+        /// <summary>
+        /// Current Resource is not found
+        /// </summary>
+        NotFound = 4040000,
+
+        /// <summary>
+        /// Name cache is stale
+        /// </summary>
+        NotFoundWithNameCacheIsStale = 4041000,
+
+        /// <summary>
+        /// Partition Key range is gone
+        /// </summary>
+        NotFoundWithPartitionKeyRangeGone = 4041002,
+
+        /// <summary>
+        /// Parent Resource is deleted
+        /// </summary>
+        NotFoundWithParentResource = 4049000,
+
+        /// <summary>
+        /// Client hit an unknown error
+        /// </summary>
+        ClientError = 900,
+
+        /// <summary>
+        /// Client side hit a socket error
+        /// </summary>
+        ClientErrorWithSocketError = 9001001
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

The SDK currently uses HttpStatusCodes which causes the following issues.

- Ambiguity between service errors, network, and client errors
- .NET HttpStatusCodes does not contain all status codes
- Difficult for users to troubleshoot since the status code are generic to all HTTP operations. It's difficult to find a Cosmos DB related content.
- Difficult to troubleshoot since sub status code is often not recorded

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)



