### PR TITLE
Moving offer operations to new V3 pipeline

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -97,7 +97,6 @@ namespace Microsoft.Azure.Cosmos
     public class CosmosClient : IDisposable
     {
         private readonly Uri DatabaseRootUri = new Uri(Paths.Databases_Root, UriKind.Relative);
-        private Lazy<CosmosOffers> offerSet;
         private ConsistencyLevel? accountConsistencyLevel;
 
         static CosmosClient()
@@ -290,7 +289,6 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         internal string AccountKey { get; }
 
-        internal CosmosOffers Offers => this.offerSet.Value;
         internal DocumentClient DocumentClient { get; set; }
         internal RequestInvokerHandler RequestHandler { get; private set; }
         internal CosmosResponseFactory ResponseFactory { get; private set; }
@@ -614,8 +612,6 @@ namespace Microsoft.Azure.Cosmos
                 requestHandler: this.RequestHandler,
                 documentClient: this.DocumentClient,
                 documentQueryClient: new DocumentQueryClient(this.DocumentClient));
-
-            this.offerSet = new Lazy<CosmosOffers>(() => new CosmosOffers(this.ClientContext), LazyThreadSafetyMode.PublicationOnly);
         }
 
         internal async virtual Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -289,7 +289,6 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         internal string AccountKey { get; }
 
-        internal CosmosOffers Offers { get; private set; }
         internal DocumentClient DocumentClient { get; set; }
         internal RequestInvokerHandler RequestHandler { get; private set; }
         internal CosmosResponseFactory ResponseFactory { get; private set; }
@@ -613,8 +612,6 @@ namespace Microsoft.Azure.Cosmos
                 requestHandler: this.RequestHandler,
                 documentClient: this.DocumentClient,
                 documentQueryClient: new DocumentQueryClient(this.DocumentClient));
-
-            this.Offers = new CosmosOffers(this.ClientContext);
         }
 
         internal async virtual Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -289,6 +289,7 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         internal string AccountKey { get; }
 
+        internal CosmosOffers Offers { get; private set; }
         internal DocumentClient DocumentClient { get; set; }
         internal RequestInvokerHandler RequestHandler { get; private set; }
         internal CosmosResponseFactory ResponseFactory { get; private set; }
@@ -612,6 +613,8 @@ namespace Microsoft.Azure.Cosmos
                 requestHandler: this.RequestHandler,
                 documentClient: this.DocumentClient,
                 documentQueryClient: new DocumentQueryClient(this.DocumentClient));
+
+            this.Offers = new CosmosOffers(this.ClientContext);
         }
 
         internal async virtual Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Azure.Cosmos
                 documentClient: this.DocumentClient,
                 documentQueryClient: new DocumentQueryClient(this.DocumentClient));
 
-            this.offerSet = new Lazy<CosmosOffers>(() => new CosmosOffers(this.DocumentClient), LazyThreadSafetyMode.PublicationOnly);
+            this.offerSet = new Lazy<CosmosOffers>(() => new CosmosOffers(this.ClientContext), LazyThreadSafetyMode.PublicationOnly);
         }
 
         internal async virtual Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()

--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
             {
                 return ex.ToCosmosResponseMessage(request);
             }
+            catch (CosmosException ex)
+            {
+                return ex.ToCosmosResponseMessage(request);
+            }
             catch (AggregateException ex)
             {
                 // TODO: because the SDK underneath this path uses ContinueWith or task.Result we need to catch AggregateExceptions here

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -150,6 +150,12 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 SetOriginalContinuationToken(request, errorResponse, originalContinuation);
                 return errorResponse;
             }
