### PR TITLE
user string encoding for binary encoding

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/JsonBinaryEncoding.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonBinaryEncoding.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.Cosmos.Json
             }
             else if (multiByteTypeMarker.Length == 2 && JsonBinaryEncoding.TypeMarker.IsTwoByteEncodedSystemString(multiByteTypeMarker.One))
             {
-                const byte OneByteCount = JsonBinaryEncoding.TypeMarker.SystemString2ByteLengthMax - JsonBinaryEncoding.TypeMarker.SystemString2ByteLengthMin;
+                const byte OneByteCount = JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMax - JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin;
                 systemStringId = OneByteCount
                     + multiByteTypeMarker.Two
                     + ((multiByteTypeMarker.One - JsonBinaryEncoding.TypeMarker.SystemString2ByteLengthMin) * 0xFF);
@@ -493,9 +493,9 @@ namespace Microsoft.Azure.Cosmos.Json
                 userStringId = multiByteTypeMarker.One - JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin;
 
             }
-            else if (multiByteTypeMarker.Length == 2 && JsonBinaryEncoding.TypeMarker.IsTwoByteEncodedSystemString(multiByteTypeMarker.One))
+            else if (multiByteTypeMarker.Length == 2 && JsonBinaryEncoding.TypeMarker.IsTwoByteEncodedUserString(multiByteTypeMarker.One))
             {
-                const byte OneByteCount = JsonBinaryEncoding.TypeMarker.UserString2ByteLengthMax - JsonBinaryEncoding.TypeMarker.UserString2ByteLengthMin;
+                const byte OneByteCount = JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMax - JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin;
                 userStringId = OneByteCount
                     + multiByteTypeMarker.Two
                     + ((multiByteTypeMarker.One - JsonBinaryEncoding.TypeMarker.UserString2ByteLengthMin) * 0xFF);

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
@@ -20,13 +20,15 @@ namespace Microsoft.Azure.Cosmos.Json
             private readonly BinaryNode rootNode;
             private readonly LittleEndianBinaryReader binaryReader;
             private readonly byte[] buffer;
+            private readonly JsonStringDictionary jsonStringDictionary;
 
             /// <summary>
             /// Initializes a new instance of the JsonBinaryNavigator class
             /// </summary>
             /// <param name="buffer">The (UTF-8) buffer to navigate.</param>
+            /// <param name="jsonStringDictionary">The JSON string dictionary.</param>
             /// <param name="skipValidation">whether to skip validation or not.</param>
-            public JsonBinaryNavigator(byte[] buffer, bool skipValidation = false)
+            public JsonBinaryNavigator(byte[] buffer, JsonStringDictionary jsonStringDictionary, bool skipValidation = false)
             {
                 if (buffer == null)
                 {
@@ -44,6 +46,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 // true, since buffer is visible
                 this.binaryReader = new LittleEndianBinaryReader(new MemoryStream(buffer, 0, buffer.Length, false, true));
                 this.buffer = buffer;
+                this.jsonStringDictionary = jsonStringDictionary;
             }
 
             /// <summary>
@@ -141,7 +144,7 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 long offset = ((BinaryNode)stringNode).Offset;
                 this.binaryReader.BaseStream.Seek(offset, SeekOrigin.Begin);
-                return JsonBinaryEncoding.GetStringValue(this.binaryReader);
+                return JsonBinaryEncoding.GetStringValue(this.binaryReader, this.jsonStringDictionary);
             }
 
             public override sbyte GetInt8Value(IJsonNavigatorNode numberNode)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonTextNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonTextNavigator.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Json
             /// <param name="skipValidation">whether to skip validation or not.</param>
             public JsonTextNavigator(byte[] buffer, bool skipValidation = false)
             {
-                IJsonReader jsonTextReader = JsonReader.Create(buffer, skipValidation);
+                IJsonReader jsonTextReader = JsonReader.Create(buffer: buffer, jsonStringDictionary: null, skipValidation: skipValidation);
                 if (jsonTextReader.SerializationFormat != JsonSerializationFormat.Text)
                 {
                     throw new ArgumentException("jsonTextReader's serialization format must actually be text");

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.cs
@@ -28,9 +28,10 @@ namespace Microsoft.Azure.Cosmos.Json
         /// Creates a JsonNavigator that can navigate a supplied buffer
         /// </summary>
         /// <param name="buffer">The buffer to navigate</param>
+        /// <param name="jsonStringDictionary">The optional json string dictionary for binary encoding.</param>
         /// <param name="skipValidation">Whether validation should be skipped.</param>
         /// <returns>A concrete JsonNavigator that can navigate the supplied buffer.</returns>
-        public static IJsonNavigator Create(byte[] buffer, bool skipValidation = false)
+        public static IJsonNavigator Create(byte[] buffer, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
         {
             if (buffer == null)
             {
@@ -44,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 // Explicitly pick from the set of supported formats
                 case JsonSerializationFormat.Binary:
-                    return new JsonBinaryNavigator(buffer, skipValidation);
+                    return new JsonBinaryNavigator(buffer, jsonStringDictionary, skipValidation);
                 default:
                     // or otherwise assume text format
                     return new JsonTextNavigator(buffer, skipValidation);

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -37,12 +37,12 @@ namespace Microsoft.Azure.Cosmos.Json
             private readonly ProgressStack progressStack;
 
             public JsonBinaryReader(byte[] buffer, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
-                : this(new JsonBinaryArrayBuffer(buffer))
+                : this(new JsonBinaryArrayBuffer(buffer, jsonStringDictionary))
             {
             }
 
             public JsonBinaryReader(Stream stream, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
-                : this(new JsonBinaryStreamBuffer(stream))
+                : this(new JsonBinaryStreamBuffer(stream, jsonStringDictionary))
             {
             }
 
@@ -980,8 +980,9 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// Initializes a new instance of the JsonBinaryStreamBuffer class.
                 /// </summary>
                 /// <param name="stream">The stream to buffer from.</param>
-                public JsonBinaryStreamBuffer(Stream stream)
-                    : base(stream)
+                /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
+                public JsonBinaryStreamBuffer(Stream stream, JsonStringDictionary jsonStringDictionary = null)
+                    : base(stream, jsonStringDictionary)
                 {
                     if (stream == null)
                     {

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -625,13 +625,15 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// Note that this reader is able to read from a little endian stream even if the client is on a big endian machine.
                 /// </summary>
                 protected readonly LittleEndianBinaryReader BinaryReader;
+                protected readonly JsonStringDictionary jsonStringDictionary;
                 private JsonTokenType currentTokenType;
 
                 /// <summary>
                 /// Initializes a new instance of the JsonBinaryBufferBase class from an array of bytes.
                 /// </summary>
                 /// <param name="stream">A stream to read from.</param>
-                protected JsonBinaryBufferBase(Stream stream)
+                /// <param name="jsonStringDictionary">The JSON string dictionary to use for user string encoding.</param>
+                protected JsonBinaryBufferBase(Stream stream, JsonStringDictionary jsonStringDictionary = null)
                 {
                     if (stream == null)
                     {
@@ -639,6 +641,7 @@ namespace Microsoft.Azure.Cosmos.Json
                     }
 
                     this.BinaryReader = new LittleEndianBinaryReader(stream, Encoding.UTF8);
+                    this.jsonStringDictionary = jsonStringDictionary;
                 }
 
                 /// <summary>
@@ -876,7 +879,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 private string GetStringValue(ArraySegment<byte> jsonToken)
                 {
                     BinaryReader binaryReader = this.GetBinaryReaderAtToken(jsonToken);
-                    return JsonBinaryEncoding.GetStringValue(binaryReader);
+                    return JsonBinaryEncoding.GetStringValue(binaryReader, this.jsonStringDictionary);
                 }
             }
             #endregion
@@ -895,8 +898,9 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// Initializes a new instance of the JsonBinaryArrayBuffer class.
                 /// </summary>
                 /// <param name="buffer">The source buffer to read from.</param>
-                public JsonBinaryArrayBuffer(byte[] buffer)
-                    : base(new MemoryStream(buffer, 0, buffer.Length, false, true))
+                /// <param name="jsonStringDictionary">The string dictionary to use for dictionary encoding.</param>
+                public JsonBinaryArrayBuffer(byte[] buffer, JsonStringDictionary jsonStringDictionary = null)
+                    : base(new MemoryStream(buffer, 0, buffer.Length, false, true), jsonStringDictionary)
                 {
                     if (buffer == null)
                     {

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -25,23 +25,28 @@ namespace Microsoft.Azure.Cosmos.Json
             private readonly JsonBinaryBufferBase jsonBinaryBuffer;
 
             /// <summary>
+            /// Dictionary used for user string encoding.
+            /// </summary>
+            private readonly JsonStringDictionary jsonStringDictionary;
+
+            /// <summary>
             /// For binary there is no end of token marker in the actual binary, but the JsonReader interface still needs to surface ObjectEndToken and ArrayEndToken.
             /// To accommodate for this we have a progress stack to let us know how many bytes there are left to read for all levels of nesting. 
             /// With this information we know that we are at the end of a context and can now surface an end object / array token.
             /// </summary>
             private readonly ProgressStack progressStack;
 
-            public JsonBinaryReader(byte[] buffer, bool skipValidation = false)
+            public JsonBinaryReader(byte[] buffer, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
                 : this(new JsonBinaryArrayBuffer(buffer))
             {
             }
 
-            public JsonBinaryReader(Stream stream, bool skipValidation = false)
+            public JsonBinaryReader(Stream stream, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
                 : this(new JsonBinaryStreamBuffer(stream))
             {
             }
 
-            private JsonBinaryReader(JsonBinaryBufferBase jsonBinaryBuffer, bool skipValidation = false)
+            private JsonBinaryReader(JsonBinaryBufferBase jsonBinaryBuffer, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
                 : base(skipValidation)
             {
                 this.jsonBinaryBuffer = jsonBinaryBuffer;
@@ -49,6 +54,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 // First byte is the serialization format so we are skipping over it
                 this.jsonBinaryBuffer.ReadByte();
                 this.progressStack = new ProgressStack();
+                this.jsonStringDictionary = jsonStringDictionary;
             }
 
             /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
@@ -66,9 +66,10 @@ namespace Microsoft.Azure.Cosmos.Json
         /// Creates a JsonReader that can read a supplied stream (assumes UTF-8 encoding).
         /// </summary>
         /// <param name="stream">the stream to read.</param>
+        /// <param name="jsonStringDictionary">The dictionary to use for binary user string encoding.</param>
         /// <param name="skipvalidation">whether or not to skip validation.</param>
         /// <returns>a concrete JsonReader that can read the supplied stream.</returns>
-        public static IJsonReader Create(Stream stream, bool skipvalidation = false)
+        public static IJsonReader Create(Stream stream, JsonStringDictionary jsonStringDictionary = null, bool skipvalidation = false)
         {
             if (stream == null)
             {
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Json
             switch ((JsonSerializationFormat)firstbyte)
             {
                 case JsonSerializationFormat.Binary:
-                    return new JsonBinaryReader(stream, skipvalidation);
+                    return new JsonBinaryReader(stream, jsonStringDictionary, skipvalidation);
                 default:
                     return new JsonTextReader(stream, Encoding.UTF8, skipvalidation);
             }
@@ -119,9 +120,10 @@ namespace Microsoft.Azure.Cosmos.Json
         /// Creates a JsonReader that can read from the supplied byte array (assumes utf-8 encoding).
         /// </summary>
         /// <param name="buffer">The byte array to read from.</param>
+        /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
         /// <param name="skipValidation">Whether or not to skip validation.</param>
         /// <returns>A concrete JsonReader that can read the supplied byte array.</returns>
-        public static IJsonReader Create(byte[] buffer, bool skipValidation = false)
+        public static IJsonReader Create(byte[] buffer, JsonStringDictionary jsonStringDictionary = null, bool skipValidation = false)
         {
             if (buffer == null)
             {
@@ -134,7 +136,7 @@ namespace Microsoft.Azure.Cosmos.Json
             switch ((JsonSerializationFormat)firstByte)
             {
                 case JsonSerializationFormat.Binary:
-                    return new JsonBinaryReader(buffer, skipValidation);
+                    return new JsonBinaryReader(buffer, jsonStringDictionary, skipValidation);
                 default:
                     return new JsonTextReader(buffer, skipValidation);
             }

--- a/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Json
     internal sealed class JsonStringDictionary
     {
         private readonly string[] stringDictionary;
+        private readonly Dictionary<string, int> stringToIndex;
         private int size;
 
         public JsonStringDictionary(int capacity)
@@ -20,11 +21,17 @@ namespace Microsoft.Azure.Cosmos.Json
             }
 
             this.stringDictionary = new string[capacity];
+            this.stringToIndex = new Dictionary<string, int>();
         }
 
         public bool TryAddString(string value, out int index)
         {
             index = default(int);
+            if (this.stringToIndex.TryGetValue(value, out index))
+            {
+                // If the string already exists just leave.
+                return true;
+            }
 
             if (size == this.stringDictionary.Length)
             {
@@ -33,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.Json
 
             index = this.size;
             this.stringDictionary[size++] = value;
+            this.stringToIndex[value] = index;
 
             return true;
         }

--- a/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
@@ -1,0 +1,51 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Json
+{
+    using System;
+
+    internal sealed class JsonStringDictionary
+    {
+        private readonly string[] stringDictionary;
+        private int size;
+
+        private JsonStringDictionary(int capacity)
+        {
+            if (capacity < 0)
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(capacity)} must be a non negative integer.");
+            }
+
+            this.stringDictionary = new string[capacity];
+        }
+
+        public bool TryAddString(string value, out int index)
+        {
+            index = default(int);
+
+            if (size == this.stringDictionary.Length)
+            {
+                return false;
+            }
+
+            index = this.size;
+            this.stringDictionary[size++] = value;
+
+            return true;
+        }
+
+        public bool TryGetStringAtIndex(int index, out string value)
+        {
+            value = default(string);
+            if (index < 0 || index >= size)
+            {
+                return false;
+            }
+
+            value = this.stringDictionary[index];
+            return true;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonStringDictionary.cs
@@ -5,13 +5,14 @@
 namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
+    using System.Collections.Generic;
 
     internal sealed class JsonStringDictionary
     {
         private readonly string[] stringDictionary;
         private int size;
 
-        private JsonStringDictionary(int capacity)
+        public JsonStringDictionary(int capacity)
         {
             if (capacity < 0)
             {

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -67,16 +67,20 @@ namespace Microsoft.Azure.Cosmos.Json
         /// Creates a JsonWriter that can write in a particular JsonSerializationFormat (utf8 if text)
         /// </summary>
         /// <param name="jsonSerializationFormat">The JsonSerializationFormat of the writer.</param>
+        /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
         /// <param name="skipValidation">Whether or not to skip validation</param>
         /// <returns>A JsonWriter that can write in a particular JsonSerializationFormat</returns>
-        public static IJsonWriter Create(JsonSerializationFormat jsonSerializationFormat, bool skipValidation = false)
+        public static IJsonWriter Create(
+            JsonSerializationFormat jsonSerializationFormat, 
+            JsonStringDictionary jsonStringDictionary = null, 
+            bool skipValidation = false)
         {
             switch (jsonSerializationFormat)
             {
                 case JsonSerializationFormat.Text:
                     return new JsonTextWriter(Encoding.UTF8, skipValidation);
                 case JsonSerializationFormat.Binary:
-                    return new JsonBinaryWriter(skipValidation, false);
+                    return new JsonBinaryWriter(skipValidation, jsonStringDictionary, serializeCount: false);
                 default:
                     throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, RMResources.UnexpectedJsonSerializationFormat, jsonSerializationFormat));
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
@@ -364,7 +364,7 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
 
             this.VerifyNavigator(json, performExtraChecks);
         }
-#endregion
+        #endregion
 
         private void VerifyNavigator(string input, bool performExtraChecks = true)
         {
@@ -390,6 +390,19 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
             JsonTokenInfo[] tokensFromBinaryNavigator = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
 
             Assert.IsTrue(tokensFromBinaryNavigator.SequenceEqual(tokensFromReader));
+
+            // Test binary + user string encoding
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 4096);
+            byte[] binaryWithUserStringEncodingInput = JsonTestUtils.ConvertTextToBinary(input, jsonStringDictionary);
+            if (jsonStringDictionary.TryGetStringAtIndex(index: 0, value: out string temp))
+            {
+                Assert.IsFalse(binaryWithUserStringEncodingInput.SequenceEqual(binaryInput), "Binary should be different with user string encoding");
+            }
+            IJsonNavigator binaryNavigatorWithUserStringEncoding = JsonNavigator.Create(binaryInput, jsonStringDictionary);
+            IJsonNavigatorNode binaryRootNodeWithUserStringEncoding = binaryNavigatorWithUserStringEncoding.GetRootNode();
+            JsonTokenInfo[] tokensFromBinaryNavigatorWithUserStringEncoding = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
+
+            Assert.IsTrue(tokensFromBinaryNavigatorWithUserStringEncoding.SequenceEqual(tokensFromReader));
         }
 
         internal static JsonTokenInfo[] GetTokensWithReader(IJsonReader jsonReader)
@@ -543,7 +556,7 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    Assert.AreEqual(navigator.SerializationFormat, JsonSerializationFormat.Binary);   
+                    Assert.AreEqual(navigator.SerializationFormat, JsonSerializationFormat.Binary);
                 }
                 catch (ArgumentOutOfRangeException)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
@@ -1,0 +1,46 @@
+﻿namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
+{
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class JsonStringDictionaryTests
+    {
+        private const byte BinaryFormat = 128;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            // Put test init code here
+        }
+
+        [ClassInitialize]
+        public static void Initialize(TestContext textContext)
+        {
+            // put class init code here
+        }
+
+        [TestMethod]
+        [Owner("brchon")]
+        public void TestBasicCase()
+        {
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(100);
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str1", expectedIndex: 0);
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str2", expectedIndex: 1);
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str3", expectedIndex: 2);
+
+            // Verify the Dictionary
+
+        }
+
+        private static void AddAndValidate(JsonStringDictionary jsonStringDictionary, string value, int expectedIndex)
+        {
+            if (!jsonStringDictionary.TryAddString(value, out int actualIndex))
+            {
+                throw new AssertFailedException($"Failed to insert {value} into {nameof(JsonStringDictionary)}.");
+            }
+
+            Assert.AreEqual(expectedIndex, actualIndex);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
@@ -24,23 +24,60 @@
         [Owner("brchon")]
         public void TestBasicCase()
         {
-            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(100);
-            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str1", expectedIndex: 0);
-            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str2", expectedIndex: 1);
-            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, value: "str3", expectedIndex: 2);
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 100);
 
-            // Verify the Dictionary
+            // First new string -> index 0
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, expectedString: "str1", expectedIndex: 0);
 
+            // Second new string -> index 1
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, expectedString: "str2", expectedIndex: 1);
+
+            // Re adding second string -> also index 1
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, expectedString: "str2", expectedIndex: 1);
+
+            // Adding third new string -> index 2
+            JsonStringDictionaryTests.AddAndValidate(jsonStringDictionary, expectedString: "str3", expectedIndex: 2);
         }
 
-        private static void AddAndValidate(JsonStringDictionary jsonStringDictionary, string value, int expectedIndex)
+        [TestMethod]
+        [Owner("brchon")]
+        public void TestDictionarySizeLimit()
         {
-            if (!jsonStringDictionary.TryAddString(value, out int actualIndex))
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 0);
+            Assert.IsFalse(jsonStringDictionary.TryAddString("hello", out int index));
+        }
+
+        [TestMethod]
+        [Owner("brchon")]
+        public void TestDifferentLengthStrings()
+        {
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 256);
+            for (int replicationCount = 0; replicationCount < 128; replicationCount++)
             {
-                throw new AssertFailedException($"Failed to insert {value} into {nameof(JsonStringDictionary)}.");
+                JsonStringDictionaryTests.AddAndValidate(
+                    jsonStringDictionary,
+                    expectedString: new string('a', replicationCount),
+                    expectedIndex: replicationCount + 1);
+            }
+        }
+
+        private static void AddAndValidate(JsonStringDictionary jsonStringDictionary, string expectedString, int expectedIndex)
+        {
+            // Try to add the string.
+            if (!jsonStringDictionary.TryAddString(expectedString, out int actualIndex))
+            {
+                throw new AssertFailedException($"{nameof(JsonStringDictionary.TryAddString)}({expectedString}, out int {actualIndex}) failed.");
             }
 
             Assert.AreEqual(expectedIndex, actualIndex);
+
+            // Try to read the string back by index
+            if (!jsonStringDictionary.TryGetStringAtIndex(expectedIndex, out string actualString))
+            {
+                throw new AssertFailedException($"{nameof(JsonStringDictionary.TryGetStringAtIndex)}({expectedIndex}, out string {actualString}) failed.");
+            }
+
+            Assert.AreEqual(expectedString, actualString);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonStringDictionaryTests.cs
@@ -57,7 +57,7 @@
                 JsonStringDictionaryTests.AddAndValidate(
                     jsonStringDictionary,
                     expectedString: new string('a', replicationCount),
-                    expectedIndex: replicationCount + 1);
+                    expectedIndex: replicationCount);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTestUtils.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTestUtils.cs
@@ -8,9 +8,9 @@
 
     internal static class JsonTestUtils
     {
-        public static byte[] ConvertTextToBinary(string text)
+        public static byte[] ConvertTextToBinary(string text, JsonStringDictionary jsonStringDictionary = null)
         {
-            IJsonWriter binaryWriter = JsonWriter.Create(JsonSerializationFormat.Binary);
+            IJsonWriter binaryWriter = JsonWriter.Create(JsonSerializationFormat.Binary, jsonStringDictionary);
             IJsonReader textReader = JsonReader.Create(Encoding.UTF8.GetBytes(text));
             binaryWriter.WriteAll(textReader);
             return binaryWriter.GetResult();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
@@ -44,6 +44,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -64,6 +65,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -84,6 +86,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
         #endregion
         #region Numbers
@@ -107,6 +110,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -129,6 +133,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -151,6 +156,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -173,6 +179,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -195,6 +202,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -217,6 +225,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -239,6 +248,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -264,6 +274,7 @@
 
             this.VerifyWriter(tokensToWrite, numberValueString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -291,6 +302,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -344,12 +356,14 @@
                 JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin,
             };
 
-            JsonTokenInfo[] tokensToWrite = 
+            JsonTokenInfo[] tokensToWrite =
             {
                 JsonTokenInfo.String(string.Empty)
             };
 
             this.VerifyWriter(tokensToWrite, expectedString);
+            this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         #region String
@@ -373,6 +387,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -401,6 +416,7 @@
 
                 this.VerifyWriter(tokensToWrite, expectedString);
                 this.VerifyWriter(tokensToWrite, binaryOutput);
+                this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
                 systemStringId++;
             }
         }
@@ -409,7 +425,66 @@
         [Owner("brchon")]
         public void UserStringTest()
         {
-            // Need to implement this when start implementing user strings.
+            // Object with 33 field names. This creates a user string with 2 byte type marker.
+
+            List<JsonTokenInfo> tokensToWrite = new List<JsonTokenInfo>() { JsonTokenInfo.ObjectStart() };
+            StringBuilder textOutput = new StringBuilder("{");
+            List<byte> binaryOutput = new List<byte>() { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object1ByteLength, };
+            List<byte> binaryOutputWithEncoding = new List<byte>() { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object1ByteLength };
+
+            const byte OneByteCount = JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMax - JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin;
+            for (int i = 0; i < OneByteCount + 1; i++)
+            {
+                string userEncodedString = "a" + i.ToString();
+
+                tokensToWrite.Add(JsonTokenInfo.FieldName(userEncodedString));
+                tokensToWrite.Add(JsonTokenInfo.String(userEncodedString));
+
+                if (i > 0)
+                {
+                    textOutput.Append(",");
+                }
+
+                textOutput.Append($@"""{userEncodedString}"":""{userEncodedString}""");
+
+                for (int j = 0; j < 2; j++)
+                {
+                    binaryOutput.Add((byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + userEncodedString.Length));
+                    binaryOutput.AddRange(Encoding.UTF8.GetBytes(userEncodedString));
+                }
+
+                if (i < OneByteCount)
+                {
+                    binaryOutputWithEncoding.Add((byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + i));
+                }
+                else
+                {
+                    int twoByteOffset = i - OneByteCount;
+                    binaryOutputWithEncoding.Add((byte)((twoByteOffset / 0xFF) + JsonBinaryEncoding.TypeMarker.UserString2ByteLengthMin));
+                    binaryOutputWithEncoding.Add((byte)(twoByteOffset % 0xFF));
+                }
+
+                binaryOutputWithEncoding.Add((byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + userEncodedString.Length));
+                binaryOutputWithEncoding.AddRange(Encoding.UTF8.GetBytes(userEncodedString));
+            }
+
+            tokensToWrite.Add(JsonTokenInfo.ObjectEnd());
+            textOutput.Append("}");
+            binaryOutput.Insert(2, (byte)(binaryOutput.Count() - 2));
+            binaryOutputWithEncoding.Insert(2, (byte)(binaryOutputWithEncoding.Count() - 2));
+
+            this.VerifyWriter(tokensToWrite.ToArray(), textOutput.ToString());
+            this.VerifyWriter(tokensToWrite.ToArray(), binaryOutput.ToArray());
+
+            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 100);
+            this.VerifyWriter(tokensToWrite.ToArray(), binaryOutputWithEncoding.ToArray(), jsonStringDictionary);
+
+            for (int i = 0; i < OneByteCount + 1; i++)
+            {
+                string userEncodedString = "a" + i.ToString();
+                Assert.IsTrue(jsonStringDictionary.TryGetStringAtIndex(i, out string value));
+                Assert.AreEqual(userEncodedString, value);
+            }
         }
         #endregion
         #region Array
@@ -925,6 +1000,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutput, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -932,19 +1008,40 @@
         public void SimpleObjectTest()
         {
             string expectedString = "{\"GlossDiv\":10,\"title\": \"example glossary\" }";
-            List<byte[]> binaryOutputBuilder = new List<byte[]>();
-            binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object1ByteLength });
 
-            List<byte[]> elements = new List<byte[]>();
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "GlossDiv".Length), 71, 108, 111, 115, 115, 68, 105, 118 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.LiteralIntMin + 10 });
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "title".Length), 116, 105, 116, 108, 101 });
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "example glossary".Length), 101, 120, 97, 109, 112, 108, 101, 32, 103, 108, 111, 115, 115, 97, 114, 121 });
-            byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+            byte[] binaryOutput;
+            {
+                List<byte[]> binaryOutputBuilder = new List<byte[]>();
+                binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object1ByteLength });
 
-            binaryOutputBuilder.Add(new byte[] { (byte)elementsBytes.Length });
-            binaryOutputBuilder.Add(elementsBytes);
-            byte[] binaryOutput = binaryOutputBuilder.SelectMany(x => x).ToArray();
+                List<byte[]> elements = new List<byte[]>();
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "GlossDiv".Length), 71, 108, 111, 115, 115, 68, 105, 118 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.LiteralIntMin + 10 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "title".Length), 116, 105, 116, 108, 101 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "example glossary".Length), 101, 120, 97, 109, 112, 108, 101, 32, 103, 108, 111, 115, 115, 97, 114, 121 });
+                byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+
+                binaryOutputBuilder.Add(new byte[] { (byte)elementsBytes.Length });
+                binaryOutputBuilder.Add(elementsBytes);
+                binaryOutput = binaryOutputBuilder.SelectMany(x => x).ToArray();
+            }
+
+            byte[] binaryOutputWithEncoding;
+            {
+                List<byte[]> binaryOutputBuilder = new List<byte[]>();
+                binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object1ByteLength });
+
+                List<byte[]> elements = new List<byte[]>();
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.LiteralIntMin + 10 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 1) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "example glossary".Length), 101, 120, 97, 109, 112, 108, 101, 32, 103, 108, 111, 115, 115, 97, 114, 121 });
+                byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+
+                binaryOutputBuilder.Add(new byte[] { (byte)elementsBytes.Length });
+                binaryOutputBuilder.Add(elementsBytes);
+                binaryOutputWithEncoding = binaryOutputBuilder.SelectMany(x => x).ToArray();
+            }
 
             JsonTokenInfo[] tokensToWrite =
             {
@@ -958,6 +1055,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutputWithEncoding, new JsonStringDictionary(capacity: 100));
         }
 
         [TestMethod]
