### PR TITLE
Fixed SpatialPath serialization and compatibility with older index versions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosIndexJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosIndexJsonConverter.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Globalization;
-    using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -34,14 +33,14 @@ namespace Microsoft.Azure.Cosmos
             if (indexToken.Type != JTokenType.Object)
             {
                 throw new JsonSerializationException(
-                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexSpecFormat));
+                    string.Format(CultureInfo.CurrentCulture, Documents.RMResources.InvalidIndexSpecFormat));
             }
 
-            JToken indexKindToken = indexToken[Constants.Properties.IndexKind];
+            JToken indexKindToken = indexToken[Documents.Constants.Properties.IndexKind];
             if (indexKindToken == null || indexKindToken.Type != JTokenType.String)
             {
                 throw new JsonSerializationException(
-                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexSpecFormat));
+                    string.Format(CultureInfo.CurrentCulture, Documents.RMResources.InvalidIndexSpecFormat));
             }
 
             IndexKind indexKind = IndexKind.Hash;
@@ -61,7 +60,7 @@ namespace Microsoft.Azure.Cosmos
                         break;
                     default:
                         throw new JsonSerializationException(
-                            string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, indexKind));
+                            string.Format(CultureInfo.CurrentCulture, Documents.RMResources.InvalidIndexKindValue, indexKind));
                 }
 
                 serializer.Populate(indexToken.CreateReader(), index);
@@ -70,7 +69,7 @@ namespace Microsoft.Azure.Cosmos
             else
             {
                 throw new JsonSerializationException(
-                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, indexKindToken.Value<string>()));
+                    string.Format(CultureInfo.CurrentCulture, Documents.RMResources.InvalidIndexKindValue, indexKindToken.Value<string>()));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosIndexJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosIndexJsonConverter.cs
@@ -1,0 +1,90 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Globalization;
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal sealed class CosmosIndexJsonConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(Index).IsAssignableFrom(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (objectType != typeof(Index))
+            {
+                return null;
+            }
+
+            JToken indexToken = JToken.Load(reader);
+
+            if (indexToken.Type == JTokenType.Null)
+            {
+                return null;
+            }
+
+            if (indexToken.Type != JTokenType.Object)
+            {
+                throw new JsonSerializationException(
+                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexSpecFormat));
+            }
+
+            JToken indexKindToken = indexToken[Constants.Properties.IndexKind];
+            if (indexKindToken == null || indexKindToken.Type != JTokenType.String)
+            {
+                throw new JsonSerializationException(
+                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexSpecFormat));
+            }
+
+            IndexKind indexKind = IndexKind.Hash;
+            if (Enum.TryParse(indexKindToken.Value<string>(), out indexKind))
+            {
+                object index = null;
+                switch (indexKind)
+                {
+                    case IndexKind.Hash:
+                        index = new HashIndex();
+                        break;
+                    case IndexKind.Range:
+                        index = new RangeIndex();
+                        break;
+                    case IndexKind.Spatial:
+                        index = new SpatialIndex();
+                        break;
+                    default:
+                        throw new JsonSerializationException(
+                            string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, indexKind));
+                }
+
+                serializer.Populate(indexToken.CreateReader(), index);
+                return index;
+            }
+            else
+            {
+                throw new JsonSerializationException(
+                    string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, indexKindToken.Value<string>()));
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Index.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Index.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Base class for IndexingPolicy Indexes in the Azure Cosmos DB service, you should use a concrete Index like HashIndex or RangeIndex.
     /// </summary> 
-    [JsonConverter(typeof(IndexJsonConverter))]
+    [JsonConverter(typeof(CosmosIndexJsonConverter))]
     internal abstract class Index
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/SpatialPath.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/SpatialPath.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public sealed class SpatialPath
     {
-        [JsonProperty(PropertyName = Constants.Properties.Types, ItemConverterType = typeof(StringEnumConverter))]
         private Collection<SpatialType> spatialTypesInternal;
 
         /// <summary>
@@ -27,6 +26,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Path's spatial type
         /// </summary>
+        [JsonProperty(PropertyName = Constants.Properties.Types, ItemConverterType = typeof(StringEnumConverter))]
         public Collection<SpatialType> SpatialTypes
         {
             get

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         [TestMethod]
         public async Task TestWithFixedLeaseContainer()
         {
-            await CosmosItemTests.CreateNonPartitionedContainer(
-                    this.database.Id,
+            await NonPartitionedContainerHelper.CreateNonPartitionedContainer(
+                    this.database,
                     "fixedLeases");
 
             Container fixedLeasesContainer = this.cosmosClient.GetContainer(this.database.Id, "fixedLeases");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -152,8 +152,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Microsoft.Azure.Cosmos.IndexingPolicy indexingPolicy = null)
         {
             string containerName = Guid.NewGuid().ToString() + "container";
-            await CosmosItemTests.CreateNonPartitionedContainer(
-                this.database.Id,
+            await NonPartitionedContainerHelper.CreateNonPartitionedContainer(
+                this.database,
                 containerName,
                 indexingPolicy == null ? null : JsonConvert.SerializeObject(indexingPolicy));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -70,6 +70,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                                 Order = CompositePathSortOrder.Descending
                             }
                         }
+                    },
+                    SpatialIndexes = new Collection<SpatialPath>()
+                    {
+                        new SpatialPath()
+                        {
+                            Path = "/address/spatial/*",
+                            SpatialTypes = new Collection<SpatialType>()
+                            {
+                                SpatialType.LineString
+                            }
+                        }
                     }
                 }
             };