+            catch (CosmosException ex)
+            {
+                ResponseMessage errorResponse = ex.ToCosmosResponseMessage(request);
+                SetOriginalContinuationToken(request, errorResponse, originalContinuation);
+                return errorResponse;
+            }
             catch (AggregateException ex)
             {
                 SetOriginalContinuationToken(request, response, originalContinuation);

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -151,6 +151,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
                     {
                         return dce.ToCosmosResponseMessage(request);
                     }
+                    catch (CosmosException ce)
+                    {
+                        return ce.ToCosmosResponseMessage(request);
+                    }
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
@@ -43,6 +43,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
             {
                 return ex.ToCosmosResponseMessage(request);
             }
+            catch (CosmosException ce)
+            {
+                return ce.ToCosmosResponseMessage(request);
+            }
             catch (AggregateException ex)
             {
                 // TODO: because the SDK underneath this path uses ContinueWith or task.Result we need to catch AggregateExceptions here
@@ -100,12 +104,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             CosmosException cosmosException = exception as CosmosException;
             if (cosmosException != null)
             {
-                return new ResponseMessage(
-                    headers: cosmosException.Headers,
-                    requestMessage: request,
-                    errorMessage: cosmosException.Message,
-                    statusCode: cosmosException.StatusCode,
-                    error: cosmosException.Error);
+                return cosmosException.ToCosmosResponseMessage(request);
             }
 
             return null;

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -125,12 +125,7 @@ namespace Microsoft.Azure.Cosmos.Query
             }
             catch (CosmosException exception)
             {
-                return new ResponseMessage(
-                    headers: exception.Headers,
-                    requestMessage: null,
-                    errorMessage: exception.Message,
-                    statusCode: exception.StatusCode,
-                    error: exception.Error);
+                return exception.ToCosmosResponseMessage(request: null);
             }
             catch (AggregateException ae)
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Cosmos
             }
             catch (DocumentClientException ex)
             {
-                throw new CosmosException(ex.StatusCode.Value, ex.Message, ex.Error);
+                throw new CosmosException(ex.ToCosmosResponseMessage(null), ex.Message, ex.Error);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -184,10 +184,10 @@ namespace Microsoft.Azure.Cosmos
         }
 
         // Name based look-up, needs re-computation and can't be cached
-        internal Task<string> GetRIDAsync(CancellationToken cancellationToken)
+        internal async Task<string> GetRIDAsync(CancellationToken cancellationToken)
         {
-            return this.GetCachedContainerPropertiesAsync(cancellationToken)
-                            .ContinueWith(containerPropertiesTask => containerPropertiesTask.Result?.ResourceId, cancellationToken);
+            ContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
+            return containerProperties?.ResourceId;
         }
 
         internal Task<PartitionKeyDefinition> GetPartitionKeyDefinitionAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -112,7 +112,8 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             string rid = await this.GetRIDAsync(cancellationToken);
