### PR TITLE
Missing count increment in Sample preventing Assert from ever failing

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/CodeSamples/Queries/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/CodeSamples/Queries/Program.cs
@@ -107,6 +107,7 @@
                 int count = 0;
                 foreach (Family item in await setIterator.ReadNextAsync())
                 {
+                    count++;
                     Assert("Should only return 1 result at a time.", count <= 1);
                     families.Add(item);
                 }


### PR DESCRIPTION
## Adding a missing count increment existing in other sample methods

Very minor change in the samples. There is an Assert that can never fail because the count is never incremented.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)