### PR TITLE
Adding specific constructors to PartitionKey

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/SinglePartitionRequestOptionsFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/SinglePartitionRequestOptionsFactory.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     {
         public override FeedOptions CreateFeedOptions() => null;
 
-        public override PartitionKey GetPartitionKey(string itemId) => PartitionKey.NonePartitionKeyValue;
+        public override PartitionKey GetPartitionKey(string itemId) => PartitionKey.None;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/SinglePartitionRequestOptionsFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/SinglePartitionRequestOptionsFactory.cs
@@ -13,6 +13,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     {
         public override FeedOptions CreateFeedOptions() => null;
 
-        public override PartitionKey GetPartitionKey(string itemId) => new PartitionKey(Documents.Undefined.Value);
+        public override PartitionKey GetPartitionKey(string itemId) => PartitionKey.NonePartitionKeyValue;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -144,11 +144,11 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
             if (partitionKey != null)
             {
-                if (cosmosContainerCore == null && Object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.NonePartitionKeyValue))
+                if (cosmosContainerCore == null && Object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.None))
                 {
                     throw new ArgumentException($"{nameof(cosmosContainerCore)} can not be null with partition key as PartitionKey.None");
                 }
-                else if (Object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.NonePartitionKeyValue))
+                else if (Object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.None))
                 {
                     try
                     {

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -3,8 +3,6 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos
 {
-    using System;
-    using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
@@ -12,17 +10,19 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public sealed class PartitionKey
     {
-        /// <summary>
-        /// The returned object represents a partition key value that allows creating and accessing documents
-        /// without a value for partition key.
-        /// </summary>
-        public static readonly PartitionKey NonePartitionKeyValue = new PartitionKey(Documents.PartitionKey.None);
+        private static readonly PartitionKeyInternal NullPartitionKeyInternal = new Documents.PartitionKey(null).InternalKey;
 
         /// <summary>
         /// The returned object represents a partition key value that allows creating and accessing documents
         /// without a value for partition key.
         /// </summary>
-        public static readonly PartitionKey NullPartitionKeyValue = new PartitionKey(new Documents.PartitionKey(null));
+        public static readonly PartitionKey NonePartitionKeyValue = new PartitionKey(Documents.PartitionKey.None.InternalKey);
+
+        /// <summary>
+        /// The returned object represents a partition key value that allows creating and accessing documents
+        /// without a value for partition key.
+        /// </summary>
+        public static readonly PartitionKey NullPartitionKeyValue = new PartitionKey(PartitionKey.NullPartitionKeyInternal);
 
         /// <summary>
         /// The tag name to use in the documents for specifying a partition key value
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (partitionKeyValue == null)
             {
-                throw new ArgumentNullException($"{nameof(partitionKeyValue)} is null. Please use {nameof(PartitionKey.NullPartitionKeyValue)} to define null");
+                this.Value = PartitionKey.NullPartitionKeyInternal;
             }
 
             this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
@@ -73,57 +73,21 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Convert a string to a partition key
-        /// </summary>
-        /// <param name="partitionKeyValue">The string value</param>
-        public static implicit operator PartitionKey(string partitionKeyValue)
-        {
-            return new PartitionKey(partitionKeyValue);
-        }
-
-        /// <summary>
-        /// Convert a double to a partition key
-        /// </summary>
-        /// <param name="partitionKeyValue">The double value</param>
-        public static implicit operator PartitionKey(double partitionKeyValue)
-        {
-            return new PartitionKey(partitionKeyValue);
-        }
-
-        /// <summary>
-        /// Convert a bool to a partition key
-        /// </summary>
-        /// <param name="partitionKeyValue">The bool value</param>
-        public static implicit operator PartitionKey(bool partitionKeyValue)
-        {
-            return new PartitionKey(partitionKeyValue);
-        }
-
-        /// <summary>
         /// Creates a new partition key value.
         /// </summary>
         /// <param name="value">The value to use as partition key.</param>
         internal PartitionKey(object value)
         {
-            if (value == null)
-            {
-                throw new ArgumentNullException(nameof(value));
-            }
-
-            Documents.PartitionKey docPk = value as Documents.PartitionKey;
-            if (docPk != null)
-            {
-                this.Value = docPk.InternalKey;
-                return;
-            }
-
-            this.Value = value as PartitionKeyInternal;
-            if (this.Value != null)
-            {
-                return;
-            }
-
             this.Value = new Documents.PartitionKey(value).InternalKey;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyInternal">The value to use as partition key.</param>
+        private PartitionKey(PartitionKeyInternal partitionKeyInternal)
+        {
+            this.Value = partitionKeyInternal;
         }
 
         /// <summary>
@@ -138,6 +102,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return this.Value.ToJsonString();
-        } 
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Azure.Cosmos
         private static readonly PartitionKeyInternal FalsePartitionKeyInternal = new Documents.PartitionKey(false).InternalKey;
 
         /// <summary>
-        /// The returned object represents a partition key value that allows creating and accessing documents
+        /// The returned object represents a partition key value that allows creating and accessing items
         /// without a value for partition key.
         /// </summary>
         public static readonly PartitionKey NonePartitionKeyValue = new PartitionKey(Documents.PartitionKey.None.InternalKey);
 
         /// <summary>
-        /// The returned object represents a partition key value that allows creating and accessing documents
-        /// without a value for partition key.
+        /// The returned object represents a partition key value that allows creating and accessing items
+        /// with a null value for the partition key.
         /// </summary>
         public static readonly PartitionKey NullPartitionKeyValue = new PartitionKey(PartitionKey.NullPartitionKeyInternal);
 

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -4,6 +4,8 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
     /// Represents a partition key value in the Azure Cosmos DB service.
@@ -15,6 +17,12 @@ namespace Microsoft.Azure.Cosmos
         /// without a value for partition key.
         /// </summary>
         public static readonly PartitionKey NonePartitionKeyValue = new PartitionKey(Documents.PartitionKey.None);
+
+        /// <summary>
+        /// The returned object represents a partition key value that allows creating and accessing documents
+        /// without a value for partition key.
+        /// </summary>
+        public static readonly PartitionKey NullPartitionKeyValue = new PartitionKey(new Documents.PartitionKey(null));
 
         /// <summary>
         /// The tag name to use in the documents for specifying a partition key value
@@ -30,20 +38,92 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the value provided at initialization.
         /// </summary>
-        internal object Value { get; }
+        internal PartitionKeyInternal Value { get; }
 
         /// <summary>
         /// Creates a new partition key value.
         /// </summary>
         /// <param name="partitionKeyValue">The value to use as partition key.</param>
-        public PartitionKey(object partitionKeyValue)
+        public PartitionKey(string partitionKeyValue)
         {
             if (partitionKeyValue == null)
             {
-                throw new ArgumentNullException(nameof(partitionKeyValue));
+                throw new ArgumentNullException($"{nameof(partitionKeyValue)} is null. Please use {nameof(PartitionKey.NullPartitionKeyValue)} to define null");
             }
 
-            this.Value = partitionKeyValue;
+            this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(bool partitionKeyValue)
+        {
+            this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="partitionKeyValue">The value to use as partition key.</param>
+        public PartitionKey(double partitionKeyValue)
+        {
+            this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+        }
+
+        /// <summary>
+        /// Convert a string to a partition key
+        /// </summary>
+        /// <param name="partitionKeyValue">The string value</param>
+        public static implicit operator PartitionKey(string partitionKeyValue)
+        {
+            return new PartitionKey(partitionKeyValue);
+        }
+
+        /// <summary>
+        /// Convert a double to a partition key
+        /// </summary>
+        /// <param name="partitionKeyValue">The double value</param>
+        public static implicit operator PartitionKey(double partitionKeyValue)
+        {
+            return new PartitionKey(partitionKeyValue);
+        }
+
+        /// <summary>
+        /// Convert a bool to a partition key
+        /// </summary>
+        /// <param name="partitionKeyValue">The bool value</param>
+        public static implicit operator PartitionKey(bool partitionKeyValue)
+        {
+            return new PartitionKey(partitionKeyValue);
+        }
+
+        /// <summary>
+        /// Creates a new partition key value.
+        /// </summary>
+        /// <param name="value">The value to use as partition key.</param>
+        internal PartitionKey(object value)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            Documents.PartitionKey docPk = value as Documents.PartitionKey;
+            if (docPk != null)
+            {
+                this.Value = docPk.InternalKey;
+                return;
+            }
+
+            this.Value = value as PartitionKeyInternal;
+            if (this.Value != null)
+            {
+                return;
+            }
+
+            this.Value = new Documents.PartitionKey(value).InternalKey;
         }
 
         /// <summary>
@@ -52,17 +132,12 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The string representation of the partition key value</returns>
         public new string ToString()
         {
-            if (this.Value is Documents.PartitionKey)
+            if (this.Value == null)
             {
-                return ((Documents.PartitionKey)this.Value).InternalKey.ToJsonString();
+                return null;
             }
 
-            if (this.Value is Cosmos.PartitionKey)
-            {
-                return ((Cosmos.PartitionKey)this.Value).ToString();
-            }
-
-            return new Documents.PartitionKey(this.Value).InternalKey.ToJsonString();
+            return this.Value.ToJsonString();
         } 
     }
 }

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Azure.Cosmos
         /// The returned object represents a partition key value that allows creating and accessing items
         /// without a value for partition key.
         /// </summary>
-        public static readonly PartitionKey NonePartitionKeyValue = new PartitionKey(Documents.PartitionKey.None.InternalKey);
+        public static readonly PartitionKey None = new PartitionKey(Documents.PartitionKey.None.InternalKey);
 
         /// <summary>
         /// The returned object represents a partition key value that allows creating and accessing items
         /// with a null value for the partition key.
         /// </summary>
-        public static readonly PartitionKey NullPartitionKeyValue = new PartitionKey(PartitionKey.NullPartitionKeyInternal);
+        public static readonly PartitionKey Null = new PartitionKey(PartitionKey.NullPartitionKeyInternal);
 
         /// <summary>
         /// The tag name to use in the documents for specifying a partition key value
@@ -52,8 +52,10 @@ namespace Microsoft.Azure.Cosmos
             {
                 this.Value = PartitionKey.NullPartitionKeyInternal;
             }
-
-            this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+            else
+            {
+                this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+            }
         }
 
         /// <summary>
@@ -98,11 +100,6 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The string representation of the partition key value</returns>
         public new string ToString()
         {
-            if (this.Value == null)
-            {
-                return null;
-            }
-
             return this.Value.ToJsonString();
         }
     }

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Cosmos
     public sealed class PartitionKey
     {
         private static readonly PartitionKeyInternal NullPartitionKeyInternal = new Documents.PartitionKey(null).InternalKey;
+        private static readonly PartitionKeyInternal TruePartitionKeyInternal = new Documents.PartitionKey(true).InternalKey;
+        private static readonly PartitionKeyInternal FalsePartitionKeyInternal = new Documents.PartitionKey(false).InternalKey;
 
         /// <summary>
         /// The returned object represents a partition key value that allows creating and accessing documents
@@ -60,7 +62,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="partitionKeyValue">The value to use as partition key.</param>
         public PartitionKey(bool partitionKeyValue)
         {
-            this.Value = new Documents.PartitionKey(partitionKeyValue).InternalKey;
+            this.Value = partitionKeyValue ? TruePartitionKeyInternal : FalsePartitionKeyInternal;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 // Dis-ambiguate the NonePK if used 
                 PartitionKeyInternal partitionKeyInternal = null;
-                if (Object.ReferenceEquals(queryRequestOptions.PartitionKey, Cosmos.PartitionKey.NonePartitionKeyValue))
+                if (Object.ReferenceEquals(queryRequestOptions.PartitionKey, Cosmos.PartitionKey.None))
                 {
                     partitionKeyInternal = collection.GetNoneValue();
                 }

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 }
                 else
                 {
-                    partitionKeyInternal = new Documents.PartitionKey(queryRequestOptions.PartitionKey.Value).InternalKey;
+                    partitionKeyInternal = queryRequestOptions.PartitionKey.Value;
                 }
 
                 targetRanges = await queryClient.GetTargetPartitionKeyRangesByEpkStringAsync(

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -510,14 +510,14 @@ namespace Microsoft.Azure.Cosmos
                     pathTraversal = pathTraversal[tokens[i]] as CosmosObject;
                     if (pathTraversal == null)
                     {
-                        return PartitionKey.NonePartitionKeyValue;
+                        return PartitionKey.None;
                     }
                 }
 
                 CosmosElement partitionKeyValue = pathTraversal[tokens[tokens.Length - 1]];
                 if (partitionKeyValue == null)
                 {
-                    return PartitionKey.NonePartitionKeyValue;
+                    return PartitionKey.None;
                 }
 
                 return this.CosmosElementToPartitionKeyObject(partitionKeyValue);
@@ -554,7 +554,7 @@ namespace Microsoft.Azure.Cosmos
                     return new PartitionKey(cosmosBool.Value);
 
                 case CosmosElementType.Null:
-                    return PartitionKey.NullPartitionKeyValue;
+                    return PartitionKey.Null;
 
                 default:
                     throw new ArgumentException(

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -515,7 +515,7 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 CosmosElement partitionKeyValue = pathTraversal[tokens[tokens.Length - 1]];
-                if (partitionKeyValue == null || partitionKeyValue is CosmosNull)
+                if (partitionKeyValue == null)
                 {
                     return PartitionKey.NonePartitionKeyValue;
                 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Azure.Cosmos
         public int? DefaultTimeToLive { get; set; }
 
         /// <summary>
-        /// The function selects the right partition key constant mapping for <see cref="PartitionKey.NonePartitionKeyValue"/>
+        /// The function selects the right partition key constant mapping for <see cref="PartitionKey.None"/>
         /// </summary>
         internal PartitionKeyInternal GetNoneValue()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -176,33 +176,33 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             int count = 0;
             CosmosClient client = TestCommon.CreateCosmosClient(builder =>
+            {
+                builder.WithConnectionModeDirect();
+                builder.WithSendingRequestEventArgs((sender, e) =>
                 {
-                    builder.WithConnectionModeDirect();
-                    builder.WithSendingRequestEventArgs((sender, e) =>
-                        {
-                            if (e.DocumentServiceRequest != null)
-                            {
-                                Trace.TraceInformation($"{e.DocumentServiceRequest.ToString()}");
-                            }
+                    if (e.DocumentServiceRequest != null)
+                    {
+                        Trace.TraceInformation($"{e.DocumentServiceRequest.ToString()}");
+                    }
 
-                            if (e.HttpRequest != null)
-                            {
-                                Trace.TraceInformation($"{e.HttpRequest.ToString()}");
-                            }
+                    if (e.HttpRequest != null)
+                    {
+                        Trace.TraceInformation($"{e.HttpRequest.ToString()}");
+                    }
 
-                            if (e.IsHttpRequest()
-                                && e.HttpRequest.RequestUri.AbsolutePath.Contains("/colls/"))
-                            {
-                                count++;
-                            }
+                    if (e.IsHttpRequest()
+                        && e.HttpRequest.RequestUri.AbsolutePath.Contains("/colls/"))
+                    {
+                        count++;
+                    }
 
-                            if (e.IsHttpRequest()
-                                && e.HttpRequest.RequestUri.AbsolutePath.Contains("/pkranges"))
-                            {
-                                Debugger.Break();
-                            }
-                        });
+                    if (e.IsHttpRequest()
+                        && e.HttpRequest.RequestUri.AbsolutePath.Contains("/pkranges"))
+                    {
+                        Debugger.Break();
+                    }
                 });
+            });
 
             string dbName = Guid.NewGuid().ToString();
             string containerName = Guid.NewGuid().ToString();
@@ -521,7 +521,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsNotNull(item["_ts"]);
                         }
 
-                        if(previousResult != null)
+                        if (previousResult != null)
                         {
                             Assert.AreEqual(previousResult, jsonString);
                         }
@@ -560,10 +560,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     sql,
                     continuationToken: lastContinuationToken,
                     requestOptions: new QueryRequestOptions()
-                        {
-                            MaxItemCount = maxItemCount,
-                            MaxConcurrency = 1,
-                            PartitionKey = new Cosmos.PartitionKey(find.status),
+                    {
+                        MaxItemCount = maxItemCount,
+                        MaxConcurrency = 1,
+                        PartitionKey = new Cosmos.PartitionKey(find.status),
                     });
 
                 ResponseMessage response = await feedIterator.ReadNextAsync();
@@ -624,7 +624,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
 
             FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-                    sql, 
+                    sql,
                     requestOptions: requestOptions);
 
             while (feedIterator.HasMoreResults)
@@ -657,7 +657,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
             FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-                sql, 
+                sql,
                 requestOptions: requestOptions);
 
             while (feedIterator.HasMoreResults)
@@ -743,12 +743,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             double totalRequstCharge = 0;
             FeedIterator setIterator = this.Container.GetItemQueryStreamIterator(
-                sql, 
+                sql,
                 requestOptions: new QueryRequestOptions()
-                    {
-                        MaxConcurrency = 1,
-                        PartitionKey = new Cosmos.PartitionKey(findPkValue),
-                    });
+                {
+                    MaxConcurrency = 1,
+                    PartitionKey = new Cosmos.PartitionKey(findPkValue),
+                });
 
             List<ToDoActivity> foundItems = new List<ToDoActivity>();
             while (setIterator.HasMoreResults)
