### PR TITLE
Builders Get contract

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/ConflictResolutionDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/ConflictResolutionDefinition.cs
@@ -12,13 +12,13 @@ namespace Microsoft.Azure.Cosmos.Fluent
     /// </summary>
     public class ConflictResolutionDefinition
     {
-        private readonly CreateContainerDefinition parent;
+        private readonly ContainerBuilder parent;
         private readonly Action<ConflictResolutionPolicy> attachCallback;
         private string conflictResolutionPath;
         private string conflictResolutionProcedure;
 
         internal ConflictResolutionDefinition(
-            CreateContainerDefinition parent,
+            ContainerBuilder parent,
             Action<ConflictResolutionPolicy> attachCallback)
         {
             this.parent = parent;
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// Applies the current definition to the parent.
         /// </summary>
         /// <returns>An instance of the parent.</returns>
-        public virtual CreateContainerDefinition Attach()
+        public virtual ContainerBuilder Attach()
         {
             ConflictResolutionPolicy resolutionPolicy = new ConflictResolutionPolicy();
             if (this.conflictResolutionPath != null)

--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/ContainerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/ContainerBuilder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
     /// <summary>
     /// <see cref="Container"/> fluent definition for creation flows.
     /// </summary>
-    public class CreateContainerDefinition : ContainerDefinition<CreateContainerDefinition>
+    public class ContainerBuilder : ContainerDefinition<ContainerBuilder>
     {
         private readonly Database cosmosContainers;
         private UniqueKeyPolicy uniqueKeyPolicy;
@@ -18,11 +18,11 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <summary>
         /// Creates an instance for unit-testing
         /// </summary>
-        public CreateContainerDefinition()
+        public ContainerBuilder()
         {
         }
 
-        internal CreateContainerDefinition(
+        internal ContainerBuilder(
             Database cosmosContainers,
             string name,
             string partitionKeyPath = null)

--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/UniqueKeyDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/UniqueKeyDefinition.cs
@@ -13,11 +13,11 @@ namespace Microsoft.Azure.Cosmos.Fluent
     public class UniqueKeyDefinition
     {
         private readonly Collection<string> paths = new Collection<string>();
-        private readonly CreateContainerDefinition parent;
+        private readonly ContainerBuilder parent;
         private readonly Action<UniqueKey> attachCallback;
 
         internal UniqueKeyDefinition(
-            CreateContainerDefinition parent,
+            ContainerBuilder parent,
             Action<UniqueKey> attachCallback)
         {
             this.parent = parent;
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// Applies the current definition to the parent.
         /// </summary>
         /// <returns>An instance of the parent.</returns>
-        public virtual CreateContainerDefinition Attach()
+        public virtual ContainerBuilder Attach()
         {
             this.attachCallback(new UniqueKey()
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -1123,7 +1123,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
         /// <param name="onChangesDelegate">Delegate to receive changes.</param>
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
-        public abstract ChangeFeedProcessorBuilder DefineChangeFeedProcessor<T>(
+        public abstract ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate);
 
@@ -1137,7 +1137,7 @@ namespace Microsoft.Azure.Cosmos
         /// The goal of the Estimator is to measure progress of a particular processor. In order to do that, the <paramref name="processorName"/> and other parameters, like the leases container, need to match that of the Processor to measure.
         /// </remarks>
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
-        public abstract ChangeFeedProcessorBuilder DefineChangeFeedEstimator(
+        public abstract ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(
             string processorName,
             ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null);

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -1123,7 +1123,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="processorName">A name that identifies the Processor and the particular work it will do.</param>
         /// <param name="onChangesDelegate">Delegate to receive changes.</param>
         /// <returns>An instance of <see cref="ChangeFeedProcessorBuilder"/></returns>
-        public abstract ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder<T>(
+        public abstract ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate);
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Cosmos
             return new CosmosLinqQuery<T>(this, this.ClientContext.CosmosSerializer, (CosmosQueryClientCore)this.queryClient, requestOptions, allowSynchronousQueryExecution);
         }
 
-        public override ChangeFeedProcessorBuilder DefineChangeFeedProcessor<T>(
+        public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate)
         {
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.Cosmos
                 applyBuilderConfiguration: changeFeedProcessor.ApplyBuildConfiguration);
         }
 
-        public override ChangeFeedProcessorBuilder DefineChangeFeedEstimator(
+        public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(
             string processorName,
             ChangesEstimationHandler estimationDelegate,
             TimeSpan? estimationPeriod = null)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Cosmos
             return new CosmosLinqQuery<T>(this, this.ClientContext.CosmosSerializer, (CosmosQueryClientCore)this.queryClient, requestOptions, allowSynchronousQueryExecution);
         }
 
-        public override ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder<T>(
+        public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(
             string processorName,
             ChangesHandler<T> onChangesDelegate)
         {

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract CreateContainerDefinition DefineContainer(
+        public abstract ContainerBuilder DefineContainer(
             string name,
             string partitionKeyPath);
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Azure.Cosmos
                 this.ContainerStreamFeedRequestExecutorAsync);
         }
 
-        public override CreateContainerDefinition DefineContainer(
+        public override ContainerBuilder DefineContainer(
             string name,
             string partitionKeyPath)
         {
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(partitionKeyPath));
             }
 
-            return new CreateContainerDefinition(this, name, partitionKeyPath);
+            return new ContainerBuilder(this, name, partitionKeyPath);
         }
 
         internal void ValidateContainerProperties(ContainerProperties containerProperties)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             int processedDocCount = 0;
             string accumulator = string.Empty;
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     processedDocCount += docs.Count();
                     foreach (var doc in docs) accumulator += doc.id.ToString() + ".";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task WhenLeasesHaveContinuationTokenNullReturn0()
         {
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task CountPendingDocuments()
         {
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/EstimatorTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         {
             long? receivedEstimation = 0;
             ChangeFeedProcessor estimator = this.Container
-                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task WhenLeasesHaveContinuationTokenNullReturn0()
         {
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         public async Task CountPendingDocuments()
         {
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     return Task.CompletedTask;
                 })
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             long? receivedEstimation = null;
             ChangeFeedProcessor estimator = this.Container
-                .DefineChangeFeedEstimator("test", (long estimation, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (long estimation, CancellationToken token) =>
                 {
                     receivedEstimation = estimation;
                     return Task.CompletedTask;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
                 {
                     foreach (TestClass doc in docs)
                     {
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
-                .DefineChangeFeedProcessor("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                .GetChangeFeedEstimatorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
                 {
                     foreach (dynamic doc in docs)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/CompositeIndexDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/CompositeIndexDefinitionTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse()
         {
-            Mock<IndexingPolicyDefinition<CreateContainerDefinition>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<CreateContainerDefinition>>();
+            Mock<IndexingPolicyDefinition<ContainerBuilder>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<ContainerBuilder>>();
             Action<Collection<CompositePath>> callback = (paths) =>
             {
                 Assert.AreEqual(2, paths.Count);
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                 Assert.AreEqual(CompositePathSortOrder.Descending, paths[1].Order);                
             };
 
-            CompositeIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>> compositeIndexFluentDefinitionCore = new CompositeIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>>(
+            CompositeIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>> compositeIndexFluentDefinitionCore = new CompositeIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>>(
                 mockIndexingPolicyDefinition.Object,
                 callback);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ConflictResolutionDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ConflictResolutionDefinitionTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse()
         {
-            Mock<CreateContainerDefinition> mockContainerDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerDefinition = new Mock<ContainerBuilder>();
 
             // LastWrite wins conflict resolution mode 
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         {
             Mock<Database> mockContainers = new Mock<Database>();
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 null);
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
 
             mockContainers.Setup(c => c.GetContainer(containerName)).Returns(mockContainer.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 null);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);
@@ -232,7 +232,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(mockContainerResponse.Object);
 
-            CreateContainerDefinition containerFluentDefinitionForCreate = new CreateContainerDefinition(
+            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
                 mockContainers.Object,
                 containerName,
                 partitionKey);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IndexingPolicyDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/IndexingPolicyDefinitionTests.cs
@@ -16,14 +16,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithIndexingMode()
         {
-            Mock<CreateContainerDefinition> mockContainerPolicyDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerPolicyDefinition = new Mock<ContainerBuilder>();
             Action<IndexingPolicy> callback = (policy) =>
             {
                 Assert.IsFalse(policy.Automatic);
                 Assert.AreEqual(IndexingMode.None, policy.IndexingMode);
             };
 
-            IndexingPolicyDefinition<CreateContainerDefinition> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<CreateContainerDefinition>(
+            IndexingPolicyDefinition<ContainerBuilder> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<ContainerBuilder>(
                 mockContainerPolicyDefinition.Object,
                 callback);
 
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithSpatialIndexes()
         {
-            Mock<CreateContainerDefinition> mockContainerPolicyDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerPolicyDefinition = new Mock<ContainerBuilder>();
             Action<IndexingPolicy> callback = (policy) =>
             {
                 Assert.AreEqual(1, policy.SpatialIndexes.Count);
                 Assert.AreEqual("/path", policy.SpatialIndexes[0].Path);
             };
 
-            IndexingPolicyDefinition<CreateContainerDefinition> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<CreateContainerDefinition>(
+            IndexingPolicyDefinition<ContainerBuilder> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<ContainerBuilder>(
                 mockContainerPolicyDefinition.Object,
                 callback);
 
@@ -57,14 +57,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithExcludedPaths()
         {
-            Mock<CreateContainerDefinition> mockContainerPolicyDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerPolicyDefinition = new Mock<ContainerBuilder>();
             Action<IndexingPolicy> callback = (policy) =>
             {
                 Assert.AreEqual(1, policy.ExcludedPaths.Count);
                 Assert.AreEqual("/path", policy.ExcludedPaths[0].Path);
             };
 
-            IndexingPolicyDefinition<CreateContainerDefinition> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<CreateContainerDefinition>(
+            IndexingPolicyDefinition<ContainerBuilder> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<ContainerBuilder>(
                 mockContainerPolicyDefinition.Object,
                 callback);
 
@@ -78,14 +78,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithIncludedPaths()
         {
-            Mock<CreateContainerDefinition> mockContainerPolicyDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerPolicyDefinition = new Mock<ContainerBuilder>();
             Action<IndexingPolicy> callback = (policy) =>
             {
                 Assert.AreEqual(1, policy.IncludedPaths.Count);
                 Assert.AreEqual("/path", policy.IncludedPaths[0].Path);
             };
 
-            IndexingPolicyDefinition<CreateContainerDefinition> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<CreateContainerDefinition>(
+            IndexingPolicyDefinition<ContainerBuilder> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<ContainerBuilder>(
                 mockContainerPolicyDefinition.Object,
                 callback);
 
@@ -99,14 +99,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithCompositeIndex()
         {
-            Mock<CreateContainerDefinition> mockContainerPolicyDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerPolicyDefinition = new Mock<ContainerBuilder>();
             Action<IndexingPolicy> callback = (policy) =>
             {
                 Assert.AreEqual(1, policy.CompositeIndexes.Count);
                 Assert.AreEqual("/path", policy.CompositeIndexes[0][0].Path);
             };
 
-            IndexingPolicyDefinition<CreateContainerDefinition> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<CreateContainerDefinition>(
+            IndexingPolicyDefinition<ContainerBuilder> indexingPolicyFluentDefinitionCore = new IndexingPolicyDefinition<ContainerBuilder>(
                 mockContainerPolicyDefinition.Object,
                 callback);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/PathsDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/PathsDefinitionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse()
         {
-            Mock<IndexingPolicyDefinition<CreateContainerDefinition>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<CreateContainerDefinition>>();
+            Mock<IndexingPolicyDefinition<ContainerBuilder>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<ContainerBuilder>>();
             Action<IEnumerable<string>> callback = (paths) =>
             {
                 Assert.AreEqual("/path1", paths.First());
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                 Assert.AreEqual(2, paths.Count());
             };
 
-            PathsDefinition<IndexingPolicyDefinition<CreateContainerDefinition>> pathsFluentDefinitionCore = new PathsDefinition<IndexingPolicyDefinition<CreateContainerDefinition>>(
+            PathsDefinition<IndexingPolicyDefinition<ContainerBuilder>> pathsFluentDefinitionCore = new PathsDefinition<IndexingPolicyDefinition<ContainerBuilder>>(
                 mockIndexingPolicyDefinition.Object,
                 callback);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/SpatialIndexDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/SpatialIndexDefinitionTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithSpatialType()
         {
-            Mock<IndexingPolicyDefinition<CreateContainerDefinition>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<CreateContainerDefinition>>();
+            Mock<IndexingPolicyDefinition<ContainerBuilder>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<ContainerBuilder>>();
             Action<SpatialPath> callback = (spatialspec) =>
             {
                 Assert.AreEqual("/path", spatialspec.Path);
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                 Assert.AreEqual(SpatialType.Point, spatialspec.SpatialTypes[1]);
             };
 
-            SpatialIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>> spatialIndexFluentDefinitionCore = new SpatialIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>>(
+            SpatialIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>> spatialIndexFluentDefinitionCore = new SpatialIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>>(
                 mockIndexingPolicyDefinition.Object,
                 callback);
 
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse_WithNoSpatialType()
         {
-            Mock<IndexingPolicyDefinition<CreateContainerDefinition>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<CreateContainerDefinition>>();
+            Mock<IndexingPolicyDefinition<ContainerBuilder>> mockIndexingPolicyDefinition = new Mock<IndexingPolicyDefinition<ContainerBuilder>>();
             Action<SpatialPath> callback = (spatialspec) =>
             {
                 Assert.AreEqual("/path", spatialspec.Path);
                 Assert.AreEqual(0, spatialspec.SpatialTypes.Count);
             };
 
-            SpatialIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>> spatialIndexFluentDefinitionCore = new SpatialIndexDefinition<IndexingPolicyDefinition<CreateContainerDefinition>>(
+            SpatialIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>> spatialIndexFluentDefinitionCore = new SpatialIndexDefinition<IndexingPolicyDefinition<ContainerBuilder>>(
                 mockIndexingPolicyDefinition.Object,
                 callback);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/UniqueKeyDefinitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/UniqueKeyDefinitionTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public void AttachReturnsCorrectResponse()
         {
-            Mock<CreateContainerDefinition> mockContainerDefinition = new Mock<CreateContainerDefinition>();
+            Mock<ContainerBuilder> mockContainerDefinition = new Mock<ContainerBuilder>();
             Action<UniqueKey> callback = (uniqueKey) =>
             {
                 Assert.AreEqual(2, uniqueKey.Paths.Count);


### PR DESCRIPTION
# Builders Get contract

## Description

To align with user intent and make the Builder discoverable, the methods in the Container to access the Change Feed Builders are changed to:

* `GetChangeFeedProcessorBuilder`
* `GetChangeFeedEstimatorBuilder`

For Container, changing `DefineContainer` to `GetContainerBuilder` and `CreateContainerDefinition` to `ContainerBuilder`.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #448