### PR TITLE
Adding continuation token property to response message

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
@@ -96,6 +96,14 @@ namespace Microsoft.Azure.Cosmos
         public virtual Headers Headers { get; }
 
         /// <summary>
+        /// Gets the Continuation Token in the current <see cref="ResponseMessage"/>.
+        /// </summary>
+        /// <remarks>
+        /// This is only used in feed operations like query and change feed
+        /// </remarks>
+        public virtual string ContinuationToken => this.Headers?.ContinuationToken;
+
+        /// <summary>
         /// Gets the original request message
         /// </summary>
         public virtual RequestMessage RequestMessage { get; internal set; }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -374,6 +374,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 pagedStreamResults.AddRange(responseResults);
                 continuationToken = response.Headers.ContinuationToken;
+                Assert.AreEqual(response.ContinuationToken, response.Headers.ContinuationToken);
             } while (continuationToken != null);
 
             Assert.AreEqual(pagedStreamResults.Count, streamResults.Count);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await feedIterator.ReadNextAsync(this.cancellationToken))
                 {
                     lastcontinuation = responseMessage.Headers.ContinuationToken;
+                    Assert.AreEqual(responseMessage.ContinuationToken, responseMessage.Headers.ContinuationToken);
                     List<CompositeContinuationToken> deserializedToken = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(lastcontinuation);
                     currentRange = deserializedToken[0].Range;
                     Assert.AreEqual(pkRangesCount, deserializedToken.Count);
@@ -107,6 +108,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await setIteratorNew.ReadNextAsync(this.cancellationToken))
                 {
                     lastcontinuation = responseMessage.Headers.ContinuationToken;
+                    Assert.AreEqual(responseMessage.ContinuationToken, responseMessage.Headers.ContinuationToken);
                     currentRange = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(lastcontinuation)[0].Range;
 
                     if (responseMessage.IsSuccessStatusCode)
@@ -158,6 +160,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await feedIterator.ReadNextAsync(this.cancellationToken))
                 {
                     lastcontinuation = responseMessage.Headers.ContinuationToken;
+                    Assert.AreEqual(responseMessage.ContinuationToken, responseMessage.Headers.ContinuationToken);
                     List<CompositeContinuationToken> deserializedToken = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(lastcontinuation);
                     currentRange = deserializedToken[0].Range;
                     if (responseMessage.IsSuccessStatusCode)
@@ -274,6 +277,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await feedIterator.ReadNextAsync(this.cancellationToken))
                 {
                     continuationToken = responseMessage.Headers.ContinuationToken;
+                    Assert.AreEqual(responseMessage.ContinuationToken, responseMessage.Headers.ContinuationToken);
                     if (responseMessage.IsSuccessStatusCode)
                     {
                         Collection<ToDoActivity> response = TestCommon.Serializer.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.Content).Data;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await feedIterator.ReadNextAsync(this.cancellationToken))
                 {
                     lastContinuationToken = responseMessage.Headers.ContinuationToken;
-
+                    Assert.AreEqual(responseMessage.ContinuationToken, responseMessage.Headers.ContinuationToken);
                     Collection<ToDoActivity> response = TestCommon.Serializer.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.Content).Data;
                     foreach (ToDoActivity toDoActivity in response)
                     {
@@ -806,6 +806,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 ResponseMessage response = await feedIterator.ReadNextAsync();
                 lastContinuationToken = response.Headers.ContinuationToken;
+                Assert.AreEqual(response.ContinuationToken, response.Headers.ContinuationToken);
+
                 Trace.TraceInformation($"ContinuationToken: {lastContinuationToken}");
                 JsonSerializer serializer = new JsonSerializer();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
@@ -91,9 +91,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 using (ResponseMessage response = await iter.ReadNextAsync())
                 {
-                    lastKnownContinuationToken = response.Headers.ContinuationToken;
-
                     Assert.IsNotNull(response);
+
+                    lastKnownContinuationToken = response.Headers.ContinuationToken;
+                    Assert.AreEqual(response.ContinuationToken, response.Headers.ContinuationToken);
+                    
                     using (StreamReader reader = new StreamReader(response.Content))
                     {
                         string json = await reader.ReadToEndAsync();
@@ -131,6 +133,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 using (ResponseMessage response = await iter.ReadNextAsync())
                 {
                     lastKnownContinuationToken = response.Headers.ContinuationToken;
+                    Assert.AreEqual(response.ContinuationToken, response.Headers.ContinuationToken);
 
                     Assert.IsNotNull(response);
                     using (StreamReader reader = new StreamReader(response.Content))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -4153,10 +4153,20 @@
           "Attributes": [],
           "MethodInfo": null
         },
+        "System.String ContinuationToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
         "System.String ErrorMessage": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
+        },
+        "System.String get_ContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ContinuationToken()"
         },
         "System.String get_ErrorMessage()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#557](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/557) Added trigger options to item request options
 - [#571](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/571) Added a default JSON.net serializer with optional settings
 - [#592](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/592) Added CreateIfNotExistsAsync to container builder
+- [#597](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/597) Added continuation token property to ResponseMessage
 
 ### Fixed
 


### PR DESCRIPTION
# Pull Request Template

## Description

Users are finding it difficult to find the continuation token. In the typed responses continuation token is directly on FeedResponse<T>, and ResponseMessage it is hidden under ResponseMessage.Headers. To make it more discoverable for users a reference will be add directly on ResponseMessage.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