@@ -981,58 +1079,118 @@
                 },
                 ""text"": ""tiger diamond newbrunswick snowleopard chocolate dog snowleopard turtle cat sapphire peach sapphire vancouver white chocolate horse diamond lion superlongcolourname ruby""
             }";
-            List<byte[]> binaryOutputBuilder = new List<byte[]>();
-            binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object2ByteLength });
 
-            List<byte[]> elements = new List<byte[]>();
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 12) });
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "7029d079-4016-4436-b7da-36c0bae54ff6".Length), 55, 48, 50, 57, 100, 48, 55, 57, 45, 52, 48, 49, 54, 45, 52, 52, 51, 54, 45, 98, 55, 100, 97, 45, 51, 54, 99, 48, 98, 97, 101, 53, 52, 102, 102, 54 });
+            byte[] binaryOutput;
+            {
+                List<byte[]> binaryOutputBuilder = new List<byte[]>();
+                binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object2ByteLength });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "double".Length), 100, 111, 117, 98, 108, 101 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x98, 0x8B, 0x30, 0xE3, 0xCB, 0x45, 0xC8, 0x3F });
+                List<byte[]> elements = new List<byte[]>();
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 12) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "7029d079-4016-4436-b7da-36c0bae54ff6".Length), 55, 48, 50, 57, 100, 48, 55, 57, 45, 52, 48, 49, 54, 45, 52, 52, 51, 54, 45, 98, 55, 100, 97, 45, 51, 54, 99, 48, 98, 97, 101, 53, 52, 102, 102, 54 });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "int".Length), 105, 110, 116 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Int32, 0x19, 0xDF, 0xB6, 0xB0 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "double".Length), 100, 111, 117, 98, 108, 101 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x98, 0x8B, 0x30, 0xE3, 0xCB, 0x45, 0xC8, 0x3F });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "string".Length), 115, 116, 114, 105, 110, 103 });
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "XCPCFXPHHF".Length), 88, 67, 80, 67, 70, 88, 80, 72, 72, 70 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "int".Length), 105, 110, 116 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Int32, 0x19, 0xDF, 0xB6, 0xB0 });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "boolean".Length), 98, 111, 111, 108, 101, 97, 110 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.True });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "string".Length), 115, 116, 114, 105, 110, 103 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "XCPCFXPHHF".Length), 88, 67, 80, 67, 70, 88, 80, 72, 72, 70 });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "null".Length), 110, 117, 108, 108 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Null });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "boolean".Length), 98, 111, 111, 108, 101, 97, 110 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.True });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "datetime".Length), 100, 97, 116, 101, 116, 105, 109, 101 });
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "2526-07-11T18:18:16.4520716".Length), 50, 53, 50, 54, 45, 48, 55, 45, 49, 49, 84, 49, 56, 58, 49, 56, 58, 49, 54, 46, 52, 53, 50, 48, 55, 49, 54 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "null".Length), 110, 117, 108, 108 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Null });
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "spatialPoint".Length), 115, 112, 97, 116, 105, 97, 108, 80, 111, 105, 110, 116 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "datetime".Length), 100, 97, 116, 101, 116, 105, 109, 101 });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "2526-07-11T18:18:16.4520716".Length), 50, 53, 50, 54, 45, 48, 55, 45, 49, 49, 84, 49, 56, 58, 49, 56, 58, 49, 54, 46, 52, 53, 50, 48, 55, 49, 54 });
 
