### PR TITLE
Make CosmosClient creation non-blocking

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -97,6 +97,7 @@ namespace Microsoft.Azure.Cosmos
     public class CosmosClient : IDisposable
     {
         private Lazy<CosmosOffers> offerSet;
+        private Lazy<ConsistencyLevel> accountConsistencyLevel;
 
         static CosmosClient()
         {
@@ -291,7 +292,7 @@ namespace Microsoft.Azure.Cosmos
         internal CosmosOffers Offers => this.offerSet.Value;
         internal DocumentClient DocumentClient { get; set; }
         internal RequestInvokerHandler RequestHandler { get; private set; }
-        internal ConsistencyLevel AccountConsistencyLevel { get; private set; }
+        internal ConsistencyLevel AccountConsistencyLevel => this.accountConsistencyLevel.Value;
         internal CosmosResponseFactory ResponseFactory { get; private set; }
         internal CosmosClientContext ClientContext { get; private set; }
 
@@ -535,7 +536,7 @@ namespace Microsoft.Azure.Cosmos
                 this.ClientOptions.CustomHandlers);
 
             // DocumentClient is not initialized with any consistency overrides so default is backend consistency
-            this.AccountConsistencyLevel = (ConsistencyLevel)this.DocumentClient.ConsistencyLevel;
+            this.accountConsistencyLevel = new Lazy<ConsistencyLevel>(() => (ConsistencyLevel)this.DocumentClient.ConsistencyLevel);
 
             this.RequestHandler = clientPipelineBuilder.Build();
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Cosmos
     public class CosmosClient : IDisposable
     {
         private Lazy<CosmosOffers> offerSet;
-        private Lazy<ConsistencyLevel> accountConsistencyLevel;
+        private ConsistencyLevel? accountConsistencyLevel;
 
         static CosmosClient()
         {
@@ -292,7 +292,6 @@ namespace Microsoft.Azure.Cosmos
         internal CosmosOffers Offers => this.offerSet.Value;
         internal DocumentClient DocumentClient { get; set; }
         internal RequestInvokerHandler RequestHandler { get; private set; }
-        internal ConsistencyLevel AccountConsistencyLevel => this.accountConsistencyLevel.Value;
         internal CosmosResponseFactory ResponseFactory { get; private set; }
         internal CosmosClientContext ClientContext { get; private set; }
 
@@ -535,9 +534,6 @@ namespace Microsoft.Azure.Cosmos
                 this.DocumentClient.ResetSessionTokenRetryPolicy,
                 this.ClientOptions.CustomHandlers);
 
-            // DocumentClient is not initialized with any consistency overrides so default is backend consistency
-            this.accountConsistencyLevel = new Lazy<ConsistencyLevel>(() => (ConsistencyLevel)this.DocumentClient.ConsistencyLevel);
-
             this.RequestHandler = clientPipelineBuilder.Build();
 
             this.ResponseFactory = new CosmosResponseFactory(
@@ -555,6 +551,17 @@ namespace Microsoft.Azure.Cosmos
                 documentQueryClient: new DocumentQueryClient(this.DocumentClient));
 
             this.offerSet = new Lazy<CosmosOffers>(() => new CosmosOffers(this.DocumentClient), LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        internal async virtual Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()
+        {
+            if (!this.accountConsistencyLevel.HasValue)
+            {
+                await this.DocumentClient.EnsureValidClientAsync();
+                this.accountConsistencyLevel = (ConsistencyLevel)this.DocumentClient.ConsistencyLevel;
+            }
+
+            return this.accountConsistencyLevel.Value;
         }
 
         internal DatabaseProperties PrepareDatabaseProperties(string id)

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             this.client = client;
         }
 
-        public override Task<ResponseMessage> SendAsync(
+        public override async Task<ResponseMessage> SendAsync(
             RequestMessage request,
             CancellationToken cancellationToken)
         {
@@ -59,30 +59,22 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 if (consistencyLevel.HasValue)
                 {
-                    if (!ValidationHelpers.ValidateConsistencyLevel(this.client.AccountConsistencyLevel, consistencyLevel.Value))
+                    Cosmos.ConsistencyLevel accountConsistency = await this.client.GetAccountConsistencyLevelAsync();
+                    if (!ValidationHelpers.ValidateConsistencyLevel(accountConsistency, consistencyLevel.Value))
                     {
                         throw new ArgumentException(string.Format(
                                 CultureInfo.CurrentUICulture,
                                 RMResources.InvalidConsistencyLevel,
                                 consistencyLevel.Value.ToString(),
-                                this.client.AccountConsistencyLevel));
+                                accountConsistency));
                     }
                 }
             }
 
-            return this.client.DocumentClient.EnsureValidClientAsync()
-                .ContinueWith(task => request.AssertPartitioningDetailsAsync(this.client, cancellationToken))
-                .ContinueWith(task =>
-                {
-                    if (task.IsFaulted)
-                    {
-                        throw task.Exception;
-                    }
-
-                    this.FillMultiMasterContext(request);
-                    return base.SendAsync(request, cancellationToken);
-                })
-                .Unwrap();
+            await this.client.DocumentClient.EnsureValidClientAsync();
+            await request.AssertPartitioningDetailsAsync(this.client, cancellationToken);
+            this.FillMultiMasterContext(request);
+            return await base.SendAsync(request, cancellationToken);
         }
 
         public virtual async Task<T> SendAsync<T>(


### PR DESCRIPTION
# Pull Request Template

## Description

During CosmosClient constructor, we are doing a locking call to obtain the account consistency. Account consistency is only ever checked if the user overwrites the Consistency at the request level, so this lock was penalizing all clients for a check that only is done in a subset of scenarios.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #475