### PR TITLE
Scaled out StandByFeedIterator

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/StandByFeedContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/StandByFeedContinuationToken.cs
@@ -50,12 +50,12 @@ namespace Microsoft.Azure.Cosmos.Query
             return StandByFeedContinuationToken.SerializeTokens(new CompositeContinuationToken[1] { StandByFeedContinuationToken.CreateCompositeContinuationTokenForRange(minInclusive, maxExclusive, null) });
         }
 
-        public static string SerializeTokens(IEnumerable<CompositeContinuationToken> compositeContinuationTokens)
+        private static string SerializeTokens(IEnumerable<CompositeContinuationToken> compositeContinuationTokens)
         {
             return JsonConvert.SerializeObject(compositeContinuationTokens);
         }
 
-        public static List<CompositeContinuationToken> DeserializeTokens(string continuationToken)
+        private static List<CompositeContinuationToken> DeserializeTokens(string continuationToken)
         {
             return JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(continuationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/StandByFeedContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/StandByFeedContinuationToken.cs
@@ -199,8 +199,8 @@ namespace Microsoft.Azure.Cosmos.Query
                 new Documents.Routing.Range<string>(
                     targetRange.Min,
                     targetRange.Max,
-                    isMaxInclusive: true,
-                    isMinInclusive: false),
+                    isMaxInclusive: false,
+                    isMinInclusive: true),
                 forceRefresh);
 
             if (keyRanges.Count == 0)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Azure.Cosmos
                             isMaxInclusive: false),
                         true);
 
-            return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive, pkRangeCache.TryGetOverlappingRangesAsync).ToString());
+            return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive));
         }
 
         internal FeedIterator GetStandByFeedIterator(

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.Cosmos
                             Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
                             isMinInclusive: true,
                             isMaxInclusive: false),
-                        false);
+                        true);
 
             return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive, pkRangeCache.TryGetOverlappingRangesAsync).ToString());
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Linq;
@@ -353,6 +354,22 @@ namespace Microsoft.Azure.Cosmos
             return new BatchCore(this, partitionKey);
         }
 #endif
+
+        internal async Task<IEnumerable<string>> GetChangeFeedTokensAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Routing.PartitionKeyRangeCache pkRangeCache = await this.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
+            string containerRid = await this.GetRIDAsync(cancellationToken);
+            IReadOnlyList<Documents.PartitionKeyRange> allRanges = await pkRangeCache.TryGetOverlappingRangesAsync(
+                        containerRid,
+                        new Documents.Routing.Range<string>(
+                            Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                            Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
+                            isMinInclusive: true,
+                            isMaxInclusive: false),
+                        false);
+
+            return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive, pkRangeCache.TryGetOverlappingRangesAsync).ToString());
+        }
 
         internal FeedIterator GetStandByFeedIterator(
             string continuationToken = null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Globalization;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query;
@@ -18,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     public class CosmosItemChangeFeedTests : BaseCosmosClientHelper
     {
         private ContainerCore Container = null;
+        private ContainerCore LargerContainer = null;
 
         [TestInitialize]
         public async Task TestInitialize()
@@ -30,7 +32,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);
             Assert.IsNotNull(response.Resource);
+
+            ContainerResponse largerContainer = await this.database.CreateContainerAsync(
+                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                throughput: 20000,
+                cancellationToken: this.cancellationToken);
+
             this.Container = (ContainerCore)response;
+            this.LargerContainer = (ContainerCore)largerContainer;
         }
 
         [TestCleanup]
@@ -56,7 +65,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             int pkRangesCount = (await this.Container.ClientContext.DocumentClient.ReadPartitionKeyRangeFeedAsync(this.Container.LinkUri)).Count;
             int visitedPkRanges = 0;
 
-            await this.CreateRandomItems(batchSize, randomPartitionKey: true);
+            await this.CreateRandomItems(this.Container, batchSize, randomPartitionKey: true);
             ContainerCore itemsCore = (ContainerCore)this.Container;
             FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
@@ -98,7 +107,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             visitedPkRanges = 0;
 
             // Insert another batch of 25 and use the last continuation token from the first cycle
-            await this.CreateRandomItems(batchSize, randomPartitionKey: true);
+            await this.CreateRandomItems(this.Container, batchSize, randomPartitionKey: true);
             FeedIterator setIteratorNew =
                 itemsCore.GetStandByFeedIterator(lastcontinuation);
 
@@ -172,7 +181,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         if(visitedPkRanges == 0)
                         {
-                            await this.CreateRandomItems(expectedDocuments, randomPartitionKey: true);
+                            await this.CreateRandomItems(this.Container, expectedDocuments, randomPartitionKey: true);
                         }
                     }
 
@@ -229,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task StandByFeedIterator_WithMaxItemCount()
         {
-            await this.CreateRandomItems(2, randomPartitionKey: true);
+            await this.CreateRandomItems(this.Container, 2, randomPartitionKey: true);
             ContainerCore itemsCore = (ContainerCore)this.Container;
             FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
@@ -260,11 +269,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task StandByFeedIterator_NoFetchNext()
         {
-            var pkRanges = await this.Container.ClientContext.DocumentClient.ReadPartitionKeyRangeFeedAsync(this.Container.LinkUri);
+            int pkRangesCount = (await this.Container.ClientContext.DocumentClient.ReadPartitionKeyRangeFeedAsync(this.Container.LinkUri)).Count;
 
             int expected = 25;
             int iterations = 0;
-            await this.CreateRandomItems(expected, randomPartitionKey: true);
+            await this.CreateRandomItems(this.Container, expected, randomPartitionKey: true);
             ContainerCore itemsCore = (ContainerCore)this.Container;
             string continuationToken = null;
             int count = 0;
@@ -295,7 +304,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     break;
                 }
 
-                if (iterations++ > pkRanges.Count)
+                if (iterations++ > pkRangesCount)
                 {
                     Assert.Fail("Feed does not contain all elements even after looping through PK ranges. Either the continuation is not moving forward or there is some state problem.");
 
@@ -319,7 +328,61 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private async Task<IList<ToDoActivity>> CreateRandomItems(int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)
+        [TestMethod]
+        public async Task GetChangeFeedTokensAsync_MatchesPkRanges()
+        {
+            int pkRangesCount = (await this.LargerContainer.ClientContext.DocumentClient.ReadPartitionKeyRangeFeedAsync(this.LargerContainer.LinkUri)).Count;
+            ContainerCore itemsCore = (ContainerCore)this.LargerContainer;
+            IEnumerable<string> tokens = await itemsCore.GetChangeFeedTokensAsync();
+            Assert.AreEqual(pkRangesCount, tokens.Count());
+        }
+
+        [TestMethod]
+        public async Task GetChangeFeedTokensAsync_AllowsParallelProcessing()
+        {
+            int pkRangesCount = (await this.LargerContainer.ClientContext.DocumentClient.ReadPartitionKeyRangeFeedAsync(this.LargerContainer.LinkUri)).Count;
+            ContainerCore itemsCore = (ContainerCore)this.LargerContainer;
+            IEnumerable<string> tokens = await itemsCore.GetChangeFeedTokensAsync();
+            Assert.IsTrue(pkRangesCount > 1, "Should have created a multi partition container.");
+            Assert.AreEqual(pkRangesCount, tokens.Count());
+            int totalDocuments = 200;
+            await this.CreateRandomItems(this.LargerContainer, totalDocuments, randomPartitionKey: true);
+            List<Task<int>> tasks = tokens.Select(token => Task.Run(async () =>
+            {
+                int count = 0;
+                FeedIterator iteratorForToken =
+                    itemsCore.GetStandByFeedIterator(continuationToken: token, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+                while (true)
+                {
+                    using (ResponseMessage responseMessage =
+                    await iteratorForToken.ReadNextAsync(this.cancellationToken))
+                    {
+                        if (!responseMessage.IsSuccessStatusCode)
+                        {
+                            break;
+                        }
+
+                        Collection<ToDoActivity> response = TestCommon.Serializer.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.Content).Data;
+                        count += response.Count;
+                    }
+                }
+
+                return count;
+
+            })).ToList();
+
+            await Task.WhenAll(tasks);
+
+            int documentsRead = 0;
+            foreach(Task<int> task in tasks)
+            {
+                documentsRead += task.Result;
+            }
+
+            Assert.AreEqual(totalDocuments, documentsRead);
+        }
+
+        private async Task<IList<ToDoActivity>> CreateRandomItems(ContainerCore container, int pkCount, int perPKItemCount = 1, bool randomPartitionKey = true)
         {
             Assert.IsFalse(!randomPartitionKey && perPKItemCount > 1);
 
@@ -338,7 +401,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     createdList.Add(temp);
 
-                    await this.Container.CreateItemAsync<ToDoActivity>(item: temp);
+                    await container.CreateItemAsync<ToDoActivity>(item: temp);
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -7,12 +7,15 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using Newtonsoft.Json;
 
     [TestClass]
     public class ChangeFeedResultSetIteratorTests
@@ -219,6 +222,41 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<Action<RequestMessage>>(),
                 It.IsAny<Func<ResponseMessage, ResponseMessage>>(),
                 It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetChangeFeedTokensAsyncReturnsOnePerPartitionKeyRange()
+        {
+            // Setting mock to have 3 ranges, to generate 3 tokens
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
+            mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
+            mockContext.Setup(x => x.DocumentQueryClient).Returns(Mock.Of<IDocumentQueryClient>());
+            mockContext.Setup(x => x.CosmosSerializer).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(UriFactory.CreateDocumentCollectionUri("test", "test"));
+
+            DatabaseCore db = new DatabaseCore(mockContext.Object, "test");
+            ContainerCore container = new ContainerCore(mockContext.Object, db, "test");
+            IEnumerable<string> tokens = await container.GetChangeFeedTokensAsync();
+            Assert.AreEqual(3, tokens.Count());
+
+            Routing.PartitionKeyRangeCache pkRangeCache = await documentClient.GetPartitionKeyRangeCacheAsync();
+            foreach (string token in tokens)
+            {
+                // Validate that each token represents a StandByFeedContinuationToken with a single Range
+                List<CompositeContinuationToken> deserialized = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(token);
+                Assert.AreEqual(1, deserialized.Count);
+                CompositeContinuationToken compositeToken = deserialized[0];
+
+                IReadOnlyList<Documents.PartitionKeyRange> rangesForTheToken = await pkRangeCache.TryGetOverlappingRangesAsync("", compositeToken.Range);
+                // Token represents one range
+                Assert.AreEqual(1, rangesForTheToken.Count);
+                Assert.AreEqual(rangesForTheToken[0].MinInclusive, compositeToken.Range.Min);
+                Assert.AreEqual(rangesForTheToken[0].MaxExclusive, compositeToken.Range.Max);
+            }
         }
 
         private class MultiRangeMockDocumentClient : MockDocumentClient

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StandByFeedContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StandByFeedContinuationTokenTests.cs
@@ -196,42 +196,27 @@ namespace Microsoft.Azure.Cosmos
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorWithNullMinRange()
         {
-            StandByFeedContinuationToken.CreateForRange("containerRid", null, "FF", null);
+            StandByFeedContinuationToken.CreateForRange("containerRid", null, "FF");
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void ConstructorWithNullMaxRange()
         {
-            StandByFeedContinuationToken.CreateForRange("containerRid", "", null, null);
+            StandByFeedContinuationToken.CreateForRange("containerRid", "", null);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentNullException))]
-        public void ConstructorForRangeWithNullDelegate()
+        public void ConstructorWithRangeGeneratesSingleQueue()
         {
-            StandByFeedContinuationToken.CreateForRange("containerRid", "", "FF", null);
-        }
+            string min = "";
+            string max = "FF";
+            string standByFeedContinuationToken = StandByFeedContinuationToken.CreateForRange("containerRid", min, max);
 
-        [TestMethod]
-        public async Task ConstructorWithRangeGeneratesSingleQueue()
-        {
-            IReadOnlyList<Documents.PartitionKeyRange> keyRanges = new List<Documents.PartitionKeyRange>()
-            {
-                new Documents.PartitionKeyRange() { MinInclusive = "", MaxExclusive ="FF", Id = "0" }
-            };
-
-            StandByFeedContinuationToken standByFeedContinuationToken = StandByFeedContinuationToken.CreateForRange("containerRid", keyRanges[0].MinInclusive, keyRanges[0].MaxExclusive, CreateCacheFromRange(keyRanges));
-            (CompositeContinuationToken token, string rangeId) = await standByFeedContinuationToken.GetCurrentTokenAsync();
-            Assert.AreEqual(keyRanges[0].Id, rangeId);
-            Assert.AreEqual(keyRanges[0].MinInclusive, token.Range.Min);
-            Assert.AreEqual(keyRanges[0].MaxExclusive, token.Range.Max);
-
-            standByFeedContinuationToken.MoveToNextToken();
-            (CompositeContinuationToken nextToken, string nextRangeId) = await standByFeedContinuationToken.GetCurrentTokenAsync();
-            Assert.AreEqual(keyRanges[0].Id, nextRangeId);
-            Assert.AreEqual(keyRanges[0].MinInclusive, nextToken.Range.Min);
-            Assert.AreEqual(keyRanges[0].MaxExclusive, nextToken.Range.Max);
+            List<CompositeContinuationToken> deserialized = StandByFeedContinuationToken.DeserializeTokens(standByFeedContinuationToken);
+            Assert.AreEqual(1, deserialized.Count);
+            Assert.AreEqual(min, deserialized[0].Range.Min);
+            Assert.AreEqual(max, deserialized[0].Range.Max);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StandByFeedContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StandByFeedContinuationTokenTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Cosmos
             string max = "FF";
             string standByFeedContinuationToken = StandByFeedContinuationToken.CreateForRange("containerRid", min, max);
 
-            List<CompositeContinuationToken> deserialized = StandByFeedContinuationToken.DeserializeTokens(standByFeedContinuationToken);
+            List<CompositeContinuationToken> deserialized = JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(standByFeedContinuationToken);
             Assert.AreEqual(1, deserialized.Count);
             Assert.AreEqual(min, deserialized[0].Range.Min);
             Assert.AreEqual(max, deserialized[0].Range.Max);


### PR DESCRIPTION
## Description

Currently, the StandByFeedIterator is a single consumer pull model. This PR adds a new API called `GetChangeFeedTokensAsync`.

```c#
`Task<IEnumerable<string>> GetChangeFeedTokensAsync(CancellationToken cancellationToken = default(CancellationToken))`
```

The goal of this API is to provide a set of Tokens that can be used as initial state on any StandByFeedIterator to limit the scope of the sequential read to a subset of partitions.

This way, the tokens can be distributed on parallel compute units and each compute unit can read in parallel changes only for the scope of the initial token.

For example:

```c#
    IEnumerable<string> tokens = await container.GetChangeFeedTokensAsync();
    // In machine 1
    FeedIterator iteratorForToken =
                    container.GetStandByFeedIterator(continuationToken: tokens[0], requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
    // In machine 2
    FeedIterator iteratorForToken =
                    container.GetStandByFeedIterator(continuationToken: tokens[1], requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
``` 

Unit test and Emulator tests were added to cover the new feature.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