-            List<byte[]> innerObjectElements = new List<byte[]>();
-            innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 27) });
-            innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 24) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "spatialPoint".Length), 115, 112, 97, 116, 105, 97, 108, 80, 111, 105, 110, 116 });
 
-            innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 09) });
-            List<byte[]> innerArrayElements = new List<byte[]>();
-            innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x7A, 0x36, 0xAB, 0x3E, 0x57, 0xBF, 0x5D, 0x40 });
-            innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x74, 0xB5, 0x15, 0xFB, 0xCB, 0x56, 0x47, 0xC0 });
-            byte[] innerArrayElementsBytes = innerArrayElements.SelectMany(x => x).ToArray();
+                List<byte[]> innerObjectElements = new List<byte[]>();
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 27) });
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 24) });
 
-            innerObjectElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Array1ByteLength, (byte)innerArrayElementsBytes.Length });
-            innerObjectElements.Add(innerArrayElementsBytes);
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 09) });
+                List<byte[]> innerArrayElements = new List<byte[]>();
+                innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x7A, 0x36, 0xAB, 0x3E, 0x57, 0xBF, 0x5D, 0x40 });
+                innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x74, 0xB5, 0x15, 0xFB, 0xCB, 0x56, 0x47, 0xC0 });
+                byte[] innerArrayElementsBytes = innerArrayElements.SelectMany(x => x).ToArray();
 