-            return await this.ClientContext.Client.Offers.ReadThroughputAsync(rid, requestOptions, cancellationToken);
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.ReadThroughputAsync(rid, requestOptions, cancellationToken);
         }
 
         public async override Task<ThroughputResponse> ReplaceThroughputAsync(
@@ -122,7 +123,8 @@ namespace Microsoft.Azure.Cosmos
         {
             string rid = await this.GetRIDAsync(cancellationToken);
 
-            return await this.ClientContext.Client.Offers.ReplaceThroughputAsync(
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.ReplaceThroughputAsync(
                 targetRID: rid,
                 throughput: throughput,
                 requestOptions: requestOptions,

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.IO;
     using System.Net;
-    using Microsoft.Azure.Cosmos.Internal;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -27,7 +26,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         internal CosmosException(
-            ResponseMessage cosmosResponseMessage, 
+            ResponseMessage cosmosResponseMessage,
             string message,
             Error error = null)
             : base(message)
@@ -103,7 +102,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The request charge measured in request units.
         /// </value>
-        public virtual double RequestCharge { get; } 
+        public virtual double RequestCharge { get; }
 
         /// <summary>
         /// Gets the activity ID for the request from the Azure Cosmos DB service.
@@ -152,6 +151,16 @@ namespace Microsoft.Azure.Cosmos
         public override string ToString()
         {
             return $"CosmosRequestException;StatusCode={this.StatusCode};SubStatusCode={this.SubStatusCode};ActivityId={this.ActivityId ?? string.Empty};RequestCharge={this.RequestCharge};Message={this.Message};";
+        }
+
+        internal ResponseMessage ToCosmosResponseMessage(RequestMessage request)
+        {
+            return new ResponseMessage(
+                 headers: this.Headers,
+                 requestMessage: request,
+                 errorMessage: this.Message,
+                 statusCode: this.StatusCode,
+                 error: this.Error);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -360,14 +360,10 @@ namespace Microsoft.Azure.Cosmos
                cancellationToken: cancellationToken);
         }
 
-        internal virtual Task<string> GetRIDAsync(CancellationToken cancellationToken = default(CancellationToken))
+        internal virtual async Task<string> GetRIDAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.ReadAsync(cancellationToken: cancellationToken)
-                .ContinueWith(task =>
-                {
-                    DatabaseResponse response = task.Result;
-                    return response.Resource.ResourceId;
-                }, cancellationToken);
+            DatabaseResponse databaseResponse = await this.ReadAsync(cancellationToken: cancellationToken);
+            return databaseResponse?.Resource?.ResourceId;
         }
 
         private Task<ResponseMessage> CreateContainerStreamInternalAsync(

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.Cosmos
                 parentLink: null,
                 uriPathSegment: Paths.DatabasesPathSegment,
                 id: databaseId);
-            this.Offers = new CosmosOffers(this.ClientContext);
         }
 
         public override string Id { get; }
@@ -45,8 +44,6 @@ namespace Microsoft.Azure.Cosmos
         internal virtual Uri LinkUri { get; }
 
         internal CosmosClientContext ClientContext { get; }
-
-        internal CosmosOffers Offers { get; private set; }
 
         public override Task<DatabaseResponse> ReadAsync(
                     RequestOptions requestOptions = null,
@@ -82,7 +79,7 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             string rid = await this.GetRIDAsync(cancellationToken);
-            return await this.Offers.ReadThroughputAsync(
+            return await this.ClientContext.Client.Offers.ReadThroughputAsync(
                 targetRID: rid,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
@@ -95,7 +92,7 @@ namespace Microsoft.Azure.Cosmos
         {
             string rid = await this.GetRIDAsync(cancellationToken);
 
-            return await this.Offers.ReplaceThroughputAsync(
+            return await this.ClientContext.Client.Offers.ReplaceThroughputAsync(
                 targetRID: rid,
                 throughput: throughput,
                 requestOptions: requestOptions,

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             string rid = await this.GetRIDAsync(cancellationToken);
-            return await this.ClientContext.Client.Offers.ReadThroughputAsync(
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.ReadThroughputAsync(
                 targetRID: rid,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
@@ -91,8 +92,8 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             string rid = await this.GetRIDAsync(cancellationToken);
-
-            return await this.ClientContext.Client.Offers.ReplaceThroughputAsync(
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.ReplaceThroughputAsync(
                 targetRID: rid,
                 throughput: throughput,
                 requestOptions: requestOptions,

--- a/Microsoft.Azure.Cosmos/src/Resource/Offer/CosmosOffers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Offer/CosmosOffers.cs
@@ -87,17 +87,30 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            FeedIterator databaseStreamIterator = new FeedIteratorCore(
+            FeedIterator databaseStreamIterator = GetOfferQueryStreamIterator(
+               queryDefinition,
+               continuationToken,
+               requestOptions,
+               cancellationToken);
+
+            return new FeedIteratorCore<T>(
+                databaseStreamIterator,
+                this.ClientContext.ResponseFactory.CreateQueryFeedResponse<T>);
+        }
+
+        internal virtual FeedIterator GetOfferQueryStreamIterator(
+            QueryDefinition queryDefinition,
+            string continuationToken = null,
+            QueryRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return new FeedIteratorCore(
                this.ClientContext,
                this.OfferRootUri,
                ResourceType.Offer,
                queryDefinition,
                continuationToken,
                requestOptions);
-
-            return new FeedIteratorCore<T>(
-                databaseStreamIterator,
-                this.ClientContext.ResponseFactory.CreateQueryFeedResponse<T>);
         }
 
         private CosmosOfferResult GetThroughputIfExists(Offer offer)

--- a/Microsoft.Azure.Cosmos/src/Resource/Offer/CosmosOffers.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Offer/CosmosOffers.cs
@@ -30,15 +30,13 @@ namespace Microsoft.Azure.Cosmos
         {
             OfferV2 offerV2 = await this.GetOfferV2Async(targetRID, cancellationToken);
 
-            Task<ResponseMessage> response = this.ProcessResourceOperationStreamAsync(
+            return await this.GetThroughputResponseAsync(
                 streamPayload: null,
                 operationType: OperationType.Read,
                 linkUri: new Uri(offerV2.SelfLink, UriKind.Relative),
                 resourceType: ResourceType.Offer,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
-
-            return await this.ClientContext.ResponseFactory.CreateThroughputResponseAsync(response);
         }
 
         internal async Task<ThroughputResponse> ReplaceThroughputAsync(
@@ -50,15 +48,13 @@ namespace Microsoft.Azure.Cosmos
             OfferV2 offerV2 = await this.GetOfferV2Async(targetRID, cancellationToken);
             OfferV2 newOffer = new OfferV2(offerV2, throughput);
 
-            Task<ResponseMessage> response = this.ProcessResourceOperationStreamAsync(
+            return await this.GetThroughputResponseAsync(
                 streamPayload: this.ClientContext.PropertiesSerializer.ToStream(newOffer),
                 operationType: OperationType.Replace,
                 linkUri: new Uri(offerV2.SelfLink, UriKind.Relative),
                 resourceType: ResourceType.Offer,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
-
-            return await this.ClientContext.ResponseFactory.CreateThroughputResponseAsync(response);
         }
 
         internal async Task<OfferV2> GetOfferV2Async(
@@ -136,7 +132,7 @@ namespace Microsoft.Azure.Cosmos
             return default(T);
         }
 
-        private Task<ResponseMessage> ProcessResourceOperationStreamAsync(
+        private async Task<ThroughputResponse> GetThroughputResponseAsync(
            Stream streamPayload,
            OperationType operationType,
            Uri linkUri,
@@ -144,7 +140,7 @@ namespace Microsoft.Azure.Cosmos
            RequestOptions requestOptions = null,
            CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.ClientContext.ProcessResourceOperationStreamAsync(
+            Task<ResponseMessage> responseMessage = this.ClientContext.ProcessResourceOperationStreamAsync(
               resourceUri: linkUri,
               resourceType: resourceType,
               operationType: operationType,
@@ -154,6 +150,7 @@ namespace Microsoft.Azure.Cosmos
               requestOptions: requestOptions,
               requestEnricher: null,
               cancellationToken: cancellationToken);
+            return await this.ClientContext.ResponseFactory.CreateThroughputResponseAsync(responseMessage);
         }
 
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 await container.ReadThroughputAsync();
                 Assert.Fail("It should throw Resource Not Found exception");
             }
-            catch (DocumentClientException ex)
+            catch (CosmosException ex)
             {
                 Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         .ReadThroughputAsync(new RequestOptions());
                 Assert.Fail("It should throw Resource Not Found exception");
             }
-            catch (DocumentClientException ex)
+            catch (CosmosException ex)
             {
                 Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
             Container container = this.cosmosDatabase.GetContainer(containerName);
 
-            int? readThroughput = await ((ContainerCore)container).ReadProvisionedThroughputAsync();
+            int? readThroughput = await container.ReadThroughputAsync();
             Assert.IsNotNull(readThroughput);
 
             containerResponse = await container.DeleteContainerAsync();
@@ -432,11 +432,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
             Container container = this.cosmosDatabase.GetContainer(containerName);
 
-            int? readThroughput = await ((ContainerCore)container).ReadProvisionedThroughputAsync();
+            int? readThroughput = await container.ReadThroughputAsync();
             Assert.IsNotNull(readThroughput);
 
-            await ((ContainerCore)container).ReplaceProvisionedThroughputAsync(readThroughput.Value + 1000);
-            int? replaceThroughput = await ((ContainerCore)container).ReadProvisionedThroughputAsync();
+            await container.ReplaceThroughputAsync(readThroughput.Value + 1000);
+            int? replaceThroughput = await ((ContainerCore)container).ReadThroughputAsync();
             Assert.IsNotNull(replaceThroughput);
             Assert.AreEqual(readThroughput.Value + 1000, replaceThroughput);
 
@@ -487,7 +487,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             Container container = this.cosmosDatabase.GetContainer(containerName);
 
-            await ((ContainerCore)container).ReadProvisionedThroughputAsync();
+            await ((ContainerCore)container).ReadThroughputAsync();
 
             ContainerResponse containerResponse = await container.DeleteContainerAsync();
             Assert.AreEqual(HttpStatusCode.NotFound, containerResponse.StatusCode);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -471,9 +471,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         .ReadThroughputAsync(new RequestOptions());
                 Assert.Fail("It should throw Resource Not Found exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException ex)
             {
-                Assert.IsTrue(ex.InnerException.Message.Contains("Resource Not Found"));
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
             }
 
             containerResponse = await container.DeleteContainerAsync();
@@ -481,16 +481,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AggregateException))]
         public async Task ThroughputNonExistingTest()
         {
             string containerName = Guid.NewGuid().ToString();
             Container container = this.cosmosDatabase.GetContainer(containerName);
 
-            await ((ContainerCore)container).ReadThroughputAsync();
-
-            ContainerResponse containerResponse = await container.DeleteContainerAsync();
-            Assert.AreEqual(HttpStatusCode.NotFound, containerResponse.StatusCode);
+            try
+            {
+                await container.ReadThroughputAsync();
+                Assert.Fail("It should throw Resource Not Found exception");
+            }
+            catch (DocumentClientException ex)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -211,8 +211,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
 
             Cosmos.Database cosmosDatabase = createResponse;
-            int? readThroughput = await ((DatabaseCore)cosmosDatabase).ReadProvisionedThroughputAsync();
-            Assert.IsNull(readThroughput);
+            try
+            {
+                int? readThroughput = await ((DatabaseCore)cosmosDatabase).ReadThroughputAsync();
+                Assert.Fail("Should through not found exception as throughput is not configured");
+            }
+            catch (CosmosException exception)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
+            }
 
             await cosmosDatabase.DeleteAsync();
         }
@@ -226,7 +233,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
 
             Cosmos.Database cosmosDatabase = createResponse;
-            int? readThroughput = await ((DatabaseCore)cosmosDatabase).ReadProvisionedThroughputAsync();
+            int? readThroughput = await cosmosDatabase.ReadThroughputAsync();
             Assert.AreEqual(throughput, readThroughput);
 
             string containerId = Guid.NewGuid().ToString();
@@ -235,8 +242,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
 
             Container container = containerResponse;
-            readThroughput = await ((ContainerCore)container).ReadProvisionedThroughputAsync();
-            Assert.IsNull(readThroughput);
+            try
+            {
+                readThroughput = await ((ContainerCore)container).ReadThroughputAsync();
+                Assert.Fail("Should through not found exception as throughput is not configured");
+            } catch (CosmosException exception)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
+            }
 
             await container.DeleteContainerAsync();
             await cosmosDatabase.DeleteAsync();
@@ -278,8 +291,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(readThroughputResponse.Resource.Throughput.Value + 1000, replaceThroughputResponse.Resource.Throughput.Value);
 
             Container container = containerResponse;
-            readThroughputResponse = await container.ReadThroughputAsync(new RequestOptions());
-            Assert.IsNull(readThroughputResponse.Resource);
+            try
+            {
+                readThroughputResponse = await container.ReadThroughputAsync(new RequestOptions());
+                Assert.Fail("Should through not found exception as throughput is not configured");
+            }
+            catch (CosmosException exception)
+            {
+                Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
+            }
 
             await container.DeleteContainerAsync();
             await cosmosDatabase.DeleteAsync();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await testContainer.GetNonePartitionKeyValueAsync();
                     Assert.Fail();
                 }
-                catch (DocumentClientException dce) when (dce.StatusCode == HttpStatusCode.NotFound)
+                catch (CosmosException dce) when (dce.StatusCode == HttpStatusCode.NotFound)
                 {
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
             Container container = this.database.GetContainer(containerName);
 
-            int? readThroughput = await ((ContainerCore)container).ReadProvisionedThroughputAsync();
+            int? readThroughput = await container.ReadThroughputAsync();
             Assert.IsNotNull(readThroughput);
             Assert.AreEqual(expectedThroughput, readThroughput);
 


### PR DESCRIPTION
This PR will move the offer operations to use new V3 pipeline for point to point and query from older documentClient.
Also it will move the read and replace throughput api code from database and container core class to common place at CosmosOffer class.

## Closing issues
Closes #450


