### PR TITLE
Renaming container stream api and improving documentation example throughout code

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
+        ///     foreach(ConflictProperties item in await conflictIterator.ReadNextAsync())
         ///     {
         ///         MyClass intendedChanges = conflicts.ReadConflictContent<MyClass>(item);
         ///         ItemResponse<MyClass> currentState = await conflicts.ReadCurrentAsync<MyClass>(intendedChanges.MyPartitionKey, item);
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
+        ///     foreach(ConflictProperties item in await conflictIterator.ReadNextAsync())
         ///     {
         ///         MyClass intendedChanges = conflicts.ReadConflictContent<MyClass>(item);
         ///         ItemResponse<MyClass> currentState = await conflicts.ReadCurrentAsync<MyClass>(intendedChanges.MyPartitionKey, item);
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
+        ///     foreach(ConflictProperties item in await conflictIterator.ReadNextAsync())
         ///     {
         ///     }
         /// }
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// Gets an iterator to go through all the conflicts for the container as the original CosmosResponseMessage
+        /// Gets an iterator to go through all the conflicts for the container as the original ResponseMessage
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator conflictIterator = conflicts.GetConflictQueryStreamIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())
+        ///     using (ResponseMessage iterator = await feedIterator.ReadNextAsync())
         ///     {
         ///     }
         /// }
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
+        ///     foreach(ConflictProperties item in await conflictIterator.ReadNextAsync())
         ///     {
         ///     }
         /// }
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// Gets an iterator to go through all the conflicts for the container as the original CosmosResponseMessage
+        /// Gets an iterator to go through all the conflicts for the container as the original ResponseMessage
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Cosmos
         /// FeedIterator conflictIterator = conflicts.GetConflictQueryStreamIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())
+        ///     using (ResponseMessage iterator = await feedIterator.ReadNextAsync())
         ///     {
         ///     }
         /// }

--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<ConflictProperties> conflictIterator = await conflicts.GetConflictsIterator();
+        /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<ConflictProperties> conflictIterator = await conflicts.GetConflictsIterator();
+        /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<ConflictProperties> conflictIterator = await conflicts.GetConflictIterator();
+        /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator conflictIterator = await conflicts.GetConflictStreamIterator();
+        /// FeedIterator conflictIterator = conflicts.GetConflictQueryStreamIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<ConflictProperties> conflictIterator = await conflicts.GetConflictIterator();
+        /// FeedIterator<ConflictProperties> conflictIterator = conflicts.GetConflictQueryIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     foreach(ConflictProperties item in await conflictIterator.FetchNextSetAsync())
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator conflictIterator = await conflicts.GetConflictStreamIterator();
+        /// FeedIterator conflictIterator = conflicts.GetConflictQueryStreamIterator();
         /// while (conflictIterator.HasMoreResults)
         /// {
         ///     using (CosmosResponseMessage iterator = await feedIterator.FetchNextSetAsync())

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// Container container = this.database.Containers["containerId"];
+        /// Container container = this.database.GetContainer("containerId");
         /// ResponseMessage response = await container.DeleteContainerStreamAsync();
         /// ]]>
         /// </code>
@@ -696,7 +696,7 @@ namespace Microsoft.Azure.Cosmos
         /// Delete an item from Cosmos
         /// <code language="c#">
         /// <![CDATA[
-        /// using(ResponseMessage response = await this.container.DeleteItemStreamAsync("itemId", "itemPartitionKey"))
+        /// using(ResponseMessage response = await this.container.DeleteItemStreamAsync("itemId", new PartitionKey("itemPartitionKey")))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -1006,19 +1006,19 @@ namespace Microsoft.Azure.Cosmos
         /// }
         ///  
         /// // Query by the Title property
-        /// Book book = container.Items.GetItemLinqQuery<Book>(true)
+        /// Book book = container.GetItemLinqQueryable<Book>(true)
         ///                      .Where(b => b.Title == "War and Peace")
         ///                      .AsEnumerable()
         ///                      .FirstOrDefault();
         /// 
         /// // Query a nested property
-        /// Book otherBook = container.Items.GetItemLinqQuery<Book>(true)
+        /// Book otherBook = container.GetItemLinqQueryable<Book>(true)
         ///                           .Where(b => b.Author.FirstName == "Leo")
         ///                           .AsEnumerable()
         ///                           .FirstOrDefault();
         /// 
         /// // Perform iteration on books
-        /// foreach (Book matchingBook in container.Items.GetItemLinqQuery<Book>(true)
+        /// foreach (Book matchingBook in container.GetItemLinqQueryable<Book>(true)
         ///                            .Where(b => b.Price > 100))
         /// {
         ///     // Iterate through books
@@ -1032,7 +1032,7 @@ namespace Microsoft.Azure.Cosmos
         /// <![CDATA[
         ///
         /// // LINQ query generation
-        /// var setIterator = container.Items.GetItemLinqQuery<Book>()
+        /// var setIterator = container.GetItemLinqQueryable<Book>()
         ///                      .Where(b => b.Title == "War and Peace")
         ///                      .ToFeedIterator();
         ///                      

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -66,11 +66,31 @@ namespace Microsoft.Azure.Cosmos
         /// <code language="c#">
         /// <![CDATA[
         /// Container container = this.database.GetContainer("containerId");
