### PR TITLE
Fixed a bug with read feed with partition key.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -91,9 +91,13 @@ namespace Microsoft.Azure.Cosmos
 
         internal bool IsPropertiesInitialized => this.properties.IsValueCreated;
 
-        internal bool IsPartitionedFeedOperation => this.OperationType == OperationType.ReadFeed && 
+        /// <summary>
+        /// The partition key range handler is only needed for read feed on partitioned resources 
+        /// where the partition key range needs to be computed. 
+        /// </summary>
+        internal bool IsPartitionKeyRangeHandlerRequired => this.OperationType == OperationType.ReadFeed && 
             (this.ResourceType == ResourceType.Document || this.ResourceType == ResourceType.Conflict) && 
-            this.PartitionKeyRangeId == null;
+            this.PartitionKeyRangeId == null && this.Headers.PartitionKey == null;
 
         /// <summary>
         /// Request properties Per request context available to handlers. 

--- a/Microsoft.Azure.Cosmos/src/Handler/RouterHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RouterHandler.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             CancellationToken cancellationToken)
         {
             RequestHandler targetHandler = null;
-            if (request.IsPartitionedFeedOperation)
+            if (request.IsPartitionKeyRangeHandlerRequired)
             {
                 targetHandler = documentFeedHandler;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -76,7 +76,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 List<DatabaseProperties> results = await this.ToListAsync(
                     client.GetDatabaseQueryStreamIterator,
                     client.GetDatabaseQueryIterator<DatabaseProperties>,
-                    null);
+                    null,
+                    RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
@@ -84,7 +85,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 List<DatabaseProperties> queryResults = await this.ToListAsync(
                     client.GetDatabaseQueryStreamIterator,
                     client.GetDatabaseQueryIterator<DatabaseProperties>,
-                    "select * from T where STARTSWITH(T.id, \"BasicQueryDb\")");
+                    "select * from T where STARTSWITH(T.id, \"BasicQueryDb\")",
+                    RequestOptions);
 
                 CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
             }
@@ -121,7 +123,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 List<ContainerProperties> results = await this.ToListAsync(
                     database.GetContainerQueryStreamIterator,
                     database.GetContainerQueryIterator<ContainerProperties>,
-                    null);
+                    null,
+                    RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
@@ -129,7 +132,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 List<ContainerProperties> queryResults = await this.ToListAsync(
                     database.GetContainerQueryStreamIterator,
                     database.GetContainerQueryIterator<ContainerProperties>,
-                    "select * from T where STARTSWITH(T.id, \"BasicQueryContainer\")");
+                    "select * from T where STARTSWITH(T.id, \"BasicQueryContainer\")",
+                    RequestOptions);
 
                 CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
             }
@@ -160,7 +164,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<dynamic> queryResults = await this.ToListAsync(
                   container.GetItemQueryStreamIterator,
                  container.GetItemQueryIterator<dynamic>,
-                 "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")");
+                 "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
+                 RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -178,7 +183,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 queryResults = await this.ToListAsync(
                   container.GetItemQueryStreamIterator,
                  container.GetItemQueryIterator<dynamic>,
-                 "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")");
+                 "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
+                 RequestOptions);
             }
 
             List<string> ids = queryResults.Select(x => (string)x.id).ToList();
@@ -188,10 +194,25 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<dynamic> results = await this.ToListAsync(
                 container.GetItemQueryStreamIterator,
                 container.GetItemQueryIterator<dynamic>,
-                null);
+                null,
+                RequestOptions);
+
 
             ids = results.Select(x => (string)x.id).ToList();
             CollectionAssert.IsSubsetOf(createdIds, ids);
+
+            //Read All with partition key
+             results = await this.ToListAsync(
+                container.GetItemQueryStreamIterator,
+                container.GetItemQueryIterator<dynamic>,
+                null,
+                new QueryRequestOptions()
+                {
+                    MaxItemCount = 1,
+                    PartitionKey = new PartitionKey("BasicQueryItem")
+                });
+
+            Assert.AreEqual(1, results.Count);
         }
 
         [TestMethod]
