### PR TITLE
.editorconfig repo override

### DIFF
--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29123.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos", "Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj", "{36F6F6A8-CEC8-4261-9948-903495BC3C25}"
 EndProject

--- a/Microsoft.Azure.Cosmos/.editorconfig
+++ b/Microsoft.Azure.Cosmos/.editorconfig
@@ -1,0 +1,68 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+root = true 
+
+# All files 
+[*] 
+indent_style = space 
+
+# Code files 
+[*.cs] 
+indent_size = 4
+tab_width = 4
+trim_trailing_whitespace = true
+
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.cs] 
+# Organize usings 
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
+# this. preferences 
+dotnet_style_qualification_for_field = true:error 
+dotnet_style_qualification_for_property = true:error 
+dotnet_style_qualification_for_method = true:error 
+dotnet_style_qualification_for_event = true:error
+
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+
+# Space preferences 
+csharp_space_after_keywords_in_control_flow_statements = true 
+
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:error 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:error 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:error 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:error 
+
+# Expression-level preferences 
+dotnet_style_prefer_auto_properties = true:error 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error 
+
+# CSharp code style settings:
+csharp_style_var_for_built_in_types = false:error
+csharp_style_var_when_type_is_apparent = false:error
+csharp_style_var_elsewhere = false:error
+
+## Naming Conventions
+# Async methods should have [Async] suffix
+[*.cs]
+dotnet_naming_rule.async_method_must_end_with_async.symbols   = async_methods
+dotnet_naming_symbols.async_methods.applicable_kinds           = method
+dotnet_naming_symbols.async_methods.applicable_accessibilities = *
+dotnet_naming_symbols.async_methods.required_modifiers         = async
+
+dotnet_naming_rule.async_method_must_end_with_async.style    = async_suffix
+dotnet_naming_style.async_suffix.required_suffix = Async
+
+dotnet_naming_rule.async_method_must_end_with_async.severity = error


### PR DESCRIPTION
.editorconfig repo override

This repo override ensures consistency of conventions.
In VS non-adherence will show up as error list. 

msuild doesn't yet consider .editorconfig into build process. When this gap is addressed we can even apply at build time.

Please upgrade VS to 2019 latest version.

[https://github.com/dotnet/roslyn/issues/33558](https://github.com/dotnet/roslyn/issues/33558)