### PR TITLE
Removed virtual from data contracts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosConflictSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosConflictSettings.cs
@@ -34,14 +34,14 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// </remarks>
         [JsonProperty(PropertyName = Documents.Constants.Properties.Id)]
-        public virtual string Id { get; internal set; }
+        public string Id { get; internal set; }
 
         /// <summary>
         /// Gets the operation that resulted in the conflict in the Azure Cosmos DB service.
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(PropertyName = Documents.Constants.Properties.OperationType)]
-        public virtual OperationKind OperationKind { get; internal set; }
+        public OperationKind OperationKind { get; internal set; }
 
         /// <summary>
         /// Gets the content of the Conflict resource in the Azure Cosmos DB service.
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type to use to deserialize the content.</typeparam>
         /// <param name="cosmosJsonSerializer">(Optional) <see cref="CosmosJsonSerializer"/> to use while parsing the content.</param>
         /// <returns>An instance of T</returns>
-        public virtual T GetResource<T>(CosmosJsonSerializer cosmosJsonSerializer = null)
+        public T GetResource<T>(CosmosJsonSerializer cosmosJsonSerializer = null)
         {
             if (!string.IsNullOrEmpty(this.Content))
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosConflictSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosConflictSettings.cs
@@ -43,36 +43,6 @@ namespace Microsoft.Azure.Cosmos
         [JsonProperty(PropertyName = Documents.Constants.Properties.OperationType)]
         public OperationKind OperationKind { get; internal set; }
 
-        /// <summary>
-        /// Gets the content of the Conflict resource in the Azure Cosmos DB service.
-        /// </summary>
-        /// <typeparam name="T">The type to use to deserialize the content.</typeparam>
-        /// <param name="cosmosJsonSerializer">(Optional) <see cref="CosmosJsonSerializer"/> to use while parsing the content.</param>
-        /// <returns>An instance of T</returns>
-        public T GetResource<T>(CosmosJsonSerializer cosmosJsonSerializer = null)
-        {
-            if (!string.IsNullOrEmpty(this.Content))
-            {
-                if (cosmosJsonSerializer == null)
-                {
-                    cosmosJsonSerializer = new CosmosJsonSerializerCore();
-                }
-
-                using (MemoryStream stream = new MemoryStream())
-                {
-                    using (StreamWriter writer = new StreamWriter(stream))
-                    {
-                        writer.Write(this.Content);
-                        writer.Flush();
-                        stream.Position = 0;
-                        return cosmosJsonSerializer.FromStream<T>(stream);
-                    }
-                }
-            }
-
-            return default(T);
-        }
-
         [JsonConverter(typeof(ConflictResourceTypeJsonConverter))]
         [JsonProperty(PropertyName = Documents.Constants.Properties.ResourceType)]
         internal Type ResourceType { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosContainerSettings.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Cosmos
         private ConflictResolutionPolicy conflictResolutionInternal;
 
         private string[] partitionKeyPathTokens;
+        private string id;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CosmosContainerSettings"/> class for the Azure Cosmos DB service.
@@ -85,13 +86,7 @@ namespace Microsoft.Azure.Cosmos
         public CosmosContainerSettings(string id, string partitionKeyPath)
         {
             this.Id = id;
-            if (!string.IsNullOrEmpty(partitionKeyPath))
-            {
-                this.PartitionKey = new PartitionKeyDefinition
-                {
-                    Paths = new Collection<string>() { partitionKeyPath }
-                };
-            }
+            this.PartitionKeyPath = partitionKeyPath;
 
             this.ValidateRequiredProperties();
         }
@@ -100,7 +95,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the Partitioning scheme version used. <see cref="Cosmos.PartitionKeyDefinitionVersion"/>
         /// </summary>
         [JsonIgnore]
-        public virtual PartitionKeyDefinitionVersion? PartitionKeyDefinitionVersion
+        public PartitionKeyDefinitionVersion? PartitionKeyDefinitionVersion
         {
             get => (Cosmos.PartitionKeyDefinitionVersion?)this.PartitionKey?.Version;
 
@@ -119,7 +114,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets or sets the <see cref="ConflictResolutionPolicy" />
         /// </summary>
         [JsonIgnore]
-        public virtual ConflictResolutionPolicy ConflictResolutionPolicy
+        public ConflictResolutionPolicy ConflictResolutionPolicy
         {
             get
             {
@@ -156,13 +151,17 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.Id)]
-        public virtual string Id { get; set; }
+        public string Id
+        {
+            get => this.id;
+            set => this.id = value ?? throw new ArgumentNullException(nameof(this.Id));
+        }
 
         /// <summary>
         /// Gets or sets the <see cref="UniqueKeyPolicy"/> that guarantees uniqueness of documents in container in the Azure Cosmos DB service.
         /// </summary>
         [JsonIgnore]
-        public virtual UniqueKeyPolicy UniqueKeyPolicy
+        public UniqueKeyPolicy UniqueKeyPolicy
         {
             get
             {
@@ -195,7 +194,7 @@ namespace Microsoft.Azure.Cosmos
         /// ETags are used for concurrency checking when updating resources. 
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.ETag)]
-        public virtual string ETag { get; private set; }
+        public string ETag { get; protected set; }
 
         /// <summary>
         /// Gets the last modified timestamp associated with <see cref="CosmosContainerSettings" /> from the Azure Cosmos DB service.
@@ -203,7 +202,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>The last modified timestamp associated with the resource.</value>
         [JsonProperty(PropertyName = Constants.Properties.LastModified, NullValueHandling = NullValueHandling.Ignore)]
         [JsonConverter(typeof(UnixDateTimeConverter))]
-        public virtual DateTime? LastModified { get; private set; }
+        public DateTime? LastModified { get; protected set; }
 
         /// <summary>
         /// Gets the <see cref="IndexingPolicy"/> associated with the container from the Azure Cosmos DB service. 
@@ -212,7 +211,7 @@ namespace Microsoft.Azure.Cosmos
         /// The indexing policy associated with the container.
         /// </value>
         [JsonIgnore]
-        public virtual IndexingPolicy IndexingPolicy
+        public IndexingPolicy IndexingPolicy
         {
             get
             {
@@ -239,7 +238,22 @@ namespace Microsoft.Azure.Cosmos
         /// JSON path used for containers partitioning
         /// </summary>
         [JsonIgnore]
-        public virtual string PartitionKeyPath => this.PartitionKey?.Paths[0];
+        public string PartitionKeyPath
+        {
+            get => this.PartitionKey?.Paths != null && this.PartitionKey.Paths.Count > 0 ? this.PartitionKey?.Paths[0] : null;
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    throw new ArgumentNullException(nameof(this.PartitionKeyPath));
+                }
+
+                this.PartitionKey = new PartitionKeyDefinition
+                {
+                    Paths = new Collection<string>() { value }
+                };
+            }
+        }
 
         /// <summary>
         /// Gets or sets the time to live base timestamp property path.
@@ -251,7 +265,7 @@ namespace Microsoft.Azure.Cosmos
         /// By default, TimeToLivePropertyPath is set to null meaning the time to live is based on the _ts property in item.
         /// </value>
         [JsonProperty(PropertyName = Constants.Properties.TimeToLivePropertyPath, NullValueHandling = NullValueHandling.Ignore)]
-        public virtual string TimeToLivePropertyPath { get; set; }
+        public string TimeToLivePropertyPath { get; set; }
 
         /// <summary>
         /// Gets the default time to live in seconds for item in a container from the Azure Cosmos service.
@@ -309,7 +323,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         [JsonProperty(PropertyName = Constants.Properties.DefaultTimeToLive)]
-        public virtual int? DefaultTimeToLive { get; set; }
+        public int? DefaultTimeToLive { get; set; }
 
         /// <summary>
         /// The function selects the right partition key constant mapping for <see cref="PartitionKey.NonePartitionKeyValue"/>
@@ -384,7 +398,7 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.RId)]
 
-        internal virtual string ResourceId { get; private set; }
+        internal string ResourceId { get; private set; }
 
         internal bool HasPartitionKey => this.PartitionKey != null;
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosDatabaseSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosDatabaseSettings.cs
@@ -60,11 +60,22 @@ namespace Microsoft.Azure.Cosmos
     /// <seealso cref="CosmosContainerSettings"/>
     public class CosmosDatabaseSettings
     {
+        private string id;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="CosmosDatabaseSettings"/> class for the Azure Cosmos DB service.
         /// </summary>
         public CosmosDatabaseSettings()
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CosmosDatabaseSettings"/> class for the Azure Cosmos DB service.
+        /// </summary>
+        /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
+        public CosmosDatabaseSettings(string id)
+        {
+            this.Id = id;
         }
 
         /// <summary>
@@ -88,7 +99,11 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.Id)]
-        public virtual string Id { get; set; }
+        public string Id
+        {
+            get => this.id;
+            set => this.id = value ?? throw new ArgumentNullException(nameof(this.Id));
+        }
 
         /// <summary>
         /// Gets the entity tag associated with the resource from the Azure Cosmos DB service.
