### PR TITLE
Adding camel case serialization on LINQ query generation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private readonly bool allowSynchronousQueryExecution;
         private readonly Action<IQueryable> onExecuteScalarQueryCallback;
         private readonly string continuationToken;
+        private readonly CosmosSerializationOptions serializationOptions;
 
         public CosmosLinqQueryProvider(
            ContainerCore container,
@@ -29,7 +30,8 @@ namespace Microsoft.Azure.Cosmos.Linq
            string continuationToken,
            QueryRequestOptions cosmosQueryRequestOptions,
            bool allowSynchronousQueryExecution,
-           Action<IQueryable> onExecuteScalarQueryCallback = null)
+           Action<IQueryable> onExecuteScalarQueryCallback = null,
+           CosmosSerializationOptions serializationOptions = null)
         {
             this.container = container;
             this.responseFactory = responseFactory;
@@ -38,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.cosmosQueryRequestOptions = cosmosQueryRequestOptions;
             this.allowSynchronousQueryExecution = allowSynchronousQueryExecution;
             this.onExecuteScalarQueryCallback = onExecuteScalarQueryCallback;
+            this.serializationOptions = serializationOptions;
         }
 
         public IQueryable<TElement> CreateQuery<TElement>(Expression expression)
@@ -49,7 +52,8 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
-                this.allowSynchronousQueryExecution);
+                this.allowSynchronousQueryExecution,
+                this.serializationOptions);
         }
 
         public IQueryable CreateQuery(Expression expression)
@@ -64,7 +68,8 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
-                this.allowSynchronousQueryExecution);
+                this.allowSynchronousQueryExecution,
+                this.serializationOptions);
         }
 
         public TResult Execute<TResult>(Expression expression)
@@ -78,7 +83,8 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.continuationToken,
                 this.cosmosQueryRequestOptions,
                 expression,
-                this.allowSynchronousQueryExecution);
+                this.allowSynchronousQueryExecution,
+                this.serializationOptions);
             this.onExecuteScalarQueryCallback?.Invoke(cosmosLINQQuery);
             return cosmosLINQQuery.ToList().FirstOrDefault();
         }
@@ -94,7 +100,8 @@ namespace Microsoft.Azure.Cosmos.Linq
                 this.queryClient,
                 this.continuationToken,
                 this.cosmosQueryRequestOptions,
