### PR TITLE
Fix for longer UserAgent suffix

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -45,17 +45,12 @@ namespace Microsoft.Azure.Cosmos
 
         private const ApiType DefaultApiType = ApiType.None;
 
-        private const int UserAgentSuffixMaxLength = 64;
-
         /// <summary>
         /// Default request timeout
         /// </summary>
         private static readonly CosmosSerializer propertiesSerializer = new CosmosJsonSerializerWrapper(new CosmosJsonDotNetSerializer());
 
-        private readonly string currentEnvironmentInformation;
-
         private int gatewayModeMaxConnectionLimit;
-        private string applicationName;
         private CosmosSerializationOptions serializerOptions;
         private CosmosSerializer serializer;
 
@@ -64,10 +59,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         public CosmosClientOptions()
         {
-            this.UserAgentContainer = new UserAgentContainer();
-            EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            this.currentEnvironmentInformation = environmentInformation.ToString();
-            this.UserAgentContainer.Suffix = this.currentEnvironmentInformation;
+            this.UserAgentContainer = new Cosmos.UserAgentContainer();
             this.GatewayModeMaxConnectionLimit = ConnectionPolicy.Default.MaxConnectionLimit;
             this.RequestTimeout = ConnectionPolicy.Default.RequestTimeout;
             this.ConnectionMode = CosmosClientOptions.DefaultConnectionMode;
@@ -84,31 +76,8 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         public string ApplicationName
         {
-            get => this.applicationName;
-            set
-            {
-                this.applicationName = value;
-
-                if (string.IsNullOrEmpty(value))
-                {
-                    return;
-                }
-
-                if (value.Length > UserAgentSuffixMaxLength)
-                {
-                    // Prioritize user suffix
-                    this.UserAgentContainer.Suffix = value;
-                }
-                else if ((value.Length + this.currentEnvironmentInformation.Length + EnvironmentInformation.Delimiter.Length) > UserAgentSuffixMaxLength)
-                {
-                    // Prioritize user suffix
-                    this.UserAgentContainer.Suffix = this.currentEnvironmentInformation.Substring(0, UserAgentSuffixMaxLength - value.Length - EnvironmentInformation.Delimiter.Length) + EnvironmentInformation.Delimiter + value;
-                }
-                else
-                {
-                    this.UserAgentContainer.Suffix = this.currentEnvironmentInformation + EnvironmentInformation.Delimiter + value;
-                }
-            }
+            get => this.UserAgentContainer.Suffix;
+            set => this.UserAgentContainer.Suffix = value;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Azure.Cosmos
 
         private const ApiType DefaultApiType = ApiType.None;
 
+        private const int UserAgentSuffixMaxLength = 64;
+
         /// <summary>
         /// Default request timeout
         /// </summary>
@@ -85,8 +87,27 @@ namespace Microsoft.Azure.Cosmos
             get => this.applicationName;
             set
             {
-                this.UserAgentContainer.Suffix = this.currentEnvironmentInformation + EnvironmentInformation.Delimiter + value;
                 this.applicationName = value;
+
+                if (string.IsNullOrEmpty(value))
+                {
+                    return;
+                }
+
+                if (value.Length > UserAgentSuffixMaxLength)
+                {
+                    // Prioritize user suffix
+                    this.UserAgentContainer.Suffix = value;
+                }
+                else if ((value.Length + this.currentEnvironmentInformation.Length + EnvironmentInformation.Delimiter.Length) > UserAgentSuffixMaxLength)
+                {
+                    // Prioritize user suffix
+                    this.UserAgentContainer.Suffix = this.currentEnvironmentInformation.Substring(0, UserAgentSuffixMaxLength - value.Length - EnvironmentInformation.Delimiter.Length) + EnvironmentInformation.Delimiter + value;
+                }
+                else
+                {
+                    this.UserAgentContainer.Suffix = this.currentEnvironmentInformation + EnvironmentInformation.Delimiter + value;
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -9,18 +9,22 @@ namespace Microsoft.Azure.Cosmos
 
     internal sealed class EnvironmentInformation
     {
-        internal const string Delimiter = " ";
         private static readonly string clientId;
         private static readonly string clientSDKVersion;
+        private static readonly string directPackageVersion;
         private static readonly string framework;
         private static readonly string architecture;
+        private static readonly string os;
 
         static EnvironmentInformation()
         {
             Version sdkVersion = Assembly.GetAssembly(typeof(CosmosClient)).GetName().Version;
             EnvironmentInformation.clientSDKVersion = $"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Build}";
+            Version directVersion = Assembly.GetAssembly(typeof(Documents.UserAgentContainer)).GetName().Version;
+            EnvironmentInformation.directPackageVersion = $"{directVersion.Major}.{directVersion.Minor}.{directVersion.Build}";
             EnvironmentInformation.framework = RuntimeInformation.FrameworkDescription;
             EnvironmentInformation.architecture = RuntimeInformation.ProcessArchitecture.ToString();
+            EnvironmentInformation.os = RuntimeInformation.OSDescription;
             string now = DateTime.UtcNow.Ticks.ToString();
             EnvironmentInformation.clientId = now.Substring(now.Length - 5); // 5 most significative digits
         }
@@ -31,9 +35,20 @@ namespace Microsoft.Azure.Cosmos
         public string ClientId => EnvironmentInformation.clientId;
 
         /// <summary>
+        /// Version of the current direct package.
+        /// </summary>
+        public string DirectVersion => EnvironmentInformation.directPackageVersion;
+
+        /// <summary>
         /// Version of the current client.
         /// </summary>
         public string ClientVersion => EnvironmentInformation.clientSDKVersion;
+
+        /// <summary>
+        /// Identifier of the Operating System.
+        /// </summary>
+        /// <seealso cref="RuntimeInformation.FrameworkDescription"/>
+        public string OperatingSystem => EnvironmentInformation.os;
 
         /// <summary>
         /// Identifier of the Framework.
@@ -49,7 +64,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override string ToString()
         {
-            return $" {this.ClientVersion}-{this.RuntimeFramework} {this.ProcessArchitecture} {this.ClientId}";
+            return $"{this.OperatingSystem}/{this.ProcessArchitecture} {this.ClientVersion}/{this.DirectVersion}-{this.RuntimeFramework} {this.ClientId}";
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Azure.Cosmos
             EnvironmentInformation.clientSDKVersion = $"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Build}";
             EnvironmentInformation.framework = RuntimeInformation.FrameworkDescription;
             EnvironmentInformation.architecture = RuntimeInformation.ProcessArchitecture.ToString();
-            EnvironmentInformation.clientId = DateTime.UtcNow.Ticks.ToString();
+            string now = DateTime.UtcNow.Ticks.ToString();
+            EnvironmentInformation.clientId = now.Substring(now.Length - 5); // 5 most significative digits
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -1,0 +1,56 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Text;
+
+    /// <summary>
+    /// Contains information about the user environment and helps identify requests.
+    /// </summary>
+    internal class UserAgentContainer : Documents.UserAgentContainer
+    {
+        internal const string Delimiter = " ";
+        internal new static readonly string baseUserAgent;
+        private const int maxSuffixLength = 64;
+        private string suffix;
+
+        static UserAgentContainer()
+        {
+            EnvironmentInformation environmentInformation = new EnvironmentInformation();
+            UserAgentContainer.baseUserAgent = environmentInformation.ToString();
+        }
+
+        public UserAgentContainer()
+        {
+            this.UserAgent = UserAgentContainer.baseUserAgent;
+            this.UserAgentUTF8 = Encoding.UTF8.GetBytes(this.UserAgent);
+        }
+
+        public new string UserAgent { get; private set; }
+
+        public new byte[] UserAgentUTF8 { get; private set; }
+
+        public new string Suffix
+        {
+            get
+            {
+                return this.suffix;
+            }
+            set
+            {
+                this.suffix = value;
+
+                // Take only the first 64 characters of the user-agent.
+                if (this.suffix.Length > maxSuffixLength)
+                {
+                    this.suffix = this.suffix.Substring(0, 64);
+                }
+
+                this.UserAgent = UserAgentContainer.baseUserAgent + UserAgentContainer.Delimiter + this.suffix;
+                this.UserAgentUTF8 = Encoding.UTF8.GetBytes(this.UserAgent);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             const string suffix = " MyCustomUserAgent/1.0";
             ConnectionPolicy policy = new ConnectionPolicy();
             policy.UserAgentSuffix = suffix;
-            var expectedUserAgent = UserAgentContainer.baseUserAgent + suffix;
+            var expectedUserAgent = Cosmos.UserAgentContainer.baseUserAgent + Cosmos.UserAgentContainer.Delimiter +  suffix;
             Assert.AreEqual(expectedUserAgent, policy.UserAgentContainer.UserAgent);
 
             byte[] expectedUserAgentUTF8 = Encoding.UTF8.GetBytes(expectedUserAgent);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -135,57 +135,14 @@ namespace Microsoft.Azure.Cosmos.Tests
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
-            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(userAgentSuffix));
-            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.Contains(expectedValue));
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.UserAgentContainer.Suffix);
+            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.UserAgent.StartsWith(expectedValue));
+            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.UserAgent.EndsWith(userAgentSuffix));
 
             ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
-            Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(userAgentSuffix));
-            Assert.IsTrue(connectionPolicy.UserAgentSuffix.Contains(expectedValue));
-        }
-
-        [TestMethod]
-        public void UserAgentContainsEnvironmentInformation_WithLargeApplicationName()
-        {
-            // When the user suffix is larger than the max, we send the user suffix as is, no environment information
-            EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            string environmentString = environmentInformation.ToString();
-            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
-            string userAgentSuffix = new string('a', 100);
-            string truncatedUserAgentSuffix = new string('a', 64);
-
-            cosmosClientOptions.ApplicationName = userAgentSuffix;
-            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
-
-            // It will get truncated by the UserAgentContainer
-            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(truncatedUserAgentSuffix));
-            Assert.IsTrue(!cosmosClientOptions.UserAgentContainer.Suffix.Contains(environmentString));
-
-            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
-            Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(truncatedUserAgentSuffix));
-            Assert.IsTrue(!connectionPolicy.UserAgentSuffix.Contains(environmentString));
-        }
-
-        [TestMethod]
-        public void UserAgentContainsEnvironmentInformation_WithMediumApplicationName()
-        {
-            // When the user suffix is larger, we cannot put the entire environment information to avoid truncating the user suffix
-            EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            string environmentString = environmentInformation.ToString();
-            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
-            string userAgentSuffix = new string('a', 64 - environmentString.Length + 10);
-            string truncatedEnvironmentString = environmentString.Substring(0, environmentString.Length - 10 - EnvironmentInformation.Delimiter.Length);
-
-            cosmosClientOptions.ApplicationName = userAgentSuffix;
-            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
-
-            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(userAgentSuffix));
-            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.Contains(truncatedEnvironmentString));
-            Assert.IsTrue(!cosmosClientOptions.UserAgentContainer.Suffix.Contains(environmentString));
-
-            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
-            Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(userAgentSuffix));
-            Assert.IsTrue(connectionPolicy.UserAgentSuffix.Contains(truncatedEnvironmentString));
-            Assert.IsTrue(!connectionPolicy.UserAgentSuffix.Contains(environmentString));
+            Assert.AreEqual(userAgentSuffix, connectionPolicy.UserAgentSuffix);
+            Assert.IsTrue(connectionPolicy.UserAgentContainer.UserAgent.StartsWith(expectedValue));
+            Assert.IsTrue(connectionPolicy.UserAgentContainer.UserAgent.EndsWith(userAgentSuffix));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -134,13 +134,58 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;
-
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
             Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(userAgentSuffix));
             Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.Contains(expectedValue));
 
             ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
             Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(userAgentSuffix));
             Assert.IsTrue(connectionPolicy.UserAgentSuffix.Contains(expectedValue));
+        }
+
+        [TestMethod]
+        public void UserAgentContainsEnvironmentInformation_WithLargeApplicationName()
+        {
+            // When the user suffix is larger than the max, we send the user suffix as is, no environment information
+            EnvironmentInformation environmentInformation = new EnvironmentInformation();
+            string environmentString = environmentInformation.ToString();
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
+            string userAgentSuffix = new string('a', 100);
+            string truncatedUserAgentSuffix = new string('a', 64);
+
+            cosmosClientOptions.ApplicationName = userAgentSuffix;
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
+
+            // It will get truncated by the UserAgentContainer
+            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(truncatedUserAgentSuffix));
+            Assert.IsTrue(!cosmosClientOptions.UserAgentContainer.Suffix.Contains(environmentString));
+
+            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
+            Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(truncatedUserAgentSuffix));
+            Assert.IsTrue(!connectionPolicy.UserAgentSuffix.Contains(environmentString));
+        }
+
+        [TestMethod]
+        public void UserAgentContainsEnvironmentInformation_WithMediumApplicationName()
+        {
+            // When the user suffix is larger, we cannot put the entire environment information to avoid truncating the user suffix
+            EnvironmentInformation environmentInformation = new EnvironmentInformation();
+            string environmentString = environmentInformation.ToString();
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
+            string userAgentSuffix = new string('a', 64 - environmentString.Length + 10);
+            string truncatedEnvironmentString = environmentString.Substring(0, environmentString.Length - 10 - EnvironmentInformation.Delimiter.Length);
+
+            cosmosClientOptions.ApplicationName = userAgentSuffix;
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
+
+            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.EndsWith(userAgentSuffix));
+            Assert.IsTrue(cosmosClientOptions.UserAgentContainer.Suffix.Contains(truncatedEnvironmentString));
+            Assert.IsTrue(!cosmosClientOptions.UserAgentContainer.Suffix.Contains(environmentString));
+
+            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
+            Assert.IsTrue(connectionPolicy.UserAgentSuffix.EndsWith(userAgentSuffix));
+            Assert.IsTrue(connectionPolicy.UserAgentSuffix.Contains(truncatedEnvironmentString));
+            Assert.IsTrue(!connectionPolicy.UserAgentSuffix.Contains(environmentString));
         }
 
         [TestMethod]

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#726](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/726) Query iterator HasMoreResults now returns false if an exception is hit
+- [#705](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/705) User agent suffix gets truncated
 
 
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR applies a refactor on the UserAgentContainer, creating a child class `Cosmos.UserAgentContainer` that has a different base user agent. The new base user agent uses `EnvironmentInformation` and generates a format of:

`{OS}/{Process Architecture} {SDK Version}/{Direct pkg Version}-{Framework} {ClientId} {UserSuffix}`

For example:

`Microsoft Windows 10.0.18362 /X64 3.1.1/3.1.4-.NET Core 4.6.27617.04 03445 mycustomsuffix`

The information is read from the RuntimeEnvironment NET Standard 2.0 https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeenvironment?view=netstandard-2.0

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #697

