### PR TITLE
Adding ToFeedIterator to LINQ

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
@@ -155,6 +155,29 @@ namespace Microsoft.Azure.Cosmos.Linq
             return container.LinkUri.ToString();
         }
 
+        public FeedIterator<T> ToFeedIterator(string continuationToken = null)
+        {
+            CosmosQueryExecutionContext cosmosQueryExecution = new CosmosQueryExecutionContextFactory(
+                client: this.queryClient,
+                resourceTypeEnum: ResourceType.Document,
+                operationType: OperationType.Query,
+                resourceType: typeof(T),
+                sqlQuerySpec: DocumentQueryEvaluator.Evaluate(this.expression),
+                continuationToken: continuationToken,
+                queryRequestOptions: cosmosQueryRequestOptions,
+                resourceLink: container.LinkUri,
+                isContinuationExpected: true,
+                allowNonValueAggregateQuery: true,
+                correlatedActivityId: Guid.NewGuid());
+
+            return new FeedIteratorCore<T>(
+                cosmosQueryRequestOptions.MaxItemCount,
+                continuationToken,
+                cosmosQueryRequestOptions,
+                container.NextResultSetAsync<T>,
+                cosmosQueryExecution);
+        }
+
         public void Dispose()
         {
             //NOTHING TO DISPOSE HERE

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             return container.LinkUri.ToString();
         }
 
-        public FeedIterator<T> ToFeedIterator(string continuationToken = null)
+        public FeedIterator<T> ToFeedIterator()
         {
             CosmosQueryExecutionContext cosmosQueryExecution = new CosmosQueryExecutionContextFactory(
                 client: this.queryClient,
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 operationType: OperationType.Query,
                 resourceType: typeof(T),
                 sqlQuerySpec: DocumentQueryEvaluator.Evaluate(this.expression),
-                continuationToken: continuationToken,
+                continuationToken: null,
                 queryRequestOptions: cosmosQueryRequestOptions,
                 resourceLink: container.LinkUri,
                 isContinuationExpected: true,
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             return new FeedIteratorCore<T>(
                 cosmosQueryRequestOptions.MaxItemCount,
-                continuationToken,
+                null,
                 cosmosQueryRequestOptions,
                 container.NextResultSetAsync<T>,
                 cosmosQueryExecution);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public static string ToSqlQueryText<T>(this IQueryable<T> query)
+        internal static string ToSqlQueryText<T>(this IQueryable<T> query)
         {
             return ((CosmosLinqQuery<T>)query).ToSqlQueryText();
         }
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <typeparam name="T">the type of object to query.</typeparam>
         /// <param name="query">the IQueryable{T} to be converted.</param>
-        /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <returns>An iterator to go through the items.</returns>
         /// <example>
         /// This example shows how to get FeedIterator from LINQ.
@@ -51,9 +50,9 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public static FeedIterator<T> ToFeedIterator<T>(this IQueryable<T> query, string continuationToken = null)
+        public static FeedIterator<T> ToFeedIterator<T>(this IQueryable<T> query)
         {
-            return ((CosmosLinqQuery<T>)query).ToFeedIterator(continuationToken);
+            return ((CosmosLinqQuery<T>)query).ToFeedIterator();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Linq;
 
     /// <summary>
-    /// This class provides extension method for converting a <see cref="System.Linq.IQueryable{T}"/> object to a  SqlQueryText.
+    /// This class provides extension methods used within cosmos sdk code.
     /// </summary>
     public static class CosmosExtensions
     {
@@ -32,6 +32,28 @@ namespace Microsoft.Azure.Cosmos
         public static string ToSqlQueryText<T>(this IQueryable<T> query)
         {
             return ((CosmosLinqQuery<T>)query).ToSqlQueryText();
+        }
+
+        /// <summary>
+        /// This extension method gets the FeedIterator from LINQ IQueryable to execute query asynchronously.
+        /// </summary>
+        /// <typeparam name="T">the type of object to query.</typeparam>
+        /// <param name="query">the IQueryable{T} to be converted.</param>
+        /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
+        /// <returns>An iterator to go through the items.</returns>
+        /// <example>
+        /// This example shows how to get FeedIterator from LINQ.
+        ///
+        /// <code language="c#">
+        /// <![CDATA[
+        /// IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>();
+        /// FeedIterator<ToDoActivity> setIterator = linqQueryable.Where(item => (item.taskNum < 100)).ToFeedIterator()
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static FeedIterator<T> ToFeedIterator<T>(this IQueryable<T> query, string continuationToken = null)
+        {
+            return ((CosmosLinqQuery<T>)query).ToFeedIterator(continuationToken);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1168,7 +1168,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 FeedResponse<ToDoActivity> queryResponse = await setIterator.ReadNextAsync();
                 resultsFetched += queryResponse.Count();
 
-                // For the items returned with NonePartitionKeyValue
                 var iter = queryResponse.GetEnumerator();
                 while (iter.MoveNext())
                 {
@@ -1214,6 +1213,54 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(exception.Message.Contains("To execute LINQ query please set allowSynchronousQueryExecution true"));
             }
         }
+
+        [TestMethod]
+        public async Task ItemLINQToFeedIteratorQueryTest()
+        {
+            //Creating items for query.
+            IList<ToDoActivity> itemList = await CreateRandomItems(pkCount: 10, perPKItemCount: 1, randomPartitionKey: true);
+
+            //V3 Asynchronous query execution with LINQ queryable extension method ToFeedIterator().
+            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(requestOptions: new QueryRequestOptions() { MaxConcurrency = 1, MaxItemCount = 1 });
+            FeedIterator<ToDoActivity> setIterator = linqQueryable.Where(item => (item.taskNum < 100)).ToFeedIterator();
+
+            int resultsFetched = 0;
+            string continuationToken = null;
+            int counter = 0;
+            do
+            {
+                FeedResponse<ToDoActivity> queryResponse = await setIterator.ReadNextAsync();
+                resultsFetched += queryResponse.Count();
+
+                var iter = queryResponse.GetEnumerator();
+                while (iter.MoveNext())
+                {
+                    ToDoActivity activity = iter.Current;
+                    Assert.AreEqual(42, activity.taskNum);
+                }
+                continuationToken = queryResponse.Continuation;
+                counter++;
+            } while (counter < 5);
+            Assert.AreEqual(5, resultsFetched);
+
+            //Resuming the work from last continuationToken, passing it to ToFeedIterator().
+            setIterator = linqQueryable.Where(item => (item.taskNum < 100)).ToFeedIterator(continuationToken);
+            do
+            {
+                FeedResponse<ToDoActivity> queryResponse = await setIterator.ReadNextAsync();
+                resultsFetched += queryResponse.Count();
+
+                var iter = queryResponse.GetEnumerator();
+                while (iter.MoveNext())
+                {
+                    ToDoActivity activity = iter.Current;
+                    Assert.AreEqual(42, activity.taskNum);
+                }
+                continuationToken = queryResponse.Continuation;
+            } while (continuationToken != null);
+            Assert.AreEqual(10, resultsFetched);
+        }
+
         // Move the data from None Partition to other logical partitions
         [TestMethod]
         public async Task MigrateDataInNonPartitionContainer()


### PR DESCRIPTION
# Pull Request Template

## Description

This will add the extension method ToFeedIterator () on IQueryable which will give user the ability
to create LINQ query and execute it asynchronously via FeedIterator.

## Closing issues

It will close #https://github.com/Azure/azure-cosmos-dotnet-v3/issues/460

