### PR TITLE
Fixed empty error message if query parsing fails from unexpected exception.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPartitionProvider.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 string errorMessage;
                 if (string.IsNullOrEmpty(serializedQueryExecutionInfo))
                 {
-                    errorMessage = $"Message: Please verify the application is using the correct version of \"Microsoft.Azure.Cosmos.ServiceInterop.dll\". Error {exception.ToString()}";
+                    errorMessage = $"Message: Query service interop parsing hit an unexpected exception: {exception.ToString()}";
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPartitionProvider.cs
@@ -226,10 +226,19 @@ namespace Microsoft.Azure.Cosmos.Query
             if (exception != null)
             {
                 DefaultTrace.TraceInformation("QueryEngineConfiguration: " + this.queryengineConfiguration);
+                string errorMessage;
+                if (string.IsNullOrEmpty(serializedQueryExecutionInfo))
+                {
+                    errorMessage = $"Message: Please verify the application is using the correct version of \"Microsoft.Azure.Cosmos.ServiceInterop.dll\". Error {exception.ToString()}";
+                }
+                else
+                {
+                    errorMessage = "Message: " + serializedQueryExecutionInfo;
+                }
 
                 throw new CosmosException(
                     HttpStatusCode.BadRequest,
-                    "Message: " + serializedQueryExecutionInfo);
+                    errorMessage);
             }
 
             PartitionedQueryExecutionInfoInternal queryInfoInternal =

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#558](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/558) LocationCache ConcurrentDict lock contention fix
 - [#561](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/561) GetItemLinqQueryable now works with null query
 - [#567](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/567) Query correctly handles different language cultures
+- [#574](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/574) Fixed empty error message if query parsing fails from unexpected exception
 
 ## [3.0.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.0.0) - 2019-07-15
 


### PR DESCRIPTION
# Pull Request Template

## Description

If the incorrect service interop version is loaded it can cause unexpected exceptions which then has no serializedQueryExecutionInfo. This causes the user to get an error with no message information.  If there is no message is now gives a warning to verify the version and gives the original exception content. 

#573 will prevent this issue in the future.
#566 fixes the empty error message, but not the root problem
 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


