### PR TITLE
Fix query continuation token throw

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedResponseBinder.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedResponseBinder.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Azure.Cosmos
 
         public static CosmosQueryResponse ConvertToCosmosQueryResponse(
             FeedResponse<CosmosElement> dynamicFeed,
-            CosmosSerializationOptions cosmosSerializationOptions)
+            CosmosSerializationOptions cosmosSerializationOptions,
+            bool hasMoreResults)
         {
             IJsonWriter jsonWriter;
             if (cosmosSerializationOptions != null)
@@ -187,6 +188,7 @@ namespace Microsoft.Azure.Cosmos
                 dynamicFeed.Headers,
                 memoryStream,
                 dynamicFeed.Count,
+                hasMoreResults,
                 dynamicFeed.InternalResponseContinuation,
                 dynamicFeed.DisallowContinuationTokenMessage,
                 dynamicFeed.QueryMetrics);

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQuery.cs
@@ -376,7 +376,8 @@ namespace Microsoft.Azure.Cosmos.Linq
             FeedResponse<CosmosElement> response = await this.queryExecutionContext.ExecuteNextAsync(cancellationToken);
             CosmosQueryResponse typedFeedResponse = FeedResponseBinder.ConvertToCosmosQueryResponse(
                        response,
-                       this.feedOptions.CosmosSerializationOptions);
+                       this.feedOptions.CosmosSerializationOptions,
+                       !this.queryExecutionContext.IsDone);
 
             if (!this.HasMoreResults && !tracedLastExecution)
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Item/CosmosItemsCore.cs
@@ -545,7 +545,8 @@ namespace Microsoft.Azure.Cosmos
                 FeedResponse<CosmosElement> feedResponse = await documentQueryExecution.ExecuteNextAsync(cancellationToken);
                 return CosmosQueryResponse.CreateResponse(
                     feedResponse: feedResponse,
-                    cosmosSerializationOptions: queryRequestOptions.CosmosSerializationOptions);
+                    cosmosSerializationOptions: queryRequestOptions.CosmosSerializationOptions,
+                    hasMoreResults: !documentQueryExecution.IsDone);
             }
             catch (DocumentClientException exception)
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Azure.Cosmos
         private bool _isDisposed = false;
         private readonly IReadOnlyDictionary<string, QueryMetrics> _queryMetrics;
         private readonly string disallowContinuationTokenMessage;
-        private readonly string continuationToken;
 
         /// <summary>
         /// Empty constructor that can be used for unit testing
@@ -48,7 +47,7 @@ namespace Microsoft.Azure.Cosmos
             this.Count = count;
             this.StatusCode = HttpStatusCode.OK;
             this.disallowContinuationTokenMessage = disallowContinuationTokenMessage;
-            this.continuationToken = continuationToken;
+            this.InternalContinuationToken = continuationToken;
         }
 
         internal CosmosQueryResponse(
@@ -57,7 +56,7 @@ namespace Microsoft.Azure.Cosmos
             TimeSpan? retryAfter,
             INameValueCollection responseHeaders = null)
         {
-            this.continuationToken = null;
+            this.InternalContinuationToken = null;
             this.Content = null;
             this.ResponseHeaders = responseHeaders;
             this.StatusCode = httpStatusCode;
@@ -77,7 +76,7 @@ namespace Microsoft.Azure.Cosmos
                     throw new ArgumentException(this.disallowContinuationTokenMessage);
                 }
 
-                return this.continuationToken;
+                return this.InternalContinuationToken;
             }
         }
 
@@ -146,6 +145,8 @@ namespace Microsoft.Azure.Cosmos
         /// Returns true if the operation succeeded
         /// </summary>
         public virtual bool IsSuccess => this.StatusCode == HttpStatusCode.OK;