-                this.allowSynchronousQueryExecution);
+                this.allowSynchronousQueryExecution,
+                this.serializationOptions);
             this.onExecuteScalarQueryCallback?.Invoke(cosmosLINQQuery);
             return cosmosLINQQuery.ToList().FirstOrDefault();
         }

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentQueryEvaluator.cs
@@ -13,7 +13,9 @@ namespace Microsoft.Azure.Cosmos.Linq
     {
         private const string SQLMethod = "AsSQL";
 
-        public static SqlQuerySpec Evaluate(Expression expression)
+        public static SqlQuerySpec Evaluate(
+            Expression expression,
+            CosmosSerializationOptions serializationOptions = null)
         {
             switch (expression.NodeType)
             {
@@ -23,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     }
                 case ExpressionType.Call:
                     {
-                        return DocumentQueryEvaluator.HandleMethodCallExpression((MethodCallExpression)expression);
+                        return DocumentQueryEvaluator.HandleMethodCallExpression((MethodCallExpression)expression, serializationOptions);
                     }
 
                 default:
@@ -69,7 +71,9 @@ namespace Microsoft.Azure.Cosmos.Linq
             return null;
         }
 
-        private static SqlQuerySpec HandleMethodCallExpression(MethodCallExpression expression)
+        private static SqlQuerySpec HandleMethodCallExpression(
+            MethodCallExpression expression,
+            CosmosSerializationOptions serializationOptions = null)
         {
             if (DocumentQueryEvaluator.IsTransformExpression(expression))
             {
@@ -86,7 +90,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 }
             }
 
-            return SqlTranslator.TranslateQuery(expression);
+            return SqlTranslator.TranslateQuery(expression, serializationOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -80,10 +80,13 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// Toplevel entry point.
         /// </summary>
         /// <param name="inputExpression">An Expression representing a Query on a IDocumentQuery object.</param>
+        /// <param name="serializationOptions">Optional serializer options.</param>
         /// <returns>The corresponding SQL query.</returns>
-        public static SqlQuery TranslateQuery(Expression inputExpression)
+        public static SqlQuery TranslateQuery(
+            Expression inputExpression,
+            CosmosSerializationOptions serializationOptions = null)
         {
-            TranslationContext context = new TranslationContext();
+            TranslationContext context = new TranslationContext(serializationOptions);
             ExpressionToSql.Translate(inputExpression, context); // ignore result here
 
             QueryUnderConstruction query = context.currentQuery;
@@ -789,7 +792,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private static SqlScalarExpression VisitMemberAccess(MemberExpression inputExpression, TranslationContext context)
         {
             SqlScalarExpression memberExpression = ExpressionToSql.VisitScalarExpression(inputExpression.Expression, context);
-            string memberName = inputExpression.Member.GetMemberName();
+            string memberName = inputExpression.Member.GetMemberName(context.serializationOptions);
 
             // if expression is nullable
             if (inputExpression.Expression.Type.IsNullable())
@@ -836,7 +839,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private static SqlObjectProperty VisitMemberAssignment(MemberAssignment inputExpression, TranslationContext context)
         {
             SqlScalarExpression assign = ExpressionToSql.VisitScalarExpression(inputExpression.Expression, context);
-            string memberName = inputExpression.Member.GetMemberName();
+            string memberName = inputExpression.Member.GetMemberName(context.serializationOptions);
             SqlPropertyName propName = SqlPropertyName.Create(memberName);
             SqlObjectProperty prop = SqlObjectProperty.Create(propName, assign);
             return prop;
@@ -878,7 +881,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 MemberInfo member = members[i];
                 SqlScalarExpression value = ExpressionToSql.VisitScalarExpression(arg, context);
 
-                string memberName = member.GetMemberName();
+                string memberName = member.GetMemberName(context.serializationOptions);
                 SqlPropertyName propName = SqlPropertyName.Create(memberName);
                 SqlObjectProperty prop = SqlObjectProperty.Create(propName, value);
                 result[i] = prop;

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -792,7 +792,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private static SqlScalarExpression VisitMemberAccess(MemberExpression inputExpression, TranslationContext context)
         {
             SqlScalarExpression memberExpression = ExpressionToSql.VisitScalarExpression(inputExpression.Expression, context);
-            string memberName = inputExpression.Member.GetMemberName(context.serializationOptions);
+            string memberName = inputExpression.Member.GetMemberName(context?.serializationOptions);
 
             // if expression is nullable
             if (inputExpression.Expression.Type.IsNullable())
@@ -839,7 +839,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         private static SqlObjectProperty VisitMemberAssignment(MemberAssignment inputExpression, TranslationContext context)
         {
             SqlScalarExpression assign = ExpressionToSql.VisitScalarExpression(inputExpression.Expression, context);
-            string memberName = inputExpression.Member.GetMemberName(context.serializationOptions);
+            string memberName = inputExpression.Member.GetMemberName(context?.serializationOptions);
             SqlPropertyName propName = SqlPropertyName.Create(memberName);
             SqlObjectProperty prop = SqlObjectProperty.Create(propName, assign);
             return prop;
@@ -881,7 +881,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 MemberInfo member = members[i];
                 SqlScalarExpression value = ExpressionToSql.VisitScalarExpression(arg, context);
 
-                string memberName = member.GetMemberName(context.serializationOptions);
+                string memberName = member.GetMemberName(context?.serializationOptions);
                 SqlPropertyName propName = SqlPropertyName.Create(memberName);
                 SqlObjectProperty prop = SqlObjectProperty.Create(propName, value);
                 result[i] = prop;

--- a/Microsoft.Azure.Cosmos/src/Linq/SQLTranslator.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/SQLTranslator.cs
@@ -16,29 +16,36 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// This function exists for testing only.
         /// </summary>
         /// <param name="inputExpression">Expression to translate.</param>
+        /// <param name="serializationOptions">Optional serializer options.</param>
         /// <returns>A string describing the expression translation.</returns>
-        internal static string TranslateExpression(Expression inputExpression)
+        internal static string TranslateExpression(
+            Expression inputExpression,
+            CosmosSerializationOptions serializationOptions = null)
         {
-            TranslationContext context = new TranslationContext();
+            TranslationContext context = new TranslationContext(serializationOptions);
 
             inputExpression = ConstantEvaluator.PartialEval(inputExpression);
             SqlScalarExpression scalarExpression = ExpressionToSql.VisitNonSubqueryScalarExpression(inputExpression, context);
             return scalarExpression.ToString();
         }
 
-        internal static string TranslateExpressionOld(Expression inputExpression)
+        internal static string TranslateExpressionOld(
+            Expression inputExpression,
+            CosmosSerializationOptions serializationOptions = null)
         {
-            TranslationContext context = new TranslationContext();
+            TranslationContext context = new TranslationContext(serializationOptions);
 
             inputExpression = ConstantFolding.Fold(inputExpression);
             SqlScalarExpression scalarExpression = ExpressionToSql.VisitNonSubqueryScalarExpression(inputExpression, context);
             return scalarExpression.ToString();
         }
 
-        internal static SqlQuerySpec TranslateQuery(Expression inputExpression)
+        internal static SqlQuerySpec TranslateQuery(
+            Expression inputExpression,
+            CosmosSerializationOptions serializationOptions = null)
         {
             inputExpression = ConstantEvaluator.PartialEval(inputExpression);
-            SqlQuery query = ExpressionToSql.TranslateQuery(inputExpression);
+            SqlQuery query = ExpressionToSql.TranslateQuery(inputExpression, serializationOptions);
             return new SqlQuerySpec(query.ToString());
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
@@ -58,6 +58,14 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.subqueryBindingStack = new Stack<SubqueryBinding>();
         }
 
+        public TranslationContext(CosmosSerializationOptions serializationOptions)
+            : this()
+        {
+            this.serializationOptions = serializationOptions;
+        }
+        
+        public CosmosSerializationOptions serializationOptions;
+
         public Expression LookupSubstitution(ParameterExpression parameter)
         {
             return this.substitutions.Lookup(parameter);

--- a/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Linq
     using System.Runtime.Serialization;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
 
     internal static class TypeSystem
     {
@@ -21,27 +22,40 @@ namespace Microsoft.Azure.Cosmos.Linq
             return GetElementType(type, new HashSet<Type>());
         }
 
-        public static string GetMemberName(this MemberInfo memberInfo)
+        public static string GetMemberName(this MemberInfo memberInfo, CosmosSerializationOptions cosmosSerializationOptions = null)
         {
+            string memberName = null;
              // Json.Net honors JsonPropertyAttribute more than DataMemberAttribute
              // So we check for JsonPropertyAttribute first.
             JsonPropertyAttribute jsonPropertyAttribute = memberInfo.GetCustomAttribute<JsonPropertyAttribute>(true);
             if (jsonPropertyAttribute != null && !string.IsNullOrEmpty(jsonPropertyAttribute.PropertyName))
             {
-                return jsonPropertyAttribute.PropertyName;
+                memberName = jsonPropertyAttribute.PropertyName;
             }
-
-            DataContractAttribute dataContractAttribute = memberInfo.DeclaringType.GetCustomAttribute<DataContractAttribute>(true);
-            if (dataContractAttribute != null)
+            else
             {
-                DataMemberAttribute dataMemberAttribute = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
-                if (dataMemberAttribute != null && !string.IsNullOrEmpty(dataMemberAttribute.Name))
+                DataContractAttribute dataContractAttribute = memberInfo.DeclaringType.GetCustomAttribute<DataContractAttribute>(true);
+                if (dataContractAttribute != null)
                 {
-                    return dataMemberAttribute.Name;
+                    DataMemberAttribute dataMemberAttribute = memberInfo.GetCustomAttribute<DataMemberAttribute>(true);
+                    if (dataMemberAttribute != null && !string.IsNullOrEmpty(dataMemberAttribute.Name))
+                    {
+                        memberName = dataMemberAttribute.Name;
+                    }
                 }
             }
 
-            return memberInfo.Name;
+            if (memberName == null)
+            {
+                memberName = memberInfo.Name;
+            }
+
+            if (cosmosSerializationOptions != null)
+            {
+                memberName = cosmosSerializationOptions.GetStrWithPropertyNamingPolicy(memberName);
+            }
+
+            return memberName;
         }
 
         private static Type GetElementType(Type type, HashSet<Type> visitedSet)
@@ -130,7 +144,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(IEnumerable<>)) return true;
 
             IEnumerable<Type> types = type.GetInterfaces().Where(interfaceType => interfaceType.IsGenericType() && interfaceType.GetGenericTypeDefinition() == typeof(IEnumerable<>));
-            return (types.FirstOrDefault() != null);
+            return types.FirstOrDefault() != null;
         }
 
         public static bool IsExtensionMethod(this MethodInfo methodInfo)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -299,7 +299,8 @@ namespace Microsoft.Azure.Cosmos
                 (CosmosQueryClientCore)this.queryClient,
                 continuationToken,
                 requestOptions,
-                allowSynchronousQueryExecution);
+                allowSynchronousQueryExecution,
+                this.ClientContext.ClientOptions.SerializerOptions);
         }
 
         public override ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder<T>(

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
@@ -4,12 +4,16 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using Newtonsoft.Json.Serialization;
+
     /// <summary>
     /// This class provides a way to configure basic
     /// serializer settings.
     /// </summary>
     public sealed class CosmosSerializationOptions
     {
+        private CamelCaseNamingStrategy camelCaseNamingStrategy { get; }
+
         /// <summary>
         /// Create an instance of CosmosSerializationOptions
         /// with the default values for the Cosmos SDK
@@ -19,6 +23,7 @@ namespace Microsoft.Azure.Cosmos
             this.IgnoreNullValues = false;
             this.Indented = false;
             this.PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default;
+            this.camelCaseNamingStrategy = new CamelCaseNamingStrategy();
         }
 
         /// <summary>
@@ -45,5 +50,15 @@ namespace Microsoft.Azure.Cosmos
         /// The default value is CosmosPropertyNamingPolicy.Default
         /// </remarks>
         public CosmosPropertyNamingPolicy PropertyNamingPolicy { get; set; }
+
+        internal string GetStrWithPropertyNamingPolicy(string str)
+        {
+            if (this.PropertyNamingPolicy == CosmosPropertyNamingPolicy.CamelCase)
+            {
+                return this.camelCaseNamingStrategy.GetPropertyName(str, false);
+            }
+
+            return str;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public double cost { get; set; }
         public string description { get; set; }
         public string status { get; set; }
+        public string CamelCase { get; set; }
 
         public override bool Equals(Object obj)
         {
@@ -79,7 +80,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 description = "CreateRandomToDoActivity",
                 status = pk,
                 taskNum = 42,
-                cost = double.MaxValue
+                cost = double.MaxValue,
+                CamelCase = "camelCase"
             };
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [#100](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/100) Configurable Tcp settings to CosmosClientOptions
+- [#716](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/716) Adding camel case serialization on LINQ query generation
 
 ### Fixed
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR will help fixing issue where LINQ query generation was not entertaining the camel case option passed as serialization option during client creation.
So the item created with the camel case serialization where not able to retrieved from LINQ query.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues
#570

**Note** : User need to explicitly set CosmosSerializationOptions on clientOption( .WithSerializerOptions()). having PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase.
WithCustomSerializer() method wont work in this case.