@@ -100,7 +115,7 @@ namespace Microsoft.Azure.Cosmos
         /// ETags are used for concurrency checking when updating resources. 
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.ETag)]
-        public virtual string ETag { get; private set; }
+        public string ETag { get; private set; }
 
         /// <summary>
         /// Gets the last modified timestamp associated with <see cref="CosmosDatabaseSettings" /> from the Azure Cosmos DB service.
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>The last modified timestamp associated with the resource.</value>
         [JsonConverter(typeof(UnixDateTimeConverter))]
         [JsonProperty(PropertyName = Constants.Properties.LastModified)]
-        public virtual DateTime? LastModified { get; private set; }
+        public DateTime? LastModified { get; private set; }
 
         /// <summary>
         /// Gets the Resource Id associated with the resource in the Azure Cosmos DB service.
@@ -122,6 +137,6 @@ namespace Microsoft.Azure.Cosmos
         /// These resource ids are used when building up SelfLinks, a static addressable Uri for each resource within a database account.
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.RId)]
-        internal virtual string ResourceId { get; private set; }
+        internal string ResourceId { get; private set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosStoredProcedureSettings.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosStoredProcedureSettings.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
     /// </remarks>
     public class CosmosStoredProcedureSettings
     {
+        private string id;
+        private string body;
+
         /// <summary>
         /// Initializes a new instance of the Stored Procedure class for the Azure Cosmos DB service.
         /// </summary>
@@ -24,20 +27,15 @@ namespace Microsoft.Azure.Cosmos.Scripts
         {
         }
 
-        internal CosmosStoredProcedureSettings(
+        /// <summary>
+        /// Initializes a new instance of the Stored Procedure class for the Azure Cosmos DB service.
+        /// </summary>
+        /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
+        /// <param name="body">The body of the Azure Cosmos DB stored procedure.</param>
+        public CosmosStoredProcedureSettings(
             string id,
             string body)
         {
-            if (string.IsNullOrEmpty(id))
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            if (string.IsNullOrEmpty(body))
-            {
-                throw new ArgumentNullException(nameof(body));
-            }
-
             this.Id = id;
             this.Body = body;
         }
@@ -48,7 +46,11 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <value>The body of the stored procedure.</value>
         /// <remarks>Must be a valid JavaScript function. For e.g. "function () { getContext().getResponse().setBody('Hello World!'); }"</remarks>
         [JsonProperty(PropertyName = Constants.Properties.Body)]
-        public virtual string Body { get; set; }
+        public string Body
+        {
+            get => this.body;
+            set => this.body = value ?? throw new ArgumentNullException(nameof(this.Body));
+        }
 
         /// <summary>
         /// Gets or sets the Id of the resource in the Azure Cosmos DB service.
@@ -64,7 +66,11 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </para>
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.Id)]
-        public virtual string Id { get; set; }
+        public string Id
+        {
+            get => this.id;
+            set => this.id = value ?? throw new ArgumentNullException(nameof(this.Id));
+        }
 
         /// <summary>
         /// Gets the entity tag associated with the resource from the Azure Cosmos DB service.
@@ -76,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// ETags are used for concurrency checking when updating resources. 
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.ETag)]
-        public virtual string ETag { get; private set; }
+        public string ETag { get; private set; }
 
         /// <summary>
         /// Gets the last modified timestamp associated with <see cref="CosmosStoredProcedureSettings" /> from the Azure Cosmos DB service.
