### PR TITLE
throw on 404

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
@@ -49,17 +49,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
                 DefaultTrace.TraceInformation("Lease with token {0} update conflict. Reading the current version of lease.", lease.CurrentLeaseToken);
 
-                ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReadItemAsync<DocumentServiceLeaseCore>(
-                    itemId, partitionKey).ConfigureAwait(false);
-                if (response.StatusCode == HttpStatusCode.NotFound)
+                try
                 {
-                    DefaultTrace.TraceInformation("Lease with token {0} no longer exists", lease.CurrentLeaseToken);
-                    throw new LeaseLostException(lease, true);
-                }
+                    ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReadItemAsync<DocumentServiceLeaseCore>(
+                    itemId, partitionKey).ConfigureAwait(false);
+                    DocumentServiceLeaseCore serverLease = response.Resource;
 
-                DocumentServiceLeaseCore serverLease = response.Resource;
-
-                DefaultTrace.TraceInformation(
+                    DefaultTrace.TraceInformation(
                     "Lease with token {0} update failed because the lease with concurrency token '{1}' was updated by host '{2}' with concurrency token '{3}'. Will retry, {4} retry(s) left.",
                     lease.CurrentLeaseToken,
                     lease.ConcurrencyToken,
@@ -67,7 +63,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                     serverLease.ConcurrencyToken,
                     retryCount);
 
-                lease = serverLease;
+                    lease = serverLease;
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    DefaultTrace.TraceInformation("Lease with token {0} no longer exists", lease.CurrentLeaseToken);
+                    throw new LeaseLostException(lease, true);
+                }
             }
 
             throw new LeaseLostException(lease);
@@ -81,18 +83,21 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             try
             {
                 ItemRequestOptions itemRequestOptions = this.CreateIfMatchOptions(lease);
-                ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReplaceItemAsync<DocumentServiceLeaseCore>(
-                    id: itemId, 
+                
+                try
+                {
+                    ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                    id: itemId,
                     item: lease,
                     partitionKey: partitionKey,
                     requestOptions: itemRequestOptions).ConfigureAwait(false);
 
-                if (response.StatusCode == HttpStatusCode.NotFound)
+                    return response.Resource;
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                 {
                     throw new LeaseLostException(lease, true);
                 }
-
-                return response.Resource;
             }
             catch (CosmosException ex)
             {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
@@ -83,24 +83,22 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             try
             {
                 ItemRequestOptions itemRequestOptions = this.CreateIfMatchOptions(lease);
-                
-                try
-                {
-                    ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReplaceItemAsync<DocumentServiceLeaseCore>(
-                    id: itemId,
-                    item: lease,
-                    partitionKey: partitionKey,
-                    requestOptions: itemRequestOptions).ConfigureAwait(false);
 
-                    return response.Resource;
-                }
-                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-                {
-                    throw new LeaseLostException(lease, true);
-                }
+                ItemResponse<DocumentServiceLeaseCore> response = await this.container.ReplaceItemAsync<DocumentServiceLeaseCore>(
+                id: itemId,
+                item: lease,
+                partitionKey: partitionKey,
+                requestOptions: itemRequestOptions).ConfigureAwait(false);
+
+                return response.Resource;
             }
             catch (CosmosException ex)
             {
+                if (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    throw new LeaseLostException(lease, true);
+                }
+
                 DefaultTrace.TraceWarning("Lease operation exception, status code: {0}", ex.StatusCode);
                 if (ex.StatusCode == HttpStatusCode.PreconditionFailed)
                 {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -22,10 +22,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                     itemId,
                     partitionKey)
                     .ConfigureAwait(false);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                return default(T);
-            }
 
             return response;
         }
@@ -52,10 +48,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             ItemRequestOptions cosmosItemRequestOptions = null)
         {
             var response = await container.DeleteItemAsync<T>(itemId, partitionKey, cosmosItemRequestOptions).ConfigureAwait(false);
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                return default(T);
-            }
 
             return response.Resource;
         }

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -436,22 +436,19 @@ namespace Microsoft.Azure.Cosmos
             {
                 return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(database, Task.FromResult(response));
             }