@@ -867,7 +867,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
             FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-                sql, 
+                sql,
                 requestOptions: requestOptions);
 
             while (feedIterator.HasMoreResults)
@@ -926,10 +926,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
                 sql,
                 requestOptions: new QueryRequestOptions()
-                    {
-                        MaxItemCount = 1,
-                        PartitionKey = new Cosmos.PartitionKey(toDoActivity.status)
-                    });
+                {
+                    MaxItemCount = 1,
+                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.status)
+                });
 
             while (feedIterator.HasMoreResults)
             {
@@ -939,12 +939,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             // Test max size at 2
             FeedIterator<ToDoActivity> setIteratorMax2 = this.Container.GetItemQueryIterator<ToDoActivity>(
-                sql, 
+                sql,
                 requestOptions: new QueryRequestOptions()
-                    {
-                        MaxItemCount = 2,
-                        PartitionKey = new Cosmos.PartitionKey(toDoActivity.status)
-                    });
+                {
+                    MaxItemCount = 2,
+                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.status)
+                });
 
             while (setIteratorMax2.HasMoreResults)
             {
@@ -980,7 +980,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 FeedIterator<dynamic> resultSet = this.Container.GetItemQueryIterator<dynamic>(
                     sqlQueryText: "SELECT r.id FROM root r WHERE r._ts >!= 0",
-                    requestOptions: new QueryRequestOptions() { MaxConcurrency = 1});
+                    requestOptions: new QueryRequestOptions() { MaxConcurrency = 1 });
 
                 await resultSet.ReadNextAsync();
                 Assert.Fail("Expected query to fail");
