### PR TITLE
Container serialization include PartitionKeyDefinition only if not null

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// <see cref="PartitionKeyDefinition"/> object.
         /// </value>
-        [JsonProperty(PropertyName = Constants.Properties.PartitionKey)]
+        [JsonProperty(PropertyName = Constants.Properties.PartitionKey, NullValueHandling = NullValueHandling.Ignore)]
         internal PartitionKeyDefinition PartitionKey { get; set; } = new PartitionKeyDefinition();
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -417,6 +417,18 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void ContainerSettingsNullPartitionKeyTest()
+        {
+            ContainerProperties cosmosContainerSettings = new ContainerProperties("id", "/partitionKey")
+            {
+                PartitionKey = null
+            };
+
+            string cosmosSerialized = SettingsContractTests.CosmosSerialize(cosmosContainerSettings);
+            Assert.IsFalse(cosmosSerialized.Contains("partitionKey"));
+        }
+
+        [TestMethod]
         public async Task ContainerV2CompatTest()
         {
             string containerId = "SerializeContainerTest";


### PR DESCRIPTION
# Pull Request Template

## Description

To maintain compatibility with previous versions, a null PartitionKey should be omitted from the serialized payload.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.