@@ -103,6 +114,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CompositePath compositePath = responseProperties.IndexingPolicy.CompositeIndexes.First().First();
             Assert.AreEqual("/address/city", compositePath.Path);
             Assert.AreEqual(CompositePathSortOrder.Ascending, compositePath.Order);
+
+            Assert.AreEqual(1, responseProperties.IndexingPolicy.SpatialIndexes.Count);
+            SpatialPath spatialPath = responseProperties.IndexingPolicy.SpatialIndexes.First();
+            Assert.AreEqual("/address/spatial/*", spatialPath.Path);
+            Assert.AreEqual(1, spatialPath.SpatialTypes.Count);
+            Assert.AreEqual(SpatialType.LineString, spatialPath.SpatialTypes.First());
         }
 
         [TestMethod]
@@ -232,7 +249,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            
             ContainerResponse containerResponse =
                 await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithIndexingPolicy()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -4,16 +4,14 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
-    using System;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.Azure.Cosmos.Fluent;
-    using System.Net;
-    using System.Linq;
     using Newtonsoft.Json.Linq;
+    using System;
     using System.Collections.ObjectModel;
     using System.IO;
-    using Microsoft.Azure.Documents;
+    using System.Linq;
+    using System.Net;
+    using System.Threading.Tasks;
 
     // Similar tests to CosmosContainerTests but with Fluent syntax
     [TestClass]
