### PR TITLE
StandByFeedIterator to continue on NotModified

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -74,9 +74,7 @@ namespace Microsoft.Azure.Cosmos
 
             (CompositeContinuationToken currentRangeToken, string rangeId) = await this.compositeContinuationToken.GetCurrentTokenAsync();
             this.partitionKeyRangeId = rangeId;
-
             this.continuationToken = currentRangeToken.Token;
-
             ResponseMessage response = await this.NextResultSetDelegateAsync(this.continuationToken, this.partitionKeyRangeId, this.maxItemCount, this.changeFeedOptions, cancellationToken);
             if (await this.ShouldRetryFailureAsync(response, cancellationToken))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
-
         [TestMethod]
         public async Task ShouldContinueUntilResponseOk()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Net;
     using System.Threading;
@@ -19,10 +20,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ContinuationTokenIsNotUpdatedOnFails()
         {
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
-            mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
+            mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
             mockContext.Setup(x => x.CosmosSerializer).Returns(MockCosmosUtil.Serializer);
             mockContext.Setup(x => x.Client).Returns(client);
 
@@ -50,10 +52,203 @@ namespace Microsoft.Azure.Cosmos.Tests
                 mockContext.Object, (ContainerCore)client.GetContainer("myDb", "myColl"), null, 10, new ChangeFeedRequestOptions());
             ResponseMessage firstRequest = await iterator.ReadNextAsync();
             Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
+            Assert.AreEqual(HttpStatusCode.NotFound, firstRequest.StatusCode);
 
-            ResponseMessage secondRequest = await iterator.ReadNextAsync();
-            Assert.IsTrue(secondRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
-            Assert.IsFalse(secondRequest.Headers.ContinuationToken.Contains(secondResponse.Headers.ETag), "Response should NOT contain the second continuation");
+            mockContext.Verify(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+
+        [TestMethod]
+        public async Task ShouldContinueUntilResponseOk()
+        {
+            // Setting 3 ranges, first one returns a 304, second returns Ok
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
+            mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
+            mockContext.Setup(x => x.CosmosSerializer).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(x => x.Client).Returns(client);
+
+            ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
+            firstResponse.Headers.ETag = "FirstContinuation";
+            ResponseMessage secondResponse = new ResponseMessage(HttpStatusCode.OK);
+            secondResponse.Headers.ETag = "SecondContinuation";
+
+            mockContext.SetupSequence(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(firstResponse))
+                .Returns(Task.FromResult(secondResponse));
+
+            ChangeFeedResultSetIteratorCore iterator = new ChangeFeedResultSetIteratorCore(
+                mockContext.Object, (ContainerCore)client.GetContainer("myDb", "myColl"), null, 10, new ChangeFeedRequestOptions());
+            ResponseMessage firstRequest = await iterator.ReadNextAsync();
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(secondResponse.Headers.ETag), "Response should contain the second continuation");
+            Assert.AreEqual(HttpStatusCode.OK, firstRequest.StatusCode);
+
+            mockContext.Verify(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public async Task ShouldReturnNotModifiedAfterCyclingOnAllRanges()
+        {
+            // Setting mock to have 3 ranges, this test will get a 304 on all 3 ranges, do 3 backend requests, and return a 304
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
+            mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
+            mockContext.Setup(x => x.CosmosSerializer).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(x => x.Client).Returns(client);
+
+            ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
+            firstResponse.Headers.ETag = "FirstContinuation";
+            ResponseMessage secondResponse = new ResponseMessage(HttpStatusCode.NotModified);
+            secondResponse.Headers.ETag = "SecondContinuation";
+            ResponseMessage thirdResponse = new ResponseMessage(HttpStatusCode.NotModified);
+            thirdResponse.Headers.ETag = "ThirdContinuation";
+
+            mockContext.SetupSequence(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(firstResponse))
+                .Returns(Task.FromResult(secondResponse))
+                .Returns(Task.FromResult(thirdResponse));
+
+            ChangeFeedResultSetIteratorCore iterator = new ChangeFeedResultSetIteratorCore(
+                mockContext.Object, (ContainerCore)client.GetContainer("myDb", "myColl"), null, 10, new ChangeFeedRequestOptions());
+            ResponseMessage firstRequest = await iterator.ReadNextAsync();
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(secondResponse.Headers.ETag), "Response should contain the second continuation");
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(thirdResponse.Headers.ETag), "Response should contain the third continuation");
+            Assert.AreEqual(HttpStatusCode.NotModified, firstRequest.StatusCode);
+
+            mockContext.Verify(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [TestMethod]
+        public async Task ShouldReturnNotModifiedOnSingleRange()
+        {
+            // Default mock is 1 range
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
+            mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
+            mockContext.Setup(x => x.CosmosSerializer).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(x => x.Client).Returns(client);
+
+            ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
+            firstResponse.Headers.ETag = "FirstContinuation";
+
+            mockContext.SetupSequence(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(firstResponse));
+
+            ChangeFeedResultSetIteratorCore iterator = new ChangeFeedResultSetIteratorCore(
+                mockContext.Object, (ContainerCore)client.GetContainer("myDb", "myColl"), null, 10, new ChangeFeedRequestOptions());
+            ResponseMessage firstRequest = await iterator.ReadNextAsync();
+            Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
+            Assert.AreEqual(HttpStatusCode.NotModified, firstRequest.StatusCode);
+
+            mockContext.Verify(x => x.ProcessResourceOperationAsync<ResponseMessage>(
+                It.IsAny<Uri>(),
+                It.IsAny<Documents.ResourceType>(),
+                It.IsAny<Documents.OperationType>(),
+                It.IsAny<RequestOptions>(),
+                It.IsAny<ContainerCore>(),
+                It.IsAny<PartitionKey?>(),
+                It.IsAny<Stream>(),
+                It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private class MultiRangeMockDocumentClient : MockDocumentClient
+        {
+            private List<Documents.PartitionKeyRange> availablePartitionKeyRanges = new List<Documents.PartitionKeyRange>() {
+                new Documents.PartitionKeyRange() { MinInclusive = "", MaxExclusive = "AA", Id = "0" },
+                new Documents.PartitionKeyRange() { MinInclusive = "AA", MaxExclusive = "BB", Id = "1" },
+                new Documents.PartitionKeyRange() { MinInclusive = "BB", MaxExclusive = "FF", Id = "2" }
+            };
+
+            internal override IReadOnlyList<Documents.PartitionKeyRange> ResolveOverlapingPartitionKeyRanges(string collectionRid, Documents.Routing.Range<string> range, bool forceRefresh)
+            {
+                if (range.Min == Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey
+                    && range.Max == Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey)
+                {
+                    return this.availablePartitionKeyRanges;
+                }
+
+                if (range.Min == this.availablePartitionKeyRanges[0].MinInclusive)
+                {
+                    return new List<Documents.PartitionKeyRange>() { this.availablePartitionKeyRanges[0] };
+                }
+
+                if (range.Min == this.availablePartitionKeyRanges[1].MinInclusive)
+                {
+                    return new List<Documents.PartitionKeyRange>() { this.availablePartitionKeyRanges[1] };
+                }
+
+                return new List<Documents.PartitionKeyRange>() { this.availablePartitionKeyRanges[2] };
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 mockContext.Object, (ContainerCore)client.GetContainer("myDb", "myColl"), null, 10, new ChangeFeedRequestOptions());
             ResponseMessage firstRequest = await iterator.ReadNextAsync();
             Assert.IsTrue(firstRequest.Headers.ContinuationToken.Contains(firstResponse.Headers.ETag), "Response should contain the first continuation");
+            Assert.IsTrue(!firstRequest.Headers.ContinuationToken.Contains(secondResponse.Headers.ETag), "Response should not contain the second continuation");
             Assert.AreEqual(HttpStatusCode.NotFound, firstRequest.StatusCode);
 
             mockContext.Verify(x => x.ProcessResourceOperationAsync<ResponseMessage>(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
@@ -135,6 +135,11 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             return null;
         }
 
+        internal virtual IReadOnlyList<PartitionKeyRange> ResolveOverlapingPartitionKeyRanges(string collectionRid, Documents.Routing.Range<string> range, bool forceRefresh)
+        {
+            return (IReadOnlyList<PartitionKeyRange>) new List<Documents.PartitionKeyRange>() {new Documents.PartitionKeyRange() { MinInclusive = "", MaxExclusive = "FF", Id = "0" } };
+        }
+
         private void Init()
         {
             this.collectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), new ServerStoreModel(null), null, null);
@@ -209,7 +214,10 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
                             It.IsAny<Documents.Routing.Range<string>>(),
                             It.IsAny<bool>()
                         )
-                ).Returns(Task.FromResult<IReadOnlyList<PartitionKeyRange>>(new List<PartitionKeyRange>() { new PartitionKeyRange() { MinInclusive = "", MaxExclusive = "FF", Id = "0" } }));
+                ).Returns((string collectionRid, Documents.Routing.Range<string> range, bool forceRefresh) =>
+                {
+                    return Task.FromResult<IReadOnlyList<PartitionKeyRange>>(this.ResolveOverlapingPartitionKeyRanges(collectionRid, range, forceRefresh));
+                });
 
             this.globalEndpointManager = new Mock<GlobalEndpointManager>(this, new ConnectionPolicy());
             


### PR DESCRIPTION
## Description

The StandByFeedIterator, when reading through multiple tokens, if the first token returns a 304 (NotModified), it will shift the Continuation Token for the next request to go to the second token, but returns the 304 to the caller.

This PR changes the behavior to continue across all tokens until either:
* One returns an OK, in which case, it will return an OK with the results and the updated Continuation Token
* All tokens return NotModified, in which case, it will return a NotModified with an updated Continuation Token

In the scenario where the container has only one partition key range (one token), and the Iterator gets a 304, it will return it as-is, since there is no other tokens to read.

The PR includes unit tests for all described scenarios.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #647

