### PR TITLE
Spatial classes with DataContract

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Spatial/BoundingBox.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/BoundingBox.cs
@@ -5,12 +5,14 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
     using Microsoft.Azure.Cosmos.Spatial.Converters;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a coordinate range for geometries in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     [JsonConverter(typeof(BoundingBoxJsonConverter))]
     public sealed class BoundingBox : IEquatable<BoundingBox>
     {
@@ -50,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Lowest values for all axes of the bounding box.
         /// </value>
+        [DataMember(Name = "min")]
         public Position Min { get; private set; }
 
         /// <summary>
@@ -58,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Highest values for all axes of the bounding box.
         /// </value>
+        [DataMember(Name = "max")]
         public Position Max { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/Crs.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Crs.cs
@@ -5,12 +5,14 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
     using Microsoft.Azure.Cosmos.Spatial.Converters;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents Coordinate Reference System in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     [JsonConverter(typeof(CrsJsonConverter))]
     public abstract class Crs
     {
@@ -53,6 +55,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Type of CRS.
         /// </value>
+        [DataMember(Name = "type")]
         public CrsType Type { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/Geometry.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Geometry.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Microsoft.Azure.Cosmos.Spatial.Converters;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -14,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// <summary>
     /// Base class for spatial geometry objects in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     [JsonObject(MemberSerialization.OptIn)]
     [JsonConverter(typeof(GeometryJsonConverter))]
     public abstract class Geometry
@@ -69,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Type of geometry.
         /// </value>
+        [DataMember(Name = "type")]
         [JsonProperty("type", Required = Required.Always, Order = 0)]
         [JsonConverter(typeof(StringEnumConverter))]
         public GeometryType Type { get; private set; }
@@ -79,6 +82,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Bounding box of the geometry.
         /// </value>
+        [DataMember(Name = "bbox")]
         [JsonProperty("bbox", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 3)]
         public BoundingBox BoundingBox { get; private set; }
 
@@ -98,6 +102,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// This is artificial property needed for serialization. If CRS is default one, we don't want
         /// to serialize anything.
         /// </remarks>
+        [DataMember(Name = "crs")]
         [JsonProperty("crs", DefaultValueHandling = DefaultValueHandling.Ignore, Order = 2)]
         private Crs CrsForSerialization { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/Geometry.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Geometry.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// Additional geometry properties.
         /// </value>
         [JsonExtensionData]
+        [DataMember(Name = "properties")]
         public IDictionary<string, object> AdditionalProperties { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/GeometryCollection.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/GeometryCollection.cs
@@ -8,11 +8,13 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a geometry consisting of other geometries.
     /// </summary>
+    [DataContract]
     internal sealed class GeometryCollection : Geometry, IEquatable<GeometryCollection>
     {
         /// <summary>
@@ -63,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Child geometries.
         /// </value>
+        [DataMember(Name = "geometries")]
         [JsonProperty("geometries", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<Geometry> Geometries { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/GeometryParams.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/GeometryParams.cs
@@ -6,10 +6,12 @@ namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Not frequently used geometry parameters in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     public class GeometryParams
     {
         /// <summary>
@@ -18,6 +20,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Additional geometry properties.
         /// </value>
+        [DataMember(Name = "properties")]
         public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
@@ -26,6 +29,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Coordinate Reference System for the geometry.
         /// </value>
+        [DataMember(Name = "crs")]
         public Crs Crs { get; set; }
 
         /// <summary>
@@ -34,6 +38,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Bounding box for the geometry.
         /// </value>
+        [DataMember(Name = "bbox")]
         public BoundingBox BoundingBox { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Spatial/GeometryValidationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/GeometryValidationResult.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.Serialization;
     using System.Text;
     using Newtonsoft.Json;
 
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// Contains detailed description why a geometyr is invalid.
     /// </para>
     /// </summary>
+    [DataContract]
     [JsonObject(MemberSerialization.OptIn)]
     internal class GeometryValidationResult
     {
@@ -28,6 +30,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// <c>true</c> if geometry for which <see cref="GeometryOperationExtensions.IsValidDetailed"/> was called is valid. <c>false</c> otherwise.
         /// </value>
+        [DataMember(Name = "valid")]
         [JsonProperty("valid", Required = Required.Always, Order = 0)]
         public bool IsValid { get; private set; }
 
@@ -37,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Description why a geometry is invalid.
         /// </value>
+        [DataMember(Name = "reason")]
         [JsonProperty("reason", Order = 1)]
         public string Reason { get; private set; }
     }

--- a/Microsoft.Azure.Cosmos/src/Spatial/LineString.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/LineString.cs
@@ -8,11 +8,13 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a geometry consisting of connected line segments.
     /// </summary>
+    [DataContract]
     public sealed class LineString : Geometry, IEquatable<LineString>
     {
         /// <summary>
@@ -63,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Positions of the line string.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<Position> Positions { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/LineStringCoordinates.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/LineStringCoordinates.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Converters;
     using Newtonsoft.Json;
 
@@ -15,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// Line string coordinates.
     /// </summary>
     /// <seealso cref="MultiLineString"/>
+    [DataContract]
     [JsonConverter(typeof(LineStringCoordinatesJsonConverter))]
     internal sealed class LineStringCoordinates : IEquatable<LineStringCoordinates>
     {
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Positions of the line string.
         /// </value>
+        [DataMember(Name = "coordinates")]
         public ReadOnlyCollection<Position> Positions { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/LinearRing.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/LinearRing.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Microsoft.Azure.Cosmos.Spatial.Converters;
     using Newtonsoft.Json;
 
@@ -17,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// Though a <see cref="LinearRing" /> is not explicitly represented as a GeoJSON geometry type, it is referred to in
     /// the <see cref="Polygon"/> geometry type definition in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     [JsonConverter(typeof(LinearRingJsonConverter))]
     public sealed class LinearRing : IEquatable<LinearRing>
     {
@@ -43,6 +45,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Positions of the <see cref="LinearRing"/>.
         /// </value>
+        [DataMember(Name = "coordinates")]
         public ReadOnlyCollection<Position> Positions { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/LinkedCrs.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/LinkedCrs.cs
@@ -5,10 +5,12 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Coordinate Reference System which is identified by link in the Azure Cosmos DB service. 
     /// </summary>
+    [DataContract]
     public sealed class LinkedCrs : Crs, IEquatable<LinkedCrs>
     {
         /// <summary>
@@ -38,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Link which identifies the Coordinate Reference System.
         /// </value>
+        [DataMember(Name = "href")]
         public string Href { get; private set; }
 
         /// <summary>
@@ -46,6 +49,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Optional string which hints at the format used to represent CRS parameters at the provided <see cref="Href"/>.
         /// </value>
+        [DataMember(Name = "hrefType")]
         public string HrefType { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/MultiLineString.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/MultiLineString.cs
@@ -8,12 +8,14 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Represents a geometry consisting of multiple <see cref="LineString"/>.
     /// </summary>
     /// <seealso cref="LineString"/>.
+    [DataContract]
     internal sealed class MultiLineString : Geometry, IEquatable<MultiLineString>
     {
         /// <summary>
@@ -64,6 +66,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Collection of <see cref="LineStringCoordinates"/> representing individual line strings.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<LineStringCoordinates> LineStrings { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/MultiPoint.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/MultiPoint.cs
@@ -8,12 +8,14 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Geometry consisting of several points.
     /// </summary>
     /// <seealso cref="Point"/>.
+    [DataContract]
     internal sealed class MultiPoint : Geometry, IEquatable<MultiPoint>
     {
         /// <summary>
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Collections of <see cref="Position"/> representing individual points.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<Position> Points { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/MultiPolygon.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/MultiPolygon.cs
@@ -8,12 +8,14 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Geometry which is comprised of multiple polygons.
     /// </summary>
     /// <seealso cref="Polygon"/>
+    [DataContract]
     internal sealed class MultiPolygon : Geometry, IEquatable<MultiPolygon>
     {
         /// <summary>
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Collection of <see cref="PolygonCoordinates"/> instances. Each <see cref="PolygonCoordinates"/> represents separate polygon.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<PolygonCoordinates> Polygons { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/NamedCrs.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/NamedCrs.cs
@@ -5,10 +5,12 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Coordinate Reference System which is identified by name in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     public sealed class NamedCrs : Crs, IEquatable<NamedCrs>
     {
         /// <summary>
@@ -34,6 +36,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Name identifying a coordinate reference system. For example "urn:ogc:def:crs:OGC:1.3:CRS84".
         /// </value>
+        [DataMember(Name = "name")]
         public string Name { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/Point.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Point.cs
@@ -5,11 +5,13 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
     /// Point geometry class in the Azure Cosmos DB service.
     /// </summary>
+    [DataContract]
     public sealed class Point : Geometry, IEquatable<Point>
     {
         /// <summary>
@@ -74,6 +76,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Coordinates of the point.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public Position Position { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/Polygon.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Polygon.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Newtonsoft.Json;
 
     /// <summary>
@@ -56,6 +57,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// ]]>        
     /// </code>
     /// </example>
+    [DataContract]
     public sealed class Polygon : Geometry, IEquatable<Polygon>
     {
         /// <summary>
@@ -123,6 +125,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Polygon rings.
         /// </value>
+        [DataMember(Name = "coordinates")]
         [JsonProperty("coordinates", Required = Required.Always, Order = 1)]
         public ReadOnlyCollection<LinearRing> Rings { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/src/Spatial/PolygonCoordinates.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/PolygonCoordinates.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Converters;
     using Newtonsoft.Json;
 
@@ -15,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// Polygon coordinates.
     /// </summary>
     /// <seealso cref="MultiPolygon"/>
+    [DataContract]
     [JsonConverter(typeof(PolygonCoordinatesJsonConverter))]
     internal sealed class PolygonCoordinates : IEquatable<PolygonCoordinates>
     {
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Rings of the polygon.
         /// </value>
+        [DataMember(Name = "rings")]
         public ReadOnlyCollection<LinearRing> Rings { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/Position.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Position.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Coordinate values.
         /// </value>
-        [DataMember(Name = "coordinates")]
+        [DataMember(Name = "Coordinates")]
         public ReadOnlyCollection<double> Coordinates { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/Position.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Position.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
+    using System.Runtime.Serialization;
     using Converters;
     using Newtonsoft.Json;
 
@@ -20,6 +21,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
     /// Any number of additional elements are allowed - interpretation and meaning of additional elements is up to the application.
     /// </para>
     /// </summary>
+    [DataContract]
     [JsonConverter(typeof(PositionJsonConverter))]
     public sealed class Position : IEquatable<Position>
     {
@@ -83,6 +85,7 @@ namespace Microsoft.Azure.Cosmos.Spatial
         /// <value>
         /// Coordinate values.
         /// </value>
+        [DataMember(Name = "coordinates")]
         public ReadOnlyCollection<double> Coordinates { get; private set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Spatial/UnspecifiedCrs.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/UnspecifiedCrs.cs
@@ -5,10 +5,12 @@
 namespace Microsoft.Azure.Cosmos.Spatial
 {
     using System;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Unspecified CRS. If a geometry has this CRS, no CRS can be assumed for it according to GeoJSON spec.
     /// </summary>
+    [DataContract]
     internal class UnspecifiedCrs : Crs, IEquatable<UnspecifiedCrs>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SpatialTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SpatialTests.cs
@@ -27,20 +27,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             BoundingBox testObj = new BoundingBox(new Position(1, 1), new Position(1, 1));
             string result = ContractObjectToXml(testObj);
-        }
-
-        [TestMethod]
-        public void GeometryParamsSerialization()
-        {
-            GeometryParams testObj = new GeometryParams();
-            string result = ContractObjectToXml(testObj);
-        }
-
-        [TestMethod]
-        public void GeometryValidationResultSerialization()
-        {
-            GeometryValidationResult testObj = new GeometryValidationResult();
-            string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -48,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             LinearRing testObj = new LinearRing(new List<Position>() { new Position(1, 1) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -55,6 +43,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             LineString testObj = new LineString(new List<Position>() { new Position(1, 1) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -62,6 +51,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             LineStringCoordinates testObj = new LineStringCoordinates(new List<Position>() { new Position(1, 1) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -69,6 +59,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             LinkedCrs testObj = new LinkedCrs("href", "hrefType");
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -76,6 +67,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             MultiLineString testObj = new MultiLineString(new List<LineStringCoordinates>());
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -83,6 +75,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             MultiPolygon testObj = new MultiPolygon(new List<PolygonCoordinates>() { new PolygonCoordinates(new List<LinearRing>() { new LinearRing(new List<Position>() { new Position(1, 1) }) } ) } );
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -90,6 +83,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             MultiPoint testObj = new MultiPoint(new List<Position>() { new Position(1, 1) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -97,6 +91,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             NamedCrs testObj = new NamedCrs("name");
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -104,6 +99,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             Point testObj = new Point(1,1);
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -111,6 +107,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             Polygon testObj = new Polygon(new List<Position>() { new Position(1,1) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -118,6 +115,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             PolygonCoordinates testObj = new PolygonCoordinates(new List<LinearRing>() { new LinearRing(new List<Position>() { new Position(1, 1) }) });
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -125,6 +123,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             Position testObj = new Position(1,1);
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         [TestMethod]
@@ -132,6 +131,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             UnspecifiedCrs testObj = new UnspecifiedCrs();
             string result = ContractObjectToXml(testObj);
+            Assert.IsTrue(VerifySerialization(result, testObj));
         }
 
         private static string ContractObjectToXml<T>(T obj)
@@ -147,7 +147,22 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
 
             return text;
+        }
 
+        private static bool VerifySerialization<T>(string serialized, T obj)
+        {
+            DataContractSerializer dataContractSerializer = new DataContractSerializer(obj.GetType());
+
+
+            using (var stream = new MemoryStream())
+            {
+                var writer = new StreamWriter(stream);
+                writer.Write(serialized);
+                writer.Flush();
+                stream.Position = 0;
+                T deserialized = (T)dataContractSerializer.ReadObject(stream);
+                return deserialized.Equals(obj);
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SpatialTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SpatialTests.cs
@@ -1,0 +1,153 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Scripts;
+    using Microsoft.Azure.Cosmos.Spatial;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class SpatialTests
+    {
+        [TestMethod]
+        public void BoundingBoxSerialization()
+        {
+            BoundingBox testObj = new BoundingBox(new Position(1, 1), new Position(1, 1));
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void GeometryParamsSerialization()
+        {
+            GeometryParams testObj = new GeometryParams();
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void GeometryValidationResultSerialization()
+        {
+            GeometryValidationResult testObj = new GeometryValidationResult();
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void LinearRingSerialization()
+        {
+            LinearRing testObj = new LinearRing(new List<Position>() { new Position(1, 1) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void LineStringSerialization()
+        {
+            LineString testObj = new LineString(new List<Position>() { new Position(1, 1) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void LineStringCoordinatesSerialization()
+        {
+            LineStringCoordinates testObj = new LineStringCoordinates(new List<Position>() { new Position(1, 1) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void LinkedCrsSerialization()
+        {
+            LinkedCrs testObj = new LinkedCrs("href", "hrefType");
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void MultiLineStringSerialization()
+        {
+            MultiLineString testObj = new MultiLineString(new List<LineStringCoordinates>());
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void MultiPolygonSerialization()
+        {
+            MultiPolygon testObj = new MultiPolygon(new List<PolygonCoordinates>() { new PolygonCoordinates(new List<LinearRing>() { new LinearRing(new List<Position>() { new Position(1, 1) }) } ) } );
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void MultiPointSerialization()
+        {
+            MultiPoint testObj = new MultiPoint(new List<Position>() { new Position(1, 1) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void NamedCrsSerialization()
+        {
+            NamedCrs testObj = new NamedCrs("name");
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void PointSerialization()
+        {
+            Point testObj = new Point(1,1);
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void PolygonSerialization()
+        {
+            Polygon testObj = new Polygon(new List<Position>() { new Position(1,1) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void PolygonCoordinatesSerialization()
+        {
+            PolygonCoordinates testObj = new PolygonCoordinates(new List<LinearRing>() { new LinearRing(new List<Position>() { new Position(1, 1) }) });
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void PositionSerialization()
+        {
+            Position testObj = new Position(1,1);
+            string result = ContractObjectToXml(testObj);
+        }
+
+        [TestMethod]
+        public void UnspecifiedCrsSerialization()
+        {
+            UnspecifiedCrs testObj = new UnspecifiedCrs();
+            string result = ContractObjectToXml(testObj);
+        }
+
+        private static string ContractObjectToXml<T>(T obj)
+        {
+            DataContractSerializer dataContractSerializer = new DataContractSerializer(obj.GetType());
+            string text;
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                dataContractSerializer.WriteObject(memoryStream, obj);
+                byte[] data = new byte[memoryStream.Length];
+                Array.Copy(memoryStream.GetBuffer(), data, data.Length);
+                text = Encoding.UTF8.GetString(data);
+            }
+
+            return text;
+
+        }
+    }
+}


### PR DESCRIPTION
# Spatial classes with DataContract

## Description

This PR adds `[DataContract]` to Spatial classes and unit tests to verify serialization.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Closing issues

Closes #16 