@@ -213,7 +234,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<StoredProcedureProperties> queryResults = await this.ToListAsync(
                 scripts.GetStoredProcedureQueryStreamIterator,
                 scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
-                "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")");
+                "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
+                RequestOptions);
 
             if(queryResults.Count < 3)
             {
@@ -229,7 +251,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 queryResults = await this.ToListAsync(
                     scripts.GetStoredProcedureQueryStreamIterator,
                     scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
-                    "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")");
+                    "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
+                    RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -238,7 +261,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<StoredProcedureProperties> results = await this.ToListAsync(
                 scripts.GetStoredProcedureQueryStreamIterator,
                 scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
-                null);
+                null,
+                RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -262,7 +286,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<UserDefinedFunctionProperties> queryResults = await this.ToListAsync(
                 scripts.GetUserDefinedFunctionQueryStreamIterator,
                 scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
-                "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")");
+                "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
+                RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -278,7 +303,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 queryResults = await this.ToListAsync(
                     scripts.GetUserDefinedFunctionQueryStreamIterator,
                     scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
-                    "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")");
+                    "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
+                    RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -287,7 +313,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<UserDefinedFunctionProperties> results = await this.ToListAsync(
                 scripts.GetUserDefinedFunctionQueryStreamIterator,
                 scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
-                null);
+                null,
+                RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -311,7 +338,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<TriggerProperties> queryResults = await this.ToListAsync(
                 scripts.GetTriggerQueryStreamIterator,
                 scripts.GetTriggerQueryIterator<TriggerProperties>,
-                "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")");
+                "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
+                RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -327,7 +355,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 queryResults = await this.ToListAsync(
                     scripts.GetTriggerQueryStreamIterator,
                     scripts.GetTriggerQueryIterator<TriggerProperties>,
-                    "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")");
+                    "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
+                    RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -336,7 +365,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<TriggerProperties> results = await this.ToListAsync(
                 scripts.GetTriggerQueryStreamIterator,
                 scripts.GetTriggerQueryIterator<TriggerProperties>,
-                null);
+                null,
+                RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -344,9 +374,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private delegate FeedIterator<T> Query<T>(string querytext, string continuationToken, QueryRequestOptions options);
         private delegate FeedIterator QueryStream(string querytext, string continuationToken, QueryRequestOptions options);
 
-        private async Task<List<T>> ToListAsync<T>(QueryStream createStreamQuery, Query<T> createQuery, string queryText)
+        private async Task<List<T>> ToListAsync<T>(
+            QueryStream createStreamQuery, 
+            Query<T> createQuery, 
+            string queryText,
+            QueryRequestOptions requestOptions)
         {
-            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, RequestOptions);
+            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, requestOptions);
             List<T> streamResults = new List<T>();
             while (feedStreamIterator.HasMoreResults)
             {
@@ -365,7 +399,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedStreamResults = new List<T>();
             do
             {
-                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, RequestOptions);
+                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, requestOptions);
                 ResponseMessage response = await pagedFeedIterator.ReadNextAsync();
                 response.EnsureSuccessStatusCode();
 
@@ -384,7 +418,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string streamPagedResultString = JsonConvert.SerializeObject(pagedStreamResults);
             Assert.AreEqual(streamPagedResultString, streamResultString);
 
-            FeedIterator<T> feedIterator = createQuery(queryText, null, RequestOptions);
+            FeedIterator<T> feedIterator = createQuery(queryText, null, requestOptions);
             List<T> results = new List<T>();
             while (feedIterator.HasMoreResults)
             {
@@ -399,7 +433,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedResults = new List<T>();
             do
             {
-                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, RequestOptions);
+                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, requestOptions);
                 FeedResponse<T> iterator = await pagedFeedIterator.ReadNextAsync();
                 Assert.IsTrue(iterator.Count <= 1);
                 Assert.IsTrue(iterator.Resource.Count() <= 1);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     client.GetDatabaseQueryStreamIterator,
                     client.GetDatabaseQueryIterator<DatabaseProperties>,
                     null,
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     client.GetDatabaseQueryStreamIterator,
                     client.GetDatabaseQueryIterator<DatabaseProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryDb\")",
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
             }
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     database.GetContainerQueryStreamIterator,
                     database.GetContainerQueryIterator<ContainerProperties>,
                     null,
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     database.GetContainerQueryStreamIterator,
                     database.GetContainerQueryIterator<ContainerProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryContainer\")",
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
             }
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                   container.GetItemQueryStreamIterator,
                  container.GetItemQueryIterator<dynamic>,
                  "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
