### PR TITLE
Adding continuation token support for LINQ

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.Cosmos.Linq
 
         /// <summary>
         /// This extension method gets the FeedIterator from LINQ IQueryable to execute query asynchronously.
+        /// This will create the fresh new FeedIterator when called.
         /// </summary>
         /// <typeparam name="T">the type of object to query.</typeparam>
         /// <param name="query">the IQueryable{T} to be converted.</param>

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
@@ -20,11 +20,13 @@ namespace Microsoft.Azure.Cosmos.Linq
         private readonly QueryRequestOptions cosmosQueryRequestOptions;
         private readonly bool allowSynchronousQueryExecution;
         private readonly Action<IQueryable> onExecuteScalarQueryCallback;
+        private readonly string continuationToken;
 
         public CosmosLinqQueryProvider(
            ContainerCore container,
            CosmosSerializer cosmosJsonSerializer,
            CosmosQueryClientCore queryClient,
+           string continuationToken,
            QueryRequestOptions cosmosQueryRequestOptions,
            bool allowSynchronousQueryExecution,
            Action<IQueryable> onExecuteScalarQueryCallback = null)
@@ -32,6 +34,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.container = container;
             this.cosmosJsonSerializer = cosmosJsonSerializer;
             this.queryClient = queryClient;
+            this.continuationToken = continuationToken;
             this.cosmosQueryRequestOptions = cosmosQueryRequestOptions;
             this.allowSynchronousQueryExecution = allowSynchronousQueryExecution;
             this.onExecuteScalarQueryCallback = onExecuteScalarQueryCallback;
@@ -43,6 +46,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.container,
                 this.cosmosJsonSerializer,
                 this.queryClient,
+                this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
                 this.allowSynchronousQueryExecution);
@@ -57,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.container,
                 this.cosmosJsonSerializer,
                 this.queryClient,
+                this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
                 this.allowSynchronousQueryExecution);
@@ -70,6 +75,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.container,
                 this.cosmosJsonSerializer,
                 this.queryClient,
+                this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
                 this.allowSynchronousQueryExecution);
@@ -86,6 +92,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.container,
                 this.cosmosJsonSerializer,
                 this.queryClient,
+                this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 this.allowSynchronousQueryExecution);
             this.onExecuteScalarQueryCallback?.Invoke(cosmosLINQQuery);

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -984,6 +984,7 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="allowSynchronousQueryExecution">(Optional)the option which allows the query to be executed synchronously via IOrderedQueryable.</param>
+        /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional)The options for the item query request.<see cref="QueryRequestOptions"/></param>
         /// <returns>(Optional) An IOrderedQueryable{T} that can evaluate the query.</returns>
         /// <example>
@@ -1053,6 +1054,7 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         public abstract IOrderedQueryable<T> GetItemLinqQueryable<T>(
             bool allowSynchronousQueryExecution = false,
+            string continuationToken = null,
             QueryRequestOptions requestOptions = null);
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -314,6 +314,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override IOrderedQueryable<T> GetItemLinqQueryable<T>(
             bool allowSynchronousQueryExecution = false,
+            string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
             requestOptions = requestOptions != null ? requestOptions : new QueryRequestOptions();
@@ -322,6 +323,7 @@ namespace Microsoft.Azure.Cosmos
                 this,
                 this.ClientContext.CosmosSerializer,
                 (CosmosQueryClientCore)this.queryClient,
+                continuationToken,
                 requestOptions,
                 allowSynchronousQueryExecution);
         }

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## Changes in [3.1.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.0.0) : ##
+
+* Fixes [#544](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/544) Adding continuation token support for LINQ
+
+
 ## Changes in [3.0.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.0.0) : ##
 
 * General availability of [Version 3.0.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/) of the .NET SDK


### PR DESCRIPTION
Continuation token will work in both the execution flow
1. Asynchronous execution via FeedIterator with extension method ToFeedIterator().

```C#
IOrderedQueryable<T> linqQueryable = this.Container.GetItemLinqQueryable<T>(
    continuationToken: continuationToken,
    requestOptions: queryRequestOptions);
IQueryable<T> queriable = linqQueryable.Where(item => (item.intField < 100));
FeedIterator<T> feedIterator = queriable.ToFeedIterator();
```

2. Synchronous blocking LINQ execution.

```c#
IOrderedQueryable<T> linqQueryable = this.Container.GetItemLinqQueryable<T>(
    allowSynchronousQueryExecution: true,
    continuationToken: continuationToken,
    requestOptions: queryRequestOptions);
List<T> list = linqQueryable.Where(item => (item.intField < 100)).ToList();
```

## Closing issues

closes #537