-        /// ContainerProperties containerProperties = container.ReadContainerAsync();
+        /// ContainerProperties containerProperties = await container.ReadContainerAsync();
         /// ]]>
         /// </code>
         /// </example>
         public abstract Task<ContainerResponse> ReadContainerAsync(
+            ContainerRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// </summary>
+        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Container container = this.database.GetContainer("containerId");
+        /// ResponseMessage response = await container.ReadContainerStreamAsync();
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// </returns>
+        public abstract Task<ResponseMessage> ReadContainerStreamAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -101,13 +121,37 @@ namespace Microsoft.Azure.Cosmos
         /// <code language="c#">
         /// <![CDATA[
         /// ContainerProperties containerProperties = containerReadResponse;
-        /// setting.IndexingPolicy.Automatic = false;
-        /// ContainerResponse response = container.ReplaceContainerAsync(containerProperties);
+        /// containerProperties.IndexingPolicy.Automatic = false;
+        /// ContainerResponse response = await container.ReplaceContainerAsync(containerProperties);
         /// ContainerProperties replacedProperties = response;
         /// ]]>
         /// </code>
         /// </example>
         public abstract Task<ContainerResponse> ReplaceContainerAsync(
+            ContainerProperties containerProperties,
+            ContainerRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// </summary>
+        /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <example>
+        ///
+        /// <code language="c#">
+        /// <![CDATA[
+        /// ContainerProperties containerProperties = containerReadResponse;
+        /// containerProperties.IndexingPolicy.Automatic = false;
+        /// ResponseMessage response = await container.ReplaceContainerStreamAsync(containerProperties);
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <returns>
+        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
+        /// </returns>
+        public abstract Task<ResponseMessage> ReplaceContainerStreamAsync(
             ContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -132,11 +176,29 @@ namespace Microsoft.Azure.Cosmos
         /// <code language="c#">
         /// <![CDATA[
         /// Container container = this.database.Containers["containerId"];
-        /// ContainerResponse response = container.DeleteContainerAsync();
+        /// ContainerResponse response = await container.DeleteContainerAsync();
         /// ]]>
         /// </code>
         /// </example>
         public abstract Task<ContainerResponse> DeleteContainerAsync(
+            ContainerRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// </summary>
+        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Container container = this.database.Containers["containerId"];
+        /// ResponseMessage response = await container.DeleteContainerStreamAsync();
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
+        public abstract Task<ResponseMessage> DeleteContainerStreamAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -217,7 +279,7 @@ namespace Microsoft.Azure.Cosmos
         /// The following example shows how to get the throughput.
         /// <code language="c#">
         /// <![CDATA[
-        /// ThroughputResponse throughput = await this.cosmosContainer.ReplaceThroughputAsync(400, requestOptions : new RequestOptions());
+        /// ThroughputResponse throughput = await this.cosmosContainer.ReplaceThroughputAsync(400);
         /// ]]>
         /// </code>
         /// </example>
@@ -228,42 +290,6 @@ namespace Microsoft.Azure.Cosmos
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             int throughput,
             RequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
-        /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
-        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
-        /// </returns>
-        public abstract Task<ResponseMessage> ReadStreamAsync(
-            ContainerRequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
-        /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
-        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
-        /// </returns>
-        public abstract Task<ResponseMessage> ReplaceStreamAsync(
-            ContainerProperties containerProperties,
-            ContainerRequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
-        /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
-        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
-        public abstract Task<ResponseMessage> DeleteStreamAsync(
-            ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -353,7 +379,7 @@ namespace Microsoft.Azure.Cosmos
         ///    status = "InProgress"
         /// };
         ///
-        /// ItemResponse item = this.container.CreateItemAsync<ToDoActivity>(tests, new PartitionKey(test.status));
+        /// ItemResponse item = await this.container.CreateItemAsync<ToDoActivity>(tests, new PartitionKey(test.status));
         /// ]]>
         /// </code>
         /// </example>
@@ -380,7 +406,7 @@ namespace Microsoft.Azure.Cosmos
         /// Read a response as a stream.
         /// <code language="c#">
         /// <![CDATA[
-        /// using(CosmosResponseMessage response = this.container.ReadItemStreamAsync("id", new PartitionKey("partitionKey")))
+        /// using(ResponseMessage response = await this.container.ReadItemStreamAsync("id", new PartitionKey("partitionKey")))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -441,7 +467,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// ToDoActivity toDoActivity = this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        /// ToDoActivity toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
         /// 
         /// ]]>
         /// </code>
@@ -471,7 +497,7 @@ namespace Microsoft.Azure.Cosmos
         /// Upsert a Stream containing the item to Cosmos
         /// <code language="c#">
         /// <![CDATA[
-        /// using(CosmosResponseMessage response = this.container.UpsertItemStreamAsync(partitionKey: new PartitionKey("itemPartitionKey"), streamPayload: stream))
+        /// using(ResponseMessage response = await this.container.UpsertItemStreamAsync(stream, new PartitionKey("itemPartitionKey")))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -539,7 +565,7 @@ namespace Microsoft.Azure.Cosmos
         ///    status = "InProgress"
         /// };
         ///
-        /// ItemResponse<ToDoActivity> item = await this.container.UpsertAsync<ToDoActivity>(test, new PartitionKey(test.status));
+        /// ItemResponse<ToDoActivity> item = await this.container.UpsertItemAsync<ToDoActivity>(test, new PartitionKey(test.status));
         /// ]]>
         /// </code>
         /// </example>
@@ -569,7 +595,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace an item in Cosmos
         /// <code language="c#">
         /// <![CDATA[
-        /// using(CosmosResponseMessage response = this.container.ReplaceItemStreamAsync(partitionKey: new PartitionKey("itemPartitionKey"), id: "itemId", streamPayload: stream))
+        /// using(ResponseMessage response = await this.container.ReplaceItemStreamAsync(stream, "itemId", new PartitionKey("itemPartitionKey"))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -670,7 +696,7 @@ namespace Microsoft.Azure.Cosmos
         /// Delete an item from Cosmos
         /// <code language="c#">
         /// <![CDATA[
-        /// using(CosmosResponseMessage response = this.container.DeleteItemStreamAsync(partitionKey: "itemPartitionKey", id: "itemId"))
+        /// using(ResponseMessage response = await this.container.DeleteItemStreamAsync("itemId", "itemPartitionKey"))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -746,7 +772,7 @@ namespace Microsoft.Azure.Cosmos
         /// 
         /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive").WithParameter("@expensive", 9000);
         /// FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-        ///     queryDefinition: queryDefinition, 
+        ///     queryDefinition: queryDefinition,
         ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
         ///     
         /// while (feedIterator.HasMoreResults)
@@ -786,9 +812,9 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// QueryDefinition sqlQuery = new QueryDefinition("select * from ToDos t where t.cost > @expensive").WithParameter("@expensive", 9000);
+        /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive").WithParameter("@expensive", 9000);
         /// FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-        ///     sqlQueryDefinition: sqlQuery, 
+        ///     queryDefinition: queryDefinition,
         ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
         ///     
         /// while (feedIterator.HasMoreResults)
@@ -920,19 +946,19 @@ namespace Microsoft.Azure.Cosmos
         /// }
         ///  
         /// // Query by the Title property
-        /// Book book = container.Items.GetItemLinqQuery<Book>(allowSynchronousQueryExecution = true)
+        /// Book book = container.Items.GetItemLinqQuery<Book>(true)
         ///                      .Where(b => b.Title == "War and Peace")
         ///                      .AsEnumerable()
         ///                      .FirstOrDefault();
         /// 
         /// // Query a nested property
-        /// Book otherBook = container.Items.GetItemLinqQuery<Book>(allowSynchronousQueryExecution = true)
+        /// Book otherBook = container.Items.GetItemLinqQuery<Book>(true)
         ///                           .Where(b => b.Author.FirstName == "Leo")
         ///                           .AsEnumerable()
         ///                           .FirstOrDefault();
         /// 
         /// // Perform iteration on books
-        /// foreach (Book matchingBook in container.Items.GetItemLinqQuery<Book>(allowSynchronousQueryExecution = true)
+        /// foreach (Book matchingBook in container.Items.GetItemLinqQuery<Book>(true)
         ///                            .Where(b => b.Price > 100))
         /// {
         ///     // Iterate through books

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
+        /// </returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
@@ -89,7 +90,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// </returns>
         public abstract Task<ResponseMessage> ReadContainerStreamAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -138,6 +138,9 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
+        /// </returns>
         /// <example>
         ///
         /// <code language="c#">
@@ -148,9 +151,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
-        /// </returns>
         public abstract Task<ResponseMessage> ReplaceContainerStreamAsync(
             ContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
@@ -206,6 +206,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets container throughput in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>Provisioned throughput in request units per second</returns>
         /// <value>
         /// The provisioned throughput for this container.
         /// </value>
@@ -222,7 +223,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>Provisioned throughput in request units per second</returns>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database"/>
         public abstract Task<int?> ReadThroughputAsync(
@@ -233,6 +233,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>The throughput response</returns>
         /// <value>
         /// The provisioned throughput for this container.
         /// </value>
@@ -261,7 +262,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>The throughput response</returns>
         public abstract Task<ThroughputResponse> ReadThroughputAsync(
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -272,6 +272,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="throughput">The cosmos container throughput, expressed in Request Units per second.</param>
         /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>The throughput response.</returns>
         /// <value>
         /// The provisioned throughput for this container.
         /// </value>
@@ -283,7 +284,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>The throughput response.</returns>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.Cosmos
         /// <code language="c#">
         /// <![CDATA[
         /// //Create the object in Cosmos
-        /// using (CosmosResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new PartitionKey("streamPartitionKey"), streamPayload: stream))
+        /// using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new PartitionKey("streamPartitionKey"), streamPayload: stream))
         /// {
         ///     if (!response.IsSuccessStatusCode)
         ///     {
@@ -751,12 +751,13 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetStreamIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
         /// </remarks>
@@ -770,14 +771,16 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive").WithParameter("@expensive", 9000);
+        /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive")
+        ///     .WithParameter("@expensive", 9000);
         /// FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-        ///     queryDefinition: queryDefinition,
-        ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
-        ///     
+        ///     queryDefinition,
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
         /// while (feedIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage response = await feedIterator.FetchNextSetAsync())
+        ///     using (ResponseMessage response = await feedIterator.ReadNextAsync())
         ///     {
         ///         using (StreamReader sr = new StreamReader(response.Content))
         ///         using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -789,7 +792,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the items.</returns>
         public abstract FeedIterator GetItemQueryStreamIterator(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -802,6 +804,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the items.</returns>
         /// <example>
         /// Create a query to get all the ToDoActivity that have a cost greater than 9000
         /// <code language="c#">
@@ -812,11 +815,13 @@ namespace Microsoft.Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive").WithParameter("@expensive", 9000);
+        /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive")
+        ///     .WithParameter("@expensive", 9000);
         /// FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-        ///     queryDefinition: queryDefinition,
-        ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
-        ///     
+        ///     queryDefinition,
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(var item in await feedIterator.ReadNextAsync()){
@@ -827,24 +832,24 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the items.</returns>
         public abstract FeedIterator<T> GetItemQueryIterator<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a CosmosResultSetStreamIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
         /// </remarks>
         /// <example>
-        /// Create a query to get all the ToDoActivity that have a cost greater than 9000 for the specified partition
+        /// 1. Create a query to get all the ToDoActivity that have a cost greater than 9000 for the specified partition
         /// <code language="c#">
         /// <![CDATA[
         /// public class ToDoActivity{
@@ -854,12 +859,13 @@ namespace Microsoft.Azure.Cosmos
         /// }
         /// 
         /// FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-        ///     queryText: "select * from ToDos t where t.cost > 9000", 
-        ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
-        ///     
+        ///     "select * from ToDos t where t.cost > 9000",
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
         /// while (feedIterator.HasMoreResults)
         /// {
-        ///     using (CosmosResponseMessage response = await feedIterator.FetchNextSetAsync())
+        ///     using (ResponseMessage response = await feedIterator.ReadNextAsync())
         ///     {
         ///         using (StreamReader sr = new StreamReader(response.Content))
         ///         using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -871,7 +877,35 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the items.</returns>
+        /// <example>
+        /// 2. Creates a FeedIterator to get all the ToDoActivity.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// public class ToDoActivity{
+        ///     public string id {get; set;}
+        ///     public string status {get; set;}
+        ///     public int cost {get; set;}
+        /// }
+        ///
+        /// FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
+        ///     null,
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        ///     using (ResponseMessage response = await feedIterator.ReadNextAsync())
+        ///     {
+        ///         using (StreamReader sr = new StreamReader(response.Content))
+        ///         using (JsonTextReader jtr = new JsonTextReader(sr))
+        ///         {
+        ///             JObject result = JObject.Load(jtr);
+        ///         }
+        ///     }
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
         public abstract FeedIterator GetItemQueryStreamIterator(
             string queryText = null,
             string continuationToken = null,
@@ -884,8 +918,9 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the items.</returns>
         /// <example>
-        /// Create a query to get all the ToDoActivity that have a cost greater than 9000
+        /// 1. Create a query to get all the ToDoActivity that have a cost greater than 9000
         /// <code language="c#">
         /// <![CDATA[
         /// public class ToDoActivity{
@@ -895,9 +930,35 @@ namespace Microsoft.Azure.Cosmos
         /// }
         /// 
         /// FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-        ///     queryText: "select * from ToDos t where t.cost > 9000", 
-        ///     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("Error")});
-        ///     
+        ///     "select * from ToDos t where t.cost > 9000",
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        ///     foreach(var item in await feedIterator.ReadNextAsync()){
+        ///     {
+        ///         Console.WriteLine(item.cost);
+        ///     }
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <example>
+        /// 2. Create a FeedIterator to get all the ToDoActivity.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// public class ToDoActivity{
+        ///     public string id {get; set;}
+        ///     public string status {get; set;}
+        ///     public int cost {get; set;}
+        /// }
+        ///
+        /// FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
+        ///     null,
+        ///     null,
+        ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")});
+        ///
         /// while (feedIterator.HasMoreResults)
         /// {
         ///     foreach(var item in await feedIterator.ReadNextAsync()){
@@ -908,7 +969,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the items.</returns>
         public abstract FeedIterator<T> GetItemQueryIterator<T>(
             string queryText = null,
             string continuationToken = null,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Task<ResponseMessage> response = this.ReadStreamAsync(
+            Task<ResponseMessage> response = this.ReadContainerStreamAsync(
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            Task<ResponseMessage> response = this.DeleteStreamAsync(
+            Task<ResponseMessage> response = this.DeleteContainerStreamAsync(
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Cosmos
             return await this.ClientContext.ResponseFactory.CreateThroughputResponseAsync(response);
         }
 
-        public override Task<ResponseMessage> DeleteStreamAsync(
+        public override Task<ResponseMessage> DeleteContainerStreamAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Cosmos
                cancellationToken: cancellationToken);
         }
 
-        public override Task<ResponseMessage> ReadStreamAsync(
+        public override Task<ResponseMessage> ReadContainerStreamAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
-        public override Task<ResponseMessage> ReplaceStreamAsync(
+        public override Task<ResponseMessage> ReplaceContainerStreamAsync(
             ContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Cosmos
         /// Returns a reference to a container object. 
         /// </summary>
         /// <param name="id">The cosmos container id.</param>
-        /// <returns>Cosmos container proxy</returns>
+        /// <returns>Cosmos container reference</returns>
         /// <remarks>
         /// Returns a Container reference. Reference doesn't guarantees existence.
         /// Please ensure container already exists or is created through a create operation.

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets database throughput in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>Provisioned throughput in request units per second</returns>
         /// <value>
         /// The provisioned throughput for this database.
         /// </value>
@@ -118,7 +119,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>Provisioned throughput in request units per second</returns>
         public abstract Task<int?> ReadThroughputAsync(
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>The throughput response.</returns>
         /// <value>
         /// The provisioned throughput for this database.
         /// </value>
@@ -158,7 +159,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>The throughput response.</returns>
         public abstract Task<ThroughputResponse> ReadThroughputAsync(
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -169,6 +169,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="throughput">The cosmos database throughput expressed in Request Units per second.</param>
         /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>The throughput response.</returns>
         /// <value>
         /// The provisioned throughput for this database.
         /// </value>
@@ -180,7 +181,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>The throughput response.</returns>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
@@ -194,6 +194,9 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>
+        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
+        /// </returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
@@ -204,9 +207,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
-        /// </returns>
         public abstract Task<ResponseMessage> ReadStreamAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken));
@@ -216,17 +216,17 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
         /// //Delete a Database resource where
         /// // - database_id is the ID property of the Database resource you wish to delete.
         /// Database database = this.cosmosClient.GetDatabase(database_id);
-        /// await database.DeleteContainerStreamAsync();
+        /// await database.DeleteStreamAsync();
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
         public abstract Task<ResponseMessage> DeleteStreamAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken));
@@ -235,9 +235,10 @@ namespace Microsoft.Azure.Cosmos
         /// Returns a reference to a container object. 
         /// </summary>
         /// <param name="id">The cosmos container id.</param>
+        /// <returns>Cosmos container proxy</returns>
         /// <remarks>
-        /// Note that the container must be explicitly created, if it does not already exist, before
-        /// you can read from it or write to it.
+        /// Returns a Container reference. Reference doesn't guarantees existence.
+        /// Please ensure container already exists or is created through a create operation.
         /// </remarks>
         /// <example>
         /// <code language="c#">
@@ -247,7 +248,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>Cosmos container proxy</returns>
         public abstract Container GetContainer(string id);
 
         /// <summary>
@@ -459,6 +459,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the created resource record.</returns>
         /// <example>
         /// Creates a container as an asynchronous operation in the Azure Cosmos service and return stream response.
         /// <code language="c#">
@@ -469,11 +470,12 @@ namespace Microsoft.Azure.Cosmos
         ///     PartitionKeyPath = "/pk",
         /// };
         ///
-        /// ResponseMessage response = await this.cosmosDatabase.CreateContainerStreamAsync(containerProperties);
+        /// using(ResponseMessage response = await this.cosmosDatabase.CreateContainerStreamAsync(containerProperties))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the created resource record.</returns>
         /// <seealso cref="DefineContainer(string, string)"/>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
@@ -491,17 +493,25 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// This create the type feed iterator for containers with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
+        /// string queryText = "SELECT * FROM c where c.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testDatabaseId");
         /// FeedIterator<ContainerProperties> resultSet = this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(queryDefinition);
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        ///     foreach (ContainerProperties properties in await feedIterator.ReadNextAsync())
+        ///     {
+        ///         Console.WriteLine(properties.Id);
+        ///     }
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator<T> GetContainerQueryIterator<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -514,6 +524,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// This create the stream feed iterator for containers with queryDefinition as input.
         /// <code language="c#">
@@ -521,10 +532,20 @@ namespace Microsoft.Azure.Cosmos
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// FeedIterator resultSet = this.cosmosDatabase.GetContainerQueryStreamIterator(queryDefinition);
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        ///     using (ResponseMessage response = await feedIterator.ReadNextAsync())
+        ///     {
+        ///         using (StreamReader sr = new StreamReader(response.Content))
+        ///         using (JsonTextReader jtr = new JsonTextReader(sr))
+        ///         {
+        ///             JObject result = JObject.Load(jtr);
+        ///         }
+        ///     }
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator GetContainerQueryStreamIterator(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -537,16 +558,34 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to go through the containers</returns>
         /// <example>
-        /// This create the type feed iterator for containers with queryText as input,
+        /// 1. This create the type feed iterator for containers with queryText as input,
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
         /// FeedIterator<ContainerProperties> resultSet = this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(queryText);
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        /// FeedResponse<ContainerProperties> iterator =
+        /// await feedIterator.ReadNextAsync(this.cancellationToken);
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <example>
+        /// 2. This create the type feed iterator for containers without queryText, retrieving all containers.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// FeedIterator<ContainerProperties> resultSet = this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>();
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        /// FeedResponse<ContainerProperties> iterator =
+        /// await feedIterator.ReadNextAsync(this.cancellationToken);
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
         public abstract FeedIterator<T> GetContainerQueryIterator<T>(
             string queryText = null,
             string continuationToken = null,
@@ -559,23 +598,41 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
-        /// <example>
-        /// This create the stream feed iterator for containers with queryText as input.
+                /// <returns>An iterator to go through the containers</returns>
+            /// <example>
+        /// 1. This create the stream feed iterator for containers with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
         /// FeedIterator resultSet = this.cosmosDatabase.GetContainerQueryStreamIterator(queryText);
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        /// ResponseMessage iterator =
+        /// await feedIterator.ReadNextAsync(this.cancellationToken);
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <example>
+        /// 2. This create the stream feed iterator for containers without queryText, retrieving all container.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// FeedIterator resultSet = this.cosmosDatabase.GetContainerQueryStreamIterator();
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        /// ResponseMessage iterator =
+        /// await feedIterator.ReadNextAsync(this.cancellationToken);
+        /// }
+        /// ]]>
+        /// </code>
+        /// </example>
         public abstract FeedIterator GetContainerQueryStreamIterator(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// Create an Azure Cosmos container through a Fluent API.
+        /// Creates a containerBuilder.
         /// </summary>
         /// <param name="name">Azure Cosmos container name to create.</param>
         /// <param name="partitionKeyPath">The path to the partition key. Example: /partitionKey</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -194,6 +194,16 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// //Reads a Database resource where
+        /// // - database_id is the ID property of the Database resource you wish to read.
+        /// Database database = this.cosmosClient.GetDatabase(database_id);
+        /// ResponseMessage response = await database.ReadContainerStreamAsync();
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
         /// </returns>
@@ -206,6 +216,16 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// //Delete a Database resource where
+        /// // - database_id is the ID property of the Database resource you wish to delete.
+        /// Database database = this.cosmosClient.GetDatabase(database_id);
+        /// await database.DeleteContainerStreamAsync();
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
         public abstract Task<ResponseMessage> DeleteStreamAsync(
                     RequestOptions requestOptions = null,
@@ -260,17 +280,18 @@ namespace Microsoft.Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerProperties containerProperties = new ContainerProperties() 
-        /// { 
+        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// {
         ///     Id = Guid.NewGuid().ToString(),
+        ///     PartitionKeyPath = "/pk",
         ///     IndexingPolicy = new IndexingPolicy()
         ///    {
         ///         Automatic = false,
         ///         IndexingMode = IndexingMode.Lazy,
         ///    };
         /// };
-        /// 
-        /// ContainerResponse response = this.cosmosDatabase.CreateContainerAsync(containerProperties);
+        ///
+        /// ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(containerProperties);
         /// ]]>
         /// </code>
         /// </example>
@@ -315,7 +336,7 @@ namespace Microsoft.Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerResponse response = this.cosmosDatabase.CreateContainerAsync(Guid.NewGuid().ToString());
+        /// ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk");
         /// ]]>
         /// </code>
         /// </example>
@@ -361,17 +382,18 @@ namespace Microsoft.Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerProperties containerProperties = new ContainerProperties() 
-        /// { 
+        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// {
         ///     Id = Guid.NewGuid().ToString(),
+        ///     PartitionKeyPath = "/pk",
         ///     IndexingPolicy = new IndexingPolicy()
         ///    {
         ///         Automatic = false,
         ///         IndexingMode = IndexingMode.Lazy,
         ///    };
         /// };
-        /// 
-        /// ContainerResponse response = this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerProperties);
+        ///
+        /// ContainerResponse response = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerProperties);
         /// ]]>
         /// </code>
         /// </example>
@@ -416,7 +438,7 @@ namespace Microsoft.Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerResponse response = this.cosmosDatabase.CreateContainerIfNotExistsAsync(Guid.NewGuid().ToString());
+        /// ContainerResponse response = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(Guid.NewGuid().ToString(), "/pk");
         /// ]]>
         /// </code>
         /// </example>
@@ -437,6 +459,20 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
+        /// <example>
+        /// Creates a container as an asynchronous operation in the Azure Cosmos service and return stream response.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// {
+        ///     Id = Guid.NewGuid().ToString(),
+        ///     PartitionKeyPath = "/pk",
+        /// };
+        ///
+        /// ResponseMessage response = await this.cosmosDatabase.CreateContainerStreamAsync(containerProperties);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the created resource record.</returns>
         /// <seealso cref="DefineContainer(string, string)"/>
         /// <remarks>
@@ -455,6 +491,16 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for containers with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// FeedIterator<ContainerProperties> resultSet = this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator<T> GetContainerQueryIterator<T>(
             QueryDefinition queryDefinition,
@@ -468,6 +514,16 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for containers with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// FeedIterator resultSet = this.cosmosDatabase.GetContainerQueryStreamIterator(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator GetContainerQueryStreamIterator(
             QueryDefinition queryDefinition,
@@ -481,6 +537,15 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for containers with queryText as input,
+        /// <code language="c#">
+        /// <![CDATA[
+        /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
+        /// FeedIterator<ContainerProperties> resultSet = this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator<T> GetContainerQueryIterator<T>(
             string queryText = null,
@@ -494,6 +559,15 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for containers with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
+        /// FeedIterator resultSet = this.cosmosDatabase.GetContainerQueryStreamIterator(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to go through the containers</returns>
         public abstract FeedIterator GetContainerQueryStreamIterator(
             string queryText = null,

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///        if (!isAccepted) throw new Error(""The query wasn't accepted by the server. Try again/use continuation token between API and script."");
         ///    }";
         ///    
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// StoredProcedureProperties storedProcedure = new StoredProcedureProperties(id, sprocBody);
         /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(storedProcedure);
         /// 
@@ -94,17 +94,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for sproc with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM s where s.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM s where s.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testSprocId");
         /// FeedIterator<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetStoredProcedureQueryIterator<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -117,17 +119,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for sproc with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM s where s.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM s where s.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testSprocId");
         /// FeedIterator iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetStoredProcedureQueryStreamIterator(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -140,17 +144,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for sproc with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
         /// FeedIterator<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryText);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetStoredProcedureQueryIterator<T>(
             string queryText = null,
             string continuationToken = null,
@@ -163,17 +167,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for sproc with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
         /// FeedIterator iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryText);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetStoredProcedureQueryStreamIterator(
             string queryText = null,
             string continuationToken = null,
@@ -206,7 +210,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///  This reads an existing stored procedure.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// StoredProcedureResponse storedProcedure = await scripts.ReadStoredProcedureAsync("ExistingId");
         /// ]]>
         /// </code>
@@ -251,7 +255,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///     getContext().getRequest().setBody(item);
         /// }";
         /// 
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// StoredProcedureResponse response = await scripts.ReplaceStoredProcedureAsync(new StoredProcedureProperties("testTriggerId", body));
         /// ]]>
         /// </code>
@@ -283,7 +287,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// This examples gets a reference to an existing stored procedure and deletes it.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// StoredProcedureResponse response = await scripts.DeleteStoredProcedureAsync("taxUdfId");
         /// ]]>
         /// </code>
@@ -328,7 +332,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///        if (!isAccepted) throw new Error(""The query wasn't accepted by the server. Try again/use continuation token between API and script."");
         ///    }";
         ///    
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string sprocId = "appendString";
         /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(
         ///         sprocId,
@@ -385,7 +389,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///        if (!isAccepted) throw new Error(""The query wasn't accepted by the server. Try again/use continuation token between API and script."");
         ///    }";
         ///    
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string sprocId = "appendString";
         /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(
         ///         sprocId,
@@ -445,7 +449,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///  This creates a trigger then uses the trigger in a create item.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// TriggerResponse triggerResponse = await scripts.CreateTriggerAsync(
         ///     new TriggerProperties
         ///     {
@@ -486,17 +490,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for Trigger with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM t where t.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM t where t.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testTriggerId");
         /// FeedIterator<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetTriggerQueryIterator<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -509,17 +515,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for Trigger with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM t where t.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM t where t.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testTriggerId");
         /// FeedIterator iter = this.scripts.GetTriggerQueryStreamIterator(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetTriggerQueryStreamIterator(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -532,17 +540,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for Trigger with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
         /// FeedIterator<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryText);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetTriggerQueryIterator<T>(
             string queryText = null,
             string continuationToken = null,
@@ -555,17 +563,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for Trigger with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
         /// FeedIterator iter = this.scripts.GetTriggerQueryStreamIterator(queryText);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetTriggerQueryStreamIterator(
             string queryText = null,
             string continuationToken = null,
@@ -594,7 +602,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///  This reads an existing trigger
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// TriggerResponse response = await scripts.ReadTriggerAsync("ExistingId");
         /// TriggerProperties triggerProperties = response;
         /// ]]>
@@ -635,7 +643,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///     TriggerType = TriggerType.Post
         /// };
         /// 
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// TriggerResponse response = await scripts.ReplaceTriggerAsync(triggerSettigs);
         /// ]]>
         /// </code>
@@ -656,7 +664,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// This examples gets a reference to an existing trigger and deletes it.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// TriggerResponse response = await scripts.DeleteTriggerAsync("existingId");
         /// ]]>
         /// </code>
@@ -698,7 +706,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///  This creates a user defined function then uses the function in an item query.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// await scripts.UserDefinedFunctions.CreateUserDefinedFunctionAsync(
         ///     new UserDefinedFunctionProperties 
         ///     { 
@@ -737,17 +745,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for UDF with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM u where u.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testUDFId");
         /// FeedIterator<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -760,17 +770,19 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for UDF with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
-        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// Scripts scripts = this.container.Scripts;
+        /// string queryText = "SELECT * FROM u where u.id like @testId";
+        /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
+        /// queryDefinition.WithParameter("@testId", "testUdfId");
         /// FeedIterator iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetUserDefinedFunctionQueryStreamIterator(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -783,17 +795,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for UDF with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
         /// FeedIterator<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
             string queryText = null,
             string continuationToken = null,
@@ -806,17 +818,17 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for UDF with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
         /// FeedIterator iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
         /// ]]>
         /// </code>
         /// </example>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetUserDefinedFunctionQueryStreamIterator(
             string queryText = null,
             string continuationToken = null,
@@ -848,7 +860,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///  This reads an existing user defined function.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// UserDefinedFunctionResponse response = await scripts.ReadUserDefinedFunctionAsync("ExistingId");
         /// UserDefinedFunctionProperties udfProperties = response;
         /// ]]>
@@ -872,7 +884,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// This examples replaces an existing user defined function.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// UserDefinedFunctionProperties udfProperties = new UserDefinedFunctionProperties
         /// {
         ///     Id = "testUserDefinedFunId",
@@ -900,7 +912,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// This examples gets a reference to an existing user defined function and deletes it.
         /// <code language="c#">
         /// <![CDATA[
-        /// Scripts scripts = this.container.GetScripts();
+        /// Scripts scripts = this.container.Scripts;
         /// UserDefinedFunctionResponse response = await this.container.DeleteUserDefinedFunctionAsync("existingId");
         /// ]]>
         /// </code>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///    
         /// Scripts scripts = this.container.GetScripts();
         /// StoredProcedureProperties storedProcedure = new StoredProcedureProperties(id, sprocBody);
-        /// CosmosStoredProcedure cosmosStoredProcedure = await scripts.CreateStoredProcedureAsync(storedProcedure);
+        /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(storedProcedure);
         /// 
         /// // Execute the stored procedure
         /// CosmosItemResponse<string> sprocResponse = await scripts.ExecuteStoredProcedureAsync<string, string>(
@@ -94,6 +94,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for sproc with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM s where s.id like '%testId%'");
+        /// FeedIterator<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetStoredProcedureQueryIterator<T>(
             QueryDefinition queryDefinition,
@@ -107,6 +117,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for sproc with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM s where s.id like '%testId%'");
+        /// FeedIterator iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetStoredProcedureQueryStreamIterator(
             QueryDefinition queryDefinition,
@@ -120,6 +140,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for sproc with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
+        /// FeedIterator<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetStoredProcedureQueryIterator<T>(
             string queryText = null,
@@ -133,6 +163,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for sproc with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
+        /// FeedIterator iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetStoredProcedureQueryStreamIterator(
             string queryText = null,
@@ -167,7 +207,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.GetScripts();
-        /// CosmosStoredProcedure storedProcedure = await scripts.ReadStoredProcedureAsync("ExistingId");
+        /// StoredProcedureResponse storedProcedure = await scripts.ReadStoredProcedureAsync("ExistingId");
         /// ]]>
         /// </code>
         /// </example>
@@ -212,7 +252,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// }";
         /// 
         /// Scripts scripts = this.container.GetScripts();
-        /// CosmosResponseMessage response = await scripts.ReplaceStoredProcedureAsync("testTriggerId", body);
+        /// StoredProcedureResponse response = await scripts.ReplaceStoredProcedureAsync(new StoredProcedureProperties("testTriggerId", body));
         /// ]]>
         /// </code>
         /// </example>
@@ -244,7 +284,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.GetScripts();
-        /// CosmosResponseMessage response = await scripts.DeleteStoredProcedureAsync("taxUdfId");
+        /// StoredProcedureResponse response = await scripts.DeleteStoredProcedureAsync("taxUdfId");
         /// ]]>
         /// </code>
         /// </example>
@@ -290,7 +330,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///    
         /// Scripts scripts = this.container.GetScripts();
         /// string sprocId = "appendString";
-        /// CosmosStoredProcedure cosmosStoredProcedure = await scripts.CreateStoredProcedureAsync(
+        /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(
         ///         sprocId,
         ///         sprocBody);
         /// 
@@ -347,12 +387,12 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///    
         /// Scripts scripts = this.container.GetScripts();
         /// string sprocId = "appendString";
-        /// CosmosStoredProcedure cosmosStoredProcedure = await scripts.CreateStoredProcedureAsync(
+        /// StoredProcedureResponse storedProcedureResponse = await scripts.CreateStoredProcedureAsync(
         ///         sprocId,
         ///         sprocBody);
         /// 
         /// // Execute the stored procedure
-        /// CosmosResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureStreamAsync(
+        /// ResponseMessage sprocResponse = await scripts.ExecuteStoredProcedureStreamAsync(
         ///                         sprocId,
         ///                         new PartitionKey(testPartitionId),
         ///                         new dynamic[] {"myPrefixString", "myPostfixString"});
@@ -406,7 +446,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.GetScripts();
-        /// CosmosTrigger cosmosTrigger = await scripts.CreateTriggerAsync(
+        /// TriggerResponse triggerResponse = await scripts.CreateTriggerAsync(
         ///     new TriggerProperties
         ///     {
         ///         Id = "addTax",
@@ -423,13 +463,13 @@ namespace Microsoft.Azure.Cosmos.Scripts
         ///         TriggerType = TriggerType.Pre
         ///     });
         ///
-        /// CosmosItemRequestOptions options = new CosmosItemRequestOptions()
+        /// ItemRequestOptions options = new ItemRequestOptions()
         /// {
-        ///     PreTriggers = new List<string>() { cosmosTrigger.Id },
+        ///     PreTriggers = new List<string>() { triggerResponse.Id },
         /// };
         ///
         /// // Create a new item with trigger set in the request options
-        /// CosmosItemResponse<dynamic> createdItem = await this.container.Items.CreateItemAsync<dynamic>(item.status, item, options);
+        /// ItemResponse<dynamic> createdItem = await this.container.Items.CreateItemAsync<dynamic>(item.status, item, options);
         /// double itemTax = createdItem.Resource.tax;
         /// ]]>
         /// </code>
@@ -446,6 +486,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for Trigger with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM t where t.id like '%testId%'");
+        /// FeedIterator<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetTriggerQueryIterator<T>(
             QueryDefinition queryDefinition,
@@ -459,6 +509,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for Trigger with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM t where t.id like '%testId%'");
+        /// FeedIterator iter = this.scripts.GetTriggerQueryStreamIterator(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetTriggerQueryStreamIterator(
             QueryDefinition queryDefinition,
@@ -472,6 +532,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for Trigger with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
+        /// FeedIterator<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetTriggerQueryIterator<T>(
             string queryText = null,
@@ -485,6 +555,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for Trigger with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
+        /// FeedIterator iter = this.scripts.GetTriggerQueryStreamIterator(queryText);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetTriggerQueryStreamIterator(
             string queryText = null,
@@ -657,6 +737,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for UDF with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// FeedIterator<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
             QueryDefinition queryDefinition,
@@ -670,6 +760,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for UDF with queryDefinition as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// FeedIterator iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetUserDefinedFunctionQueryStreamIterator(
             QueryDefinition queryDefinition,
@@ -683,6 +783,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the type feed iterator for UDF with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// FeedIterator<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
             string queryText = null,
@@ -696,6 +806,16 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <example>
+        /// This create the stream feed iterator for UDF with queryText as input.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// Scripts scripts = this.container.GetScripts();
+        /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
+        /// FeedIterator iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
+        /// ]]>
+        /// </code>
+        /// </example>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         public abstract FeedIterator GetUserDefinedFunctionQueryStreamIterator(
             string queryText = null,

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/UserDefinedFunctionProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/UserDefinedFunctionProperties.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
     ///
     /// while (feedIterator.HasMoreResults)
     /// {
-    ///     foreach (var tax in await feedIterator.FetchNextSetAsync())
+    ///     foreach (var tax in await feedIterator.ReadNextAsync())
     ///     {
     ///         Console.WriteLine(tax);
     ///     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
             }
 
-            using (ResponseMessage containerResponse = await this.cosmosDatabase.GetContainer(containerName).DeleteStreamAsync())
+            using (ResponseMessage containerResponse = await this.cosmosDatabase.GetContainer(containerName).DeleteContainerStreamAsync())
             {
                 Assert.AreEqual(HttpStatusCode.NoContent, containerResponse.StatusCode);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -91,11 +91,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             Container doesNotExistContainer = database.GetContainer(DoesNotExist);
-            this.VerifyNotFoundResponse(await doesNotExistContainer.ReadStreamAsync());
+            this.VerifyNotFoundResponse(await doesNotExistContainer.ReadContainerStreamAsync());
 
             ContainerProperties containerSettings = new ContainerProperties(id: DoesNotExist, partitionKeyPath: "/pk");
-            this.VerifyNotFoundResponse(await doesNotExistContainer.ReplaceStreamAsync(containerSettings));
-            this.VerifyNotFoundResponse(await doesNotExistContainer.DeleteStreamAsync());
+            this.VerifyNotFoundResponse(await doesNotExistContainer.ReplaceContainerStreamAsync(containerSettings));
+            this.VerifyNotFoundResponse(await doesNotExistContainer.DeleteContainerStreamAsync());
 
             // Validate Child resources
             await this.ItemOperations(doesNotExistContainer, true);


### PR DESCRIPTION
This PR will remain the stream APIs for container
From  - ReadStreamAsync,DeleteStreamAsync,ReplaceStreamAsync 
To  - ReadContainerStreamAsync,DeleteConatinerStreamAsync,ReplaceContainerStreamAsync 

Also it will fix the gap between actual APIs and example implementation in documentation on all the resources through out the code and add missing examples.

