### PR TITLE
Rename workflowName and WithCosmosLeaseContainer 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Cosmos
         private bool isBuilt;
 
         internal ChangeFeedProcessorBuilder(
-            string workflowName, 
+            string processorName, 
             CosmosContainerCore cosmosContainer, 
             ChangeFeedProcessor changeFeedProcessor,
             Action<DocumentServiceLeaseStoreManager,
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Cosmos
                 CosmosContainerCore> applyBuilderConfiguration)
         {
             this.changeFeedLeaseOptions = new ChangeFeedLeaseOptions();
-            this.changeFeedLeaseOptions.LeasePrefix = workflowName;
+            this.changeFeedLeaseOptions.LeasePrefix = processorName;
             this.monitoredContainer = cosmosContainer;
             this.changeFeedProcessor = changeFeedProcessor;
             this.applyBuilderConfiguration = applyBuilderConfiguration;
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Sets a custom configuration to be used by this instance of <see cref="ChangeFeedProcessor"/> to control how leases are maintained in a container when using <see cref="WithCosmosLeaseContainer"/>.
+        /// Sets a custom configuration to be used by this instance of <see cref="ChangeFeedProcessor"/> to control how leases are maintained in a container when using <see cref="WithLeaseContainer"/>.
         /// </summary>
         /// <param name="acquireInterval">Interval to kick off a task to verify if leases are distributed evenly among known host instances.</param>
         /// <param name="expirationInterval">Interval for which the lease is taken. If the lease is not renewed within this interval, it will cause it to expire and ownership of the lease will move to another processor instance.</param>
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="leaseContainer">Instance of a Cosmos Container to hold the leases.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
-        public virtual ChangeFeedProcessorBuilder WithCosmosLeaseContainer(CosmosContainer leaseContainer)
+        public virtual ChangeFeedProcessorBuilder WithLeaseContainer(CosmosContainer leaseContainer)
         {
             if (leaseContainer == null) throw new ArgumentNullException(nameof(leaseContainer));
             if (this.leaseContainer != null) throw new InvalidOperationException("The builder already defined a lease container.");
@@ -228,12 +228,12 @@ namespace Microsoft.Azure.Cosmos
 
             if (this.leaseContainer == null && this.LeaseStoreManager == null)
             {
-                throw new InvalidOperationException($"Defining the lease store by WithCosmosLeaseContainer or WithInMemoryLeaseContainer is required.");
+                throw new InvalidOperationException($"Defining the lease store by WithLeaseContainer or WithInMemoryLeaseContainer is required.");
             }
 
             if (this.changeFeedLeaseOptions.LeasePrefix == null)
             {
-                throw new InvalidOperationException("Workflow name was not specified using WithWorkflowName");
+                throw new InvalidOperationException("Processor name not specified during creation.");
             }
 
             this.InitializeDefaultOptions();

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItems.cs
@@ -883,25 +883,25 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed processing.
         /// </summary>
-        /// <param name="workflowName">A name that identifies the work that the Processor will do.</param>
+        /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
         /// <param name="onChangesDelegate">Delegate to receive changes.</param>
         /// <returns>An instace of <see cref="ChangeFeedProcessorBuilder"/></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
-            string workflowName, 
+            string processorName, 
             Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate);
 
         /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed monitoring.
         /// </summary>
-        /// <param name="workflowName">A name that identifies the work associated with the Processor the Estimator is going to measure.</param>
+        /// <param name="processorName">The name of the Processor the Estimator is going to measure.</param>
         /// <param name="estimationDelegate">Delegate to receive estimation.</param>
         /// <param name="estimationPeriod">Time interval on which to report the estimation.</param>
         /// <remarks>
-        /// The goal of the Estimator is to measure progress of a particular processor. In order to do that, the <paramref name="workflowName"/> and other parameters, like the leases container, need to match that of the Processor to measure.
+        /// The goal of the Estimator is to measure progress of a particular processor. In order to do that, the <paramref name="processorName"/> and other parameters, like the leases container, need to match that of the Processor to measure.
         /// </remarks>
         /// <returns>An instace of <see cref="ChangeFeedProcessorBuilder"/></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
-            string workflowName, 
+            string processorName, 
             Func<long, CancellationToken, Task> estimationDelegate, 
             TimeSpan? estimationPeriod = null);
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -403,12 +403,12 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
-            string workflowName,
+            string processorName,
             Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate)
         {
-            if (workflowName == null)
+            if (processorName == null)
             {
-                throw new ArgumentNullException(nameof(workflowName));
+                throw new ArgumentNullException(nameof(processorName));
             }
 
             if (onChangesDelegate == null)
@@ -419,20 +419,20 @@ namespace Microsoft.Azure.Cosmos
             ChangeFeedObserverFactoryCore<T> observerFactory = new ChangeFeedObserverFactoryCore<T>(onChangesDelegate);
             ChangeFeedProcessorCore<T> changeFeedProcessor = new ChangeFeedProcessorCore<T>(observerFactory);
             return new ChangeFeedProcessorBuilder(
-                workflowName: workflowName,
+                processorName: processorName,
                 cosmosContainer: this,
                 changeFeedProcessor: changeFeedProcessor,
                 applyBuilderConfiguration: changeFeedProcessor.ApplyBuildConfiguration);
         }
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
-            string workflowName,
+            string processorName,
             Func<long, CancellationToken, Task> estimationDelegate,
             TimeSpan? estimationPeriod = null)
         {
-            if (workflowName == null)
+            if (processorName == null)
             {
-                throw new ArgumentNullException(nameof(workflowName));
+                throw new ArgumentNullException(nameof(processorName));
             }
 
             if (estimationDelegate == null)
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.Cosmos
 
             ChangeFeedEstimatorCore changeFeedEstimatorCore = new ChangeFeedEstimatorCore(estimationDelegate, estimationPeriod);
             return new ChangeFeedProcessorBuilder(
-                workflowName: workflowName,
+                processorName: processorName,
                 cosmosContainer: this,
                 changeFeedProcessor: changeFeedEstimatorCore,
                 applyBuilderConfiguration: changeFeedEstimatorCore.ApplyBuildConfiguration);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     return Task.CompletedTask;
                 })
                 .WithInstanceName("random")
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             // Start the processor, insert 1 document to generate a checkpoint
             await processor.StartAsync();
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                 .WithStartFromBeginning()
                 .WithInstanceName("random")
                 .WithMaxItems(6)
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             // Generate the payload
             await scripts.ExecuteStoredProcedureAsync<int, object>(new PartitionKey(partitionKey), sprocId, 0);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await estimator.StartAsync();
             await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     return Task.CompletedTask;
                 })
                 .WithInstanceName("random")
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await processor.StartAsync();
             await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await estimator.StartAsync();
             await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     return Task.CompletedTask;
                 })
                 .WithInstanceName("random")
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await processor.StartAsync();
             // Letting processor initialize
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
                 }, TimeSpan.FromSeconds(1))
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             
             // Inserting more documents

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     return Task.CompletedTask;
                 })
                 .WithInstanceName("random")
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await processor.StartAsync();
             // Letting processor initialize
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     return Task.CompletedTask;
                 })
                 .WithInstanceName("random")