@@ -1100,7 +1100,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 //Quering items on fixed container with CosmosContainerSettings.NonePartitionKeyValue.
                 feedIterator = fixedContainer.GetItemQueryIterator<dynamic>(
                     new QueryDefinition("select * from r"),
-                    requestOptions: new QueryRequestOptions() { MaxItemCount = 10 , PartitionKey = Cosmos.PartitionKey.NonePartitionKeyValue });
+                    requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = Cosmos.PartitionKey.NonePartitionKeyValue });
                 while (feedIterator.HasMoreResults)
                 {
                     FeedResponse<dynamic> queryResponse = await feedIterator.ReadNextAsync();
@@ -1109,7 +1109,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 //Quering items on fixed container with non-none PK.
                 feedIterator = fixedContainer.GetItemQueryIterator<dynamic>(
-                    sql, 
+                    sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = new Cosmos.PartitionKey(itemWithPK.status) });
                 while (feedIterator.HasMoreResults)
                 {
@@ -1161,7 +1161,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => (item.taskNum < 100));
             //V3 Asynchronous query execution with LINQ query generation sql text.
             FeedIterator<ToDoActivity> setIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-                queriable.ToSqlQueryText(), 
+                queriable.ToSqlQueryText(),
                 requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
             int resultsFetched = 0;
@@ -1214,7 +1214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             //LINQ query execution with correct partition key.
             linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(
-                allowSynchronousQueryExecution: true, requestOptions: 
+                allowSynchronousQueryExecution: true, requestOptions:
                 new QueryRequestOptions { PartitionKey = new Cosmos.PartitionKey(itemList[1].status), ConsistencyLevel = Cosmos.ConsistencyLevel.Eventual });
             queriable = linqQueryable.Where(item => (item.taskNum < 100));
             Assert.AreEqual(1, queriable.Count());
@@ -1258,7 +1258,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 int resultsFetched = 0;
                 QueryDefinition sql = new QueryDefinition("select * from r");
                 FeedIterator<ToDoActivity> setIterator = fixedContainer.GetItemQueryIterator<ToDoActivity>(
-                    sql, 
+                    sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 2, PartitionKey = Cosmos.PartitionKey.NonePartitionKeyValue });
 
                 while (setIterator.HasMoreResults)
@@ -1292,7 +1292,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 // Re-Query the items on the container with NonePartitionKeyValue
                 setIterator = fixedContainer.GetItemQueryIterator<ToDoActivity>(
-                    sql, 
+                    sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = ItemsToCreate, PartitionKey = Cosmos.PartitionKey.NonePartitionKeyValue });
 
                 Assert.IsTrue(setIterator.HasMoreResults);
@@ -1303,7 +1303,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 // Query the items with newly inserted PartitionKey
                 setIterator = fixedContainer.GetItemQueryIterator<ToDoActivity>(
-                    sql, 
+                    sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = ItemsToCreate + 1, PartitionKey = new Cosmos.PartitionKey("TestPK") });
 
                 Assert.IsTrue(setIterator.HasMoreResults);
@@ -1336,6 +1336,62 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
             Assert.IsNotNull(readResponse.Headers.Session);
             Assert.AreEqual(sessionToken, readResponse.Headers.Session);
+        }
+
+        [TestMethod]
+        public async Task NullandNonePartitionKeyTest()
+        {
+            // This will test PartitionKey.NullPartitionKeyValue
+            ToDoActivity temp = new ToDoActivity()
+            {
+                id = Guid.NewGuid().ToString(),
+                description = "CreateRandomToDoActivity",
+                taskNum = 42,
+                cost = double.MaxValue
+            };
+
+            ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync<ToDoActivity>(item: temp, partitionKey: Cosmos.PartitionKey.NullPartitionKeyValue);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(temp.id, response.Resource.id);
+
+            response = await this.Container.ReadItemAsync<ToDoActivity>(id: temp.id, partitionKey: Cosmos.PartitionKey.NullPartitionKeyValue);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(temp.id, response.Resource.id);
+
+            temp.id = Guid.NewGuid().ToString();
+            response = await this.Container.CreateItemAsync<ToDoActivity>(item: temp);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(temp.id, response.Resource.id);
+
+            response = await this.Container.ReadItemAsync<ToDoActivity>(id: temp.id, partitionKey: Cosmos.PartitionKey.NullPartitionKeyValue);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(temp.id, response.Resource.id);
+
+            // This will test PartitionKey.NonePartitionKeyValue
+            ToDoActivityWithPkIgnored tempWithPkIgnored = new ToDoActivityWithPkIgnored()
+            {
+                id = Guid.NewGuid().ToString(),
+                description = "CreateRandomToDoActivityWithPkIgnored",
+                taskNum = 42,
+                cost = double.MaxValue
+            };
+
+            ItemResponse<ToDoActivityWithPkIgnored> responseWithPkIgnored = await this.Container.CreateItemAsync<ToDoActivityWithPkIgnored>(item: tempWithPkIgnored, partitionKey: Cosmos.PartitionKey.NonePartitionKeyValue);
+            Assert.IsNotNull(responseWithPkIgnored);
+            Assert.AreEqual(tempWithPkIgnored.id, responseWithPkIgnored.Resource.id);
+
+            responseWithPkIgnored = await this.Container.ReadItemAsync<ToDoActivityWithPkIgnored>(id: tempWithPkIgnored.id, partitionKey: Cosmos.PartitionKey.NonePartitionKeyValue);
+            Assert.IsNotNull(responseWithPkIgnored);
+            Assert.AreEqual(tempWithPkIgnored.id, responseWithPkIgnored.Resource.id);
+
+            tempWithPkIgnored.id = Guid.NewGuid().ToString();
+            responseWithPkIgnored = await this.Container.CreateItemAsync<ToDoActivityWithPkIgnored>(item: tempWithPkIgnored);
+            Assert.IsNotNull(responseWithPkIgnored);
+            Assert.AreEqual(tempWithPkIgnored.id, responseWithPkIgnored.Resource.id);
+
+            responseWithPkIgnored = await this.Container.ReadItemAsync<ToDoActivityWithPkIgnored>(id: tempWithPkIgnored.id, partitionKey: Cosmos.PartitionKey.NonePartitionKeyValue);
+            Assert.IsNotNull(responseWithPkIgnored);
+            Assert.AreEqual(tempWithPkIgnored.id, responseWithPkIgnored.Resource.id);
         }
 
         private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)