-                 RequestOptions);
+                 CosmosBasicQueryTests.RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                   container.GetItemQueryStreamIterator,
                  container.GetItemQueryIterator<dynamic>,
                  "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
-                 RequestOptions);
+                 CosmosBasicQueryTests.RequestOptions);
             }
 
             List<string> ids = queryResults.Select(x => (string)x.id).ToList();
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 container.GetItemQueryStreamIterator,
                 container.GetItemQueryIterator<dynamic>,
                 null,
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
 
             ids = results.Select(x => (string)x.id).ToList();
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetStoredProcedureQueryStreamIterator,
                 scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             if(queryResults.Count < 3)
             {
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     scripts.GetStoredProcedureQueryStreamIterator,
                     scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetStoredProcedureQueryStreamIterator,
                 scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
                 null,
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetUserDefinedFunctionQueryStreamIterator,
                 scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     scripts.GetUserDefinedFunctionQueryStreamIterator,
                     scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetUserDefinedFunctionQueryStreamIterator,
                 scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
                 null,
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetTriggerQueryStreamIterator,
                 scripts.GetTriggerQueryIterator<TriggerProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             if (queryResults.Count < 3)
             {
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     scripts.GetTriggerQueryStreamIterator,
                     scripts.GetTriggerQueryIterator<TriggerProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
-                    RequestOptions);
+                    CosmosBasicQueryTests.RequestOptions);
             }
 
             CollectionAssert.AreEquivalent(createdIds, queryResults.Select(x => x.Id).ToList());
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 scripts.GetTriggerQueryStreamIterator,
                 scripts.GetTriggerQueryIterator<TriggerProperties>,
                 null,
-                RequestOptions);
+                CosmosBasicQueryTests.RequestOptions);
 
             CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
         }
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string queryText,
             QueryRequestOptions requestOptions)
         {
-            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, requestOptions);
+            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, CosmosBasicQueryTests.RequestOptions);
             List<T> streamResults = new List<T>();
             while (feedStreamIterator.HasMoreResults)
             {
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedStreamResults = new List<T>();
             do
             {
-                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, requestOptions);
+                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, CosmosBasicQueryTests.RequestOptions);
                 ResponseMessage response = await pagedFeedIterator.ReadNextAsync();
                 response.EnsureSuccessStatusCode();
 
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string streamPagedResultString = JsonConvert.SerializeObject(pagedStreamResults);
             Assert.AreEqual(streamPagedResultString, streamResultString);
 
-            FeedIterator<T> feedIterator = createQuery(queryText, null, requestOptions);
+            FeedIterator<T> feedIterator = createQuery(queryText, null, CosmosBasicQueryTests.RequestOptions);
             List<T> results = new List<T>();
             while (feedIterator.HasMoreResults)
             {
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedResults = new List<T>();
             do
             {
-                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, requestOptions);
+                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, CosmosBasicQueryTests.RequestOptions);
                 FeedResponse<T> iterator = await pagedFeedIterator.ReadNextAsync();
                 Assert.IsTrue(iterator.Count <= 1);
                 Assert.IsTrue(iterator.Resource.Count() <= 1);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -213,6 +213,35 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 });
 
             Assert.AreEqual(1, results.Count);