@@ -38,48 +36,48 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/users")
             {
-                IndexingPolicy = new Cosmos.IndexingPolicy()
+                IndexingPolicy = new IndexingPolicy()
                 {
                     Automatic = true,
-                    IndexingMode = Cosmos.IndexingMode.Consistent,
-                    IncludedPaths = new Collection<Cosmos.IncludedPath>()
+                    IndexingMode = IndexingMode.Consistent,
+                    IncludedPaths = new Collection<IncludedPath>()
                     {
-                        new Cosmos.IncludedPath()
+                        new IncludedPath()
                         {
                             Path = "/*"
                         }
                     },
-                    ExcludedPaths = new Collection<Cosmos.ExcludedPath>()
+                    ExcludedPaths = new Collection<ExcludedPath>()
                     {
-                        new Cosmos.ExcludedPath()
+                        new ExcludedPath()
                         {
                             Path = "/test/*"
                         }
                     },
-                    CompositeIndexes = new Collection<Collection<Cosmos.CompositePath>>()
+                    CompositeIndexes = new Collection<Collection<CompositePath>>()
                     {
-                        new Collection<Cosmos.CompositePath>()
+                        new Collection<CompositePath>()
                         {
-                            new Cosmos.CompositePath()
+                            new CompositePath()
                             {
                                 Path = "/address/city",
-                                Order = Cosmos.CompositePathSortOrder.Ascending
+                                Order = CompositePathSortOrder.Ascending
                             },
-                            new Cosmos.CompositePath()
+                            new CompositePath()
                             {
                                 Path = "/address/zipcode",
-                                Order = Cosmos.CompositePathSortOrder.Descending
+                                Order = CompositePathSortOrder.Descending
                             }
                         }
                     },
-                    SpatialIndexes = new Collection<Cosmos.SpatialPath>()
+                    SpatialIndexes = new Collection<SpatialPath>()
                     {
-                        new Cosmos.SpatialPath()
+                        new SpatialPath()
                         {
                             Path = "/address/spatial/*",
-                            SpatialTypes = new Collection<Cosmos.SpatialType>()
+                            SpatialTypes = new Collection<SpatialType>()
                             {
-                                Cosmos.SpatialType.LineString
+                                SpatialType.LineString
                             }
                         }
                     }
@@ -105,14 +103,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(responseProperties.LastModified.Value > new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), responseProperties.LastModified.Value.ToString());
 
             Assert.AreEqual(1, responseProperties.IndexingPolicy.IncludedPaths.Count);
-            Cosmos.IncludedPath includedPath = responseProperties.IndexingPolicy.IncludedPaths.First();
+            IncludedPath includedPath = responseProperties.IndexingPolicy.IncludedPaths.First();
             Assert.AreEqual("/*", includedPath.Path);
 
             Assert.AreEqual("/test/*", responseProperties.IndexingPolicy.ExcludedPaths.First().Path);
 
             Assert.AreEqual(1, responseProperties.IndexingPolicy.CompositeIndexes.Count);
             Assert.AreEqual(2, responseProperties.IndexingPolicy.CompositeIndexes.First().Count);
-            Cosmos.CompositePath compositePath = responseProperties.IndexingPolicy.CompositeIndexes.First().First();
+            CompositePath compositePath = responseProperties.IndexingPolicy.CompositeIndexes.First().First();
             Assert.AreEqual("/address/city", compositePath.Path);
             Assert.AreEqual(CompositePathSortOrder.Ascending, compositePath.Order);
 
@@ -128,11 +126,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/users")
             {
-                IndexingPolicy = new Cosmos.IndexingPolicy()
+                IndexingPolicy = new IndexingPolicy()
                 {
-                    SpatialIndexes = new Collection<Cosmos.SpatialPath>()
+                    SpatialIndexes = new Collection<SpatialPath>()
                     {
-                        new Cosmos.SpatialPath()
+                        new SpatialPath()
                         {
                             Path = "/address/spatial/*"
                         }
@@ -155,19 +153,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ContainerMigrationTest()
         {
             string containerName = "MigrationIndexTest";
-            Index index1 = new RangeIndex(DataType.String, -1);
-            Index index2 = new RangeIndex(DataType.Number, -1);
-            DocumentCollection documentCollection = new DocumentCollection()
+            Documents.Index index1 = new Documents.RangeIndex(Documents.DataType.String, -1);
+            Documents.Index index2 = new Documents.RangeIndex(Documents.DataType.Number, -1);
+            Documents.DocumentCollection documentCollection = new Microsoft.Azure.Documents.DocumentCollection()
             {
                 Id = containerName,
-                IndexingPolicy = new IndexingPolicy()
+                IndexingPolicy = new Documents.IndexingPolicy()
                 {
-                    IncludedPaths = new Collection<IncludedPath>()
+                    IncludedPaths = new Collection<Documents.IncludedPath>()
                     {
-                        new IncludedPath()
+                        new Documents.IncludedPath()
                         {
                             Path = "/*",
-                            Indexes = new Collection<Index>()
+                            Indexes = new Collection<Documents.Index>()
                             {
                                 index1,
                                 index2
@@ -177,11 +175,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             };
 
-            DocumentCollection createResponse = await NonPartitionedContainerHelper.CreateNonPartitionedContainer(this.database, documentCollection);
+            Documents.DocumentCollection createResponse = await NonPartitionedContainerHelper.CreateNonPartitionedContainer(this.database, documentCollection);
 
             // Verify the collection was created with deprecated Index objects
             Assert.AreEqual(2, createResponse.IndexingPolicy.IncludedPaths.First().Indexes.Count);
-            Index createIndex = createResponse.IndexingPolicy.IncludedPaths.First().Indexes.First();
+            Documents.Index createIndex = createResponse.IndexingPolicy.IncludedPaths.First().Indexes.First();
             Assert.AreEqual(index1.Kind, createIndex.Kind);
 
             // Verify v3 can add composite indexes and update the container
@@ -189,34 +187,34 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ContainerProperties containerProperties = await container.ReadContainerAsync();
             string cPath0 = "/address/city";
             string cPath1 = "/address/state";
-            containerProperties.IndexingPolicy.CompositeIndexes.Add(new Collection<Cosmos.CompositePath>()
+            containerProperties.IndexingPolicy.CompositeIndexes.Add(new Collection<CompositePath>()
             {
-                new Cosmos.CompositePath()
+                new CompositePath()
                 {
                     Path= cPath0,
-                    Order = Cosmos.CompositePathSortOrder.Descending
+                    Order = CompositePathSortOrder.Descending
                 },
-                new Cosmos.CompositePath()
+                new CompositePath()
                 {
                     Path= cPath1,
-                    Order = Cosmos.CompositePathSortOrder.Ascending
+                    Order = CompositePathSortOrder.Ascending
                 }
             });
 
             containerProperties.IndexingPolicy.SpatialIndexes.Add(
-                new Cosmos.SpatialPath()
+                new SpatialPath()
                 {
                     Path = "/address/test/*",
-                    SpatialTypes = new Collection<Cosmos.SpatialType>() { Cosmos.SpatialType.Point }
+                    SpatialTypes = new Collection<SpatialType>() { SpatialType.Point }
                 });
 
             ContainerProperties propertiesAfterReplace = await container.ReplaceContainerAsync(containerProperties);
             Assert.AreEqual(0, propertiesAfterReplace.IndexingPolicy.IncludedPaths.First().Indexes.Count);
             Assert.AreEqual(1, propertiesAfterReplace.IndexingPolicy.CompositeIndexes.Count);
-            Collection<Cosmos.CompositePath> compositePaths = propertiesAfterReplace.IndexingPolicy.CompositeIndexes.First();
+            Collection<CompositePath> compositePaths = propertiesAfterReplace.IndexingPolicy.CompositeIndexes.First();
             Assert.AreEqual(2, compositePaths.Count);
-            Cosmos.CompositePath compositePath0 = compositePaths.ElementAt(0);
-            Cosmos.CompositePath compositePath1 = compositePaths.ElementAt(1);
+            CompositePath compositePath0 = compositePaths.ElementAt(0);
+            CompositePath compositePath1 = compositePaths.ElementAt(1);
             Assert.IsTrue(string.Equals(cPath0, compositePath0.Path) || string.Equals(cPath1, compositePath0.Path));
             Assert.IsTrue(string.Equals(cPath0, compositePath1.Path) || string.Equals(cPath1, compositePath1.Path));
 
@@ -233,7 +231,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ContainerResponse containerResponse =
                 await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithIndexingPolicy()
-                        .WithIndexingMode(Cosmos.IndexingMode.None)
+                        .WithIndexingMode(IndexingMode.None)
                         .WithAutomaticIndexing(false)
                         .Attach()
                     .CreateAsync();
@@ -242,14 +240,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(containerName, containerResponse.Resource.Id);
             Assert.AreEqual(partitionKeyPath, containerResponse.Resource.PartitionKey.Paths.First());
             Container container = containerResponse;
-            Assert.AreEqual(Cosmos.IndexingMode.None, containerResponse.Resource.IndexingPolicy.IndexingMode);
+            Assert.AreEqual(IndexingMode.None, containerResponse.Resource.IndexingPolicy.IndexingMode);
             Assert.IsFalse(containerResponse.Resource.IndexingPolicy.Automatic);
 
             containerResponse = await container.ReadContainerAsync();
             Assert.AreEqual(HttpStatusCode.OK, containerResponse.StatusCode);
             Assert.AreEqual(containerName, containerResponse.Resource.Id);
             Assert.AreEqual(partitionKeyPath, containerResponse.Resource.PartitionKey.Paths.First());
-            Assert.AreEqual(Cosmos.IndexingMode.None, containerResponse.Resource.IndexingPolicy.IndexingMode);
+            Assert.AreEqual(IndexingMode.None, containerResponse.Resource.IndexingPolicy.IndexingMode);
             Assert.IsFalse(containerResponse.Resource.IndexingPolicy.Automatic);
 
             containerResponse = await containerResponse.Container.DeleteContainerAsync();
@@ -295,7 +293,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task TestConflictResolutionPolicy()
         {
-            Cosmos.Database databaseForConflicts = await this.cosmosClient.CreateDatabaseAsync("conflictResolutionContainerTest",
+            Database databaseForConflicts = await this.cosmosClient.CreateDatabaseAsync("conflictResolutionContainerTest",
                 cancellationToken: this.cancellationToken);
 
             try
@@ -363,7 +361,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             .Attach()
                         .WithCompositeIndex()
                             .Path("/composite1")
-                            .Path("/composite2", Cosmos.CompositePathSortOrder.Descending)
+                            .Path("/composite2", CompositePathSortOrder.Descending)
                             .Attach()
                         .Attach()
                     .CreateAsync();
@@ -532,7 +530,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<dynamic> createItemResponse = await container.CreateItemAsync<dynamic>(payload);
             Assert.IsNotNull(createItemResponse.Resource);
             Assert.AreEqual(createItemResponse.StatusCode, HttpStatusCode.Created);
-            ItemResponse<dynamic> readItemResponse = await container.ReadItemAsync<dynamic>(payload.id, new Cosmos.PartitionKey(payload.user));
+            ItemResponse<dynamic> readItemResponse = await container.ReadItemAsync<dynamic>(payload.id, new PartitionKey(payload.user));
             Assert.IsNotNull(readItemResponse.Resource);
             Assert.AreEqual(readItemResponse.StatusCode, HttpStatusCode.OK);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/NonPartitionedContainerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/NonPartitionedContainerHelper.cs
@@ -4,20 +4,10 @@
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
-    using System.Collections.Generic;
-    using System.Collections.Specialized;
-    using System.Globalization;
-    using System.IO;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Collections;
-    using Microsoft.Azure.Cosmos.Internal;
-    using Microsoft.Azure.Cosmos.Services.Management.Tests;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Client;
-    using Microsoft.Azure.Documents.Collections;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
 
@@ -65,11 +55,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             client.DefaultRequestHeaders.Add("x-ms-version", NonPartitionedContainerHelper.PreNonPartitionedMigrationApiVersion);
 
             string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
-                verb, 
-                resourceId, 
+                verb,
+                resourceId,
                 resourceType,
-                accountInfo.authKey, 
-                "master", 
+                accountInfo.authKey,
+                "master",
                 "1.0");
 
             client.DefaultRequestHeaders.Add("authorization", authHeader);
@@ -106,11 +96,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string resourceId = container.LinkUri.OriginalString;
             string resourceLink = string.Format("dbs/{0}/colls/{1}/docs", container.Database.Id, container.Id);
             string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
-                verb, 
-                resourceId, 
-                resourceType, 
-                accountInfo.authKey, 
-                "master", 
+                verb,
+                resourceId,
+                resourceType,
+                accountInfo.authKey,
+                "master",
                 "1.0");
 
             client.DefaultRequestHeaders.Remove("authorization");
@@ -124,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         internal static async Task CreateItemInNonPartitionedContainer(
-            ContainerCore container, 
+            ContainerCore container,
             string itemId)
         {
             (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
@@ -135,10 +125,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string resourceType = "docs";
             string resourceLink = string.Format("dbs/{0}/colls/{1}/docs", container.Database.Id, container.Id);
             string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
-                verb, container.LinkUri.OriginalString, 
+                verb, container.LinkUri.OriginalString,
                 resourceType,
-                accountInfo.authKey, 
-                "master", 
+                accountInfo.authKey,
+                "master",
                 "1.0");
 
             client.DefaultRequestHeaders.Add("x-ms-date", utc_date);
@@ -155,11 +145,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         private static string GenerateMasterKeyAuthorizationSignature(
-            string verb, 
-            string resourceId, 
-            string resourceType, 
-            string key, 
-            string keyType, 
+            string verb,
+            string resourceId,
+            string resourceType,
+            string key,
+            string keyType,
             string tokenVersion)
         {
             System.Security.Cryptography.HMACSHA256 hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/NonPartitionedContainerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/NonPartitionedContainerHelper.cs
@@ -1,0 +1,185 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Collections;
+    using Microsoft.Azure.Cosmos.Internal;
+    using Microsoft.Azure.Cosmos.Services.Management.Tests;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Collections;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    internal static class NonPartitionedContainerHelper
+    {
+        private static readonly string PreNonPartitionedMigrationApiVersion = "2018-08-31";
+        private static readonly string utc_date = DateTime.UtcNow.ToString("r");
+
+        internal static async Task<ContainerCore> CreateNonPartitionedContainer(
+            Cosmos.Database database,
+            string containerId,
+            string indexingPolicy = null)
+        {
+            DocumentCollection documentCollection = new DocumentCollection()
+            {
+                Id = containerId
+            };
+
+            if (indexingPolicy != null)
+            {
+                documentCollection.IndexingPolicy = JsonConvert.DeserializeObject<IndexingPolicy>(indexingPolicy);
+            }
+
+            await NonPartitionedContainerHelper.CreateNonPartitionedContainer(
+                database,
+                documentCollection);
+
+            return (ContainerCore)database.GetContainer(containerId);
+        }
+
+        internal static async Task<DocumentCollection> CreateNonPartitionedContainer(
+            Cosmos.Database database,
+            DocumentCollection documentCollection)
+        {
+            (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
+
+            //Creating non partition Container, rest api used instead of .NET SDK api as it is not supported anymore.
+            HttpClient client = new System.Net.Http.HttpClient();
+            Uri baseUri = new Uri(accountInfo.endpoint);
+            string verb = "POST";
+            string resourceType = "colls";
+            string resourceId = string.Format("dbs/{0}", database.Id);
+            string resourceLink = string.Format("dbs/{0}/colls", database.Id);
+            client.DefaultRequestHeaders.Add("x-ms-date", utc_date);
+            client.DefaultRequestHeaders.Add("x-ms-version", NonPartitionedContainerHelper.PreNonPartitionedMigrationApiVersion);
+
+            string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
+                verb, 
+                resourceId, 
+                resourceType,
+                accountInfo.authKey, 
+                "master", 
+                "1.0");
+
+            client.DefaultRequestHeaders.Add("authorization", authHeader);
+            string containerDefinition = documentCollection.ToString();
+            StringContent containerContent = new StringContent(containerDefinition);
+            Uri requestUri = new Uri(baseUri, resourceLink);
+
+            DocumentCollection responseCollection = null;
+            using (HttpResponseMessage response = await client.PostAsync(requestUri.ToString(), containerContent))
+            {
+                response.EnsureSuccessStatusCode();
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode, response.ToString());
+                responseCollection = await response.Content.ToResourceAsync<DocumentCollection>();
+            }
+
+            return responseCollection;
+        }
+
+        internal static async Task CreateUndefinedPartitionItem(
+            ContainerCore container,
+            string itemId)
+        {
+            (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
+            //Creating undefined partition key  item, rest api used instead of .NET SDK api as it is not supported anymore.
+            HttpClient client = new System.Net.Http.HttpClient();
+            Uri baseUri = new Uri(accountInfo.endpoint);
+            client.DefaultRequestHeaders.Add("x-ms-date", utc_date);
+            client.DefaultRequestHeaders.Add("x-ms-version", NonPartitionedContainerHelper.PreNonPartitionedMigrationApiVersion);
+            client.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", "[{}]");
+
+            //Creating undefined partition Container item.
+            string verb = "POST";
+            string resourceType = "docs";
+            string resourceId = container.LinkUri.OriginalString;
+            string resourceLink = string.Format("dbs/{0}/colls/{1}/docs", container.Database.Id, container.Id);
+            string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
+                verb, 
+                resourceId, 
+                resourceType, 
+                accountInfo.authKey, 
+                "master", 
+                "1.0");
+
+            client.DefaultRequestHeaders.Remove("authorization");
+            client.DefaultRequestHeaders.Add("authorization", authHeader);
+
+            var payload = new { id = itemId, user = itemId };
+            string itemDefinition = JsonConvert.SerializeObject(payload);
+            StringContent itemContent = new StringContent(itemDefinition);
+            Uri requestUri = new Uri(baseUri, resourceLink);
+            await client.PostAsync(requestUri.ToString(), itemContent);
+        }
+
+        internal static async Task CreateItemInNonPartitionedContainer(
+            ContainerCore container, 
+            string itemId)
+        {
+            (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
+            //Creating non partition Container item.
+            HttpClient client = new System.Net.Http.HttpClient();
+            Uri baseUri = new Uri(accountInfo.endpoint);
+            string verb = "POST";
+            string resourceType = "docs";
+            string resourceLink = string.Format("dbs/{0}/colls/{1}/docs", container.Database.Id, container.Id);
+            string authHeader = NonPartitionedContainerHelper.GenerateMasterKeyAuthorizationSignature(
+                verb, container.LinkUri.OriginalString, 
+                resourceType,
+                accountInfo.authKey, 
+                "master", 
+                "1.0");
+
+            client.DefaultRequestHeaders.Add("x-ms-date", utc_date);
+            client.DefaultRequestHeaders.Add("x-ms-version", NonPartitionedContainerHelper.PreNonPartitionedMigrationApiVersion);
+            client.DefaultRequestHeaders.Add("authorization", authHeader);
+
+            string itemDefinition = JsonConvert.SerializeObject(ToDoActivity.CreateRandomToDoActivity(id: itemId));
+            {
+                StringContent itemContent = new StringContent(itemDefinition);
+                Uri requestUri = new Uri(baseUri, resourceLink);
+                HttpResponseMessage response = await client.PostAsync(requestUri.ToString(), itemContent);
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode, response.ToString());
+            }
+        }
+
+        private static string GenerateMasterKeyAuthorizationSignature(
+            string verb, 
+            string resourceId, 
+            string resourceType, 
+            string key, 
+            string keyType, 
+            string tokenVersion)
+        {
+            System.Security.Cryptography.HMACSHA256 hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
+
+            string payLoad = string.Format(System.Globalization.CultureInfo.InvariantCulture, "{0}\n{1}\n{2}\n{3}\n{4}\n",
+                    verb.ToLowerInvariant(),
+                    resourceType.ToLowerInvariant(),
+                    resourceId,
+                    utc_date.ToLowerInvariant(),
+                    ""
+            );
+
+            byte[] hashPayLoad = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payLoad));
+            string signature = Convert.ToBase64String(hashPayLoad);
+
+            return System.Web.HttpUtility.UrlEncode(string.Format(System.Globalization.CultureInfo.InvariantCulture, "type={0}&ver={1}&sig={2}",
+                keyType,
+                tokenVersion,
+                signature));
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -51,12 +51,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             TestCommon.masterStalenessIntervalInSeconds = int.Parse(ConfigurationManager.AppSettings["MasterStalenessIntervalInSeconds"], CultureInfo.InvariantCulture);
         }
 
-        internal static CosmosClientBuilder GetDefaultConfiguration()
+        internal static (string endpoint, string authKey) GetAccountInfo()
         {
             string authKey = ConfigurationManager.AppSettings["MasterKey"];
             string endpoint = ConfigurationManager.AppSettings["GatewayEndpoint"];
 
-            return new CosmosClientBuilder(accountEndpoint: endpoint, accountKey: authKey);
+            return (endpoint, authKey);
+        }
+
+        internal static CosmosClientBuilder GetDefaultConfiguration()
+        {
+            (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
+
+            return new CosmosClientBuilder(accountEndpoint: accountInfo.endpoint, accountKey: accountInfo.authKey);
         }
 
         internal static CosmosClient CreateCosmosClient(Action<CosmosClientBuilder> customizeClientBuilder = null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -6104,9 +6104,11 @@
           "Attributes": [],
           "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] get_SpatialTypes()"
         },
-        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] SpatialTypes": {
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] SpatialTypes[Newtonsoft.Json.JsonPropertyAttribute(ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter), PropertyName = \"types\")]": {
           "Type": "Property",
-          "Attributes": [],
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
           "MethodInfo": null
         },
         "System.String get_Path()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -4,6 +4,11 @@
 
 namespace Microsoft.Azure.Cosmos.Tests
 {
+    using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.Scripts;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
     using System;
     using System.Collections.ObjectModel;
     using System.IO;
@@ -11,10 +16,6 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Reflection;
     using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Scripts;
-    using Microsoft.Azure.Documents;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Newtonsoft.Json;
 
     [TestClass]
     public class SettingsContractTests
@@ -87,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     + "\",\"_etag\":\"" + etag
                     + "\",\"_colls\":\"colls\\/\",\"_users\":\"users\\/\",\"_ts\":" + ts + "}";
 
-            DatabaseProperties deserializedPayload = 
+            DatabaseProperties deserializedPayload =
                 JsonConvert.DeserializeObject<DatabaseProperties>(testPyaload);
 
             Assert.IsTrue(deserializedPayload.LastModified.HasValue);
@@ -348,11 +349,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             string id = Guid.NewGuid().ToString();
             string pkPath = "/partitionKey";
 
-            SettingsContractTests.TypeAccessorGuard(typeof(ContainerProperties), 
-                "Id", 
-                "UniqueKeyPolicy", 
-                "DefaultTimeToLive", 
-                "IndexingPolicy", 
+            SettingsContractTests.TypeAccessorGuard(typeof(ContainerProperties),
+                "Id",
+                "UniqueKeyPolicy",
+                "DefaultTimeToLive",
+                "IndexingPolicy",
                 "TimeToLivePropertyPath",
                 "PartitionKeyPath",
                 "PartitionKeyDefinitionVersion",
@@ -388,6 +389,33 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task ContainerSettingsIndexTest()
+        {
+            string containerJsonString = "{\"indexingPolicy\":{\"automatic\":true,\"indexingMode\":\"Consistent\",\"includedPaths\":[{\"path\":\"/*\",\"indexes\":[{\"dataType\":\"Number\",\"precision\":-1,\"kind\":\"Range\"},{\"dataType\":\"String\",\"precision\":-1,\"kind\":\"Range\"}]}],\"excludedPaths\":[{\"path\":\"/\\\"_etag\\\"/?\"}],\"compositeIndexes\":[],\"spatialIndexes\":[]},\"id\":\"MigrationTest\",\"partitionKey\":{\"paths\":[\"/id\"],\"kind\":\"Hash\"}}";
+
+            CosmosJsonDotNetSerializer cosmosSerializer = new CosmosJsonDotNetSerializer();
+            ContainerProperties containerProperties = null;
+            using (MemoryStream memory = new MemoryStream(Encoding.UTF8.GetBytes(containerJsonString)))
+            {
+                containerProperties = cosmosSerializer.FromStream<ContainerProperties>(memory);
+            }
+
+            Assert.IsNotNull(containerProperties);
+            Assert.AreEqual("MigrationTest", containerProperties.Id);
+
+            string containerJsonAfterConversion = null;
+            using (Stream stream = cosmosSerializer.ToStream<ContainerProperties>(containerProperties))
+            {
+                using(StreamReader sr = new StreamReader(stream))
+                {
+                    containerJsonAfterConversion = await sr.ReadToEndAsync();
+                }
+            }
+
+            Assert.AreEqual(containerJsonString, containerJsonAfterConversion);
+        }
+
+        [TestMethod]
         public void CosmosAccountSettingsSerializationTest()
         {
             AccountProperties cosmosAccountSettings = new AccountProperties();
@@ -395,7 +423,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             cosmosAccountSettings.EnableMultipleWriteLocations = true;
             cosmosAccountSettings.ResourceId = "/uri";
             cosmosAccountSettings.ETag = "etag";
-            cosmosAccountSettings.WriteLocationsInternal = new Collection<AccountRegion>() { new AccountRegion() { Name="region1", Endpoint = "endpoint1" } };
+            cosmosAccountSettings.WriteLocationsInternal = new Collection<AccountRegion>() { new AccountRegion() { Name = "region1", Endpoint = "endpoint1" } };
             cosmosAccountSettings.ReadLocationsInternal = new Collection<AccountRegion>() { new AccountRegion() { Name = "region2", Endpoint = "endpoint2" } };
             cosmosAccountSettings.AddressesLink = "link";
             cosmosAccountSettings.Consistency = new AccountConsistency() { DefaultConsistencyLevel = Cosmos.ConsistencyLevel.BoundedStaleness };
@@ -486,7 +514,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
-        private static T DirectDeSerialize<T>(string payload) where T: JsonSerializable, new()
+        private static T DirectDeSerialize<T>(string payload) where T : JsonSerializable, new()
         {
             using (MemoryStream ms = new MemoryStream())
             {
@@ -510,7 +538,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
-        private static string DirectSerialize<T>(T input) where T: JsonSerializable
+        private static string DirectSerialize<T>(T input) where T : JsonSerializable
         {
             using (MemoryStream ms = new MemoryStream())
             {
@@ -527,7 +555,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         private static void TypeAccessorGuard(Type input, params string[] publicSettable)
         {
             // All properties are public readable only by-default
-            PropertyInfo[] allProperties = input.GetProperties(BindingFlags.Instance|BindingFlags.Public);
+            PropertyInfo[] allProperties = input.GetProperties(BindingFlags.Instance | BindingFlags.Public);
             foreach (PropertyInfo pInfo in allProperties)
             {
                 MethodInfo[] accessors = pInfo.GetAccessors();
@@ -550,7 +578,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
-        private void AssertEnums<TFirstEnum,TSecondEnum>() where TFirstEnum : struct, IConvertible where TSecondEnum : struct, IConvertible
+        private void AssertEnums<TFirstEnum, TSecondEnum>() where TFirstEnum : struct, IConvertible where TSecondEnum : struct, IConvertible
         {
             string[] allCosmosEntries = Enum.GetNames(typeof(TFirstEnum));
             string[] allDocumentsEntries = Enum.GetNames(typeof(TSecondEnum));

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#612](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/612) Bug fix for ReadFeed with partition-key
-- [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed SpatialPath serialization and compatibility with older index versions 
+- [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed SpatialPath serialization and compatibility with older index versions
 
 ## [3.1.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.1.0) - 2019-07-26
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed Index serialization bug
+
 ## [3.1.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.1.0) - 2019-07-26
 
 ### Added
@@ -14,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#557](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/557) Added trigger options to item request options
 - [#571](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/571) Added a default JSON.net serializer with optional settings
 - [#572](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/572) Added partition key validation on CreateContainerIfNotExistsAsync
-- [#581](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/581) Adding LINQ to QueryDefinition API
+- [#581](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/581) Added LINQ to QueryDefinition API
 - [#592](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/592) Added CreateIfNotExistsAsync to container builder
 - [#597](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/597) Added continuation token property to ResponseMessage
 - [#604](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/604) Added LINQ ToStreamIterator extension method

--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#612] (https://github.com/Azure/azure-cosmos-dotnet-v3/pull/612) Bug fix for ReadFeed with partition-key
-- [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed Index serialization bug
+- [#612](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/612) Bug fix for ReadFeed with partition-key
+- [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed SpatialPath serialization and compatibility with older index versions 
 
 ## [3.1.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.1.0) - 2019-07-26
 


### PR DESCRIPTION
# Pull Request Template

## Description

The indexing policy's include path index object was using a converter from the Direct dependency which was using the Document namespace object instead of the v3 Cosmos namespace types. This caused the conversion to fail and return random results. Ported the converter to github repo and updated it to use the v3 types.

Fixed Spatial indexes serialization. There was bug that caused it to get serialized with an extra property which the backend did not understand which caused a bad request. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

