### PR TITLE
Change Feed Processor supporting fixed lease containers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -99,15 +99,16 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 bool isPartitioned =
                     containerProperties.PartitionKey != null &&
                     containerProperties.PartitionKey.Paths != null &&
-                    containerProperties.PartitionKey.Paths.Count > 0 &&
-                    !(containerProperties.PartitionKey.IsSystemKey == true);
-                if (isPartitioned &&
-                    (containerProperties.PartitionKey.Paths.Count != 1 || containerProperties.PartitionKey.Paths[0] != "/id"))
+                    containerProperties.PartitionKey.Paths.Count > 0;
+                bool isMigratedFixed = (containerProperties.PartitionKey?.IsSystemKey == true);
+                if (isPartitioned
+                    && !isMigratedFixed
+                    && (containerProperties.PartitionKey.Paths.Count != 1 || containerProperties.PartitionKey.Paths[0] != "/id"))
                 {
                     throw new ArgumentException("The lease collection, if partitioned, must have partition key equal to id.");
                 }
 
-                RequestOptionsFactory requestOptionsFactory = isPartitioned ?
+                RequestOptionsFactory requestOptionsFactory = isPartitioned && !isMigratedFixed ?
                     (RequestOptionsFactory)new PartitionedByIdCollectionRequestOptionsFactory() :
                     (RequestOptionsFactory)new SinglePartitionRequestOptionsFactory();
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     containerProperties.PartitionKey != null &&
                     containerProperties.PartitionKey.Paths != null &&
                     containerProperties.PartitionKey.Paths.Count > 0 &&
-                    (!containerProperties.PartitionKey.IsSystemKey.HasValue || !containerProperties.PartitionKey.IsSystemKey.Value);
+                    !(containerProperties.PartitionKey.IsSystemKey == true);
                 if (isPartitioned &&
                     (containerProperties.PartitionKey.Paths.Count != 1 || containerProperties.PartitionKey.Paths[0] != "/id"))
                 {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 bool isPartitioned =
                     containerProperties.PartitionKey != null &&
                     containerProperties.PartitionKey.Paths != null &&
-                    containerProperties.PartitionKey.Paths.Count > 0;
+                    containerProperties.PartitionKey.Paths.Count > 0 &&
+                    (!containerProperties.PartitionKey.IsSystemKey.HasValue || !containerProperties.PartitionKey.IsSystemKey.Value);
                 if (isPartitioned &&
                     (containerProperties.PartitionKey.Paths.Count != 1 || containerProperties.PartitionKey.Paths[0] != "/id"))
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -83,22 +83,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             try
             {
 
-
                 int partitionKey = 0;
-                // Create some docs to make sure that one separate response is returned for 1st execute of query before retries.
-                // These are to make sure continuation token is passed along during retries.
-                string sprocId = "createTwoDocs";
-                string sprocBody = @"function(startIndex) { for (var i = 0; i < 2; ++i) __.createDocument(
-                            __.getSelfLink(),
-                            { id: 'doc' + (i + startIndex).toString(), value: 'y'.repeat(1500000), pk:0 },
-                            err => { if (err) throw err;}
-                        );}";
-
-                Scripts scripts = this.Container.Scripts;
-
-                StoredProcedureResponse storedProcedureResponse =
-                    await scripts.CreateStoredProcedureAsync(new StoredProcedureProperties(sprocId, sprocBody));
-
                 ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
 
                 int processedDocCount = 0;
@@ -108,29 +93,25 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     {
                         processedDocCount += docs.Count();
                         foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
-                        if (processedDocCount == 5) allDocsProcessed.Set();
+                        if (processedDocCount == 10) allDocsProcessed.Set();
 
                         return Task.CompletedTask;
                     })
-                    .WithStartFromBeginning()
                     .WithInstanceName("random")
-                    .WithMaxItems(6)
                     .WithLeaseContainer(fixedLeasesContainer).Build();
 
-                // Generate the payload
-                await scripts.ExecuteStoredProcedureAsync<int, object>(new PartitionKey(partitionKey), sprocId, 0);
-                // Create 3 docs each 1.5MB. All 3 do not fit into MAX_RESPONSE_SIZE (4 MB). 2nd and 3rd are in same transaction.
-                var content = string.Format("{{\"id\": \"doc2\", \"value\": \"{0}\", \"pk\": 0}}", new string('x', 1500000));
-                await this.Container.CreateItemAsync(JsonConvert.DeserializeObject<dynamic>(content), new PartitionKey(partitionKey));
-
-                await scripts.ExecuteStoredProcedureAsync<int, object>(new PartitionKey(partitionKey), sprocId, 3);
-
+                // Start the processor, insert 1 document to generate a checkpoint
                 await processor.StartAsync();
