### PR TITLE
Porting Fix query split bug loses continuation token (#531) to releases\3.0.0

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/ItemProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ParallelQuery/ItemProducer.cs
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
                 this.fetchSchedulingMetrics.Stop();
                 this.hasStartedFetching = true;
-                this.BackendContinuationToken = feedResponse.Headers.ContinuationToken;
+                
                 this.ActivityId = Guid.Parse(feedResponse.Headers.ActivityId);
                 await this.bufferedPages.AddAsync(feedResponse);
                 if (!feedResponse.IsSuccessStatusCode)
@@ -329,6 +329,10 @@ namespace Microsoft.Azure.Cosmos.Query
                     this.hitException = true;
                     return;
                 }
+
+                // The backend continuation token is used for the children on splits 
+                // and should not be updated on exceptions
+                this.BackendContinuationToken = feedResponse.Headers.ContinuationToken;
 
                 Interlocked.Add(ref this.bufferedItemCount, feedResponse.Count);
                 QueryMetrics queryMetrics = QueryMetrics.Zero;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockItemProducerFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockItemProducerFactory.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
     internal static class MockItemProducerFactory
     {
-        public const string DefaultCollectionRid = "MockDefaultCollectionRid";
+        public static readonly string DefaultDatabaseRid = MockQueryFactory.DefaultDatabaseRid;
+        public static readonly string DefaultCollectionRid = MockQueryFactory.DefaultCollectionRid;
         public static readonly IReadOnlyList<int> Dataset = Enumerable.Range(1, 1000).ToList();
         public static readonly SqlQuerySpec DefaultQuerySpec = new SqlQuerySpec("SELECT * FROM C ");
         public static readonly PartitionKeyRange DefaultPartitionKeyRange = new PartitionKeyRange() { MinInclusive = "A", MaxExclusive = "B", Id = "0" };
@@ -113,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             string continuationToken = null,
             int maxPageSize = 50,
             bool deferFirstPage = true,
-            string collectionRid = DefaultCollectionRid,
+            string collectionRid = null,
             IComparer<ItemProducerTree> itemProducerTreeComparer = null,
             ItemProducerTree.ProduceAsyncCompleteDelegate completeDelegate = null,
             TimeSpan? responseDelay = null,
@@ -213,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     newContinuationToken = Guid.NewGuid().ToString();
                 }
 
-                (QueryResponse response, ReadOnlyCollection<ToDoItem> items) queryResponse = QueryResponseMessageFactory.Create(
+                (QueryResponse response, IList<ToDoItem> items) queryResponse = QueryResponseMessageFactory.Create(
                     itemIdPrefix: $"page{i}-pk{partitionKeyRange.Id}-",
                     continuationToken: newContinuationToken,
                     collectionRid: collectionRid,
@@ -242,7 +243,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                             }
                         })
                         .Returns(Task.FromResult(queryResponse.response));
-                previousContinuationToken = newContinuationToken;
+
+
+                if (responseMessagesPageSize[i] != QueryResponseMessageFactory.SPLIT)
+                {
+                    previousContinuationToken = newContinuationToken;
+                }
             }
 
             return allItems;
@@ -272,7 +278,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     newContinuationToken = Guid.NewGuid().ToString();
                 }
 