-            else
-            {
-                if (response.StatusCode == HttpStatusCode.NotFound)
-                {
-                    DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
-                    Stream stream = this.ClientContext.PropertiesSerializer.ToStream(databaseProperties);
-                    response = await this.CreateDatabaseStreamInternalAsync(stream, throughput, requestOptions, cancellationToken);
-                    
-                    if (response.StatusCode == HttpStatusCode.Conflict)
-                    {
-                        response = await database.ReadStreamAsync(requestOptions: requestOptions, cancellationToken: cancellationToken);
-                        return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(database, Task.FromResult(response));
-                    }
 
-                    return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this.GetDatabase(databaseProperties.Id), Task.FromResult(response));
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
+                Stream stream = this.ClientContext.PropertiesSerializer.ToStream(databaseProperties);
+                response = await this.CreateDatabaseStreamInternalAsync(stream, throughput, requestOptions, cancellationToken);
+                    
+                if (response.StatusCode == HttpStatusCode.Conflict)
+                {
+                    return await database.ReadAsync(requestOptions: requestOptions, cancellationToken: cancellationToken);            
                 }
+
+                return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this.GetDatabase(databaseProperties.Id), Task.FromResult(response));
             }
 
             // This second Read is to handle the race condition when 2 or more threads have Read the database and only one succeeds with Create

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             }
 
             await this.client.DocumentClient.EnsureValidClientAsync();