-                // Letting processor initialize and pickup changes
+                await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+                foreach (int id in Enumerable.Range(0, 10))
+                {
+                    await this.Container.CreateItemAsync<dynamic>(new { id = id.ToString(), pk = partitionKey });
+                }
+
                 var isStartOk = allDocsProcessed.WaitOne(10 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
                 await processor.StopAsync();
                 Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
-                Assert.AreEqual("doc0.doc1.doc2.doc3.doc4.", accumulator);
+                Assert.AreEqual("0.1.2.3.4.5.6.7.8.9.", accumulator);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -72,6 +72,73 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         }
 
         [TestMethod]
+        public async Task TestWithFixedLeaseContainer()
+        {
+            await CosmosItemTests.CreateNonPartitionedContainer(
+                    this.database.Id,
+                    "fixedLeases");
+
+            Container fixedLeasesContainer = this.cosmosClient.GetContainer(this.database.Id, "fixedLeases");
+
+            try
+            {
+
+
+                int partitionKey = 0;
+                // Create some docs to make sure that one separate response is returned for 1st execute of query before retries.
+                // These are to make sure continuation token is passed along during retries.
+                string sprocId = "createTwoDocs";
+                string sprocBody = @"function(startIndex) { for (var i = 0; i < 2; ++i) __.createDocument(
+                            __.getSelfLink(),
+                            { id: 'doc' + (i + startIndex).toString(), value: 'y'.repeat(1500000), pk:0 },
+                            err => { if (err) throw err;}
+                        );}";
+
+                Scripts scripts = this.Container.Scripts;
+
+                StoredProcedureResponse storedProcedureResponse =
+                    await scripts.CreateStoredProcedureAsync(new StoredProcedureProperties(sprocId, sprocBody));
+
+                ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
+
+                int processedDocCount = 0;
+                string accumulator = string.Empty;
+                ChangeFeedProcessor processor = this.Container
+                    .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<dynamic> docs, CancellationToken token) =>
+                    {
+                        processedDocCount += docs.Count();
+                        foreach (var doc in docs) accumulator += doc.id.ToString() + ".";
+                        if (processedDocCount == 5) allDocsProcessed.Set();
+
+                        return Task.CompletedTask;
+                    })
+                    .WithStartFromBeginning()
+                    .WithInstanceName("random")
+                    .WithMaxItems(6)
+                    .WithLeaseContainer(fixedLeasesContainer).Build();
+
+                // Generate the payload
+                await scripts.ExecuteStoredProcedureAsync<int, object>(new PartitionKey(partitionKey), sprocId, 0);
+                // Create 3 docs each 1.5MB. All 3 do not fit into MAX_RESPONSE_SIZE (4 MB). 2nd and 3rd are in same transaction.
+                var content = string.Format("{{\"id\": \"doc2\", \"value\": \"{0}\", \"pk\": 0}}", new string('x', 1500000));
+                await this.Container.CreateItemAsync(JsonConvert.DeserializeObject<dynamic>(content), new PartitionKey(partitionKey));
+
+                await scripts.ExecuteStoredProcedureAsync<int, object>(new PartitionKey(partitionKey), sprocId, 3);
+
+                await processor.StartAsync();
+                // Letting processor initialize and pickup changes
+                var isStartOk = allDocsProcessed.WaitOne(10 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+                await processor.StopAsync();
+                Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
+                Assert.AreEqual("doc0.doc1.doc2.doc3.doc4.", accumulator);
+            }
+            finally
+            {
+                await fixedLeasesContainer.DeleteContainerAsync();
+            }
+        }
+
+        [TestMethod]
         public async Task TestReducePageSizeScenario()
         {
             int partitionKey = 0;


### PR DESCRIPTION
# Pull Request Template

## Description

Current CFP V2 supports Lease container to be fixed. If a user on V2 migrates to V3, we need to also support the possibility of fixed lease containers. The code was meant to support it but since migrated Fixed containers now have a system PK, it was not behaving as it should.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #491