### PR TITLE
Azure Functions sample fix

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/AzureFunctions/Startup.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/AzureFunctions/Startup.cs
@@ -13,6 +13,7 @@ namespace Cosmos.Samples.AzureFunctions
         private static IConfigurationRoot configuration = new ConfigurationBuilder()
                 .SetBasePath(Environment.CurrentDirectory)
                 .AddJsonFile("AppSettings.json", optional: true, reloadOnChange: true)
+                .AddEnvironmentVariables()
                 .Build();
 
         public override void Configure(IFunctionsHostBuilder builder)
@@ -23,13 +24,13 @@ namespace Cosmos.Samples.AzureFunctions
                 string endpoint = configuration["EndPointUrl"];
                 if (string.IsNullOrEmpty(endpoint))
                 {
-                    throw new ArgumentNullException("Please specify a valid endpoint in the appSettings.json");
+                    throw new ArgumentNullException("Please specify a valid endpoint in the appSettings.json file or your Azure Functions Settings.");
                 }
 
                 string authKey = configuration["AuthorizationKey"];
                 if (string.IsNullOrEmpty(authKey) || string.Equals(authKey, "Super secret key"))
                 {
-                    throw new ArgumentException("Please specify a valid AuthorizationKey in the appSettings.json");
+                    throw new ArgumentException("Please specify a valid AuthorizationKey in the appSettings.json file or your Azure Functions Settings.");
                 }
 
                 CosmosClientBuilder configurationBuilder = new CosmosClientBuilder(endpoint, authKey);


### PR DESCRIPTION
# Azure Functions sample fix

## Description

Current Azure Functions sample ran locally, but when deployed to Azure, it was missing the Environment aware extension to read the configuration.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

This PR closes #374