-            byte[] innerObjectElementsBytes = innerObjectElements.SelectMany(x => x).ToArray();
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Object1ByteLength, (byte)innerObjectElementsBytes.Length });
-            elements.Add(innerObjectElementsBytes);
+                innerObjectElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Array1ByteLength, (byte)innerArrayElementsBytes.Length });
+                innerObjectElements.Add(innerArrayElementsBytes);
 
-            elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "text".Length), 116, 101, 120, 116 });
-            elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.String1ByteLength, (byte)"tiger diamond newbrunswick snowleopard chocolate dog snowleopard turtle cat sapphire peach sapphire vancouver white chocolate horse diamond lion superlongcolourname ruby".Length, 116, 105, 103, 101, 114, 32, 100, 105, 97, 109, 111, 110, 100, 32, 110, 101, 119, 98, 114, 117, 110, 115, 119, 105, 99, 107, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 100, 111, 103, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 116, 117, 114, 116, 108, 101, 32, 99, 97, 116, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 112, 101, 97, 99, 104, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 118, 97, 110, 99, 111, 117, 118, 101, 114, 32, 119, 104, 105, 116, 101, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 104, 111, 114, 115, 101, 32, 100, 105, 97, 109, 111, 110, 100, 32, 108, 105, 111, 110, 32, 115, 117, 112, 101, 114, 108, 111, 110, 103, 99, 111, 108, 111, 117, 114, 110, 97, 109, 101, 32, 114, 117, 98, 121 });
+                byte[] innerObjectElementsBytes = innerObjectElements.SelectMany(x => x).ToArray();
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Object1ByteLength, (byte)innerObjectElementsBytes.Length });
+                elements.Add(innerObjectElementsBytes);
 