@@ -1504,15 +1560,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
         }
 
-
-
         public class ToDoActivity
         {
             public string id { get; set; }
             public int taskNum { get; set; }
             public double cost { get; set; }
             public string description { get; set; }
-            public string status { get; set; }
+            public virtual string status { get; set; }
+        }
+
+        public class ToDoActivityWithPkIgnored : ToDoActivity
+        {
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public override string status { get; set; }
         }
 
         public class ToDoActivityAfterMigration

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using JsonReader = Json.JsonReader;
     using JsonWriter = Json.JsonWriter;
     using Newtonsoft.Json.Linq;
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Documents.Routing;
 
     [TestClass]
     public class CosmosItemTests : BaseCosmosClientHelper
@@ -84,13 +86,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 id = Guid.NewGuid().ToString()
             };
 
-            ItemResponse<dynamic> response = await this.Container.CreateItemAsync<dynamic>(item: testItem, partitionKey: new Cosmos.PartitionKey(Undefined.Value));
+            ItemResponse<dynamic> response = await this.Container.CreateItemAsync<dynamic>(item: testItem, partitionKey: Cosmos.PartitionKey.NonePartitionKeyValue);
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             Assert.IsNotNull(response.MaxResourceQuota);
             Assert.IsNotNull(response.CurrentResourceQuotaUsage);
 
