### PR TITLE
Fixed flaky tests: ValidateAsync, TestOpenAsyncFailFast, GetCosmosSerializerWithWrapperOrDefaultWithOptionsTest

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 {
                     string jsonString = sr.ReadToEnd();
                     // Notice description is not included, camelCaseProperty starts lower case, the white space shows the indents
-                    string expectedJsonString = "{\r\n  \"id\": \"testid\",\r\n  \"camelCaseProperty\": \"TestCamelCase\"\r\n}";
+                    string expectedJsonString = $"{{{Environment.NewLine}  \"id\": \"testid\",{Environment.NewLine}  \"camelCaseProperty\": \"TestCamelCase\"{Environment.NewLine}}}";
                     Assert.AreEqual(expectedJsonString, jsonString);
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -655,7 +655,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                     int delayInMilliSeconds = int.Parse(
                                                   expirationTime,
                                                   NumberStyles.Integer,
-                                                  CultureInfo.InvariantCulture) * 1000;
+                                                  CultureInfo.InvariantCulture) * 1000 * 2;
                     await Task.Delay(delayInMilliSeconds);
 
                     string config =  $"Delay{expirationTime};" + 


### PR DESCRIPTION
# Pull Request Template

## Description

GetCosmosSerializerWithWrapperOrDefaultWithOptionsTest had a test with newline characters hard coded as Windows. This caused the comparison to fail for Unix systems. Test is updated to use Enivornment.NewLine to ensure the new line characters are correct.

ValidateAsync doubled the wait time to match internal repo version
TestOpenAsyncFailFast: Updated to match internal repo version that uses call back rather than timeout to validate.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #712, #711 , #710