+
+            //Read All with partition key
+            results = container.GetItemLinqQueryable<dynamic>(
+                allowSynchronousQueryExecution: true,
+                requestOptions: new QueryRequestOptions()
+                {
+                    MaxItemCount = 1,
+                    PartitionKey = new PartitionKey("BasicQueryItem")
+                }).ToList();
+
+            Assert.AreEqual(1, results.Count);
+
+            // LINQ to feed iterator Read All with partition key
+            FeedIterator<dynamic> iterator = container.GetItemLinqQueryable<dynamic>(
+                allowSynchronousQueryExecution: true,
+                requestOptions: new QueryRequestOptions()
+                {
+                    MaxItemCount = 1,
+                    PartitionKey = new PartitionKey("BasicQueryItem")
+                }).ToFeedIterator();
+
+            List<dynamic> linqResults = new List<dynamic>();
+            while (iterator.HasMoreResults)
+            {
+                linqResults.AddRange(await iterator.ReadNextAsync());
+            }
+
+            Assert.AreEqual(1, linqResults.Count);
+            Assert.AreEqual("BasicQueryItem", linqResults.First().pk.ToString());
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string queryText,
             QueryRequestOptions requestOptions)
         {
-            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, CosmosBasicQueryTests.RequestOptions);
+            FeedIterator feedStreamIterator = createStreamQuery(queryText, null, requestOptions);
             List<T> streamResults = new List<T>();
             while (feedStreamIterator.HasMoreResults)
             {
@@ -428,7 +428,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedStreamResults = new List<T>();
             do
             {
-                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, CosmosBasicQueryTests.RequestOptions);
+                FeedIterator pagedFeedIterator = createStreamQuery(queryText, continuationToken, requestOptions);
                 ResponseMessage response = await pagedFeedIterator.ReadNextAsync();
                 response.EnsureSuccessStatusCode();
 
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string streamPagedResultString = JsonConvert.SerializeObject(pagedStreamResults);
             Assert.AreEqual(streamPagedResultString, streamResultString);
 
-            FeedIterator<T> feedIterator = createQuery(queryText, null, CosmosBasicQueryTests.RequestOptions);
+            FeedIterator<T> feedIterator = createQuery(queryText, null, requestOptions);
             List<T> results = new List<T>();
             while (feedIterator.HasMoreResults)
             {
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<T> pagedResults = new List<T>();
             do
             {
-                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, CosmosBasicQueryTests.RequestOptions);
+                FeedIterator<T> pagedFeedIterator = createQuery(queryText, continuationToken, requestOptions);
                 FeedResponse<T> iterator = await pagedFeedIterator.ReadNextAsync();
                 Assert.IsTrue(iterator.Count <= 1);
                 Assert.IsTrue(iterator.Resource.Count() <= 1);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResponseMessageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResponseMessageTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestMessage request = new RequestMessage();
             request.OperationType = OperationType.ReadFeed;
             request.ResourceType = ResourceType.Document;
-            Assert.IsTrue(request.IsPartitionedFeedOperation);
+            Assert.IsTrue(request.IsPartitionKeyRangeHandlerRequired);
         }
 
         [TestMethod]
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestMessage request = new RequestMessage();
             request.OperationType = OperationType.ReadFeed;
             request.ResourceType = ResourceType.Conflict;
-            Assert.IsTrue(request.IsPartitionedFeedOperation);
+            Assert.IsTrue(request.IsPartitionKeyRangeHandlerRequired);
         }
 
         [TestMethod]
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             request.OperationType = OperationType.ReadFeed;
             request.ResourceType = ResourceType.Document;
             request.PartitionKeyRangeId = new PartitionKeyRangeIdentity("something");
-            Assert.IsFalse(request.IsPartitionedFeedOperation);
+            Assert.IsFalse(request.IsPartitionKeyRangeHandlerRequired);
         }
 
         [TestMethod]
@@ -44,12 +44,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestMessage request = new RequestMessage();
             request.OperationType = OperationType.Upsert;
             request.ResourceType = ResourceType.Document;
-            Assert.IsFalse(request.IsPartitionedFeedOperation);
+            Assert.IsFalse(request.IsPartitionKeyRangeHandlerRequired);
 
             RequestMessage request2 = new RequestMessage();
             request2.OperationType = OperationType.ReadFeed;
             request2.ResourceType = ResourceType.Database;
-            Assert.IsFalse(request2.IsPartitionedFeedOperation);
+            Assert.IsFalse(request2.IsPartitionKeyRangeHandlerRequired);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResultSetIteratorTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             TestHandler testHandler = new TestHandler((request, cancellationToken) =>
             {
-                Assert.IsTrue(request.IsPartitionedFeedOperation);
+                Assert.IsTrue(request.IsPartitionKeyRangeHandlerRequired);
                 Assert.AreEqual(OperationType.ReadFeed, request.OperationType);
                 Assert.AreEqual(ResourceType.Conflict, request.ResourceType);
                 ResponseMessage handlerResponse = TestHandler.ReturnSuccess().Result;

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- [#612] (https://github.com/Azure/azure-cosmos-dotnet-v3/pull/612) Bug fix for ReadFeed with partition-key
+
 ## [3.1.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.1.0) - 2019-07-26
 
 ### Added


### PR DESCRIPTION
# Pull Request Template

## Description

Read feed with partition key has bug that causes it to go down the wrong pipeline which adds additional values which are not compatible with partition key. I updated the logic and added tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #610  



