### PR TITLE
Fix mis-typed message in CosmosException.ToString() 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A string representation of the exception.</returns>
         public override string ToString()
         {
-            return $"CosmosRequestException;StatusCode={this.StatusCode};SubStatusCode={this.SubStatusCode};ActivityId={this.ActivityId ?? string.Empty};RequestCharge={this.RequestCharge};Message={this.Message};";
+            return $"{nameof(CosmosException)};StatusCode={this.StatusCode};SubStatusCode={this.SubStatusCode};ActivityId={this.ActivityId ?? string.Empty};RequestCharge={this.RequestCharge};Message={this.Message};";
         }
     }
 }


### PR DESCRIPTION
Fix mis-typed message in CosmosException.ToString() 

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #547 
