### PR TITLE
Change Feed Processor public API name changes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -13,12 +13,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
     using Microsoft.Azure.Documents;
+    using static Microsoft.Azure.Cosmos.Container;
 
     internal sealed class ChangeFeedEstimatorCore : ChangeFeedProcessor
     {
         private const string EstimatorDefaultHostName = "Estimator";
 
-        private readonly Func<long, CancellationToken, Task> initialEstimateDelegate;
+        private readonly ChangesEstimationHandler initialEstimateDelegate;
         private CancellationTokenSource shutdownCts;
         private ContainerCore leaseContainer;
         private string monitoredContainerRid;
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         private Task runAsync;
 
         public ChangeFeedEstimatorCore(
-            Func<long, CancellationToken, Task> initialEstimateDelegate, 
+            ChangesEstimationHandler initialEstimateDelegate, 
             TimeSpan? estimatorPeriod)
         {
             if (initialEstimateDelegate == null) throw new ArgumentNullException(nameof(initialEstimateDelegate));
@@ -44,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         }
 
         internal ChangeFeedEstimatorCore(
-            Func<long, CancellationToken, Task> initialEstimateDelegate,
+            ChangesEstimationHandler initialEstimateDelegate,
             TimeSpan? estimatorPeriod,
             RemainingWorkEstimator remainingWorkEstimator)
             : this(initialEstimateDelegate, estimatorPeriod)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedEstimatorDispatcher.cs
@@ -8,12 +8,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
+    using static Microsoft.Azure.Cosmos.Container;
 
     internal sealed class ChangeFeedEstimatorDispatcher
     {
-        private readonly Func<long, CancellationToken, Task> dispatchEstimation;
+        private readonly ChangesEstimationHandler dispatchEstimation;
 
-        public ChangeFeedEstimatorDispatcher(Func<long, CancellationToken, Task> dispatchEstimation, TimeSpan? estimationPeriod = null)
+        public ChangeFeedEstimatorDispatcher(
+            ChangesEstimationHandler dispatchEstimation, 
+            TimeSpan? estimationPeriod = null)
         {
             this.dispatchEstimation = dispatchEstimation;
             this.DispatchPeriod = estimationPeriod;
@@ -21,7 +24,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
         public TimeSpan? DispatchPeriod { get; private set; }
 
-        public async Task DispatchEstimationAsync(long estimation, CancellationToken cancellationToken)
+        public async Task DispatchEstimationAsync(
+            long estimation, 
+            CancellationToken cancellationToken)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverBase.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverBase.cs
@@ -4,16 +4,16 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using static Microsoft.Azure.Cosmos.Container;
 
     internal sealed class ChangeFeedObserverBase<T> : ChangeFeedObserver<T>
     {
-        private readonly Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges;
+        private readonly ChangesHandler<T> onChanges;
 
-        public ChangeFeedObserverBase(Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges)
+        public ChangeFeedObserverBase(ChangesHandler<T> onChanges)
         {
             this.onChanges = onChanges;
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ChangeFeedObserverFactoryCore.cs
@@ -4,16 +4,13 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
+    using static Microsoft.Azure.Cosmos.Container;
 
     internal sealed class ChangeFeedObserverFactoryCore<T> : ChangeFeedObserverFactory<T>
     {
-        private readonly Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges;
+        private readonly ChangesHandler<T> onChanges;
 
-        public ChangeFeedObserverFactoryCore(Func<IReadOnlyCollection<T>, CancellationToken, Task> onChanges)
+        public ChangeFeedObserverFactoryCore(ChangesHandler<T> onChanges)
         {
             this.onChanges = onChanges;
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -1090,6 +1090,26 @@ namespace Microsoft.Azure.Cosmos
         public abstract IOrderedQueryable<T> CreateItemQuery<T>(object partitionKey = null, bool allowSynchronousQueryExecution = false, QueryRequestOptions requestOptions = null);
 
         /// <summary>
+        /// Delegate to receive the changes within a <see cref="ChangeFeedProcessor"/> execution.
+        /// </summary>
+        /// <param name="changes">The changes that happened.</param>
+        /// <param name="cancellationToken">A cancellation token representing the current cancellation status of the <see cref="ChangeFeedProcessor"/> instance.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation that is going to be done with the changes.</returns>
+        public delegate Task ChangesHandler<T>(
+            IReadOnlyCollection<T> changes,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Delegate to receive the estimation of pending changes to be read by the associated <see cref="ChangeFeedProcessor"/> instance.
+        /// </summary>
+        /// <param name="estimatedPendingChanges">An estimation in number of items.</param>
+        /// <param name="cancellationToken">A cancellation token representing the current cancellation status of the <see cref="ChangeFeedProcessor"/> instance.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation that is going to be done with the estimation.</returns>
+        public delegate Task ChangesEstimationHandler(
+            long estimatedPendingChanges,
+            CancellationToken cancellationToken);
+
+        /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed processing.
         /// </summary>
         /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
@@ -1097,7 +1117,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
             string processorName,
-            Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate);
+            ChangesHandler<T> onChangesDelegate);
 
         /// <summary>
         /// Initializes a <see cref="ChangeFeedProcessorBuilder"/> for change feed monitoring.
@@ -1111,7 +1131,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
         public abstract ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string processorName,
-            Func<long, CancellationToken, Task> estimationDelegate,
+            ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -1115,7 +1115,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
         /// <param name="onChangesDelegate">Delegate to receive changes.</param>
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
-        public abstract ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
+        public abstract ChangeFeedProcessorBuilder DefineChangeFeedProcessor<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate);
 
@@ -1129,7 +1129,7 @@ namespace Microsoft.Azure.Cosmos
         /// The goal of the Estimator is to measure progress of a particular processor. In order to do that, the <paramref name="processorName"/> and other parameters, like the leases container, need to match that of the Processor to measure.
         /// </remarks>
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
-        public abstract ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
+        public abstract ChangeFeedProcessorBuilder DefineChangeFeedEstimator(
             string processorName,
             ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null);

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -5,11 +5,9 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -404,7 +402,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
             string processorName,
-            Func<IReadOnlyCollection<T>, CancellationToken, Task> onChangesDelegate)
+            ChangesHandler<T> onChangesDelegate)
         {
             if (processorName == null)
             {
@@ -427,7 +425,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
             string processorName,
-            Func<long, CancellationToken, Task> estimationDelegate,
+            ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null)
         {
             if (processorName == null)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Cosmos
             return new CosmosLinqQuery<T>(this, this.ClientContext.CosmosSerializer, (CosmosQueryClientCore)this.queryClient, requestOptions, allowSynchronousQueryExecution);
         }
 
-        public override ChangeFeedProcessorBuilder CreateChangeFeedProcessorBuilder<T>(
+        public override ChangeFeedProcessorBuilder DefineChangeFeedProcessor<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate)
         {
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Cosmos
                 applyBuilderConfiguration: changeFeedProcessor.ApplyBuildConfiguration);
         }
 
-        public override ChangeFeedProcessorBuilder CreateChangeFeedEstimatorBuilder(
+        public override ChangeFeedProcessorBuilder DefineChangeFeedEstimator(
             string processorName,
             ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         {
             long? receivedEstimation = 0;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task WhenLeasesHaveContinuationTokenNullReturn0()
         {
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task CountPendingDocuments()
         {
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .CreateChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
+                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .CreateChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Microsoft.Azure.Cosmos.Client.Core.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using static Microsoft.Azure.Cosmos.Container;
 
     [TestClass]
     [TestCategory("ChangeFeed")]
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ApplyBuildConfiguration_ValidCustomStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            ChangesEstimationHandler estimationDelegate = (long estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public void ApplyBuildConfiguration_ValidContainerStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            ChangesEstimationHandler estimationDelegate = (long estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -67,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ApplyBuildConfiguration_ValidatesNullStore()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            ChangesEstimationHandler estimationDelegate = (long estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [ExpectedException(typeof(ArgumentNullException))]
         public void ApplyBuildConfiguration_ValidatesNullMonitoredContainer()
         {
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            ChangesEstimationHandler estimationDelegate = (long estimation, CancellationToken token) =>
             {
                 return Task.CompletedTask;
             };
@@ -109,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             const long remainingWork = 15;
             long estimationDelegateValue = 0;
             bool receivedEstimation = false;
-            Func<long, CancellationToken, Task> estimationDelegate = (long estimation, CancellationToken token) =>
+            ChangesEstimationHandler estimationDelegate = (long estimation, CancellationToken token) =>
             {
                 estimationDelegateValue = estimation;
                 receivedEstimation = true;
@@ -145,7 +146,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(remainingWork, estimationDelegateValue);
         }
 
-        private static ChangeFeedEstimatorCore CreateEstimator(Func<long, CancellationToken, Task> estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator)
+        private static ChangeFeedEstimatorCore CreateEstimator(ChangesEstimationHandler estimationDelegate, out Mock<RemainingWorkEstimator> remainingWorkEstimator)
         {
             remainingWorkEstimator = new Mock<RemainingWorkEstimator>();
             return new ChangeFeedEstimatorCore(estimationDelegate, TimeSpan.FromSeconds(5), remainingWorkEstimator.Object);


### PR DESCRIPTION
# Change Feed Processor public API name changes

## Description

Based on feedback, we are renaming the builder methods for Change Feed processor and estimator and replacing `Func` with explicit delegates to avoid parameter confusion:

    public delegate Task ChangesHandler<T>(
        IReadOnlyCollection<T> changes, 
        CancellationToken cancellationToken);

    public delegate Task ChangesEstimationHandler(
        long estimatedPendingChanges, 
        CancellationToken cancellationToken);

    public abstract ChangeFeedProcessorBuilder DefineChangeFeedProcessor<T>(
        string processorName,
        ChangesHandler<T> onChangesHandler);

    public abstract ChangeFeedProcessorBuilder DefineChangeFeedEstimator(
        string processorName,
        ChangesEstimationHandler estimationHandler,
        TimeSpan? estimationPeriod = null);

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #432