### PR TITLE
Adding ToQueryDefinition method on an IQueryable

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// ]]>
         /// </code>
         /// </example>
-        internal static QueryDefinition ToQueryDefinition<T>(this IQueryable<T> query)
+        public static QueryDefinition ToQueryDefinition<T>(this IQueryable<T> query)
         {
             CosmosLinqQuery<T> linqQuery = query as CosmosLinqQuery<T>;
 

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -73,23 +73,23 @@ namespace Microsoft.Azure.Cosmos.Linq
         }
 
         /// <summary>
-        /// This method generate query text from LINQ query.
+        /// This method generate query definition from LINQ query.
         /// </summary>
         /// <typeparam name="T">the type of object to query.</typeparam>
         /// <param name="query">the IQueryable{T} to be converted.</param>
-        /// <returns>An IDocumentQuery{T} that can evaluate the query.</returns>
+        /// <returns>The queryDefinition which can be used in query execution.</returns>
         /// <example>
-        /// This example shows how to generate query text from LINQ.
+        /// This example shows how to generate query definition from LINQ.
         ///
         /// <code language="c#">
         /// <![CDATA[
         /// IQueryable<T> queryable = container.GetItemsQueryIterator<T>(allowSynchronousQueryExecution = true)
         ///                      .Where(t => b.id.contains("test"));
-        /// String sqlQueryText = queryable.ToSqlQueryText();
+        /// QueryDefinition queryDefinition = queryable.ToQueryDefinition();
         /// ]]>
         /// </code>
         /// </example>
-        internal static string ToSqlQueryText<T>(this IQueryable<T> query)
+        internal static QueryDefinition ToQueryDefinition<T>(this IQueryable<T> query)
         {
             CosmosLinqQuery<T> linqQuery = query as CosmosLinqQuery<T>;
 
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 throw new ArgumentOutOfRangeException(nameof(linqQuery), "ToSqlQueryText is only supported on cosmos LINQ query operations");
             }
 
-            return linqQuery.ToSqlQueryText();
+            return linqQuery.ToQueryDefinition();
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
@@ -132,10 +132,10 @@ namespace Microsoft.Azure.Cosmos.Linq
             return this.container.LinkUri.ToString();
         }
 
-        public string ToSqlQueryText()
+        public QueryDefinition ToQueryDefinition()
         {
             SqlQuerySpec querySpec = DocumentQueryEvaluator.Evaluate(this.Expression);
-            return querySpec?.QueryText;
+            return new QueryDefinition(querySpec);
         }
 
         public FeedIterator<T> ToFeedIterator()

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
@@ -87,5 +87,23 @@ namespace Microsoft.Azure.Cosmos
         {
             return new SqlQuerySpec(this.Query, new SqlParameterCollection(this.SqlParameters.Values));
         }
+
+        /// <summary>
+        /// This method gets the query text from QueryDefinition.
+        /// </summary>
+        /// <returns>The query text from QueryDefinition.</returns>
+        /// <example>
+        /// This example shows how to get query text from QueryDefinition.
+        ///
+        /// <code language="c#">
+        /// <![CDATA[
+        /// String sqlQueryText = queryDefinition.ToSqlQueryText();
+        /// ]]>
+        /// </code>
+        /// </example>
+        public string ToSqlQueryText()
+        {
+            return this.Query;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
@@ -39,6 +39,21 @@ namespace Microsoft.Azure.Cosmos
             this.SqlParameters = new Dictionary<string, SqlParameter>();
         }
 
+        internal QueryDefinition(SqlQuerySpec sqlQuery)
+        {
+            if (sqlQuery == null)
+            {
+                throw new ArgumentNullException(nameof(sqlQuery));
+            }
+
+            this.Query = sqlQuery.QueryText;
+            this.SqlParameters = new Dictionary<string, SqlParameter>();
+            foreach (SqlParameter sqlParameter in sqlQuery.Parameters)
+            {
+                this.SqlParameters.Add(sqlParameter.Name, sqlParameter);
+            }
+        }
+
         /// <summary>
         /// Add parameters to the SQL query
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/QueryDefinition.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public class QueryDefinition
     {
-        private string Query { get; }
         private Dictionary<string, SqlParameter> SqlParameters { get; }
 
         /// <summary>
@@ -35,9 +34,15 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(query));
             }
 
-            this.Query = query;
+            this.QueryText = query;
             this.SqlParameters = new Dictionary<string, SqlParameter>();
         }
+
+        /// <summary>
+        /// Gets the text of the Azure Cosmos DB SQL query.
+        /// </summary>
+        /// <value>The text of the SQL query.</value>
+        public string QueryText { get; }
 
         internal QueryDefinition(SqlQuerySpec sqlQuery)
         {
@@ -46,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(sqlQuery));
             }
 
-            this.Query = sqlQuery.QueryText;
+            this.QueryText = sqlQuery.QueryText;
             this.SqlParameters = new Dictionary<string, SqlParameter>();
             foreach (SqlParameter sqlParameter in sqlQuery.Parameters)
             {
@@ -85,25 +90,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal SqlQuerySpec ToSqlQuerySpec()
         {
-            return new SqlQuerySpec(this.Query, new SqlParameterCollection(this.SqlParameters.Values));
-        }
-
-        /// <summary>
-        /// This method gets the query text from QueryDefinition.
-        /// </summary>
-        /// <returns>The query text from QueryDefinition.</returns>
-        /// <example>
-        /// This example shows how to get query text from QueryDefinition.
-        ///
-        /// <code language="c#">
-        /// <![CDATA[
-        /// String sqlQueryText = queryDefinition.ToSqlQueryText();
-        /// ]]>
-        /// </code>
-        /// </example>
-        public string ToSqlQueryText()
-        {
-            return this.Query;
+            return new SqlQuerySpec(this.QueryText, new SqlParameterCollection(this.SqlParameters.Values));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1348,7 +1348,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => (item.taskNum < 100));
             //V3 Asynchronous query execution with LINQ query generation sql text.
             FeedIterator<ToDoActivity> setIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
-                queriable.ToSqlQueryText(),
+                queriable.ToQueryDefinition(),
                 requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
             int resultsFetched = 0;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2938,6 +2938,13 @@
             "ExtensionAttribute"
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] ToFeedIterator[T](System.Linq.IQueryable`1[T])"
+        },
+        "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T])"
         }
       },
       "NestedTypes": {}
@@ -3054,6 +3061,18 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)"
+        },
+        "System.String get_QueryText()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_QueryText()"
+        },
+        "System.String QueryText": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
         },
         "Void .ctor(System.String)": {
           "Type": "Constructor",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             sqlParameters.Add(new SqlParameter("@name", "ABC"));
             sqlQuerySpec = new SqlQuerySpec(query, sqlParameters);
             sqlQueryDefinition = new QueryDefinition(sqlQuerySpec);
-            Assert.AreEqual(sqlQueryDefinition.ToSqlQueryText(), sqlQuerySpec.QueryText);
+            Assert.AreEqual(sqlQueryDefinition.QueryText, sqlQuerySpec.QueryText);
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().QueryText, sqlQueryDefinition.QueryText);
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.Count(), sqlQuerySpec.Parameters.Count());
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Name, sqlQuerySpec.Parameters.First().Name);
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Value, sqlQuerySpec.Parameters.First().Value);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -37,13 +37,25 @@ namespace Microsoft.Azure.Cosmos.Tests
             sqlParameter = sqlQuerySpec.Parameters.First();
             Assert.AreEqual(paramName, sqlParameter.Name);
             Assert.AreEqual(newParamValue, sqlParameter.Value);
+
+            query = "select * from s where s.Account = @account and s.Name = @name";
+            SqlParameterCollection sqlParameters = new SqlParameterCollection();
+            sqlParameters.Add(new SqlParameter("@account", "12345"));
+            sqlParameters.Add(new SqlParameter("@name", "ABC"));
+            sqlQuerySpec = new SqlQuerySpec(query, sqlParameters);
+            sqlQueryDefinition = new QueryDefinition(sqlQuerySpec);
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().QueryText, sqlQuerySpec.QueryText);
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.Count(), sqlQuerySpec.Parameters.Count());
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Name, sqlQuerySpec.Parameters.First().Name);
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Value, sqlQuerySpec.Parameters.First().Value);
+
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ThrowOnNullQueryText()
         {
-            new QueryDefinition(null);
+            new QueryDefinition(query: null);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             sqlParameters.Add(new SqlParameter("@name", "ABC"));
             sqlQuerySpec = new SqlQuerySpec(query, sqlParameters);
             sqlQueryDefinition = new QueryDefinition(sqlQuerySpec);
-            Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().QueryText, sqlQuerySpec.QueryText);
+            Assert.AreEqual(sqlQueryDefinition.ToSqlQueryText(), sqlQuerySpec.QueryText);
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.Count(), sqlQuerySpec.Parameters.Count());
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Name, sqlQuerySpec.Parameters.First().Name);
             Assert.AreEqual(sqlQueryDefinition.ToSqlQuerySpec().Parameters.First().Value, sqlQuerySpec.Parameters.First().Value);

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#557](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/557) Added trigger options to item request options
 - [#571](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/571) Added a default JSON.net serializer with optional settings
 - [#572](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/572) Added partition key validation on CreateContainerIfNotExistsAsync
-- [#581](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/581) Adding ToQueryDefinition method on an IQueryable
+- [#581](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/581) Adding LINQ to QueryDefinition API
 - [#592](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/592) Added CreateIfNotExistsAsync to container builder
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#544](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/544) Added continuation token support for LINQ
 - [#557](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/557) Added trigger options to item request options
 - [#571](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/571) Added a default JSON.net serializer with optional settings
+- [#581](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/581) Adding ToQueryDefinition method on an IQueryable
 
 ### Fixed
 


### PR DESCRIPTION
This PR will add ToQueryDefinition() method on IQueryable<T>.
User can generate QueryDefinition() from LINQ and used it in stream api GetItemQueryStreamIterator.

## Closing issues

closes #578