-            byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "text".Length), 116, 101, 120, 116 });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.String1ByteLength, (byte)"tiger diamond newbrunswick snowleopard chocolate dog snowleopard turtle cat sapphire peach sapphire vancouver white chocolate horse diamond lion superlongcolourname ruby".Length, 116, 105, 103, 101, 114, 32, 100, 105, 97, 109, 111, 110, 100, 32, 110, 101, 119, 98, 114, 117, 110, 115, 119, 105, 99, 107, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 100, 111, 103, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 116, 117, 114, 116, 108, 101, 32, 99, 97, 116, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 112, 101, 97, 99, 104, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 118, 97, 110, 99, 111, 117, 118, 101, 114, 32, 119, 104, 105, 116, 101, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 104, 111, 114, 115, 101, 32, 100, 105, 97, 109, 111, 110, 100, 32, 108, 105, 111, 110, 32, 115, 117, 112, 101, 114, 108, 111, 110, 103, 99, 111, 108, 111, 117, 114, 110, 97, 109, 101, 32, 114, 117, 98, 121 });
 
-            binaryOutputBuilder.Add(BitConverter.GetBytes((short)elementsBytes.Length));
-            binaryOutputBuilder.Add(elementsBytes);
-            byte[] binaryOutput = binaryOutputBuilder.SelectMany(x => x).ToArray();
+                byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+
+                binaryOutputBuilder.Add(BitConverter.GetBytes((short)elementsBytes.Length));
+                binaryOutputBuilder.Add(elementsBytes);
+                binaryOutput = binaryOutputBuilder.SelectMany(x => x).ToArray();
+            }
+
+            byte[] binaryOutputWithEncoding;
+            {
+                List<byte[]> binaryOutputBuilder = new List<byte[]>();
+                binaryOutputBuilder.Add(new byte[] { BinaryFormat, JsonBinaryEncoding.TypeMarker.Object2ByteLength });
+
+                List<byte[]> elements = new List<byte[]>();
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 12) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "7029d079-4016-4436-b7da-36c0bae54ff6".Length), 55, 48, 50, 57, 100, 48, 55, 57, 45, 52, 48, 49, 54, 45, 52, 52, 51, 54, 45, 98, 55, 100, 97, 45, 51, 54, 99, 48, 98, 97, 101, 53, 52, 102, 102, 54 });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x98, 0x8B, 0x30, 0xE3, 0xCB, 0x45, 0xC8, 0x3F });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 1) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Int32, 0x19, 0xDF, 0xB6, 0xB0 });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 2) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "XCPCFXPHHF".Length), 88, 67, 80, 67, 70, 88, 80, 72, 72, 70 });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 3) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.True });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 4) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Null });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 5) });
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.EncodedStringLengthMin + "2526-07-11T18:18:16.4520716".Length), 50, 53, 50, 54, 45, 48, 55, 45, 49, 49, 84, 49, 56, 58, 49, 56, 58, 49, 54, 46, 52, 53, 50, 48, 55, 49, 54 });
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 6) });
+
+                List<byte[]> innerObjectElements = new List<byte[]>();
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 27) });
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 24) });
+
+                innerObjectElements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.SystemString1ByteLengthMin + 09) });
+                List<byte[]> innerArrayElements = new List<byte[]>();
+                innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x7A, 0x36, 0xAB, 0x3E, 0x57, 0xBF, 0x5D, 0x40 });
+                innerArrayElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Double, 0x74, 0xB5, 0x15, 0xFB, 0xCB, 0x56, 0x47, 0xC0 });
+                byte[] innerArrayElementsBytes = innerArrayElements.SelectMany(x => x).ToArray();
+
+                innerObjectElements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Array1ByteLength, (byte)innerArrayElementsBytes.Length });
+                innerObjectElements.Add(innerArrayElementsBytes);
+
+                byte[] innerObjectElementsBytes = innerObjectElements.SelectMany(x => x).ToArray();
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.Object1ByteLength, (byte)innerObjectElementsBytes.Length });
+                elements.Add(innerObjectElementsBytes);
+
+                elements.Add(new byte[] { (byte)(JsonBinaryEncoding.TypeMarker.UserString1ByteLengthMin + 7) });
+                elements.Add(new byte[] { JsonBinaryEncoding.TypeMarker.String1ByteLength, (byte)"tiger diamond newbrunswick snowleopard chocolate dog snowleopard turtle cat sapphire peach sapphire vancouver white chocolate horse diamond lion superlongcolourname ruby".Length, 116, 105, 103, 101, 114, 32, 100, 105, 97, 109, 111, 110, 100, 32, 110, 101, 119, 98, 114, 117, 110, 115, 119, 105, 99, 107, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 100, 111, 103, 32, 115, 110, 111, 119, 108, 101, 111, 112, 97, 114, 100, 32, 116, 117, 114, 116, 108, 101, 32, 99, 97, 116, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 112, 101, 97, 99, 104, 32, 115, 97, 112, 112, 104, 105, 114, 101, 32, 118, 97, 110, 99, 111, 117, 118, 101, 114, 32, 119, 104, 105, 116, 101, 32, 99, 104, 111, 99, 111, 108, 97, 116, 101, 32, 104, 111, 114, 115, 101, 32, 100, 105, 97, 109, 111, 110, 100, 32, 108, 105, 111, 110, 32, 115, 117, 112, 101, 114, 108, 111, 110, 103, 99, 111, 108, 111, 117, 114, 110, 97, 109, 101, 32, 114, 117, 98, 121 });
+
+                byte[] elementsBytes = elements.SelectMany(x => x).ToArray();
+
+                binaryOutputBuilder.Add(BitConverter.GetBytes((short)elementsBytes.Length));
+                binaryOutputBuilder.Add(elementsBytes);
+                binaryOutputWithEncoding = binaryOutputBuilder.SelectMany(x => x).ToArray();
+            }
 
             JsonTokenInfo[] tokensToWrite =
             {
@@ -1078,6 +1236,7 @@
 
             this.VerifyWriter(tokensToWrite, expectedString);
             this.VerifyWriter(tokensToWrite, binaryOutput);
+            this.VerifyWriter(tokensToWrite, binaryOutputWithEncoding, new JsonStringDictionary(capacity: 100));
         }
         #endregion
         #region Exceptions
