### PR TITLE
The class TypeCheckFunctionsExtensions must be public to be used outs…

### DIFF
--- a/Microsoft.Azure.Cosmos/src/TypeCheckFunctionsExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/TypeCheckFunctionsExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos.SystemFunctions
     /// These methods are to be used in LINQ expressions only and will be evaluated on server.
     /// There's no implementation provided in the client library.
     /// </summary>
-    internal static class TypeCheckFunctionsExtensions
+    public static class TypeCheckFunctionsExtensions
     {
         /// <summary>
         /// Determines if a certain property is defined or not.


### PR DESCRIPTION
## Description

The class TypeCheckFunctionsExtensions is internal so it is not possible to used IsDefined, IsNull or isPrimitive. This is a breaking change because we have the functionnalities in the current client.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