-                .WithCosmosLeaseContainer(this.LeaseContainer).Build();
+                .WithLeaseContainer(this.LeaseContainer).Build();
 
             await processor.StartAsync();
             // Letting processor initialize

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorBuilderTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
                 verifier);
 
-            builder.WithCosmosLeaseContainer(leaseContainerForBuilder);
+            builder.WithLeaseContainer(leaseContainerForBuilder);
 
             builder.Build();
         }
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
                 verifier);
 
-            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+            builder.WithLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
             builder.WithLeaseConfiguration(acquireInterval, expirationInterval, renewInterval);
 
             builder.Build();
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
                 ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
 
-            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+            builder.WithLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
 
             // This build should not throw
             builder.Build();
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
                 ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
 
-            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+            builder.WithLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
 
             Assert.IsInstanceOfType(builder.Build(), typeof(ChangeFeedProcessor));
         }
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 ChangeFeedProcessorBuilderTests.GetMockedProcessor(),
                 ChangeFeedProcessorBuilderTests.GetEmptyInitialization());
 
-            builder.WithCosmosLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
+            builder.WithLeaseContainer(ChangeFeedProcessorBuilderTests.GetMockedContainer());
 
             Assert.IsInstanceOfType(builder.Build(), typeof(ChangeFeedProcessor));
         }


### PR DESCRIPTION
# Rename workflowName and WithCosmosLeaseContainer 

## Description

This PR addresses 2 renames:
* workflowName -> processorName
* WithCosmosLeaseContainer -> WithLeaseContainer 

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

This PR closes #387