+
+        internal virtual string InternalContinuationToken { get; }
 
         internal TimeSpan? RetryAfter { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosQueryResponse.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Cosmos
         private bool _isDisposed = false;
         private readonly IReadOnlyDictionary<string, QueryMetrics> _queryMetrics;
         private readonly string disallowContinuationTokenMessage;
+        private bool hasMoreResults;
 
         /// <summary>
         /// Empty constructor that can be used for unit testing
@@ -37,6 +38,7 @@ namespace Microsoft.Azure.Cosmos
             INameValueCollection responseHeaders,
             Stream content,
             int count,
+            bool hasMoreResults,
             string continuationToken,
             string disallowContinuationTokenMessage,
             IReadOnlyDictionary<string, QueryMetrics> queryMetrics = null)
@@ -45,6 +47,7 @@ namespace Microsoft.Azure.Cosmos
             this._queryMetrics = queryMetrics;
             this.Content = content;
             this.Count = count;
+            this.hasMoreResults = hasMoreResults;
             this.StatusCode = HttpStatusCode.OK;
             this.disallowContinuationTokenMessage = disallowContinuationTokenMessage;
             this.InternalContinuationToken = continuationToken;
@@ -154,9 +157,10 @@ namespace Microsoft.Azure.Cosmos
 
         internal static CosmosQueryResponse CreateResponse(
             FeedResponse<CosmosElement> feedResponse,
-            CosmosSerializationOptions cosmosSerializationOptions)
+            CosmosSerializationOptions cosmosSerializationOptions,
+            bool hasMoreResults)
         {
-            return FeedResponseBinder.ConvertToCosmosQueryResponse(feedResponse, cosmosSerializationOptions);
+            return FeedResponseBinder.ConvertToCosmosQueryResponse(feedResponse, cosmosSerializationOptions, hasMoreResults);
         }
 
         /// <summary>
@@ -173,7 +177,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal bool GetHasMoreResults()
         {
-            return !string.IsNullOrEmpty(this.ContinuationToken);
+            return this.hasMoreResults;
         }
     }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/CosmosResultSetIteratorCore.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos
             cancellationToken.ThrowIfCancellationRequested();
 
             CosmosQueryResponse response = await this.nextResultSetDelegate(this.continuationToken, this.queryOptions, this.state, cancellationToken);
-            this.continuationToken = response.ContinuationToken;
+            this.continuationToken = response.InternalContinuationToken;
             this.HasMoreResults = response.GetHasMoreResults();
             return response;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1841,6 +1841,34 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     string disallowContinuationErrorMessage = RMResources.UnorderedDistinctQueryContinuationToken;
                     Assert.AreEqual(disallowContinuationErrorMessage, ex.Message);
                 }
+
+                try
+                {
+                    string continuationToken = null;
+                    do
+                    {
+                        CosmosResultSetIterator documentQuery = container.Items.CreateItemQueryAsStream(
+                            queryWithDistinct,
+                            maxItemCount: 10,
+                            maxConcurrency: 100);
+
+                        CosmosQueryResponse cosmosQueryResponse = await documentQuery.FetchNextSetAsync();
+
+                        continuationToken = cosmosQueryResponse.ContinuationToken;
+
+                    }
+                    while (continuationToken != null);
+                    Assert.IsTrue(
+                        documentsFromWithDistinct.IsSubsetOf(documentsFromWithoutDistinct),
+                        $"Documents didn't match for {queryWithDistinct} on a Partitioned container");
+
+                    Assert.Fail("Expected an exception when using continuation tokens on an unordered distinct query.");
+                }
+                catch (ArgumentException ex)
+                {
+                    string disallowContinuationErrorMessage = RMResources.UnorderedDistinctQueryContinuationToken;
+                    Assert.AreEqual(disallowContinuationErrorMessage, ex.Message);
+                }
             }
             #endregion
             #region Ordered Region


### PR DESCRIPTION
# Pull Request Template

## Description

Stream query are not accessing the internal continuation token. This is causing the query API to always throw as the iterator tries to access the value. It now correctly access the continuation token and added tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