-            ItemResponse<dynamic> deleteResponse = await this.Container.DeleteItemAsync<dynamic>(id: testItem.id, partitionKey: new Cosmos.PartitionKey(Undefined.Value));
+            ItemResponse<dynamic> deleteResponse = await this.Container.DeleteItemAsync<dynamic>(id: testItem.id, partitionKey: Cosmos.PartitionKey.NonePartitionKeyValue);
             Assert.IsNotNull(deleteResponse);
             Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -375,19 +375,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             string lastContinuationToken = null;
             int pageSize = 1;
-            ItemFeedRequestOptions requestOptions = new ItemFeedRequestOptions()
-            {
-                MaxItemCount = pageSize
-            };
+            ItemRequestOptions requestOptions = new ItemRequestOptions();
 
-            FeedIterator feedIterator =
-                this.Container.GetItemStreamIterator(continuationToken: lastContinuationToken, requestOptions: requestOptions);
+            FeedIterator feedIterator = this.Container.GetItemStreamIterator(
+                maxItemCount: pageSize, 
+                continuationToken: lastContinuationToken, 
+                requestOptions: requestOptions);
 
             while (feedIterator.HasMoreResults)
             {
                 if (useStatelessIterator)
                 {
-                    feedIterator = this.Container.GetItemStreamIterator(continuationToken: lastContinuationToken, requestOptions: requestOptions);
+                    feedIterator = this.Container.GetItemStreamIterator(
+                        maxItemCount: pageSize, 
+                        continuationToken: lastContinuationToken, 
+                        requestOptions: requestOptions);
                 }
 
                 using (ResponseMessage responseMessage =
@@ -1092,7 +1094,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
 
                 //Reading all items on fixed container.
-                feedIterator = fixedContainer.GetItemIterator<dynamic>(requestOptions: new ItemFeedRequestOptions() { MaxItemCount = 10 });
+                feedIterator = fixedContainer.GetItemIterator<dynamic>(maxItemCount: 10);
                 while (feedIterator.HasMoreResults)
                 {
                     FeedResponse<dynamic> queryResponse = await feedIterator.ReadNextAsync();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
                 else
                 {
-                    pkValue = Cosmos.PartitionKey.NonePartitionKeyValue;
+                    pkValue = Cosmos.PartitionKey.None;
                 }
 
                 insertedDocuments.Add((await container.CreateItemAsync<JObject>(documentObject)).Resource.ToObject<Document>());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterInMemoryTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task RetriesIfCannotFind()
         {
             string itemId = "1";
-            object partitionKey = "1";
+            string partitionKey = "1";
             
             List<KeyValuePair<string, DocumentServiceLease>> state = new List<KeyValuePair<string, DocumentServiceLease>>();
 
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task UpdatesLease()
         {
             string itemId = "1";
-            object partitionKey = "1";
+            string partitionKey = "1";
             
             List<KeyValuePair<string, DocumentServiceLease>> state = new List<KeyValuePair<string, DocumentServiceLease>>()
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -49,6 +49,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = true,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[true]", item);
+
+            item = new
+            {
+                id = Guid.NewGuid().ToString()
+            };
+            await VerifyItemOperations(Cosmos.PartitionKey.NonePartitionKeyValue, "[{}]", item);
         }
 
         [TestMethod]
@@ -59,7 +65,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 id = Guid.NewGuid().ToString()
             };
 
-            await VerifyItemOperations(new Cosmos.PartitionKey(Undefined.Value), "[{}]", testItem);
+            await VerifyItemOperations(Cosmos.PartitionKey.NonePartitionKeyValue, "[{}]", testItem);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = "FF627B77-568E-4541-A47E-041EAC10E46F",
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[\"FF627B77-568E-4541-A47E-041EAC10E46F\"]", item);
+            await VerifyItemOperations(item.pk, "[\"FF627B77-568E-4541-A47E-041EAC10E46F\"]", item);
 
             item = new
             {
@@ -35,6 +36,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = 4567,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[4567.0]", item);
+            await VerifyItemOperations(item.pk, "[4567.0]", item);
 
             item = new
             {
@@ -42,6 +44,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = 4567.1234,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[4567.1234]", item);
+            await VerifyItemOperations(item.pk, "[4567.1234]", item);
 
             item = new
             {
@@ -49,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = true,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[true]", item);
+            await VerifyItemOperations(item.pk, "[true]", item);
 
             item = new
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = "FF627B77-568E-4541-A47E-041EAC10E46F",
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[\"FF627B77-568E-4541-A47E-041EAC10E46F\"]", item);
-            await VerifyItemOperations(item.pk, "[\"FF627B77-568E-4541-A47E-041EAC10E46F\"]", item);
 
             item = new
             {
@@ -36,7 +35,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = 4567,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[4567.0]", item);
-            await VerifyItemOperations(item.pk, "[4567.0]", item);
 
             item = new
             {
@@ -44,7 +42,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = 4567.1234,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[4567.1234]", item);
-            await VerifyItemOperations(item.pk, "[4567.1234]", item);
 
             item = new
             {
@@ -52,13 +49,19 @@ namespace Microsoft.Azure.Cosmos.Tests
                 pk = true,
             };
             await VerifyItemOperations(new Cosmos.PartitionKey(item.pk), "[true]", item);
-            await VerifyItemOperations(item.pk, "[true]", item);
 
             item = new
             {
                 id = Guid.NewGuid().ToString()
             };
             await VerifyItemOperations(Cosmos.PartitionKey.NonePartitionKeyValue, "[{}]", item);
+
+            item = new
+            {
+                id = Guid.NewGuid().ToString(),
+                pk = (object)null
+            };
+            await VerifyItemOperations(Cosmos.PartitionKey.NullPartitionKeyValue, "[null]", item);
         }
 
         [TestMethod]
@@ -204,7 +207,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             //null should return Undefined
             object pkValue = await container.GetPartitionKeyValueFromStreamAsync(new CosmosJsonSerializerCore().ToStream(new { pk = (object)null }));
-            Assert.AreEqual(Cosmos.PartitionKey.NonePartitionKeyValue, pkValue);
+            Assert.AreEqual(Cosmos.PartitionKey.NullPartitionKeyValue, pkValue);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -26,29 +26,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void ValueContainsOriginalValue()
-        {
-            const string somePK = "somePK";
-            PartitionKey pk = new PartitionKey(somePK);
-            Assert.AreEqual(somePK, pk.Value);
-        }
-
-        [TestMethod]
         public void ToStringGetsJsonString()
         {
             const string somePK = "somePK";
             string expected = $"[\"{somePK}\"]";
             PartitionKey pk = new PartitionKey(somePK);
             Assert.AreEqual(expected, pk.ToString());
-        }
-
-        [TestMethod]
-        public void WithCosmosPartitionKey()
-        {
-            const string somePK = "somePK";
-            PartitionKey v3PK = new PartitionKey(somePK);
-            PartitionKey pk = new PartitionKey(v3PK);
-            Assert.AreEqual(v3PK.ToString(), pk.ToString());
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -9,20 +9,10 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class PartitionKeyTests
     {
-        [ExpectedException(typeof(ArgumentNullException))]
         [TestMethod]
         public void NullValue()
         {
             new PartitionKey(null);
-        }
-
-        [TestMethod]
-        public void WithDocumentPartitionKey()
-        {
-            const string somePK = "somePK";
-            Documents.PartitionKey v2PK = new Documents.PartitionKey(somePK);
-            PartitionKey pk = new PartitionKey(v2PK);
-            Assert.AreEqual(v2PK.InternalKey.ToJsonString(), pk.ToString());
         }
 
         [TestMethod]
@@ -37,13 +27,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestPartitionKeyValues()
         {
-            Tuple<object, string>[] testcases =
+            Tuple<dynamic, string>[] testcases =
             {
-                Tuple.Create<object, string>(Documents.Undefined.Value, "[{}]"),
-                Tuple.Create<object, string>(false, "[false]"),
-                Tuple.Create<object, string>(true, "[true]"),
-                Tuple.Create<object, string>(123.456, "[123.456]"),
-                Tuple.Create<object, string>("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
+                Tuple.Create<dynamic, string>(Documents.Undefined.Value, "[{}]"),
+                Tuple.Create<dynamic, string>(Documents.Undefined.Value, "[{}]"),
+                Tuple.Create<dynamic, string>(false, "[false]"),
+                Tuple.Create<dynamic, string>(true, "[true]"),
+                Tuple.Create<dynamic, string>(123.456, "[123.456]"),
+                Tuple.Create<dynamic, string>("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
             };
 
             foreach (Tuple<object, string> testcase in testcases)


### PR DESCRIPTION
# Pull Request Template

## Description

Partition Key currently takes an object as a parameter for the constructor. This is very confusing to users since only a few primitives are supported.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

closes #354, fixes #471

