### PR TITLE
CosmosException response headers are public and adding retry after

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             if (cosmosException != null)
             {
                 return new ResponseMessage(
-                    headers: cosmosException.ResponseHeaders,
+                    headers: cosmosException.Headers,
                     requestMessage: request,
                     errorMessage: cosmosException.Message,
                     statusCode: cosmosException.StatusCode,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -624,7 +624,7 @@ namespace Microsoft.Azure.Cosmos
             catch (CosmosException exception)
             {
                 return new ResponseMessage(
-                    headers: exception.ResponseHeaders,
+                    headers: exception.Headers,
                     requestMessage: null,
                     errorMessage: exception.Message,
                     statusCode: exception.StatusCode,

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Cosmos
         {
             this.StatusCode = statusCode;
             this.Error = error;
+            this.ResponseHeaders = new Headers();
         }
 
         internal CosmosException(
@@ -35,10 +36,16 @@ namespace Microsoft.Azure.Cosmos
             {
                 this.StatusCode = cosmosResponseMessage.StatusCode;
                 this.ResponseHeaders = cosmosResponseMessage.Headers;
-                this.ActivityId = this.ResponseHeaders?.GetHeaderValue<string>(HttpConstants.HttpHeaders.ActivityId);
-                this.RequestCharge = this.ResponseHeaders == null ? 0 : this.ResponseHeaders.GetHeaderValue<double>(HttpConstants.HttpHeaders.RequestCharge);
+                if (this.ResponseHeaders == null)
+                {
+                    this.ResponseHeaders = new Headers();
+                }
+
+                this.ActivityId = this.ResponseHeaders.ActivityId;
+                this.RequestCharge = this.ResponseHeaders.RequestCharge;
+                this.RetryAfter = this.ResponseHeaders.RetryAfter;
                 this.SubStatusCode = (int)this.ResponseHeaders.SubStatusCode;
-                if (cosmosResponseMessage.Headers.ContentLengthAsLong > 0)
+                if (this.ResponseHeaders.ContentLengthAsLong > 0)
                 {
                     using (StreamReader responseReader = new StreamReader(cosmosResponseMessage.Content))
                     {
@@ -70,6 +77,7 @@ namespace Microsoft.Azure.Cosmos
             this.StatusCode = statusCode;
             this.RequestCharge = requestCharge;
             this.ActivityId = activityId;
+            this.ResponseHeaders = new Headers();
         }
 
         /// <summary>
@@ -106,14 +114,19 @@ namespace Microsoft.Azure.Cosmos
         public virtual string ActivityId { get; }
 
         /// <summary>
+        /// Gets the retry after time. This tells how long a request should wait before doing a retry.
+        /// </summary>
+        public virtual TimeSpan? RetryAfter { get; }
+
+        /// <summary>
+        /// Gets the response headers
+        /// </summary>
+        public virtual Headers ResponseHeaders { get; }
+
+        /// <summary>
         /// Gets the internal error object
         /// </summary>
         internal virtual Error Error { get; }
-
-        /// <summary>
-        /// Gets the internal headers
-        /// </summary>
-        internal virtual Headers ResponseHeaders { get; }
 
         /// <summary>
         /// Try to get a header from the cosmos response message

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos
         {
             this.StatusCode = statusCode;
             this.Error = error;
-            this.ResponseHeaders = new Headers();
+            this.Headers = new Headers();
         }
 
         internal CosmosException(
@@ -35,17 +35,17 @@ namespace Microsoft.Azure.Cosmos
             if (cosmosResponseMessage != null)
             {
                 this.StatusCode = cosmosResponseMessage.StatusCode;
-                this.ResponseHeaders = cosmosResponseMessage.Headers;
-                if (this.ResponseHeaders == null)
+                this.Headers = cosmosResponseMessage.Headers;
+                if (this.Headers == null)
                 {
-                    this.ResponseHeaders = new Headers();
+                    this.Headers = new Headers();
                 }
 
-                this.ActivityId = this.ResponseHeaders.ActivityId;
-                this.RequestCharge = this.ResponseHeaders.RequestCharge;
-                this.RetryAfter = this.ResponseHeaders.RetryAfter;
-                this.SubStatusCode = (int)this.ResponseHeaders.SubStatusCode;
-                if (this.ResponseHeaders.ContentLengthAsLong > 0)
+                this.ActivityId = this.Headers.ActivityId;
+                this.RequestCharge = this.Headers.RequestCharge;
+                this.RetryAfter = this.Headers.RetryAfter;
+                this.SubStatusCode = (int)this.Headers.SubStatusCode;
+                if (this.Headers.ContentLengthAsLong > 0)
                 {
                     using (StreamReader responseReader = new StreamReader(cosmosResponseMessage.Content))
                     {
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos
             this.StatusCode = statusCode;
             this.RequestCharge = requestCharge;
             this.ActivityId = activityId;
-            this.ResponseHeaders = new Headers();
+            this.Headers = new Headers();
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the response headers
         /// </summary>
-        public virtual Headers ResponseHeaders { get; }
+        public virtual Headers Headers { get; }
 
         /// <summary>
         /// Gets the internal error object
@@ -136,13 +136,13 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A value indicating if the header was read.</returns>
         public virtual bool TryGetHeader(string headerName, out string value)
         {
-            if (this.ResponseHeaders == null)
+            if (this.Headers == null)
             {
                 value = null;
                 return false;
             }
 
-            return this.ResponseHeaders.TryGetValue(headerName, out value);
+            return this.Headers.TryGetValue(headerName, out value);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -86,11 +86,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 await container.CreateItemAsync<dynamic>(
                     item: new { id = "429testid", pk = "429pkvalue" },
                     partitionKey: new Cosmos.PartitionKey("429pkvalue"));
+                Assert.Fail("Request should have thrown");
+
             }catch(CosmosException ce)
             {
                 Assert.IsNotNull(ce.RetryAfter);
-                Assert.IsNotNull(ce.ResponseHeaders);
-                Assert.AreEqual(ce.RetryAfter, ce.ResponseHeaders.RetryAfter);
+                Assert.IsNotNull(ce.Headers);
+                Assert.AreEqual(ce.RetryAfter, ce.Headers.RetryAfter);
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Making the CosmosException headers public, and adding retry after. This is needed for different retry scenarios.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