@@ -84,7 +90,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <value>The last modified timestamp associated with the resource.</value>
         [JsonConverter(typeof(UnixDateTimeConverter))]
         [JsonProperty(PropertyName = Constants.Properties.LastModified)]
-        public virtual DateTime? LastModified { get; private set; }
+        public DateTime? LastModified { get; private set; }
 
         /// <summary>
         /// Gets the Resource Id associated with the resource in the Azure Cosmos DB service.
@@ -98,6 +104,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// These resource ids are used when building up SelfLinks, a static addressable Uri for each resource within a database account.
         /// </remarks>
         [JsonProperty(PropertyName = Constants.Properties.RId)]
-        internal virtual string ResourceId { get; private set; }
+        internal string ResourceId { get; private set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
@@ -20,9 +20,10 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void VerifyAllPublicMembersAreVirtualUnitTesting()
         {
             // All of the public properties and methods should be virtual to allow users to 
-            // create unit tests by mocking the different types.
+            // create unit tests by mocking the different types. Data Contracts do not support mocking so exclude all types that end with Settings.
             IEnumerable<Type> allClasses = from t in Assembly.GetAssembly(typeof(CosmosClient)).GetTypes()
                                            where t.IsClass && t.Namespace == "Microsoft.Azure.Cosmos" && t.IsPublic && !t.IsAbstract && !t.IsSealed
+                                           where !t.Name.EndsWith("Settings")
                                            select t;
 
             // Get the entire list to prevent running the test for each method/property

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -354,6 +354,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 "DefaultTimeToLive", 
                 "IndexingPolicy", 
                 "TimeToLivePropertyPath",
+                "PartitionKeyPath",
                 "PartitionKeyDefinitionVersion",
                 "ConflictResolutionPolicy");
 
@@ -537,13 +538,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                         // Set accessor 
                         bool publicSetAllowed = publicSettable.Where(e => m.Name.EndsWith("_" + e)).Any();
                         Assert.AreEqual(publicSetAllowed, m.IsPublic, m.ToString());
-                        Assert.AreEqual(publicSetAllowed, m.IsVirtual, m.ToString());
+                        Assert.IsFalse(m.IsVirtual, m.ToString());
                     }
                     else
                     {
                         // get accessor 
                         Assert.IsTrue(m.IsPublic, m.ToString());
-                        Assert.IsTrue(m.IsVirtual, m.ToString());
+                        Assert.IsFalse(m.IsVirtual, m.ToString());
                     }
                 }
             }


### PR DESCRIPTION
# Pull Request Template

## Description
Updating the data contract to match the SDK .NET standards. This removes virtual from all the properties which will block the ability to mock the contracts.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Put closes #344