@@ -1211,6 +1370,12 @@
         private void VerifyWriter(JsonTokenInfo[] tokensToWrite, byte[] binaryOutput, Exception expectedException = null)
         {
             IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Binary);
+            this.VerifyWriter(jsonWriter, tokensToWrite, binaryOutput, JsonSerializationFormat.Binary, expectedException);
+        }
+
+        private void VerifyWriter(JsonTokenInfo[] tokensToWrite, byte[] binaryOutput, JsonStringDictionary jsonStringDictionary, Exception expectedException = null)
+        {
+            IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Binary, jsonStringDictionary);
             this.VerifyWriter(jsonWriter, tokensToWrite, binaryOutput, JsonSerializationFormat.Binary, expectedException);
         }
 


### PR DESCRIPTION
# User String Encoding for Binary Encoding

The PR adds user string encoding for binary encoding. For field names in documents can be converted to a single byte to save on storage. The PR is mainly a port of the native implementation:

https://msdata.visualstudio.com/_git/CosmosDB/commit/09b4b84c7424ef9a86936248c462e76fcaebbaf8?path=%2FProduct%2FBackend%2Fnative%2FTest%2Fcommon%2Fserialization%2FJsonWriterTest.cpp&gridItemType=2&mpath=%2FProduct%2FBackend%2Fnative%2FTest%2Fcommon%2Fserialization%2FJsonWriterTest.cpp&opath=%2FProduct%2FBackend%2Fnative%2FTest%2Fcommon%2Fserialization%2FJsonWriterTest.cpp&mversion=GC09b4b84c7424ef9a86936248c462e76fcaebbaf8&oversion=GC49c76647064e9ecaeb3c28be959f1ed818010bc6&_a=compare

Once the handshake protocol is finalized we can leverage this in production.

