### PR TITLE
Query correctly handles different language cultures

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Json
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Text;
 
@@ -911,7 +912,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 public double GetNumberValue()
                 {
                     string stringDouble = this.encoding.GetString(this.bufferedToken.GetBuffer(), 0, this.tokenLength);
-                    return double.Parse(stringDouble);
+                    return double.Parse(stringDouble, CultureInfo.InvariantCulture);
                 }
 
                 /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Json/JsonTextUtil.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonTextUtil.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
+    using System.Globalization;
     using System.Text;
 
     /// <summary>
@@ -23,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Json
             int offset = bufferedToken.Offset;
             int count = bufferedToken.Count;
             string stringDouble = Encoding.UTF8.GetString(rawBufferedTokenArray, offset, count);
-            return double.Parse(stringDouble);
+            return double.Parse(stringDouble, CultureInfo.InvariantCulture);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Text;
 
@@ -179,7 +180,7 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 this.JsonObjectState.RegisterToken(JsonTokenType.Number);
                 this.PrefixMemberSeparator();
-                this.streamWriter.Write(value.ToString());
+                this.streamWriter.Write(value.ToString(CultureInfo.InvariantCulture));
             }
 
             /// <summary>
@@ -226,7 +227,7 @@ namespace Microsoft.Azure.Cosmos.Json
                     // If you require more precision, specify format with the "G17" format specification, which always returns 17 digits of precision,
                     // or "R", which returns 15 digits if the number can be represented with that precision or 17 digits if the number can only be represented with maximum precision.
                     // In some cases, Double values formatted with the "R" standard numeric format string do not successfully round-trip if compiled using the /platform:x64 or /platform:anycpu switches and run on 64-bit systems. To work around this problem, you can format Double values by using the "G17" standard numeric format string. 
-                    this.streamWriter.Write(value.ToString("R"));
+                    this.streamWriter.Write(value.ToString("R", CultureInfo.InvariantCulture));
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/src/Json/NewtonsoftInterop/JsonNewtonsoftReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/NewtonsoftInterop/JsonNewtonsoftReader.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.Cosmos.Json.NewtonsoftInterop
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Globalization;
     using Newtonsoft.Json;
 
     internal sealed class JsonNewtonsoftReader : Microsoft.Azure.Cosmos.Json.JsonReader
@@ -40,14 +42,14 @@ namespace Microsoft.Azure.Cosmos.Json.NewtonsoftInterop
             object value = this.reader.Value;
             if (value is double)
             {
-                numberString = ((double)value).ToString("R");
+                numberString = ((double)value).ToString("R", CultureInfo.InvariantCulture);
             }
             else
             {
                 numberString = value.ToString();
             }
 
-            return double.Parse(numberString);
+            return double.Parse(numberString, CultureInfo.InvariantCulture);
         }
 
         public override string GetStringValue()

--- a/Microsoft.Azure.Cosmos/src/Json/NewtonsoftInterop/JsonNewtonsoftWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/NewtonsoftInterop/JsonNewtonsoftWriter.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Json.NewtonsoftInterop
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Text;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Diagnostics;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -16,16 +17,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Linq;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Routing;
-    using Microsoft.Azure.Cosmos.Linq;
     using Microsoft.Azure.Cosmos.Utils;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using JsonReader = Json.JsonReader;
     using JsonWriter = Json.JsonWriter;
-    using Newtonsoft.Json.Linq;
 
     [TestClass]
     public class CosmosItemTests : BaseCosmosClientHelper
@@ -694,45 +695,65 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ItemMultiplePartitionOrderByQueryStream()
         {
-            IList<ToDoActivity> deleteList = await this.CreateRandomItems(300, randomPartitionKey: true);
+            CultureInfo defaultCultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
 
-            QueryDefinition sql = new QueryDefinition("SELECT * FROM toDoActivity t ORDER BY t.taskNum ");
-
-            QueryRequestOptions requestOptions = new QueryRequestOptions()
+            CultureInfo[] cultureInfoList = new CultureInfo[]
             {
-                MaxBufferedItemCount = 10,
-                ResponseContinuationTokenLimitInKb = 500,
-                MaxConcurrency = 5,
-                MaxItemCount = 1,
+                defaultCultureInfo,
+                System.Globalization.CultureInfo.GetCultureInfo("fr-FR")
             };
 
-            List<ToDoActivity> resultList = new List<ToDoActivity>();
-            double totalRequstCharge = 0;
-            FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
-                sql,
-                requestOptions: requestOptions);
+            IList<ToDoActivity> deleteList = await this.CreateRandomItems(300, randomPartitionKey: true);
 
-            while (feedIterator.HasMoreResults)
+            try
             {
-                ResponseMessage iter = await feedIterator.ReadNextAsync();
-                Assert.IsTrue(iter.IsSuccessStatusCode);
-                Assert.IsNull(iter.ErrorMessage);
-                totalRequstCharge += iter.Headers.RequestCharge;
+                foreach (CultureInfo cultureInfo in cultureInfoList)
+                {
+                    System.Threading.Thread.CurrentThread.CurrentCulture = cultureInfo;
 
-                ToDoActivity[] activities = this.jsonSerializer.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(iter.Content).Data.ToArray();
-                Assert.AreEqual(1, activities.Length);
-                ToDoActivity response = activities.First();
-                resultList.Add(response);
+                    QueryDefinition sql = new QueryDefinition("SELECT * FROM toDoActivity t ORDER BY t.taskNum ");
+
+                    QueryRequestOptions requestOptions = new QueryRequestOptions()
+                    {
+                        MaxBufferedItemCount = 10,
+                        ResponseContinuationTokenLimitInKb = 500,
+                        MaxConcurrency = 5,
+                        MaxItemCount = 1,
+                    };
+
+                    List<ToDoActivity> resultList = new List<ToDoActivity>();
+                    double totalRequstCharge = 0;
+                    FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(
+                        sql,
+                        requestOptions: requestOptions);
+
+                    while (feedIterator.HasMoreResults)
+                    {
+                        ResponseMessage iter = await feedIterator.ReadNextAsync();
+                        Assert.IsTrue(iter.IsSuccessStatusCode);
+                        Assert.IsNull(iter.ErrorMessage);
+                        totalRequstCharge += iter.Headers.RequestCharge;
+
+                        ToDoActivity[] activities = this.jsonSerializer.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(iter.Content).Data.ToArray();
+                        Assert.AreEqual(1, activities.Length);
+                        ToDoActivity response = activities.First();
+                        resultList.Add(response);
+                    }
+
+                    Assert.AreEqual(deleteList.Count, resultList.Count);
+                    Assert.IsTrue(totalRequstCharge > 0);
+
+                    List<ToDoActivity> verifiedOrderBy = deleteList.OrderBy(x => x.taskNum).ToList();
+                    for (int i = 0; i < verifiedOrderBy.Count(); i++)
+                    {
+                        Assert.AreEqual(verifiedOrderBy[i].taskNum, resultList[i].taskNum);
+                        Assert.AreEqual(verifiedOrderBy[i].id, resultList[i].id);
+                    }
+                }
             }
-
-            Assert.AreEqual(deleteList.Count, resultList.Count);
-            Assert.IsTrue(totalRequstCharge > 0);
-
-            List<ToDoActivity> verifiedOrderBy = deleteList.OrderBy(x => x.taskNum).ToList();
-            for (int i = 0; i < verifiedOrderBy.Count(); i++)
+            finally
             {
-                Assert.AreEqual(verifiedOrderBy[i].taskNum, resultList[i].taskNum);
-                Assert.AreEqual(verifiedOrderBy[i].id, resultList[i].id);
+                System.Threading.Thread.CurrentThread.CurrentCulture = defaultCultureInfo;
             }
         }
 
@@ -1228,7 +1249,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ItemLINQQueryTest()
         {
             //Creating items for query.
-            IList<ToDoActivity> itemList = await CreateRandomItems(pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
+            IList<ToDoActivity> itemList = await this.CreateRandomItems(pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
 
             IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>();
             IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => (item.taskNum < 100));
@@ -1244,7 +1265,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 resultsFetched += queryResponse.Count();
 
                 // For the items returned with NonePartitionKeyValue
-                var iter = queryResponse.GetEnumerator();
+                IEnumerator<ToDoActivity> iter = queryResponse.GetEnumerator();
                 while (iter.MoveNext())
                 {
                     ToDoActivity activity = iter.Current;
@@ -1256,7 +1277,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //Checking for exception in case of ToFeedIterator() use on non cosmos linq IQueryable.
             try
             {
-                IQueryable<ToDoActivity> nonLinqQueryable = (new List<ToDoActivity> { CreateRandomToDoActivity() }).AsQueryable();
+                IQueryable<ToDoActivity> nonLinqQueryable = (new List<ToDoActivity> { this.CreateRandomToDoActivity() }).AsQueryable();
                 setIterator = nonLinqQueryable.ToFeedIterator();
                 Assert.Fail("It should throw ArgumentOutOfRangeException as ToFeedIterator() only applicable to cosmos LINQ query");
             }
@@ -1306,7 +1327,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ItemLINQQueryWithContinuationTokenTest()
         {
             //Creating items for query.
-            IList<ToDoActivity> itemList = await CreateRandomItems(pkCount: 10, perPKItemCount: 1, randomPartitionKey: true);
+            IList<ToDoActivity> itemList = await this.CreateRandomItems(pkCount: 10, perPKItemCount: 1, randomPartitionKey: true);
 
             QueryRequestOptions queryRequestOptions = new QueryRequestOptions();
             queryRequestOptions.MaxConcurrency = 1;
@@ -1322,7 +1343,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 FeedResponse<ToDoActivity> feedResponse = await feedIterator.ReadNextAsync();
                 firstItemSet = feedResponse.Count();
                 continuationToken = feedResponse.ContinuationToken;
-                if(firstItemSet > 0)
+                if (firstItemSet > 0)
                 {
                     break;
                 }
@@ -1343,7 +1364,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(10 - firstItemSet, secondItemSet);
 
             //Test continuationToken with blocking LINQ execution
-            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(allowSynchronousQueryExecution:true, continuationToken: continuationToken, requestOptions: queryRequestOptions);
+            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(allowSynchronousQueryExecution: true, continuationToken: continuationToken, requestOptions: queryRequestOptions);
             int linqExecutionItemCount = linqQueryable.Where(item => (item.taskNum < 100)).Count();
             Assert.AreEqual(10 - firstItemSet, linqExecutionItemCount);
         }
@@ -1380,7 +1401,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     resultsFetched += queryResponse.Count();
 
                     // For the items returned with NonePartitionKeyValue
-                    var iter = queryResponse.GetEnumerator();
+                    IEnumerator<ToDoActivity> iter = queryResponse.GetEnumerator();
                     while (iter.MoveNext())
                     {
                         ToDoActivity activity = iter.Current;
@@ -1463,7 +1484,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 for (int i = 0; i < 500 && failedToManyRequests.Count == 0; i++)
                 {
                     createQuery.Add(VerifyQueryToManyExceptionAsync(
-                        container, 
+                        container,
                         isQuery,
                         failedToManyRequests));
                 }
@@ -1569,7 +1590,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static async Task VerifyQueryToManyExceptionAsync(
             Container container,
-            bool isQuery, 
+            bool isQuery,
             List<ResponseMessage> failedToManyMessages)
         {
             string queryText = null;
@@ -1607,7 +1628,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 ResponseMessage response = await iterator.ReadNextAsync();
                 Assert.AreEqual(expected, response.StatusCode, $"ExecuteReadFeedAsync substatuscode: {response.Headers.SubStatusCode} ");
-            } 
+            }
         }
 
         private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
@@ -386,6 +386,8 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
             {
                 foreach (CultureInfo cultureInfo in cultureInfoList)
                 {
+                    System.Threading.Thread.CurrentThread.CurrentCulture = cultureInfo;
+
                     IJsonReader jsonReader = JsonReader.Create(Encoding.UTF8.GetBytes(input));
                     JsonTokenInfo[] tokensFromReader = JsonNavigatorTests.GetTokensWithReader(jsonReader);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
@@ -375,7 +375,6 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
         private void VerifyNavigator(string input, Exception expectedException, bool performExtraChecks = true)
         {
             CultureInfo defaultCultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
 
             CultureInfo[] cultureInfoList = new CultureInfo[]
             {
@@ -385,7 +384,6 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
 
             try
             {
-
                 foreach (CultureInfo cultureInfo in cultureInfoList)
                 {
                     IJsonReader jsonReader = JsonReader.Create(Encoding.UTF8.GetBytes(input));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonNavigatorTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Cosmos.Json;
     using System.IO;
+    using System.Globalization;
 
     [TestClass]
     public class JsonNavigatorTests
@@ -373,36 +374,56 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
 
         private void VerifyNavigator(string input, Exception expectedException, bool performExtraChecks = true)
         {
-            IJsonReader jsonReader = JsonReader.Create(Encoding.UTF8.GetBytes(input));
-            JsonTokenInfo[] tokensFromReader = JsonNavigatorTests.GetTokensWithReader(jsonReader);
+            CultureInfo defaultCultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
 
-            // Test text
-            IJsonNavigator textNavigator = JsonNavigator.Create(Encoding.UTF8.GetBytes(input));
-            IJsonNavigatorNode textRootNode = textNavigator.GetRootNode();
-            JsonTokenInfo[] tokensFromTextNavigator = JsonNavigatorTests.GetTokensFromNode(textRootNode, textNavigator, performExtraChecks);
-
-            Assert.IsTrue(tokensFromTextNavigator.SequenceEqual(tokensFromReader));
-
-            // Test binary
-            byte[] binaryInput = JsonTestUtils.ConvertTextToBinary(input);
-            IJsonNavigator binaryNavigator = JsonNavigator.Create(binaryInput);
-            IJsonNavigatorNode binaryRootNode = binaryNavigator.GetRootNode();
-            JsonTokenInfo[] tokensFromBinaryNavigator = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
-
-            Assert.IsTrue(tokensFromBinaryNavigator.SequenceEqual(tokensFromReader));
-
-            // Test binary + user string encoding
-            JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 4096);
-            byte[] binaryWithUserStringEncodingInput = JsonTestUtils.ConvertTextToBinary(input, jsonStringDictionary);
-            if (jsonStringDictionary.TryGetStringAtIndex(index: 0, value: out string temp))
+            CultureInfo[] cultureInfoList = new CultureInfo[]
             {
-                Assert.IsFalse(binaryWithUserStringEncodingInput.SequenceEqual(binaryInput), "Binary should be different with user string encoding");
-            }
-            IJsonNavigator binaryNavigatorWithUserStringEncoding = JsonNavigator.Create(binaryInput, jsonStringDictionary);
-            IJsonNavigatorNode binaryRootNodeWithUserStringEncoding = binaryNavigatorWithUserStringEncoding.GetRootNode();
-            JsonTokenInfo[] tokensFromBinaryNavigatorWithUserStringEncoding = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
+                defaultCultureInfo,
+                System.Globalization.CultureInfo.GetCultureInfo("fr-FR")
+            };
 
-            Assert.IsTrue(tokensFromBinaryNavigatorWithUserStringEncoding.SequenceEqual(tokensFromReader));
+            try
+            {
+
+                foreach (CultureInfo cultureInfo in cultureInfoList)
+                {
+                    IJsonReader jsonReader = JsonReader.Create(Encoding.UTF8.GetBytes(input));
+                    JsonTokenInfo[] tokensFromReader = JsonNavigatorTests.GetTokensWithReader(jsonReader);
+
+                    // Test text
+                    IJsonNavigator textNavigator = JsonNavigator.Create(Encoding.UTF8.GetBytes(input));
+                    IJsonNavigatorNode textRootNode = textNavigator.GetRootNode();
+                    JsonTokenInfo[] tokensFromTextNavigator = JsonNavigatorTests.GetTokensFromNode(textRootNode, textNavigator, performExtraChecks);
+
+                    Assert.IsTrue(tokensFromTextNavigator.SequenceEqual(tokensFromReader));
+
+                    // Test binary
+                    byte[] binaryInput = JsonTestUtils.ConvertTextToBinary(input);
+                    IJsonNavigator binaryNavigator = JsonNavigator.Create(binaryInput);
+                    IJsonNavigatorNode binaryRootNode = binaryNavigator.GetRootNode();
+                    JsonTokenInfo[] tokensFromBinaryNavigator = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
+
+                    Assert.IsTrue(tokensFromBinaryNavigator.SequenceEqual(tokensFromReader));
+
+                    // Test binary + user string encoding
+                    JsonStringDictionary jsonStringDictionary = new JsonStringDictionary(capacity: 4096);
+                    byte[] binaryWithUserStringEncodingInput = JsonTestUtils.ConvertTextToBinary(input, jsonStringDictionary);
+                    if (jsonStringDictionary.TryGetStringAtIndex(index: 0, value: out string temp))
+                    {
+                        Assert.IsFalse(binaryWithUserStringEncodingInput.SequenceEqual(binaryInput), "Binary should be different with user string encoding");
+                    }
+                    IJsonNavigator binaryNavigatorWithUserStringEncoding = JsonNavigator.Create(binaryInput, jsonStringDictionary);
+                    IJsonNavigatorNode binaryRootNodeWithUserStringEncoding = binaryNavigatorWithUserStringEncoding.GetRootNode();
+                    JsonTokenInfo[] tokensFromBinaryNavigatorWithUserStringEncoding = JsonNavigatorTests.GetTokensFromNode(binaryRootNode, binaryNavigator, performExtraChecks);
+
+                    Assert.IsTrue(tokensFromBinaryNavigatorWithUserStringEncoding.SequenceEqual(tokensFromReader));
+                }
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = defaultCultureInfo;
+            }
         }
 
         internal static JsonTokenInfo[] GetTokensWithReader(IJsonReader jsonReader)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTokenInfo.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTokenInfo.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using Microsoft.Azure.Cosmos.Json;
@@ -59,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.Json
                 case JsonTokenType.String:
                     return Encoding.UTF8.GetString(this.BufferedToken.ToArray());
                 case JsonTokenType.Number:
-                    return this.Value.ToString();
+                    return this.Value.ToString(CultureInfo.InvariantCulture);
                 case JsonTokenType.True:
                     return "true";
                 case JsonTokenType.False:

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
@@ -1341,6 +1341,8 @@
             {
                 foreach (CultureInfo cultureInfo in cultureInfoList)
                 {
+                    System.Threading.Thread.CurrentThread.CurrentCulture = cultureInfo;
+
                     Encoding[] encodings =
                     {
                         Encoding.UTF8,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
@@ -7,6 +7,7 @@
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Reflection;
+    using System.Globalization;
 
     [TestClass]
     public class JsonWriterTests
@@ -1328,43 +1329,63 @@
 
         private void VerifyWriter(JsonTokenInfo[] tokensToWrite, string expectedString = null, Exception expectedException = null)
         {
-            Encoding[] encodings =
+            CultureInfo defaultCultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
+
+            CultureInfo[] cultureInfoList = new CultureInfo[]
             {
-                Encoding.UTF8,
-                Encoding.Unicode,
-                Encoding.UTF32,
+                defaultCultureInfo,
+                System.Globalization.CultureInfo.GetCultureInfo("fr-FR")
             };
 
-            foreach (Encoding encoding in encodings)
+            try
             {
-                // Create through encoding API
-                IJsonWriter jsonWriterWithEncoding = JsonWriter.Create(encoding);
-                if (expectedString != null)
-                {
-                    // remove formatting on the json and also replace "/" with "\/" since newtonsoft is dumb.
-                    string expectedStringNoWhiteSpace = Newtonsoft.Json.Linq.JToken.Parse(expectedString).ToString(Newtonsoft.Json.Formatting.None).Replace("/", @"\/");
-                    this.VerifyWriter(jsonWriterWithEncoding, tokensToWrite, encoding.GetBytes(expectedStringNoWhiteSpace), JsonSerializationFormat.Text, expectedException);
-                }
-                else
-                {
-                    this.VerifyWriter(jsonWriterWithEncoding, tokensToWrite, null, JsonSerializationFormat.Text, expectedException);
-                }
-            }
 
-            // Create through serializtion api
-            IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
-            byte[] expectedOutput;
-            if (expectedString != null)
-            {
-                string expectedStringNoWhiteSpace = Newtonsoft.Json.Linq.JToken.Parse(expectedString).ToString(Newtonsoft.Json.Formatting.None).Replace("/", @"\/");
-                expectedOutput = Encoding.UTF8.GetBytes(expectedStringNoWhiteSpace);
-            }
-            else
-            {
-                expectedOutput = null;
-            }
+                foreach (CultureInfo cultureInfo in cultureInfoList)
+                {
+                    Encoding[] encodings =
+                    {
+                        Encoding.UTF8,
+                        Encoding.Unicode,
+                        Encoding.UTF32,
+                    };
 
-            this.VerifyWriter(jsonWriter, tokensToWrite, expectedOutput, JsonSerializationFormat.Text, expectedException);
+                    foreach (Encoding encoding in encodings)
+                    {
+                        // Create through encoding API
+                        IJsonWriter jsonWriterWithEncoding = JsonWriter.Create(encoding);
+                        if (expectedString != null)
+                        {
+                            // remove formatting on the json and also replace "/" with "\/" since newtonsoft is dumb.
+                            string expectedStringNoWhiteSpace = Newtonsoft.Json.Linq.JToken.Parse(expectedString).ToString(Newtonsoft.Json.Formatting.None).Replace("/", @"\/");
+                            this.VerifyWriter(jsonWriterWithEncoding, tokensToWrite, encoding.GetBytes(expectedStringNoWhiteSpace), JsonSerializationFormat.Text, expectedException);
+                        }
+                        else
+                        {
+                            this.VerifyWriter(jsonWriterWithEncoding, tokensToWrite, null, JsonSerializationFormat.Text, expectedException);
+                        }
+                    }
+
+                    // Create through serializtion api
+                    IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
+                    byte[] expectedOutput;
+                    if (expectedString != null)
+                    {
+                        string expectedStringNoWhiteSpace = Newtonsoft.Json.Linq.JToken.Parse(expectedString).ToString(Newtonsoft.Json.Formatting.None).Replace("/", @"\/");
+                        expectedOutput = Encoding.UTF8.GetBytes(expectedStringNoWhiteSpace);
+                    }
+                    else
+                    {
+                        expectedOutput = null;
+                    }
+
+                    this.VerifyWriter(jsonWriter, tokensToWrite, expectedOutput, JsonSerializationFormat.Text, expectedException);
+                }
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = defaultCultureInfo;
+            }
         }
 
         private void VerifyWriter(JsonTokenInfo[] tokensToWrite, byte[] binaryOutput, Exception expectedException = null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonWriterTests.cs
@@ -1330,7 +1330,6 @@
         private void VerifyWriter(JsonTokenInfo[] tokensToWrite, string expectedString = null, Exception expectedException = null)
         {
             CultureInfo defaultCultureInfo = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.GetCultureInfo("fr-FR");
 
             CultureInfo[] cultureInfoList = new CultureInfo[]
             {
@@ -1340,7 +1339,6 @@
 
             try
             {
-
                 foreach (CultureInfo cultureInfo in cultureInfoList)
                 {
                     Encoding[] encodings =

--- a/changelog.md
+++ b/changelog.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#544](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/544) Added continuation token support for LINQ
 - [#557](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/557) Added trigger options to item request options
 
-
 ### Fixed
 
 - [#548](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/548) Fixed mis-typed message in CosmosException.ToString();
 - [#558](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/558) LocationCache ConcurrentDict lock contention fix
 - [#561](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/561) GetItemLinqQueryable now works with null query
+- [#567](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/567) Query correctly handles different language cultures
 
 ## [3.0.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.0.0) - 2019-07-15
 


### PR DESCRIPTION
# Pull Request Template

## Description

The query pipeline was using the local culture settings to parse the JSON.  Cosmos stores the JSON as invariant culture. This would cause query parsing to fail and prevent the user from getting the results. The JSON navigator, reader, and writer are updated to always use invariant culture for parsing now.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #542