-#if DEBUG                 
+#if DEBUG
             ResponseMessage response = await this.AssertPartitioningDetailsAsync(request, cancellationToken);
             if (response != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -144,34 +144,6 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal async Task AssertPartitioningDetailsAsync(CosmosClient client, CancellationToken cancellationToken)
-        {
-            if (this.IsMasterOperation())
-            {
-                return;
-            }
-
-#if DEBUG
-            CollectionCache collectionCache = await client.DocumentClient.GetCollectionCacheAsync();
-            try
-            {
-                ContainerProperties collectionFromCache =
-                await collectionCache.ResolveCollectionAsync(this.ToDocumentServiceRequest(), cancellationToken);
-
-                if (collectionFromCache.PartitionKey?.Paths?.Count > 0)
-                {
-                    Debug.Assert(this.AssertPartitioningPropertiesAndHeaders());
-                }
-            }
-            catch (DocumentClientException ex)
-            {
-                throw new CosmosException(ex.Message, ex.StatusCode ?? System.Net.HttpStatusCode.Ambiguous, (int)ex.GetSubStatus(), ex.ActivityId, ex.RequestCharge);
-            }
-#else
-            await Task.CompletedTask;
-#endif
-        }
-
         internal DocumentServiceRequest ToDocumentServiceRequest()
         {
             if (this.DocumentServiceRequest == null)
@@ -232,7 +204,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        private bool AssertPartitioningPropertiesAndHeaders()
+        internal bool AssertPartitioningPropertiesAndHeaders()
         {
             // Either PK/key-range-id is assumed
             bool pkExists = !string.IsNullOrEmpty(this.Headers.PartitionKey);
@@ -266,7 +238,7 @@ namespace Microsoft.Azure.Cosmos
             return true;
         }
 
-        private bool IsMasterOperation()
+        internal bool IsMasterOperation()
         {
             return this.ResourceType != ResourceType.Document;
         }

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -153,11 +153,19 @@ namespace Microsoft.Azure.Cosmos
 
 #if DEBUG
             CollectionCache collectionCache = await client.DocumentClient.GetCollectionCacheAsync();
-            ContainerProperties collectionFromCache =
-                await collectionCache.ResolveCollectionAsync(this.ToDocumentServiceRequest(), cancellationToken);
-            if (collectionFromCache.PartitionKey?.Paths?.Count > 0)
+            try
             {
-                Debug.Assert(this.AssertPartitioningPropertiesAndHeaders());
+                ContainerProperties collectionFromCache =
+                await collectionCache.ResolveCollectionAsync(this.ToDocumentServiceRequest(), cancellationToken);
+
+                if (collectionFromCache.PartitionKey?.Paths?.Count > 0)
+                {
+                    Debug.Assert(this.AssertPartitioningPropertiesAndHeaders());
+                }
+            }
+            catch (DocumentClientException ex)
+            {
+                throw new CosmosException(ex.Message, ex.StatusCode ?? System.Net.HttpStatusCode.Ambiguous, (int)ex.GetSubStatus(), ex.ActivityId, ex.RequestCharge);
             }
 #else
             await Task.CompletedTask;

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
@@ -161,14 +161,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         internal T ToObjectInternal<T>(ResponseMessage cosmosResponseMessage, CosmosSerializer jsonSerializer)
-        {
-            // Not finding something is part of a normal work-flow and should not be an exception.
-            // This prevents the unnecessary overhead of an exception
-            if (cosmosResponseMessage.StatusCode == HttpStatusCode.NotFound)
-            {
-                return default(T);
-            }
-
+        {            
             //Throw the exception
             cosmosResponseMessage.EnsureSuccessStatusCode();
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -242,8 +242,10 @@ namespace Microsoft.Azure.Cosmos
             else
             {
                 if (response.StatusCode == HttpStatusCode.NotFound)
-                {                    
-                    response = await this.CreateContainerStreamInternalAsync(null, throughput, requestOptions, cancellationToken: cancellationToken);
+                {
+                    this.ValidateContainerProperties(containerProperties);
+                    Stream stream = this.ClientContext.PropertiesSerializer.ToStream(containerProperties);
+                    response = await this.CreateContainerStreamInternalAsync(stream, throughput, requestOptions, cancellationToken: cancellationToken);
 
                     if (response.StatusCode == HttpStatusCode.Conflict)
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -361,8 +361,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             Container container = this.cosmosDatabase.GetContainer(containerName);
 
-            ContainerResponse containerResponse = await container.DeleteContainerAsync();
-            Assert.AreEqual(HttpStatusCode.NotFound, containerResponse.StatusCode);
+            try
+            {
+                ContainerResponse containerResponse = await container.DeleteContainerAsync();
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }            
         }
 
         [TestMethod]
@@ -492,17 +498,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.GetContainer(containerName).ReadContainerAsync();
+            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             Container container = containerResponse;
             ContainerProperties containerSettings = containerResponse;
-
-            Assert.AreEqual(HttpStatusCode.NotFound, containerResponse.StatusCode);
-            Assert.IsNotNull(container);
-            Assert.IsNull(containerSettings);
-
-            containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
-            container = containerResponse;
-            containerSettings = containerResponse;
             Assert.IsNotNull(container);
             Assert.IsNotNull(containerSettings);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -364,6 +364,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 ContainerResponse containerResponse = await container.DeleteContainerAsync();
+                Assert.Fail();
             }
             catch (CosmosException ex)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -153,17 +153,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ImplicitConversion()
         {
-            string databaseName = Guid.NewGuid().ToString();
-
-            DatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.GetDatabase(databaseName).ReadAsync(cancellationToken: this.cancellationToken);
+            DatabaseResponse cosmosDatabaseResponse = await this.CreateDatabaseHelper();
             Cosmos.Database cosmosDatabase = cosmosDatabaseResponse;
             DatabaseProperties cosmosDatabaseSettings = cosmosDatabaseResponse;
-            Assert.IsNotNull(cosmosDatabase);
-            Assert.IsNull(cosmosDatabaseSettings);
-
-            cosmosDatabaseResponse = await this.CreateDatabaseHelper();
-            cosmosDatabase = cosmosDatabaseResponse;
-            cosmosDatabaseSettings = cosmosDatabaseResponse;
             Assert.IsNotNull(cosmosDatabase);
             Assert.IsNotNull(cosmosDatabaseSettings);
 
@@ -177,11 +169,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task DropNonExistingDatabase()
         {
-            DatabaseResponse response = await this.cosmosClient.GetDatabase(Guid.NewGuid().ToString()).DeleteAsync(cancellationToken: this.cancellationToken);
-
-            string activityId = response.ActivityId;
-            double? ru = response.RequestCharge;
-            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
+            try
+            {
+                DatabaseResponse response = await this.cosmosClient.GetDatabase(Guid.NewGuid().ToString()).DeleteAsync(cancellationToken: this.cancellationToken);
+                Assert.Fail();
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }                      
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1720,7 +1720,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(response.Headers.ActivityId);
             Assert.IsNotNull(response.ErrorMessage);
 
-            // For typed, it will throw         
+            // For typed, it will throw 
             try
             {
                 ItemResponse<string> typedResponse = await container.ReadItemAsync<string>("id1", Cosmos.PartitionKey.None);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1474,37 +1474,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static async Task ExecuteQueryAsync(Container container, HttpStatusCode expected)
         {
-            try
+            FeedIterator iterator = container.GetItemQueryStreamIterator("select * from r");
+            while (iterator.HasMoreResults)
             {
-                FeedIterator iterator = container.GetItemQueryStreamIterator("select * from r");
-                while (iterator.HasMoreResults)
-                {
-                    ResponseMessage response = await iterator.ReadNextAsync();
-                    Assert.AreEqual(expected, response.StatusCode, $"ExecuteQueryAsync substatuscode: {response.Headers.SubStatusCode} ");
-                }
+                ResponseMessage response = await iterator.ReadNextAsync();
+                Assert.AreEqual(expected, response.StatusCode, $"ExecuteQueryAsync substatuscode: {response.Headers.SubStatusCode} ");
             }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                Assert.AreEqual(HttpStatusCode.NotFound, expected);
-            }
-            
         }
 
         private static async Task ExecuteReadFeedAsync(Container container, HttpStatusCode expected)
         {
-            try
+            FeedIterator iterator = container.GetItemQueryStreamIterator();
+            while (iterator.HasMoreResults)
             {
-                FeedIterator iterator = container.GetItemQueryStreamIterator();
-                while (iterator.HasMoreResults)
-                {
-                    ResponseMessage response = await iterator.ReadNextAsync();
-                    Assert.AreEqual(expected, response.StatusCode, $"ExecuteReadFeedAsync substatuscode: {response.Headers.SubStatusCode} ");
-                }
-            }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                Assert.AreEqual(HttpStatusCode.NotFound, expected);
-            }            
+                ResponseMessage response = await iterator.ReadNextAsync();
+                Assert.AreEqual(expected, response.StatusCode, $"ExecuteReadFeedAsync substatuscode: {response.Headers.SubStatusCode} ");
+            } 
         }
 
         private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException ex)
             {
                 Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
-            }                                    
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -116,9 +116,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(deleteResponse);
             Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
-            readResponse = await this.Container.ReadItemAsync<dynamic>(id: testItem.id, partitionKey: Cosmos.PartitionKey.None);
-            Assert.IsNotNull(readResponse);
-            Assert.AreEqual(HttpStatusCode.NotFound, readResponse.StatusCode);
+            try
+            {
+                readResponse = await this.Container.ReadItemAsync<dynamic>(id: testItem.id, partitionKey: Cosmos.PartitionKey.None);
+                Assert.Fail("Should throw exception.");
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }                                    
         }
 
         [TestMethod]
@@ -150,9 +156,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(deleteResponse);
             Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
 
-            readResponse = await multiPartPkContainer.ReadItemAsync<dynamic>(id: testItem.id, partitionKey: new Cosmos.PartitionKey("pk1"));
-            Assert.IsNotNull(readResponse);
-            Assert.AreEqual(HttpStatusCode.NotFound, readResponse.StatusCode);
+            try
+            {
+                readResponse = await multiPartPkContainer.ReadItemAsync<dynamic>(id: testItem.id, partitionKey: new Cosmos.PartitionKey("pk1"));
+                Assert.Fail("Should throw exception.");
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }
         }
 
         [TestMethod]
@@ -1462,22 +1474,37 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static async Task ExecuteQueryAsync(Container container, HttpStatusCode expected)
         {
-            FeedIterator iterator = container.GetItemQueryStreamIterator("select * from r");
-            while (iterator.HasMoreResults)
+            try
             {
-                ResponseMessage response = await iterator.ReadNextAsync();
-                Assert.AreEqual(expected, response.StatusCode, $"ExecuteQueryAsync substatuscode: {response.Headers.SubStatusCode} ");
+                FeedIterator iterator = container.GetItemQueryStreamIterator("select * from r");
+                while (iterator.HasMoreResults)
+                {
+                    ResponseMessage response = await iterator.ReadNextAsync();
+                    Assert.AreEqual(expected, response.StatusCode, $"ExecuteQueryAsync substatuscode: {response.Headers.SubStatusCode} ");
+                }
             }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, expected);
+            }
+            
         }
 
         private static async Task ExecuteReadFeedAsync(Container container, HttpStatusCode expected)
         {
-            FeedIterator iterator = container.GetItemQueryStreamIterator();
-            while (iterator.HasMoreResults)
+            try
             {
-                ResponseMessage response = await iterator.ReadNextAsync();
-                Assert.AreEqual(expected, response.StatusCode, $"ExecuteReadFeedAsync substatuscode: {response.Headers.SubStatusCode} ");
+                FeedIterator iterator = container.GetItemQueryStreamIterator();
+                while (iterator.HasMoreResults)
+                {
+                    ResponseMessage response = await iterator.ReadNextAsync();
+                    Assert.AreEqual(expected, response.StatusCode, $"ExecuteReadFeedAsync substatuscode: {response.Headers.SubStatusCode} ");
+                }
             }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, expected);
+            }            
         }
 
         private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)
@@ -1693,10 +1720,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(response.Headers.ActivityId);
             Assert.IsNotNull(response.ErrorMessage);
 
-            // FOr typed also its not error
-            var typedResponse = await container.ReadItemAsync<string>("id1", Cosmos.PartitionKey.None);
-            Assert.AreEqual(HttpStatusCode.NotFound, typedResponse.StatusCode);
-            Assert.IsNotNull(typedResponse.Headers.ActivityId);
+            // For typed, it will throw         
+            try
+            {
+                ItemResponse<string> typedResponse = await container.ReadItemAsync<string>("id1", Cosmos.PartitionKey.None);
+                Assert.Fail("Should throw exception.");
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 await func();
+                Assert.Fail();
             }
             catch (CosmosException ex)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -117,30 +117,30 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 dynamic randomItem = new { id = "test", pk = "doesnotexist" };
                 Stream create = jsonSerializer.ToStream<dynamic>(randomItem);
-                await this.VerifyNotFoundErrorAsync(async () => await container.CreateItemStreamAsync(create, new PartitionKey(randomItem.pk)));
+                await this.VerifyNotFoundExceptionAsync(async () => await container.CreateItemStreamAsync(create, new PartitionKey(randomItem.pk)));
 
                 var queryIterator = container.GetItemQueryStreamIterator(
                     "select * from t where true", 
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
-                await this.VerifyNotFoundErrorAsync(async () => await queryIterator.ReadNextAsync());
+                await this.VerifyNotFoundExceptionAsync(async () => await queryIterator.ReadNextAsync());
 
                 var feedIterator = container.GetItemQueryStreamIterator();
-                await this.VerifyNotFoundErrorAsync(async () => await feedIterator.ReadNextAsync());
+                await this.VerifyNotFoundExceptionAsync(async () => await feedIterator.ReadNextAsync());
 
                 dynamic randomUpsertItem = new { id = DoesNotExist, pk = DoesNotExist, status = 42 };
                 Stream upsert = jsonSerializer.ToStream<dynamic>(randomUpsertItem);
-                await this.VerifyNotFoundErrorAsync(async () => await container.UpsertItemStreamAsync(
+                await this.VerifyNotFoundExceptionAsync(async () => await container.UpsertItemStreamAsync(
                     partitionKey: new Cosmos.PartitionKey(randomUpsertItem.pk),
                     streamPayload: upsert));
             }
 
-            await this.VerifyNotFoundErrorAsync(async () => await container.ReadItemStreamAsync(partitionKey: new Cosmos.PartitionKey(DoesNotExist), id: DoesNotExist));
-            await this.VerifyNotFoundErrorAsync(async () => await container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(DoesNotExist), id: DoesNotExist));
+            await this.VerifyNotFoundExceptionAsync(async () => await container.ReadItemStreamAsync(partitionKey: new Cosmos.PartitionKey(DoesNotExist), id: DoesNotExist));
+            await this.VerifyNotFoundExceptionAsync(async () => await container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(DoesNotExist), id: DoesNotExist));
 
             dynamic randomReplaceItem = new { id = "test", pk = "doesnotexist", status = 42 };
             Stream replace = jsonSerializer.ToStream<dynamic>(randomReplaceItem);
-            await this.VerifyNotFoundErrorAsync(async () => await container.ReplaceItemStreamAsync(
+            await this.VerifyNotFoundExceptionAsync(async () => await container.ReplaceItemStreamAsync(
                 partitionKey: new Cosmos.PartitionKey(randomReplaceItem.pk),
                 id: randomReplaceItem.id,
                 streamPayload: replace));
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        private async Task VerifyNotFoundErrorAsync(Func<Task> func)
+        private async Task VerifyNotFoundExceptionAsync(Func<Task> func)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -1508,8 +1508,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             Container collection = await database.CreateContainerAsync(collectionSpec);
 
-            Scripts scripts = collection.Scripts;
-            StoredProcedureProperties sprocUri = await scripts.ReadStoredProcedureAsync("__.sys.echo");
+            Scripts scripts = collection.Scripts;            
             string input = "foobar";
 
             string result = string.Empty;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using System.Threading.Tasks;
+    using System.Net;
 
     [TestClass]
     public class LinqSQLTranslationBaselineTest : BaselineTests<LinqTestInput, LinqTestOutput>
@@ -39,9 +40,14 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
                 })).WithConnectionModeGateway();
             });
 
-            await cosmosClient.GetDatabase(id: nameof(LinqSQLTranslationBaselineTest)).DeleteAsync();
-            testDb = await cosmosClient.CreateDatabaseAsync(nameof(LinqSQLTranslationBaselineTest));
-
+            try
+            {
+                await cosmosClient.GetDatabase(id: nameof(LinqSQLTranslationBaselineTest)).DeleteAsync();
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                testDb = await cosmosClient.CreateDatabaseAsync(nameof(LinqSQLTranslationBaselineTest));
+            }                        
         }
 
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
@@ -46,8 +46,10 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             }
             catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
             {
-                testDb = await cosmosClient.CreateDatabaseAsync(nameof(LinqSQLTranslationBaselineTest));
-            }                        
+                //swallow
+            }
+
+            testDb = await cosmosClient.CreateDatabaseAsync(nameof(LinqSQLTranslationBaselineTest));
         }
 
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1076,7 +1076,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException e)
             {
                 Assert.IsNotNull(e.Message);
-                Assert.AreEqual(e.StatusCode, HttpStatusCode.NotFound);
+                Assert.IsTrue(e.StatusCode == HttpStatusCode.BadRequest || e.StatusCode == HttpStatusCode.Unauthorized || e.StatusCode == HttpStatusCode.NotFound);
             }
 
             try
