### PR TITLE
Draft PR to have FeedIterator<T> use FeedIterator

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIterator.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Net;
 
     internal class ChangeFeedResultSetIterator<T> : FeedIteratorCore<T>
@@ -12,9 +13,16 @@ namespace Microsoft.Azure.Cosmos
             int? maxItemCount,
             string continuationToken,
             QueryRequestOptions options,
-            NextResultSetDelegate nextDelegate,
+            FeedIteratorCore.NextResultSetDelegate nextDelegate,
+            Func<CosmosResponseMessage, FeedResponse<T>> responseCreator,
             object state = null)
-            : base(maxItemCount, continuationToken, options, nextDelegate, state)
+            : base(
+                  maxItemCount, 
+                  continuationToken, 
+                  options, 
+                  nextDelegate, 
+                  responseCreator, 
+                  state)
         {
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetStreamIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetStreamIterator.cs
@@ -23,22 +23,5 @@ namespace Microsoft.Azure.Cosmos
                 state)
         {
         }
-
-        /// <summary>
-        /// Get the next set of results from the cosmos service
-        /// </summary>
-        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A query response from cosmos service</returns>
-        public override Task<CosmosResponseMessage> FetchNextSetAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return this.nextResultSetDelegate(this.MaxItemCount, this.continuationToken, this.queryOptions, this.state, cancellationToken)
-                .ContinueWith(task =>
-                {
-                    CosmosResponseMessage response = task.Result;
-                    this.continuationToken = response.Headers.ETag;
-                    this.HasMoreResults = ChangeFeedResultSetStreamIterator.GetHasMoreResults(this.continuationToken, response.StatusCode);
-                    return response;
-                }, cancellationToken);
-        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/FeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/FeedResponse.cs
@@ -64,9 +64,5 @@ namespace Microsoft.Azure.Cosmos
         {
             return this.GetEnumerator();
         }
-
-        internal abstract string InternalContinuationToken { get; }
-
-        internal abstract bool HasMoreResults { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryResponse.cs
@@ -166,13 +166,11 @@ namespace Microsoft.Azure.Cosmos
         private QueryResponse(
             IEnumerable<CosmosElement> cosmosElements,
             CosmosQueryResponseMessageHeaders responseMessageHeaders,
-            bool hasMoreResults,
             CosmosJsonSerializer jsonSerializer,
             CosmosSerializationOptions serializationOptions)
         {
             this.cosmosElements = cosmosElements;
             this.QueryHeaders = responseMessageHeaders;
-            this.HasMoreResults = hasMoreResults;
             this.jsonSerializer = jsonSerializer;
             this.serializationOptions = serializationOptions;
         }
@@ -201,10 +199,6 @@ namespace Microsoft.Azure.Cosmos
         public override int Count { get; }
 
         internal CosmosQueryResponseMessageHeaders QueryHeaders { get; }
-
-        internal override string InternalContinuationToken => this.QueryHeaders.InternalContinuationToken;
-
-        internal override bool HasMoreResults { get; }
 
         /// <summary>
         /// Get the enumerators to iterate through the results
@@ -241,8 +235,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal static QueryResponse<TInput> CreateResponse<TInput>(
             QueryResponse cosmosQueryResponse,
-            CosmosJsonSerializer jsonSerializer,
-            bool hasMoreResults)
+            CosmosJsonSerializer jsonSerializer)
         {
             QueryResponse<TInput> queryResponse;
             using (cosmosQueryResponse)
@@ -251,7 +244,6 @@ namespace Microsoft.Azure.Cosmos
                 queryResponse = new QueryResponse<TInput>(
                     cosmosElements: cosmosQueryResponse.CosmosElements,
                     responseMessageHeaders: cosmosQueryResponse.QueryHeaders,
-                    hasMoreResults: hasMoreResults,
                     jsonSerializer: jsonSerializer,
                     serializationOptions: cosmosQueryResponse.CosmosSerializationOptions);
             }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ReadFeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ReadFeedResponse.cs
@@ -11,23 +11,17 @@ namespace Microsoft.Azure.Cosmos
     {
         protected ReadFeedResponse(
             IEnumerable<T> resource,
-            CosmosResponseMessageHeaders responseMessageHeaders,
-            bool hasMoreResults)
+            CosmosResponseMessageHeaders responseMessageHeaders)
             : base(
                 httpStatusCode: HttpStatusCode.Accepted,
                 headers: responseMessageHeaders,
                 resource: resource)
         {
-            this.HasMoreResults = hasMoreResults;
         }
 
         public override int Count { get; }
 
         public override string Continuation => this.Headers.Continuation;
-
-        internal override string InternalContinuationToken => this.Continuation;
-
-        internal override bool HasMoreResults { get; }
 
         public override IEnumerator<T> GetEnumerator()
         {
@@ -46,8 +40,7 @@ namespace Microsoft.Azure.Cosmos
                 IEnumerable<TInput> resources = response.Data;
                 ReadFeedResponse<TInput> readFeedResponse = new ReadFeedResponse<TInput>(
                     resource: resources,
-                    responseMessageHeaders: responseMessageHeaders,
-                    hasMoreResults: hasMoreResults);
+                    responseMessageHeaders: responseMessageHeaders);
 
                 return readFeedResponse;
             }
@@ -60,8 +53,7 @@ namespace Microsoft.Azure.Cosmos
         {
             ReadFeedResponse<TInput> readFeedResponse = new ReadFeedResponse<TInput>(
                 resource: resources,
-                responseMessageHeaders: responseMessageHeaders,
-                hasMoreResults: hasMoreResults);
+                responseMessageHeaders: responseMessageHeaders);
 
             return readFeedResponse;
         }


### PR DESCRIPTION
# Pull Request Template

## Description
This is a DRAFT PR to get feedback on the design. I only updated Items to support the FeedIterator changes. I will update the rest after I get feedback.

The feed iterators inherit from two different base abstract interfaces. In all the point operations the typed API just calls the stream implementation. This updates the FeedIterator<T> to use the FeedIterator for streams instead of having a separate implementation. 

Pros:

- Follows the rest of the SDK design
- Ensures that the typed tests also test the Stream APIs. This prevents duplicate tests and also ensure that they have the same behavior.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Closing issues

Put closes #413