-                (QueryResponse response, ReadOnlyCollection<ToDoItem> items) queryResponse = QueryResponseMessageFactory.Create(
+                (QueryResponse response, IList<ToDoItem> items) queryResponse = QueryResponseMessageFactory.Create(
                     itemIdPrefix: $"page{i}-pk{partitionKeyRange.Id}-",
                     continuationToken: newContinuationToken,
                     collectionRid: collectionRid,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryFactory.cs
@@ -1,0 +1,552 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
+    using Moq;
+
+    internal static class MockQueryFactory
+    {
+        public static readonly string DefaultDatabaseRid = ResourceId.NewDatabaseId(3810641).ToString();
+        public static readonly string DefaultCollectionRid = ResourceId.NewDocumentCollectionId(DefaultDatabaseRid, 1376573569).ToString();
+        public static readonly SqlQuerySpec DefaultQuerySpec = new SqlQuerySpec("SELECT * FROM C ");
+        public static readonly CancellationToken DefaultCancellationToken = new CancellationTokenSource().Token;
+        public static readonly Uri DefaultResourceLink = new Uri("dbs/MockDb/colls/MockQueryFactoryDefault", UriKind.Relative);
+        public static readonly PartitionKeyRange DefaultPartitionKeyRange = new PartitionKeyRange() { MinInclusive = "00", MaxExclusive = "FF", Id = "0" };
+        public static readonly PartitionKeyRange DefaultPartitionKeyRange1AfterSplit = new PartitionKeyRange() { MinInclusive = "00", MaxExclusive = "B", Id = "1" };
+        public static readonly PartitionKeyRange DefaultPartitionKeyRange2AfterSplit = new PartitionKeyRange() { MinInclusive = "B", MaxExclusive = "FF", Id = "2" };
+        public static readonly IReadOnlyList<PartitionKeyRange> DefaultPartitionKeyRangesAfterSplit = new List<PartitionKeyRange>()
+        {
+            DefaultPartitionKeyRange1AfterSplit,
+            DefaultPartitionKeyRange2AfterSplit,
+        }.AsReadOnly();
+
+        public static IList<ToDoItem> GenerateAndMockResponse(
+            Mock<CosmosQueryClient> mockQueryClient,
+            SqlQuerySpec sqlQuerySpec,
+            string containerRid,
+            string initContinuationToken,
+            int maxPageSize,
+            MockResponseForSinglePartition[] mockResponseForSinglePartition,
+            CancellationToken cancellationToken)
+        {
+            if (mockResponseForSinglePartition == null)
+            {
+                throw new ArgumentNullException(nameof(mockResponseForSinglePartition));
+            }
+
+            // Setup the routing map in case there is a split and the ranges need to be updated
+            Mock<IRoutingMapProvider> mockRoutingMap = new Mock<IRoutingMapProvider>();
+            mockQueryClient.Setup(x => x.GetRoutingMapProviderAsync()).Returns(Task.FromResult(mockRoutingMap.Object));
+
+            // Get the total item count
+            int totalItemCount = 0;
+            foreach (MockResponseForSinglePartition response in mockResponseForSinglePartition)
+            {
+                foreach(var message in response.Messages)
+                {
+                    int? currentItemCount = message.ItemsIndexPosition?.Length;
+                    totalItemCount += currentItemCount ?? 0;
+                }
+            }
+
+            // Create all the items and order by id
+            IList<ToDoItem> allItemsOrdered = ToDoItem.CreateItems(
+                totalItemCount,
+                "MockQueryFactory",
+                containerRid).OrderBy(item => item.id).ToList();
+
+            // Loop through all the partitions
+            foreach (MockResponseForSinglePartition partitionAndMessages in mockResponseForSinglePartition)
+            {
+                PartitionKeyRange partitionKeyRange = partitionAndMessages.PartitionKeyRange;
+
+                string previousContinuationToken = partitionAndMessages.StartingContinuationToken;
+
+                // Loop through each message inside the partition
+                MockResponseMessages[] messages = partitionAndMessages.Messages;
+                for (int i = 0; i < messages.Length; i++)
+                {
+                    MockResponseMessages message = partitionAndMessages.Messages[i];
+                    QueryResponse queryResponse = null;
+                    string newContinuationToken = null;
+
+                    if (message.UpdatedRangesAfterSplit != null)
+                    {
+                        queryResponse = QueryResponseMessageFactory.CreateSplitResponse(containerRid);
+                        mockRoutingMap.Setup(x =>
+                            x.TryGetOverlappingRangesAsync(
+                                containerRid,
+                                It.Is<Documents.Routing.Range<string>>(inputRange => inputRange.Equals(partitionKeyRange.ToRange())),
+                                true)).Returns(Task.FromResult(message.UpdatedRangesAfterSplit));
+                    }
+                    else
+                    { 
+                        List<ToDoItem> currentPageItems = new List<ToDoItem>();
+                        // Null represents an empty page
+                        if(message.ItemsIndexPosition != null)
+                        {
+                            foreach (int itemPosition in message.ItemsIndexPosition)
+                            {
+                                currentPageItems.Add(allItemsOrdered[itemPosition]);
+                            }
+                        }
+
+                        // Last message should have null continuation token
+                        if (i + 1 != messages.Length)
+                        {
+                            newContinuationToken = Guid.NewGuid().ToString();
+                        }
+
+                        queryResponse = QueryResponseMessageFactory.CreateQueryResponse(
+                            currentPageItems,
+                            newContinuationToken,
+                            containerRid);
+                    }
+
+                    mockQueryClient.Setup(x =>
+                      x.ExecuteItemQueryAsync(
+                          It.IsAny<Uri>(),
+                          ResourceType.Document,
+                          OperationType.Query,
+                          containerRid,
+                          It.IsAny<QueryRequestOptions>(),
+                          It.Is<SqlQuerySpec>(specInput => MockItemProducerFactory.IsSqlQuerySpecEqual(sqlQuerySpec, specInput)),
+                          previousContinuationToken,
+                          It.Is<PartitionKeyRangeIdentity>(rangeId => string.Equals(rangeId.PartitionKeyRangeId, partitionKeyRange.Id) && string.Equals(rangeId.CollectionRid, containerRid)),
+                          It.IsAny<bool>(),
+                          maxPageSize,
+                          cancellationToken))
+                          .Callback(() =>
+                          {
+                              if (message.DelayResponse.HasValue)
+                              {
+                                  Thread.Sleep(message.DelayResponse.Value);
+                              }
+                          })
+                          .Returns(Task.FromResult(queryResponse));
+
+                    previousContinuationToken = newContinuationToken;
+                }
+            }
+
+            return allItemsOrdered;
+        }
+
+        public static CosmosQueryContext CreateContext(
+            CosmosQueryClient cosmosQueryClient)
+        {
+            return new CosmosQueryContext(
+                client: cosmosQueryClient,
+                resourceTypeEnum: ResourceType.Document,
+                operationType: OperationType.Query,
+                resourceType: typeof(ToDoItem),
+                sqlQuerySpecFromUser: DefaultQuerySpec,
+                queryRequestOptions: new QueryRequestOptions(),
+                resourceLink: DefaultResourceLink,
+                correlatedActivityId: Guid.NewGuid(),
+                isContinuationExpected: true,
+                allowNonValueAggregateQuery: true,
+                containerResourceId: DefaultCollectionRid);
+        }
+
+        public static List<MockResponseForSinglePartition[]> GetSplitScenarios(string initialContinuationToken)
+        {
+            List<MockResponseForSinglePartition[]> allSplitScenario = new List<MockResponseForSinglePartition[]>();
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(1)
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0),
+                        new MockResponseMessages(2)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(1),
+                        new MockResponseMessages(3)
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0),
+                        new MockResponseMessages(1),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(0),
+                        new MockResponseMessages(1),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                        new MockResponseMessages(0),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(1),
+                        new MockResponseMessages(2),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                        new MockResponseMessages(0),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                        new MockResponseMessages(1),
+                    }
+                }
+            });
+
+            allSplitScenario.Add(new MockResponseForSinglePartition[]{
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(DefaultPartitionKeyRangesAfterSplit)
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange1AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                        new MockResponseMessages(),
+                        new MockResponseMessages(0),
+                        new MockResponseMessages(2),
+                    }
+                },
+                new MockResponseForSinglePartition()
+                {
+                    PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange2AfterSplit,
+                    StartingContinuationToken = initialContinuationToken,
+                    Messages = new MockResponseMessages[]
+                    {
+                        new MockResponseMessages(),
+                        new MockResponseMessages(1),
+                    }
+                }
+            });
+
+            return allSplitScenario;
+        }
+
+        public static MockResponseForSinglePartition GetDefaultMockResponseForSinglePartition(string initialContinuationToken, params MockResponseMessages[] messages)
+        {
+            return new MockResponseForSinglePartition()
+            {
+                PartitionKeyRange = MockQueryFactory.DefaultPartitionKeyRange,
+                StartingContinuationToken = initialContinuationToken,
+                Messages = messages
+            };
+        }
+
+        public static MockResponseForSinglePartition[] GetAllCombinationWithEmptyPage(string initialContinuationToken = null)
+        {
+            return new MockResponseForSinglePartition[]
+            {
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages()),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(),
+                    new MockResponseMessages(0)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0),
+                    new MockResponseMessages()),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0),
+                    new MockResponseMessages(1)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                     new MockResponseMessages(0),
+                    new MockResponseMessages(),
+                    new MockResponseMessages()),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(),
+                    new MockResponseMessages(0),
+                    new MockResponseMessages()),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(),
+                    new MockResponseMessages(),
+                    new MockResponseMessages(0)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0),
+                    new MockResponseMessages(1),
+                    new MockResponseMessages()),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0),
+                    new MockResponseMessages(),
+                    new MockResponseMessages(1)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(),
+                    new MockResponseMessages(0),
+                    new MockResponseMessages(1)),
+                GetDefaultMockResponseForSinglePartition(
+                    initialContinuationToken,
+                    new MockResponseMessages(0),
+                    new MockResponseMessages(1),
+                    new MockResponseMessages(2))
+            };
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockResponseForSinglePartition.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockResponseForSinglePartition.cs
@@ -1,0 +1,49 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Documents;
+
+    /// <summary>
+    /// This represent a single partition and the list of messages
+    /// the partition should receive
+    /// </summary>
+    internal class MockResponseForSinglePartition
+    {
+        public PartitionKeyRange PartitionKeyRange { get; set; }
+
+        public string StartingContinuationToken { get; set; }
+
+        public MockResponseMessages[] Messages { get; set; }
+    }
+
+    /// <summary>
+    /// This represent a single query response message. 
+    /// 1. Response message contains a list of items
+    /// 2. Response message is a split failure
+    /// </summary>
+    internal class MockResponseMessages
+    {
+        public MockResponseMessages(params int[] itemsIndexPosition)
+        {
+            this.ItemsIndexPosition = itemsIndexPosition;
+            this.DelayResponse = null;
+        }
+
+        public MockResponseMessages(IReadOnlyList<PartitionKeyRange> updatedRangesAfterSplit)
+        {
+            this.UpdatedRangesAfterSplit = updatedRangesAfterSplit;
+            this.DelayResponse = null;
+        }
+
+        public TimeSpan? DelayResponse { get; }
+
+        public int[] ItemsIndexPosition { get; }
+
+        public IReadOnlyList<PartitionKeyRange> UpdatedRangesAfterSplit { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPipelineMockTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPipelineMockTests.cs
@@ -31,252 +31,61 @@ namespace Microsoft.Azure.Cosmos.Tests
         private CosmosSerializer cosmosSerializer = new CosmosJsonSerializerCore();
 
         [TestMethod]
-        public async Task TestQueryPipelineSplitAsync()
+        [DataRow(null)]
+        public async Task TestCosmosCrossPartitionQueryExecutionContextWithEmptyPagesAndSplitAsync(string initialContinuationToken)
         {
-            int maxPageSize = 10;
-            const string collectionRid = "UipSALL8vxE";
-            Uri resourceLink = new Uri("dbs/test/colls/collTest", UriKind.Relative);
-            SqlQuerySpec sqlQuerySpec = MockItemProducerFactory.DefaultQuerySpec;
-            ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(collectionRid);
-            containerProperties.Id = "SplitContainerId";
-            containerProperties.PartitionKeyPath = "/pk";
+            int maxPageSize = 5;
 
-            // pkRange1 is the original range, newPkRange2/newPkRange3 are the ranges after the split
-            PartitionKeyRange pkRange0 = new PartitionKeyRange() { Id = "0", MinInclusive = "", MaxExclusive = "FF" };
-            PartitionKeyRange newPkRange1 = new PartitionKeyRange() { Id = "1", MinInclusive = "", MaxExclusive = "BB" };
-            PartitionKeyRange newPkRange2 = new PartitionKeyRange() { Id = "2", MinInclusive = "BB", MaxExclusive = "FF" };
-            IReadOnlyList<PartitionKeyRange> newPkRanges = new List<PartitionKeyRange>()
+            List<MockResponseForSinglePartition[]> mockResponsesScenario = MockQueryFactory.GetSplitScenarios(initialContinuationToken);
+            foreach (MockResponseForSinglePartition[] mockResponse in mockResponsesScenario)
             {
-                newPkRange1,
-                newPkRange2,
-            };
+                Mock<CosmosQueryClient> mockQueryClient = new Mock<CosmosQueryClient>();
+                IList<ToDoItem> allItems = MockQueryFactory.GenerateAndMockResponse(
+                    mockQueryClient,
+                    sqlQuerySpec: MockQueryFactory.DefaultQuerySpec,
+                    containerRid: MockQueryFactory.DefaultCollectionRid,
+                    initContinuationToken: initialContinuationToken,
+                    maxPageSize: maxPageSize,
+                    mockResponseForSinglePartition: mockResponse,
+                    cancellationToken: cancellationToken);
 
-            PartitionedQueryExecutionInfo partitionedQueryExecutionInfo = new PartitionedQueryExecutionInfo()
-            {
-                QueryInfo = new QueryInfo(),
-                QueryRanges = new List<Microsoft.Azure.Documents.Routing.Range<string>>()
-                {
-                    new Microsoft.Azure.Documents.Routing.Range<string>(
-                        min: pkRange0.MinInclusive,
-                        max: pkRange0.MaxExclusive,
-                        isMinInclusive: true,
-                        isMaxInclusive: true)
-                }
-            };
+                CosmosQueryContext context = MockQueryFactory.CreateContext(
+                    mockQueryClient.Object);
 
-            // Setup the necessary partition key range update calls
-            Mock<IRoutingMapProvider> mockRoutingMap = new Mock<IRoutingMapProvider>();
-            mockRoutingMap.Setup(x =>
-                x.TryGetOverlappingRangesAsync(
-                    collectionRid,
-                    pkRange0.ToRange(),
-                    true)).Returns(Task.FromResult(newPkRanges));
-
-            Mock<CosmosQueryClient> mockQueryClient = new Mock<CosmosQueryClient>();
-            mockQueryClient.Setup(x => x.GetRoutingMapProviderAsync()).Returns(Task.FromResult(mockRoutingMap.Object));
-            mockQueryClient.Setup(x => x.GetCachedContainerPropertiesAsync(cancellationToken)).Returns(Task.FromResult(containerProperties));
-            mockQueryClient.Setup(x => x.GetPartitionedQueryExecutionInfoAsync(
-                sqlQuerySpec,
-                containerProperties.PartitionKey,
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                It.IsAny<bool>(),
-                cancellationToken)).Returns(Task.FromResult(partitionedQueryExecutionInfo));
-
-            mockQueryClient.Setup(x => x.GetTargetPartitionKeyRangesAsync(
-                resourceLink.OriginalString,
-                collectionRid,
-                partitionedQueryExecutionInfo.QueryRanges))
-                .Returns(Task.FromResult(new List<PartitionKeyRange>() { pkRange0 }));
-
-            Mock<CosmosQueryContext> mockContext = new Mock<CosmosQueryContext>();
-            mockContext.Setup(x => x.QueryClient).Returns(mockQueryClient.Object);
-            mockContext.Setup(x => x.ContainerResourceId).Returns(collectionRid);
-            mockContext.Setup(x => x.SqlQuerySpec).Returns(sqlQuerySpec);
-
-            QueryRequestOptions requestOptions = new QueryRequestOptions()
-            {
-                MaxItemCount = maxPageSize
-            };
-  
-            mockContext.Setup(x => x.QueryRequestOptions).Returns(requestOptions);
-            List<ToDoItem> allMockedToDoItems = new List<ToDoItem>();
-
-            // Setup the mocks for the new partitions ranges
-            List<ToDoItem> itemsFromPkRange1 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                 mockQueryClient,
-                 responseMessagesPageSize: new int[] { 2, QueryResponseMessageFactory.SPLIT },
-                 sqlQuerySpec: sqlQuerySpec,
-                 partitionKeyRange: pkRange0,
-                 continuationToken: null,
-                 maxPageSize: maxPageSize,
-                 collectionRid: collectionRid,
-                 responseDelay: null,
-                 cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange1);
-
-            List<ToDoItem> itemsFromPkRange2 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                mockQueryClient,
-                responseMessagesPageSize: new int[] { 1 },
-                sqlQuerySpec: sqlQuerySpec,
-                partitionKeyRange: newPkRange1,
-                continuationToken: null,
-                maxPageSize: maxPageSize,
-                collectionRid: collectionRid,
-                responseDelay: null,
-                cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange2);
-
-            List<ToDoItem> itemsFromPkRange3 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                 mockQueryClient,
-                 responseMessagesPageSize: new int[] { 1 },
-                 sqlQuerySpec: sqlQuerySpec,
-                 partitionKeyRange: newPkRange2,
-                 continuationToken: null,
-                 maxPageSize: maxPageSize,
-                 collectionRid: collectionRid,
-                 responseDelay: null,
-                 cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange3);
-
-            FeedIterator executionContext = new CosmosQueryExecutionContextFactory(
-                client: mockQueryClient.Object,
-                resourceTypeEnum: ResourceType.Document,
-                operationType: OperationType.Query,
-                resourceType: typeof(ToDoItem),
-                sqlQuerySpec: sqlQuerySpec,
-                continuationToken: null,
-                queryRequestOptions: requestOptions,
-                resourceLink: resourceLink,
-                isContinuationExpected: true,
-                allowNonValueAggregateQuery: true,
-                correlatedActivityId: Guid.NewGuid());
-
-            // Read all the pages from both splits
-            List<ToDoItem> itemsRead = new List<ToDoItem>();
-            Assert.IsTrue(executionContext.HasMoreResults);
-
-            while (executionContext.HasMoreResults)
-            {
-                using (ResponseMessage response = await executionContext.ReadNextAsync(cancellationToken))
-                {
-                    Collection<ToDoItem> items = this.cosmosSerializer.FromStream<CosmosFeedResponseUtil<ToDoItem>>(response.Content).Data;
-                    itemsRead.AddRange(items);
-                }
-            }
-
-            Assert.AreEqual(allMockedToDoItems.Count, itemsRead.Count);
-
-            CollectionAssert.AreEqual(itemsRead, allMockedToDoItems, new ToDoItemComparer());
-        }
-
-        [TestMethod]
-        public async Task TestSplitWithExecutionContextAsync()
-        {
-            int maxPageSize = 10;
-            const string collectionRid = "MockTestSplitContainerRid";
-            SqlQuerySpec sqlQuerySpec = MockItemProducerFactory.DefaultQuerySpec;
-
-            // pkRange1 is the original range, newPkRange2/newPkRange3 are the ranges after the split
-            PartitionKeyRange pkRange1 = new PartitionKeyRange() { Id = "0", MinInclusive = "", MaxExclusive = "FF" };
-            PartitionKeyRange newPkRange2 = new PartitionKeyRange() { Id = "1", MinInclusive = "", MaxExclusive = "BB" };
-            PartitionKeyRange newPkRange3 = new PartitionKeyRange() { Id = "2", MinInclusive = "BB", MaxExclusive = "FF" };
-            IReadOnlyList<PartitionKeyRange> newPkRanges = new List<PartitionKeyRange>()
-            {
-                newPkRange2,
-                newPkRange3,
-            };
-
-            // Setup the necessary partition key range update calls
-            Mock<IRoutingMapProvider> mockRoutingMap = new Mock<IRoutingMapProvider>();
-            mockRoutingMap.Setup(x =>
-                x.TryGetOverlappingRangesAsync(
-                    collectionRid,
-                    pkRange1.ToRange(),
-                    true)).Returns(Task.FromResult(newPkRanges));
-
-            Mock<CosmosQueryClient> mockQueryClient = new Mock<CosmosQueryClient>();
-            mockQueryClient.Setup(x => x.GetRoutingMapProviderAsync()).Returns(Task.FromResult(mockRoutingMap.Object));
-
-            Mock<CosmosQueryContext> mockContext = new Mock<CosmosQueryContext>();
-            mockContext.Setup(x => x.QueryClient).Returns(mockQueryClient.Object);
-            mockContext.Setup(x => x.ContainerResourceId).Returns(collectionRid);
-            mockContext.Setup(x => x.SqlQuerySpec).Returns(sqlQuerySpec);
-
-            QueryRequestOptions requestOptions = new QueryRequestOptions();
-            mockContext.Setup(x => x.QueryRequestOptions).Returns(requestOptions);
-            List<ToDoItem> allMockedToDoItems = new List<ToDoItem>();
-
-
-            // Setup the mocks for the new partitions ranges
-            List<ToDoItem> itemsFromPkRange1 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                 mockContext,
-                 responseMessagesPageSize: new int[] { 2, QueryResponseMessageFactory.SPLIT },
-                 sqlQuerySpec: sqlQuerySpec,
-                 partitionKeyRange: pkRange1,
-                 continuationToken: null,
-                 maxPageSize: maxPageSize,
-                 collectionRid: collectionRid,
-                 responseDelay: null,
-                 cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange1);
-
-            List<ToDoItem> itemsFromPkRange2 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                mockContext,
-                responseMessagesPageSize: new int[] { 1 },
-                sqlQuerySpec: sqlQuerySpec,
-                partitionKeyRange: newPkRange2,
-                continuationToken: null,
-                maxPageSize: maxPageSize,
-                collectionRid: collectionRid,
-                responseDelay: null,
-                cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange2);
-
-            List<ToDoItem> itemsFromPkRange3 = MockItemProducerFactory.MockSinglePartitionKeyRangeContext(
-                 mockContext,
-                 responseMessagesPageSize: new int[] { 1 },
-                 sqlQuerySpec: sqlQuerySpec,
-                 partitionKeyRange: newPkRange3,
-                 continuationToken: null,
-                 maxPageSize: maxPageSize,
-                 collectionRid: collectionRid,
-                 responseDelay: null,
-                 cancellationToken: cancellationToken);
-            allMockedToDoItems.AddRange(itemsFromPkRange3);
-
-            CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams initParams = new CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams(
-                    collectionRid,
+                CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams initParams = new CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams(
+                    MockQueryFactory.DefaultCollectionRid,
                     new PartitionedQueryExecutionInfo() { QueryInfo = new QueryInfo() },
-                    new List<PartitionKeyRange>() { pkRange1 },
+                    new List<PartitionKeyRange>() { MockQueryFactory.DefaultPartitionKeyRange },
                     maxPageSize,
-                    null);
+                    initialContinuationToken);
 
-            CosmosParallelItemQueryExecutionContext executionContext = await CosmosParallelItemQueryExecutionContext.CreateAsync(
-                mockContext.Object,
-                initParams,
-                cancellationToken);
+                CosmosParallelItemQueryExecutionContext executionContext = await CosmosParallelItemQueryExecutionContext.CreateAsync(
+                    context,
+                    initParams,
+                    cancellationToken);
 
-            // Read all the pages from both splits
-            List<ToDoItem> itemsRead = new List<ToDoItem>();
-            Assert.IsTrue(!executionContext.IsDone);
+                // Read all the pages from both splits
+                List<ToDoItem> itemsRead = new List<ToDoItem>();
+                Assert.IsTrue(!executionContext.IsDone);
 
-            while (!executionContext.IsDone)
-            {
-                QueryResponse queryResponse = await executionContext.DrainAsync(maxPageSize, cancellationToken);
-
-                foreach (CosmosElement element in queryResponse.CosmosElements)
+                while (!executionContext.IsDone)
                 {
-                    string jsonValue = element.ToString();
-                    ToDoItem item = JsonConvert.DeserializeObject<ToDoItem>(jsonValue);
-                    itemsRead.Add(item);
+                    QueryResponse queryResponse = await executionContext.DrainAsync(maxPageSize, cancellationToken);
+
+                    foreach (CosmosElement element in queryResponse.CosmosElements)
+                    {
+                        string jsonValue = element.ToString();
+                        ToDoItem item = JsonConvert.DeserializeObject<ToDoItem>(jsonValue);
+                        itemsRead.Add(item);
+                    }
                 }
+
+                Assert.AreEqual(allItems.Count, itemsRead.Count);
+                List<ToDoItem> exepected = allItems.OrderBy(x => x.id).ToList();
+                List<ToDoItem> actual = itemsRead.OrderBy(x => x.id).ToList();
+
+                CollectionAssert.AreEqual(exepected, actual, new ToDoItemComparer());
             }
-
-            Assert.AreEqual(allMockedToDoItems.Count, itemsRead.Count);
-
-            CollectionAssert.AreEqual(itemsRead, allMockedToDoItems, new ToDoItemComparer());
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         private static readonly CosmosSerializer cosmosSerializer = new CosmosJsonSerializerCore();
         public const int SPLIT = -1;
 
-        public static (QueryResponse queryResponse, ReadOnlyCollection<ToDoItem> items) Create(
+        public static (QueryResponse queryResponse, IList<ToDoItem> items) Create(
             string itemIdPrefix,
             string continuationToken,
             string collectionRid,
@@ -33,10 +33,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             // Use -1 to represent a split response
             if (itemCount == QueryResponseMessageFactory.SPLIT)
             {
-                return CreateSplitResponse(collectionRid);
+                return (CreateSplitResponse(collectionRid), new List<ToDoItem>().AsReadOnly());
             }
 
-            ReadOnlyCollection<ToDoItem> items = ToDoItem.CreateItems(itemCount, itemIdPrefix);
+            IList<ToDoItem> items = ToDoItem.CreateItems(itemCount, itemIdPrefix);
             MemoryStream memoryStream = (MemoryStream)cosmosSerializer.ToStream<IList<ToDoItem>>(items);
             long responseLengthBytes = memoryStream.Length;
 
@@ -57,7 +57,32 @@ namespace Microsoft.Azure.Cosmos.Tests
             return (message, items);
         }
 
-        public static (QueryResponse queryResponse, ReadOnlyCollection<ToDoItem> items) CreateSplitResponse(string collectionRid)
+        public static QueryResponse CreateQueryResponse(
+            IList<ToDoItem> items,
+            string continuationToken,
+            string collectionRid)
+        {
+            MemoryStream memoryStream = (MemoryStream)cosmosSerializer.ToStream<IList<ToDoItem>>(items);
+            long responseLengthBytes = memoryStream.Length;
+
+            IJsonNavigator jsonNavigator = JsonNavigator.Create(memoryStream.ToArray());
+            IJsonNavigatorNode jsonNavigatorNode = jsonNavigator.GetRootNode();
+            CosmosArray cosmosArray = CosmosArray.Create(jsonNavigator, jsonNavigatorNode);
+
+            Headers headers = new Headers();
+            headers.ContinuationToken = continuationToken;
+            headers.ActivityId = Guid.NewGuid().ToString();
+
+            QueryResponse message = QueryResponse.CreateSuccess(
+                    result: cosmosArray,
+                    count: items.Count,
+                    responseHeaders: CosmosQueryResponseMessageHeaders.ConvertToQueryHeaders(headers, ResourceType.Document, collectionRid),
+                    responseLengthBytes: responseLengthBytes);
+
+            return message;
+        }
+
+        public static QueryResponse CreateSplitResponse(string collectionRid)
         {
             QueryResponse splitResponse = QueryResponse.CreateFailure(
                new CosmosQueryResponseMessageHeaders(null, null, ResourceType.Document, collectionRid)
@@ -70,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                "Partition split error",
                null);
 
-            return (splitResponse, new List<ToDoItem>().AsReadOnly());
+            return splitResponse;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ToDoItem.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ToDoItem.cs
@@ -3,18 +3,20 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text;
+using Microsoft.Azure.Documents;
 
-namespace Microsoft.Azure.Cosmos.Query
+namespace Microsoft.Azure.Cosmos.Tests
 {
-    public class ToDoItem
+    internal class ToDoItem
     {
         public string id { get; set; }
         public string pk { get; set; }
         public double cost { get; set; }
         public bool isDone { get; set; }
         public int count { get; set; }
+        public string _rid { get; set; }
 
-        public static ToDoItem Create(string idPrefix)
+        public static ToDoItem Create(string idPrefix, ResourceId itemRid = null)
         {
             if(idPrefix == null)
             {
@@ -29,19 +31,30 @@ namespace Microsoft.Azure.Cosmos.Query
                 pk = Guid.NewGuid().ToString(),
                 cost = 9000.00001,
                 isDone = true,
-                count = 42
+                count = 42,
+                _rid = itemRid?.ToString()
             };
         }
 
-        public static ReadOnlyCollection<ToDoItem> CreateItems(int count, string idPrefix)
+        public static IList<ToDoItem> CreateItems(
+            int count, 
+            string idPrefix, 
+            string containerRid = null)
         {
             List<ToDoItem> items = new List<ToDoItem>();
-            for (int i = 0; i < count; i++)
+            for (uint i = 0; i < count; i++)
             {
-                items.Add(ToDoItem.Create(idPrefix));
+                ResourceId rid = null;
+                if(containerRid != null)
+                {
+                    // id 0 returns null for resource id
+                    rid = ResourceId.NewDocumentId(containerRid, i+1);
+                }
+                
+                items.Add(ToDoItem.Create(idPrefix, rid));
             }
 
-            return items.AsReadOnly();
+            return items;
         }
     }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes bug that causes item producer tree to lose continuation token on split. Added more mocks tests to include continuation token.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