@@ -1087,7 +1087,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException e)
             {
                 Assert.IsNotNull(e.Message);
-                Assert.AreEqual(e.StatusCode, HttpStatusCode.NotFound);
+                Assert.IsTrue(e.StatusCode == HttpStatusCode.BadRequest || e.StatusCode == HttpStatusCode.Unauthorized || e.StatusCode == HttpStatusCode.NotFound);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     try
                     {
                         doc3 = await container.DeleteItemAsync<Document>(partitionKey: new Cosmos.PartitionKey(resourceRandomId), id: resourceRandomId);
+                        Assert.Fail();
                     }
                     catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                     {
@@ -671,7 +672,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private async Task DeleteContainerAsync(Container container)
+        private async Task DeleteContainerIfExistsAsync(Container container)
         {
             try
             {
@@ -724,7 +725,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             if (type == FabircServiceReuseType.Bindable)
             {
-                await this.DeleteContainerAsync(collBar);
+                await this.DeleteContainerIfExistsAsync(collBar);
             }
 
             // Now verify the collectionFooId, the cache has collectionFooId -> OldRid cache
@@ -745,7 +746,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             if (type == FabircServiceReuseType.BoundToDifferentName)
             {
-                await this.DeleteContainerAsync(collBar);
+                await this.DeleteContainerIfExistsAsync(collBar);
             }
         }
 
@@ -1007,19 +1008,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
 
         [TestMethod]
-        public async Task NameRoutingBadUrlTest()
+        public void NameRoutingBadUrlTest()
         {
             CosmosClient client;
 
             client = TestCommon.CreateCosmosClient(true);
-            await this.NameRoutingBadUrlTestPrivateAsync(client, false);
+            this.NameRoutingBadUrlTestPrivateAsync(client, false).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             client = TestCommon.CreateClient(false, Protocol.Https);
-            this.NameRoutingBadUrlTestPrivateAsync(client, false);
+            this.NameRoutingBadUrlTestPrivateAsync(client, false).Wait();
 
             client = TestCommon.CreateClient(false, Protocol.Tcp);
-            this.NameRoutingBadUrlTestPrivateAsync(client, false, true);
+            this.NameRoutingBadUrlTestPrivateAsync(client, false, true).Wait();
 #endif
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -282,8 +282,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string sprocId = Guid.NewGuid().ToString();
 
-            StoredProcedureResponse storedProcedureResponse = await this.scripts.DeleteStoredProcedureAsync(sprocId);
-            Assert.AreEqual(HttpStatusCode.NotFound, storedProcedureResponse.StatusCode);
+            try
+            {
+                StoredProcedureResponse storedProcedureResponse = await this.scripts.DeleteStoredProcedureAsync(sprocId);
+                Assert.Fail();
+            }
+            catch (CosmosException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -81,8 +81,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ValidateTriggersTest()
         {
             // Prevent failures if previous test did not clean up correctly 
-            await this.scripts.DeleteTriggerAsync("addTax");
-
+            try
+            {
+                await this.scripts.DeleteTriggerAsync("addTax");
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                //swallow
+            }
+            
             ToDoActivity item = new ToDoActivity()
             {
                 id = Guid.NewGuid().ToString(),

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -80,8 +80,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ValidateUserDefinedFunctionsTest()
         {
-            // Prevent failures if previous test did not clean up correctly 
-            await this.scripts.DeleteUserDefinedFunctionAsync("calculateTax");
+            try
+            {
+                // Prevent failures if previous test did not clean up correctly 
+                await this.scripts.DeleteUserDefinedFunctionAsync("calculateTax");
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                //swallow
+            }
 
             ToDoActivity item = new ToDoActivity()
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -227,9 +227,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<CancellationToken>()))
                 .Returns(() =>
                 {
-                    var itemResponse = new Mock<ItemResponse<DocumentServiceLeaseCore>>();
-                    itemResponse.Setup(i => i.StatusCode).Returns(HttpStatusCode.NotFound);
-                    return Task.FromResult(itemResponse.Object);
+                    throw new CosmosException(HttpStatusCode.NotFound, "");
                 })
                 .Returns(() =>
                 {
@@ -262,9 +260,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() =>
                 {
-                    var itemResponse = new Mock<ItemResponse<DocumentServiceLeaseCore>>();
-                    itemResponse.Setup(i => i.StatusCode).Returns(HttpStatusCode.NotFound);
-                    return itemResponse.Object;
+                    throw new CosmosException(HttpStatusCode.NotFound, "");
                 });
 
             mockedItems.SetupSequence(i => i.ReplaceItemAsync<DocumentServiceLeaseCore>(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -61,8 +61,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             HttpStatusCode[] testHttpStatusCodes = new HttpStatusCode[]
                                 {
-                                    HttpStatusCode.OK,
-                                    HttpStatusCode.NotFound
+                                    HttpStatusCode.OK                                    
                                 };
 
             // User operations

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             HttpStatusCode[] testHttpStatusCodes = new HttpStatusCode[]
                                 {
-                                    HttpStatusCode.OK                                    
+                                    HttpStatusCode.OK                          
                                 };
 
             // User operations

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             HttpStatusCode[] testHttpStatusCodes = new HttpStatusCode[]
                                 {
-                                    HttpStatusCode.OK                          
+                                    HttpStatusCode.OK          
                                 };
 
             // User operations


### PR DESCRIPTION
# Pull Request Template

## Description

Currently 404 is not treated as failure and returns status code. Its causing confusion with proxy objects + CRUD operations resulting in success.

With stream API's we have the choice of non-exception API. Typed API throwing exceptions on 404 will help with V2 customers migration and also eases get-started scenarios as well.

## Type of change

Please delete options that are not relevant.

- [X ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

#513

