### PR TITLE
GetConflicts instead of property

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainer.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Operations for reading/querying all conflicts
         /// </summary>
-        public abstract CosmosConflicts Conflicts { get; }
+        /// <returns>An instance of <see cref="CosmosConflicts"/> to do operations on Conflicts.</returns>
+        public abstract CosmosConflicts GetConflicts();
 
         /// <summary>
         /// Reads a <see cref="CosmosContainerSettings"/> from the Azure Cosmos service as an asynchronous operation.

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/CosmosContainerCore.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal partial class CosmosContainerCore : CosmosContainer
     {
+        private readonly CosmosConflictsCore conflicts;
+
         /// <summary>
         /// Only used for unit testing
         /// </summary>
@@ -40,7 +42,7 @@ namespace Microsoft.Azure.Cosmos
                 id: containerId);
 
             this.Database = database;
-            this.Conflicts = new CosmosConflictsCore(this.ClientContext, this);
+            this.conflicts = new CosmosConflictsCore(this.ClientContext, this);
             this.cachedUriSegmentWithoutId = this.GetResourceSegmentUriWithoutId();
             this.queryClient = queryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
         }
@@ -49,11 +51,14 @@ namespace Microsoft.Azure.Cosmos
 
         public override CosmosDatabase Database { get; }
 
-        public override CosmosConflicts Conflicts { get; }
-
         internal virtual Uri LinkUri { get; }
 
         internal virtual CosmosClientContext ClientContext { get; }
+
+        public override CosmosConflicts GetConflicts()
+        {
+            return this.conflicts;
+        }
 
         public override Task<ContainerResponse> ReadAsync(
             ContainerRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConflictTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConflictTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 Assert.IsNotNull(request.DocumentServiceRequest.PartitionKeyRangeIdentity);
                 return TestHandler.ReturnSuccess();
             });
-            FeedIterator iterator = container.Conflicts.GetConflictsStreamIterator();
+            FeedIterator iterator = container.GetConflicts().GetConflictsStreamIterator();
             while (iterator.HasMoreResults)
             {
                 CosmosResponseMessage responseMessage = await iterator.FetchNextSetAsync();
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosConflictSettings conflictSettings = new CosmosConflictSettings();
             conflictSettings.SourceResourceId = expectedRID;
 
-            await container.Conflicts.ReadCurrentAsync<JObject>(partitionKey, conflictSettings);
+            await container.GetConflicts().ReadCurrentAsync<JObject>(partitionKey, conflictSettings);
         }
 
         [TestMethod]
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosConflictSettings conflictSettings = new CosmosConflictSettings();
             conflictSettings.Content = someJsonObject.ToString();
 
-            Assert.AreEqual(someJsonObject.ToString(), container.Conflicts.ReadConflictContent<JObject>(conflictSettings).ToString());
+            Assert.AreEqual(someJsonObject.ToString(), container.GetConflicts().ReadConflictContent<JObject>(conflictSettings).ToString());
         }
 
         [TestMethod]
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosConflictSettings conflictSettings = new CosmosConflictSettings();
             conflictSettings.Id = expectedId;
 
-            await container.Conflicts.DeleteConflictAsync(partitionKey, conflictSettings);
+            await container.GetConflicts().DeleteConflictAsync(partitionKey, conflictSettings);
         }
 
         private static CosmosContainerCore GetMockedContainer(Func<CosmosRequestMessage,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 (cosmosClientBuilder) => cosmosClientBuilder.WithConnectionModeDirect());
 
             CosmosContainer container = mockClient.GetContainer("database", "container");
-            FeedIterator<CosmosConflictSettings> feedIterator = container.Conflicts.GetConflictsIterator();
+            FeedIterator<CosmosConflictSettings> feedIterator = container.GetConflicts().GetConflictsIterator();
 
             TestHandler testHandler = new TestHandler((request, cancellationToken) =>
             {
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 (cosmosClientBuilder) => cosmosClientBuilder.WithConnectionModeDirect());
 
             CosmosContainer container = mockClient.GetContainer("database", "container");
-            FeedIterator feedIterator = container.Conflicts.GetConflictsStreamIterator();
+            FeedIterator feedIterator = container.GetConflicts().GetConflictsStreamIterator();
 
             TestHandler testHandler = new TestHandler((request, cancellationToken) =>
             {


### PR DESCRIPTION
# GetConflicts instead of property

## Description

Following #333, the Container -> Conflicts property is converted to Container -> GetConflicts() following the pattern of GetContainer().

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

This PR closes #333