### PR TITLE
Fixed query handling 429s by removing unnecessary null check.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryResponse.cs
@@ -85,16 +85,6 @@ namespace Microsoft.Azure.Cosmos
             long responseLengthBytes,
             CosmosQueryResponseMessageHeaders responseHeaders)
         {
-            if (result == null)
-            {
-                throw new ArgumentNullException(nameof(result));
-            }
-
-            if (responseHeaders == null)
-            {
-                throw new ArgumentNullException(nameof(responseHeaders));
-            }
-
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException("count must be positive");
@@ -125,16 +115,6 @@ namespace Microsoft.Azure.Cosmos
             string errorMessage,
             Error error)
         {
-            if (responseHeaders == null)
-            {
-                throw new ArgumentNullException(nameof(responseHeaders));
-            }
-
-            if (errorMessage == null)
-            {
-                throw new ArgumentNullException(nameof(errorMessage));
-            }
-
             QueryResponse cosmosQueryResponse = new QueryResponse(
                 result: Enumerable.Empty<CosmosElement>(),
                 count: 0,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1375,6 +1375,53 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public async Task VerifyToManyRequestTest(bool isQuery)
+        {
+            CosmosClient client = TestCommon.CreateCosmosClient();
+            Cosmos.Database db = await client.CreateDatabaseIfNotExistsAsync("LoadTest");
+            Container container = await db.CreateContainerIfNotExistsAsync("LoadContainer", "/status");
+
+            try
+            {
+                Task[] createItems = new Task[100];
+                for (int i = 0; i < createItems.Length; i++)
+                {
+                    ToDoActivity temp = this.CreateRandomToDoActivity();
+                    createItems[i] = container.CreateItemStreamAsync(
+                        partitionKey: new Cosmos.PartitionKey(temp.status),
+                        streamPayload: this.jsonSerializer.ToStream<ToDoActivity>(temp));
+                }
+
+                Task.WaitAll(createItems);
+
+                List<Task> createQuery = new List<Task>(100);
+                List<ResponseMessage> failedToManyRequests = new List<ResponseMessage>();
+                for (int i = 0; i < 100 && failedToManyRequests.Count == 0; i++)
+                {
+                    createQuery.Add(VerifyQueryToManyExceptionAsync(
+                        container, 
+                        isQuery,
+                        failedToManyRequests));
+                }
+
+                Task[] tasks = createQuery.ToArray();
+                Task.WaitAll(tasks);
+
+                Assert.IsTrue(failedToManyRequests.Count > 0);
+                ResponseMessage failedResponseMessage = failedToManyRequests.First();
+                Assert.AreEqual(failedResponseMessage.StatusCode, (HttpStatusCode)429);
+                Assert.IsNull(failedResponseMessage.ErrorMessage);
+            }
+            finally
+            {
+                await db.DeleteAsync();
+            }
+        }
+
         [TestMethod]
         public async Task VerifySessionTokenPassThrough()
         {
@@ -1457,6 +1504,43 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 await db1.DeleteAsync();
                 cc1.Dispose();
                 cc2.Dispose();
+            }
+        }
+
+        private static async Task VerifyQueryToManyExceptionAsync(
+            Container container,
+            bool isQuery, 
+            List<ResponseMessage> failedToManyMessages)
+        {
+            string queryText = null;
+            if (isQuery)
+            {
+                queryText = "select * from r";
+            }
+
+            FeedIterator iterator = container.GetItemQueryStreamIterator(queryText);
+            while (iterator.HasMoreResults && failedToManyMessages.Count == 0)
+            {
+                ResponseMessage response = await iterator.ReadNextAsync();
+                if (response.StatusCode == (HttpStatusCode)429)
+                {
+                    failedToManyMessages.Add(response);
+                    return;
+                }
+            }
+        }
+
+        private static async Task VerifyReadFeedToManyExceptionAsync(Container container, List<ResponseMessage> failedToManyMessages)
+        {
+            FeedIterator iterator = container.GetItemQueryStreamIterator();
+            while (iterator.HasMoreResults && failedToManyMessages.Count == 0)
+            {
+                ResponseMessage response = await iterator.ReadNextAsync();
+                if (response.StatusCode == (HttpStatusCode)429)
+                {
+                    failedToManyMessages.Add(response);
+                    return;
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1387,7 +1387,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                Task[] createItems = new Task[100];
+                Task[] createItems = new Task[300];
                 for (int i = 0; i < createItems.Length; i++)
                 {
                     ToDoActivity temp = this.CreateRandomToDoActivity();
@@ -1398,9 +1398,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 Task.WaitAll(createItems);
 
-                List<Task> createQuery = new List<Task>(100);
+                List<Task> createQuery = new List<Task>(500);
                 List<ResponseMessage> failedToManyRequests = new List<ResponseMessage>();
-                for (int i = 0; i < 100 && failedToManyRequests.Count == 0; i++)
+                for (int i = 0; i < 500 && failedToManyRequests.Count == 0; i++)
                 {
                     createQuery.Add(VerifyQueryToManyExceptionAsync(
                         container, 
@@ -1411,7 +1411,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task[] tasks = createQuery.ToArray();
                 Task.WaitAll(tasks);
 
-                Assert.IsTrue(failedToManyRequests.Count > 0);
+                Assert.IsTrue(failedToManyRequests.Count > 0, "Rate limiting appears to be disabled");
                 ResponseMessage failedResponseMessage = failedToManyRequests.First();
                 Assert.AreEqual(failedResponseMessage.StatusCode, (HttpStatusCode)429);
                 Assert.IsNull(failedResponseMessage.ErrorMessage);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1530,20 +1530,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private static async Task VerifyReadFeedToManyExceptionAsync(Container container, List<ResponseMessage> failedToManyMessages)
-        {
-            FeedIterator iterator = container.GetItemQueryStreamIterator();
-            while (iterator.HasMoreResults && failedToManyMessages.Count == 0)
-            {
-                ResponseMessage response = await iterator.ReadNextAsync();
-                if (response.StatusCode == (HttpStatusCode)429)
-                {
-                    failedToManyMessages.Add(response);
-                    return;
-                }
-            }
-        }
-
         private static async Task ExecuteQueryAsync(Container container, HttpStatusCode expected)
         {
             FeedIterator iterator = container.GetItemQueryStreamIterator("select * from r");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1379,6 +1379,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         [DataRow(false)]
         [DataRow(true)]
+        [TestCategory("Quarantine") /* Gated runs emulator as rate limiting disabled */]
         public async Task VerifyToManyRequestTest(bool isQuery)
         {
             CosmosClient client = TestCommon.CreateCosmosClient();


### PR DESCRIPTION
# Pull Request Template

## Description

There was a previous assumption that all exceptions from Cosmos DB contained an error message. This is not true for the throttle exception(429 ToManyRequests). I removed the unnecessary null check and added tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Put closes #518 


