### PR TITLE
Cross Partition Non Value Aggregates

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <ClientVersion>3.1.1</ClientVersion>
-    <DirectVersion>3.1.4</DirectVersion>
+    <DirectVersion>3.1.5</DirectVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <DirectPackageName Condition=" '$(SignAssembly)' == 'true' ">Microsoft.Azure.Cosmos.Direct</DirectPackageName>
     <DirectPackageName Condition=" '$(SignAssembly)' != 'true' ">Microsoft.Azure.Cosmos.Direct.MyGet</DirectPackageName>

--- a/Microsoft.Azure.Cosmos/src/Query/Aggregation/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Aggregation/SingleGroupAggregator.cs
@@ -1,0 +1,286 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Aggregation;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Aggregates all the projections for a single grouping.
+    /// </summary>
+    internal abstract class SingleGroupAggregator
+    {
+        /// <summary>
+        /// Adds the payload for group by values 
+        /// </summary>
+        /// <param name="values"></param>
+        public abstract void AddValues(CosmosElement values);
+
+        /// <summary>
+        /// Forms the final result of the grouping.
+        /// </summary>
+        public abstract CosmosElement GetResult();
+
+        public static SingleGroupAggregator Create(
+            AggregateOperator[] aggregates,
+            IReadOnlyDictionary<string, AggregateOperator?> aggregateAliasToAggregateType,
+            bool hasSelectValue)
+        {
+            SingleGroupAggregator aggregateValues;
+            if (hasSelectValue)
+            {
+                if (aggregates != null && aggregates.Any())
+                {
+                    // SELECT VALUE <AGGREGATE>
+                    aggregateValues = SelectValueAggregateValues.Create(aggregates[0]);
+                }
+                else
+                {
+                    // SELECT VALUE <NON AGGREGATE>
+                    aggregateValues = SelectValueAggregateValues.Create(aggregateOperator: null);
+                }
+            }
+            else
+            {
+                aggregateValues = SelectListAggregateValues.Create(aggregateAliasToAggregateType);
+            }
+
+            return aggregateValues;
+        }
+
+        /// <summary>
+        /// For SELECT VALUE queries there is only one value for each grouping.
+        /// This class just helps maintain that and captures the first value across all continuations.
+        /// </summary>
+        private sealed class SelectValueAggregateValues : SingleGroupAggregator
+        {
+            private readonly AggregateValue aggregateValue;
+
+            private SelectValueAggregateValues(AggregateValue aggregateValue)
+            {
+                if (aggregateValue == null)
+                {
+                    throw new ArgumentNullException(nameof(AggregateValue));
+                }
+
+                this.aggregateValue = aggregateValue;
+            }
+
+            public static SelectValueAggregateValues Create(AggregateOperator? aggregateOperator)
+            {
+                AggregateValue aggregateValue = AggregateValue.Create(aggregateOperator);
+                return new SelectValueAggregateValues(aggregateValue);
+            }
+
+            public override void AddValues(CosmosElement values)
+            {
+                this.aggregateValue.AddValue(values);
+            }
+
+            public override CosmosElement GetResult()
+            {
+                return this.aggregateValue.Result;
+            }
+
+            public override string ToString()
+            {
+                return this.aggregateValue.ToString();
+            }
+        }
+
+        /// <summary>
+        /// For select list queries we need to create a dictionary of alias to group by value.
+        /// For each grouping drained from the backend we merge it with the results here.
+        /// At the end this class will form a JSON object with the correct aliases and grouping result.
+        /// </summary>
+        private sealed class SelectListAggregateValues : SingleGroupAggregator
+        {
+            private readonly IReadOnlyDictionary<string, AggregateValue> aliasToValue;
+
+            private SelectListAggregateValues(IReadOnlyDictionary<string, AggregateValue> aliasToValue)
+            {
+                this.aliasToValue = aliasToValue;
+            }
+
+            public override CosmosElement GetResult()
+            {
+                Dictionary<string, CosmosElement> aliasToElement = new Dictionary<string, CosmosElement>();
+                foreach (KeyValuePair<string, AggregateValue> aliasAndValue in this.aliasToValue)
+                {
+                    string alias = aliasAndValue.Key;
+                    AggregateValue aggregateValue = aliasAndValue.Value;
+                    if (aggregateValue.Result != null)
+                    {
+                        aliasToElement[alias] = aggregateValue.Result;
+                    }
+                }
+
+                return CosmosObject.Create(aliasToElement);
+            }
+
+            public static SelectListAggregateValues Create(IReadOnlyDictionary<string, AggregateOperator?> aggregateAliasToAggregateType)
+            {
+                Dictionary<string, AggregateValue> groupingTable = new Dictionary<string, AggregateValue>();
+                foreach (KeyValuePair<string, AggregateOperator?> aliasToAggregate in aggregateAliasToAggregateType)
+                {
+                    string alias = aliasToAggregate.Key;
+                    AggregateOperator? aggregateOperator = aliasToAggregate.Value;
+                    groupingTable[alias] = AggregateValue.Create(aggregateOperator);
+                }
+
+                return new SelectListAggregateValues(groupingTable);
+            }
+
+            public override void AddValues(CosmosElement values)
+            {
+                if (!(values is CosmosObject payload))
+                {
+                    throw new ArgumentException("values is not an object.");
+                }
+
+                foreach (KeyValuePair<string, AggregateValue> aliasAndValue in this.aliasToValue)
+                {
+                    string alias = aliasAndValue.Key;
+                    AggregateValue aggregateValue = aliasAndValue.Value;
+                    aggregateValue.AddValue(payload[alias]);
+                }
+            }
+
+            public override string ToString()
+            {
+                return JsonConvert.SerializeObject(this.aliasToValue);
+            }
+        }
+
+        /// <summary>
+        /// With a group by value we need to encapsulate the fact that we have:
+        /// 1) aggregate group by values
+        /// 2) scalar group by values.
+        /// </summary>
+        private abstract class AggregateValue
+        {
+            public abstract void AddValue(CosmosElement aggregateValue);
+
+            public abstract CosmosElement Result { get; }
+
+            public override string ToString()
+            {
+                return this.Result.ToString();
+            }
+
+            public static AggregateValue Create(AggregateOperator? aggregateOperator)
+            {
+                AggregateValue value;
+                if (aggregateOperator.HasValue)
+                {
+                    value = AggregateAggregateValue.Create(aggregateOperator.Value);
+                }
+                else
+                {
+                    value = ScalarAggregateValue.Create();
+                }
+
+                return value;
+            }
+
+            private sealed class AggregateAggregateValue : AggregateValue
+            {
+                private readonly IAggregator aggregator;
+
+                public override CosmosElement Result => this.aggregator.GetResult();
+
+                private AggregateAggregateValue(IAggregator aggregator)
+                {
+                    if (aggregator == null)
+                    {
+                        throw new ArgumentNullException(nameof(aggregator));
+                    }
+
+                    this.aggregator = aggregator;
+                }
+
+                public override void AddValue(CosmosElement aggregateValue)
+                {
+                    AggregateItem aggregateItem = new AggregateItem(aggregateValue);
+                    this.aggregator.Aggregate(aggregateItem.Item);
+                }
+
+                public static AggregateAggregateValue Create(AggregateOperator aggregateOperator)
+                {
+                    IAggregator aggregator;
+                    switch (aggregateOperator)
+                    {
+                        case AggregateOperator.Average:
+                            aggregator = new AverageAggregator();
+                            break;
+
+                        case AggregateOperator.Count:
+                            aggregator = new CountAggregator();
+                            break;
+
+                        case AggregateOperator.Max:
+                            aggregator = new MinMaxAggregator(isMinAggregation: false);
+                            break;
+
+                        case AggregateOperator.Min:
+                            aggregator = new MinMaxAggregator(isMinAggregation: true);
+                            break;
+
+                        case AggregateOperator.Sum:
+                            aggregator = new SumAggregator();
+                            break;
+
+                        default:
+                            throw new ArgumentException($"Unknown {nameof(AggregateOperator)}: {aggregateOperator}.");
+                    }
+
+                    return new AggregateAggregateValue(aggregator);
+                }
+            }
+
+            private sealed class ScalarAggregateValue : AggregateValue
+            {
+                private CosmosElement value;
+                private bool initialized;
+
+                private ScalarAggregateValue()
+                {
+                    this.value = null;
+                    this.initialized = false;
+                }
+
+                public override CosmosElement Result
+                {
+                    get
+                    {
+                        if (!this.initialized)
+                        {
+                            throw new InvalidOperationException($"{nameof(ScalarAggregateValue)} is not yet initialized.");
+                        }
+
+                        return this.value;
+                    }
+                }
+
+                public static ScalarAggregateValue Create()
+                {
+                    return new ScalarAggregateValue();
+                }
+
+                public override void AddValue(CosmosElement aggregateValue)
+                {
+                    if (!this.initialized)
+                    {
+                        this.value = aggregateValue;
+                        this.initialized = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosQueryExecutionContextFactory.cs
@@ -426,28 +426,6 @@ namespace Microsoft.Azure.Cosmos.Query
             return targetRanges;
         }
 
-        public static Task<PartitionedQueryExecutionInfo> GetPartitionedQueryExecutionInfoAsync(
-            CosmosQueryClient queryClient,
-            SqlQuerySpec sqlQuerySpec,
-            PartitionKeyDefinition partitionKeyDefinition,
-            bool requireFormattableOrderByQuery,
-            bool isContinuationExpected,
-            bool allowNonValueAggregateQuery,
-            bool hasLogicalPartitionKey,
-            CancellationToken cancellationToken)
-        {
-            // $ISSUE-felixfan-2016-07-13: We should probably get PartitionedQueryExecutionInfo from Gateway in GatewayMode
-
-            return queryClient.GetPartitionedQueryExecutionInfoAsync(
-                sqlQuerySpec,
-                partitionKeyDefinition,
-                requireFormattableOrderByQuery,
-                isContinuationExpected,
-                allowNonValueAggregateQuery,
-                hasLogicalPartitionKey,
-                cancellationToken);
-        }
-
         private static bool TryGetEpkProperty(
             QueryRequestOptions queryRequestOptions,
             out string effectivePartitionKeyString)

--- a/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/DocumentQueryExecutionContextFactory.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     partitionKeyDefinition: collection.PartitionKey,
                     requireFormattableOrderByQuery: true,
                     isContinuationExpected: isContinuationExpected,
-                    allowNonValueAggregateQuery: false,
+                    allowNonValueAggregateQuery: true,
                     hasLogicalPartitionKey: feedOptions.PartitionKey != null,
                     cancellationToken: token);
 

--- a/Microsoft.Azure.Cosmos/src/Query/ExecutionComponent/AggregateDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ExecutionComponent/AggregateDocumentQueryExecutionComponent.cs
@@ -5,23 +5,17 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Azure.Cosmos.Collections;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Internal;
-    using Microsoft.Azure.Cosmos.Query.Aggregation;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Collections;
 
     /// <summary>
     /// Execution component that is able to aggregate local aggregates from multiple continuations and partitions.
-    /// At a high level aggregates queries only return a local aggregate meaning that the value that is returned is only valid for that one continuation (and one partition).
-    /// For example suppose you have the query "SELECT Count(1) from c" and you have a single partition collection, 
+    /// At a high level aggregates queries only return a "partial" aggregate.
+    /// "partial" means that the result is only valid for that one continuation (and one partition).
+    /// For example suppose you have the query "SELECT COUNT(1) FROM c" and you have a single partition collection, 
     /// then you will get one count for each continuation of the query.
     /// If you wanted the true result for this query, then you will have to take the sum of all continuations.
     /// The reason why we have multiple continuations is because for a long running query we have to break up the results into multiple continuations.
@@ -30,64 +24,66 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
     internal sealed class AggregateDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {
         /// <summary>
-        /// aggregators[i] is the i'th aggregate in this query execution component.
+        /// This class does most of the work, since a query like:
+        /// 
+        /// SELECT VALUE AVG(c.age)
+        /// FROM c
+        /// 
+        /// is really just an aggregation on a single grouping (the whole collection).
         /// </summary>
-        private readonly IAggregator[] aggregators;
+        private readonly SingleGroupAggregator singleGroupAggregator;
+
+        /// <summary>
+        /// We need to keep track of whether the projection has the 'VALUE' keyword.
+        /// </summary>
+        private readonly bool isValueAggregateQuery;
 
         /// <summary>
         /// Initializes a new instance of the AggregateDocumentQueryExecutionComponent class.
         /// </summary>
         /// <param name="source">The source component that will supply the local aggregates from multiple continuations and partitions.</param>
-        /// <param name="aggregateOperators">The aggregate operators for this query.</param>
+        /// <param name="singleGroupAggregator">The single group aggregator that we will feed results into.</param>
+        /// <param name="isValueAggregateQuery">Whether or not the query has the 'VALUE' keyword.</param>
         /// <remarks>This constructor is private since there is some async initialization that needs to happen in CreateAsync().</remarks>
-        private AggregateDocumentQueryExecutionComponent(IDocumentQueryExecutionComponent source, AggregateOperator[] aggregateOperators)
+        private AggregateDocumentQueryExecutionComponent(
+            IDocumentQueryExecutionComponent source,
+            SingleGroupAggregator singleGroupAggregator,
+            bool isValueAggregateQuery)
             : base(source)
         {
-            this.aggregators = new IAggregator[aggregateOperators.Length];
-            for (int i = 0; i < aggregateOperators.Length; ++i)
+            if (singleGroupAggregator == null)
             {
-                switch (aggregateOperators[i])
-                {
-                    case AggregateOperator.Average:
-                        this.aggregators[i] = new AverageAggregator();
-                        break;
-                    case AggregateOperator.Count:
-                        this.aggregators[i] = new CountAggregator();
-                        break;
-                    case AggregateOperator.Max:
-                        this.aggregators[i] = new MinMaxAggregator(false);
-                        break;
-                    case AggregateOperator.Min:
-                        this.aggregators[i] = new MinMaxAggregator(true);
-                        break;
-                    case AggregateOperator.Sum:
-                        this.aggregators[i] = new SumAggregator();
-                        break;
-                    default:
-                        string errorMessage = "Unexpected value: " + aggregateOperators[i].ToString();
-                        Debug.Assert(false, errorMessage);
-                        throw new InvalidProgramException(errorMessage);
-                }
+                throw new ArgumentNullException(nameof(singleGroupAggregator));
             }
+
+            this.singleGroupAggregator = singleGroupAggregator;
+            this.isValueAggregateQuery = isValueAggregateQuery;
         }
 
         /// <summary>
         /// Creates a AggregateDocumentQueryExecutionComponent.
         /// </summary>
-        /// <param name="aggregateOperators">The aggregate operators for this query.</param>
+        /// <param name="aggregates">The aggregates.</param>
+        /// <param name="aliasToAggregateType">The alias to aggregate type.</param>
+        /// <param name="hasSelectValue">Whether or not the query has the 'VALUE' keyword.</param>
         /// <param name="requestContinuation">The continuation token to resume from.</param>
         /// <param name="createSourceCallback">The callback to create the source component that supplies the local aggregates.</param>
         /// <returns>The AggregateDocumentQueryExecutionComponent.</returns>
         public static async Task<AggregateDocumentQueryExecutionComponent> CreateAsync(
-            AggregateOperator[] aggregateOperators,
+            AggregateOperator[] aggregates,
+            IReadOnlyDictionary<string, AggregateOperator?> aliasToAggregateType,
+            bool hasSelectValue,
             string requestContinuation,
             Func<string, Task<IDocumentQueryExecutionComponent>> createSourceCallback)
         {
-            return new AggregateDocumentQueryExecutionComponent(await createSourceCallback(requestContinuation), aggregateOperators);
+            return new AggregateDocumentQueryExecutionComponent(
+                await createSourceCallback(requestContinuation),
+                SingleGroupAggregator.Create(aggregates, aliasToAggregateType, hasSelectValue),
+                aggregates != null && aggregates.Count() == 1);
         }
 
         /// <summary>
-        /// Drains at most 'maxElements' documents from the <see cref="AggregateDocumentQueryExecutionComponent"/> .
+        /// Drains at most 'maxElements' documents from the AggregateDocumentQueryExecutionComponent.
         /// </summary>
         /// <param name="maxElements">This value is ignored, since the aggregates are aggregated for you.</param>
         /// <param name="token">The cancellation token.</param>
@@ -98,9 +94,10 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
         /// </remarks>
         public override async Task<QueryResponse> DrainAsync(int maxElements, CancellationToken token)
         {
-            token.ThrowIfCancellationRequested();
-
             // Note-2016-10-25-felixfan: Given what we support now, we should expect to return only 1 document.
+            // Note-2019-07-11-brchon: We can return empty pages until all the documents are drained,
+            // but then we will have to design a continuation token.
+
             double requestCharge = 0;
             long responseLengthBytes = 0;
             List<Uri> replicaUris = new List<Uri>();
@@ -121,84 +118,96 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                 resourceType = result.QueryHeaders.ResourceType;
                 requestCharge += result.Headers.RequestCharge;
                 responseLengthBytes += result.ResponseLengthBytes;
-                //partitionedQueryMetrics += new PartitionedQueryMetrics(result.QueryMetrics);
+                // DEVNOTE: Add when query metrics is supported
+                // partitionedQueryMetrics += new PartitionedQueryMetrics(results.QueryMetrics);
                 if (result.RequestStatistics != null)
                 {
                     replicaUris.AddRange(result.RequestStatistics.ContactedReplicas);
                 }
 
-                foreach (CosmosElement item in result.CosmosElements)
+                foreach (CosmosElement element in result.CosmosElements)
                 {
-                    if (!(item is CosmosArray comosArray))
-                    {
-                        throw new InvalidOperationException("Expected an array of aggregate results from the execution context.");
-                    }
-
-                    List<AggregateItem> aggregateItems = new List<AggregateItem>();
-                    foreach (CosmosElement arrayItem in comosArray)
-                    {
-                        aggregateItems.Add(new AggregateItem(arrayItem));
-                    }
-
-                    Debug.Assert(
-                        aggregateItems.Count == this.aggregators.Length,
-                        $"Expected {this.aggregators.Length} values, but received {aggregateItems.Count}.");
-
-                    for (int i = 0; i < this.aggregators.Length; ++i)
-                    {
-                        this.aggregators[i].Aggregate(aggregateItems[i].Item);
-                    }
+                    RewrittenAggregateProjections rewrittenAggregateProjections = new RewrittenAggregateProjections(
+                        this.isValueAggregateQuery,
+                        element);
+                    this.singleGroupAggregator.AddValues(rewrittenAggregateProjections.Payload);
                 }
             }
 
-            List<CosmosElement> finalResult = this.BindAggregateResults(
-                this.aggregators.Select(aggregator => aggregator.GetResult()));
+            List<CosmosElement> finalResult = new List<CosmosElement>();
+            CosmosElement aggregationResult = this.singleGroupAggregator.GetResult();
+            if (aggregationResult != null)
+            {
+                finalResult.Add(aggregationResult);
+            }
 
             // The replicaUris may have duplicates.
             requestStatistics.ContactedReplicas.AddRange(replicaUris);
 
             return QueryResponse.CreateSuccess(
-                result: finalResult,
-                count: finalResult.Count,
-                responseLengthBytes: responseLengthBytes,
-                responseHeaders: new CosmosQueryResponseMessageHeaders(
-                    continauationToken: null, 
-                    disallowContinuationTokenMessage: null, 
-                    resourceType: resourceType, 
-                    containerRid: containerRid)
-                {
-                    RequestCharge = requestCharge
-                });
+               result: finalResult,
+               count: finalResult.Count,
+               responseLengthBytes: responseLengthBytes,
+               responseHeaders: new CosmosQueryResponseMessageHeaders(
+                   continauationToken: null,
+                   disallowContinuationTokenMessage: null,
+                   resourceType: resourceType,
+                   containerRid: containerRid)
+               {
+                   RequestCharge = requestCharge
+               });
         }
 
         /// <summary>
-        /// Filters out all the aggregate results that are Undefined.
+        /// Struct for getting the payload out of the rewritten projection.
         /// </summary>
-        /// <param name="aggregateResults">The result for each aggregator.</param>
-        /// <returns>The aggregate results that are not Undefined.</returns>
-        private List<CosmosElement> BindAggregateResults(IEnumerable<CosmosElement> aggregateResults)
+        private struct RewrittenAggregateProjections
         {
-            // Note-2016-11-08-felixfan: Given what we support now, we should expect aggregateResults.Length == 1.
-            // Note-2018-03-07-brchon: This is because we only support aggregate queries like "SELECT VALUE max(c.blah) from c"
-            // and that is because it allows us to sum the local maxes and also avoids queries like "SELECT ABS(max(c.blah)) / 10 from c",
-            // which would require more static analysis to pull off.
-            string assertMessage = "Only support binding 1 aggregate function to projection.";
-            Debug.Assert(this.aggregators.Length == 1, assertMessage);
-            if (this.aggregators.Length != 1)
+            public RewrittenAggregateProjections(bool isValueAggregateQuery, CosmosElement raw)
             {
-                throw new NotSupportedException(assertMessage);
-            }
-
-            List<CosmosElement> result = new List<CosmosElement>();
-            foreach (CosmosElement aggregateResult in aggregateResults)
-            {
-                if (aggregateResult != null)
+                if (raw == null)
                 {
-                    result.Add(aggregateResult);
+                    throw new ArgumentNullException(nameof(raw));
+                }
+
+                if (isValueAggregateQuery)
+                {
+                    // SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
+                    CosmosArray aggregates = raw as CosmosArray;
+                    if (aggregates == null)
+                    {
+                        throw new ArgumentException($"{nameof(RewrittenAggregateProjections)} was not an array for a value aggregate query. Type is: {raw.Type}");
+                    }
+
+                    this.Payload = aggregates[0];
+                }
+                else
+                {
+                    CosmosObject cosmosObject = raw as CosmosObject;
+                    if (cosmosObject == null)
+                    {
+                        throw new ArgumentException($"{nameof(raw)} must not be an object.");
+                    }
+
+                    if (!cosmosObject.TryGetValue("payload", out CosmosElement cosmosPayload))
+                    {
+                        throw new InvalidOperationException($"Underlying object does not have an 'payload' field.");
+                    }
+
+                    // SELECT {"$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+                    if (cosmosPayload == null)
+                    {
+                        throw new ArgumentException($"{nameof(RewrittenAggregateProjections)} does not have a 'payload' property.");
+                    }
+
+                    this.Payload = cosmosPayload;
                 }
             }
 
-            return result;
+            public CosmosElement Payload
+            {
+                get;
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
@@ -43,10 +43,13 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
     {
         public const string ContinuationTokenNotSupportedWithGroupBy = "Continuation token is not supported for queries with GROUP BY. Do not use FeedResponse.ResponseContinuation or remove the GROUP BY from the query.";
         private static readonly List<CosmosElement> EmptyResults = new List<CosmosElement>();
+        private static readonly Dictionary<string, QueryMetrics> EmptyQueryMetrics = new Dictionary<string, QueryMetrics>();
+        private static readonly AggregateOperator[] EmptyAggregateOperators = new AggregateOperator[] { };
 
         private readonly IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType;
-        private readonly Dictionary<UInt192, GroupByValues> groupingTable;
+        private readonly Dictionary<UInt192, SingleGroupAggregator> groupingTable;
         private readonly DistinctMap distinctMap;
+        private readonly bool hasSelectValue;
 
         private int numPagesDrainedFromGroupingTable;
         private bool isDone;
@@ -54,6 +57,7 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
 
         private GroupByDocumentQueryExecutionComponent(
             IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType,
+            bool hasSelectValue,
             IDocumentQueryExecutionComponent source)
             : base(source)
         {
@@ -62,11 +66,12 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                 throw new ArgumentNullException(nameof(groupByAliasToAggregateType));
             }
 
-            this.groupingTable = new Dictionary<UInt192, GroupByValues>();
+            this.groupingTable = new Dictionary<UInt192, SingleGroupAggregator>();
 
             // Using an ordered distinct map to get hashes.
             this.distinctMap = DistinctMap.Create(DistinctQueryType.Ordered, null);
             this.groupByAliasToAggregateType = groupByAliasToAggregateType;
+            this.hasSelectValue = hasSelectValue;
         }
 
         public override bool IsDone => this.isDone;
@@ -74,11 +79,13 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
         public static async Task<IDocumentQueryExecutionComponent> CreateAsync(
             string requestContinuation,
             Func<string, Task<IDocumentQueryExecutionComponent>> createSourceCallback,
-            IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType)
+            IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType,
+            bool hasSelectValue)
         {
             // We do not support continuation tokens for GROUP BY.
             return new GroupByDocumentQueryExecutionComponent(
                 groupByAliasToAggregateType,
+                hasSelectValue,
                 await createSourceCallback(requestContinuation));
         }
 
@@ -112,14 +119,17 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                         throw new InvalidOperationException("hash invariant was broken");
                     }
 
-                    if (!this.groupingTable.TryGetValue(groupByKeysHash.Value, out GroupByValues groupByValues))
+                    if (!this.groupingTable.TryGetValue(groupByKeysHash.Value, out SingleGroupAggregator singleGroupAggregator))
                     {
-                        groupByValues = GroupByValues.CreateFromAggregateTypeDictionary(this.groupByAliasToAggregateType);
-                        this.groupingTable[groupByKeysHash.Value] = groupByValues;
+                        singleGroupAggregator = SingleGroupAggregator.Create(
+                            EmptyAggregateOperators,
+                            this.groupByAliasToAggregateType,
+                            this.hasSelectValue);
+                        this.groupingTable[groupByKeysHash.Value] = singleGroupAggregator;
                     }
 
                     CosmosElement payload = groupByItem.Payload;
-                    groupByValues.AddValues(payload);
+                    singleGroupAggregator.AddValues(payload);
                 }
 
                 string updatedContinuationToken = null;
@@ -136,14 +146,14 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
             {
                 // Stage 2:
                 // Emit the results from the grouping table page by page
-                IEnumerable<GroupByValues> groupByValuesList = this.groupingTable
+                IEnumerable<SingleGroupAggregator> groupByValuesList = this.groupingTable
                     .OrderBy(kvp => kvp.Key)
                     .Skip(this.numPagesDrainedFromGroupingTable * maxElements)
                     .Take(maxElements)
                     .Select(kvp => kvp.Value);
 
                 List<CosmosElement> results = new List<CosmosElement>();
-                foreach (GroupByValues groupByValues in groupByValuesList)
+                foreach (SingleGroupAggregator groupByValues in groupByValuesList)
                 {
                     results.Add(groupByValues.GetResult());
                 }
@@ -227,269 +237,6 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                     }
 
                     return cosmosElement;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Represents all the values in a group by projection.
-        /// </summary>
-        private abstract class GroupByValues
-        {
-            /// <summary>
-            /// Adds the payload for group by values 
-            /// </summary>
-            /// <param name="values"></param>
-            public abstract void AddValues(CosmosElement values);
-
-            /// <summary>
-            /// Forms the final result of the grouping.
-            /// </summary>
-            /// <returns>
-            /// The final result of the grouping.
-            /// </returns>
-            public abstract CosmosElement GetResult();
-
-            public static GroupByValues CreateFromAggregateTypeDictionary(
-                IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType)
-            {
-                GroupByValues groupByValues;
-                if ((groupByAliasToAggregateType == null) || (groupByAliasToAggregateType.Count() == 0))
-                {
-                    groupByValues = SelectValueGroupByValues.Create();
-                }
-                else
-                {
-                    groupByValues = SelectListGroupByValues.Create(groupByAliasToAggregateType);
-                }
-
-                return groupByValues;
-            }
-
-            /// <summary>
-            /// For SELECT VALUE queries there is only one value for each grouping.
-            /// This class just helps maintain that and captures the first value across all continuations.
-            /// </summary>
-            private sealed class SelectValueGroupByValues : GroupByValues
-            {
-                private readonly GroupByValue groupByValue;
-
-                private SelectValueGroupByValues(GroupByValue groupByValue)
-                {
-                    if (groupByValue == null)
-                    {
-                        throw new ArgumentNullException(nameof(groupByValue));
-                    }
-
-                    this.groupByValue = groupByValue;
-                }
-
-                public static SelectValueGroupByValues Create()
-                {
-                    GroupByValue groupByValue = GroupByValue.Create(aggregateOperator: null);
-                    return new SelectValueGroupByValues(groupByValue);
-                }
-
-                public override void AddValues(CosmosElement values)
-                {
-                    this.groupByValue.AddValue(values);
-                }
-
-                public override CosmosElement GetResult()
-                {
-                    return this.groupByValue.Result;
-                }
-
-                public override string ToString()
-                {
-                    return this.groupByValue.ToString();
-                }
-            }
-
-            /// <summary>
-            /// For select list queries we need to create a dictionary of alias to group by value.
-            /// For each grouping drained from the backend we merge it with the results here.
-            /// At the end this class will form a JSON object with the correct aliases and grouping result.
-            /// </summary>
-            private sealed class SelectListGroupByValues : GroupByValues
-            {
-                private readonly IReadOnlyDictionary<string, GroupByValue> aliasToValue;
-
-                private SelectListGroupByValues(IReadOnlyDictionary<string, GroupByValue> aliasToValue)
-                {
-                    this.aliasToValue = aliasToValue;
-                }
-
-                public override CosmosElement GetResult()
-                {
-                    Dictionary<string, CosmosElement> mergedResult = new Dictionary<string, CosmosElement>();
-                    foreach (KeyValuePair<string, GroupByValue> aliasAndValue in this.aliasToValue)
-                    {
-                        string alias = aliasAndValue.Key;
-                        GroupByValue groupByValue = aliasAndValue.Value;
-                        mergedResult[alias] = groupByValue.Result;
-                    }
-
-                    return CosmosObject.Create(mergedResult);
-                }
-
-                public static SelectListGroupByValues Create(IReadOnlyDictionary<string, AggregateOperator?> groupByAliasToAggregateType)
-                {
-                    Dictionary<string, GroupByValue> groupingTable = new Dictionary<string, GroupByValue>();
-                    foreach (KeyValuePair<string, AggregateOperator?> aliasToAggregate in groupByAliasToAggregateType)
-                    {
-                        string alias = aliasToAggregate.Key;
-                        AggregateOperator? aggregateOperator = aliasToAggregate.Value;
-                        groupingTable[alias] = GroupByValue.Create(aggregateOperator);
-                    }
-
-                    return new SelectListGroupByValues(groupingTable);
-                }
-
-                public override void AddValues(CosmosElement values)
-                {
-                    if (!(values is CosmosObject payload))
-                    {
-                        throw new ArgumentException("values is not an object.");
-                    }
-
-                    foreach (KeyValuePair<string, GroupByValue> aliasAndValue in this.aliasToValue)
-                    {
-                        string alias = aliasAndValue.Key;
-                        GroupByValue groupByValue = aliasAndValue.Value;
-                        groupByValue.AddValue(payload[alias]);
-                    }
-                }
-
-                public override string ToString()
-                {
-                    return JsonConvert.SerializeObject(this.aliasToValue);
-                }
-            }
-        }
-
-        /// <summary>
-        /// With a group by value we need to encapsulate the fact that we have:
-        /// 1) aggregate group by values
-        /// 2) scalar group by values.
-        /// </summary>
-        private abstract class GroupByValue
-        {
-            public abstract void AddValue(CosmosElement groupByValue);
-
-            public abstract CosmosElement Result { get; }
-
-            public override string ToString()
-            {
-                return this.Result.ToString();
-            }
-
-            public static GroupByValue Create(AggregateOperator? aggregateOperator)
-            {
-                GroupByValue value;
-                if (aggregateOperator.HasValue)
-                {
-                    value = AggregateGroupByValue.Create(aggregateOperator.Value);
-                }
-                else
-                {
-                    value = ScalarGroupByValue.Create();
-                }
-
-                return value;
-            }
-
-            private sealed class AggregateGroupByValue : GroupByValue
-            {
-                private readonly IAggregator aggregator;
-
-                public override CosmosElement Result => this.aggregator.GetResult();
-
-                private AggregateGroupByValue(IAggregator aggregator)
-                {
-                    if (aggregator == null)
-                    {
-                        throw new ArgumentNullException(nameof(aggregator));
-                    }
-
-                    this.aggregator = aggregator;
-                }
-
-                public override void AddValue(CosmosElement groupByValue)
-                {
-                    AggregateItem aggregateItem = new AggregateItem(groupByValue);
-                    this.aggregator.Aggregate(aggregateItem.Item);
-                }
-
-                public static AggregateGroupByValue Create(AggregateOperator aggregateOperator)
-                {
-                    IAggregator aggregator;
-                    switch (aggregateOperator)
-                    {
-                        case AggregateOperator.Average:
-                            aggregator = new AverageAggregator();
-                            break;
-
-                        case AggregateOperator.Count:
-                            aggregator = new CountAggregator();
-                            break;
-
-                        case AggregateOperator.Max:
-                            aggregator = new MinMaxAggregator(isMinAggregation: false);
-                            break;
-
-                        case AggregateOperator.Min:
-                            aggregator = new MinMaxAggregator(isMinAggregation: true);
-                            break;
-
-                        case AggregateOperator.Sum:
-                            aggregator = new SumAggregator();
-                            break;
-
-                        default:
-                            throw new ArgumentException($"Unknown {nameof(AggregateOperator)}: {aggregateOperator}.");
-                    }
-
-                    return new AggregateGroupByValue(aggregator);
-                }
-            }
-
-            private sealed class ScalarGroupByValue : GroupByValue
-            {
-                private CosmosElement value;
-                private bool initialized;
-
-                private ScalarGroupByValue()
-                {
-                    this.value = null;
-                    this.initialized = false;
-                }
-
-                public override CosmosElement Result
-                {
-                    get
-                    {
-                        if (!this.initialized)
-                        {
-                            throw new InvalidOperationException($"{nameof(ScalarGroupByValue)} is not yet initialized.");
-                        }
-
-                        return this.value;
-                    }
-                }
-
-                public static ScalarGroupByValue Create()
-                {
-                    return new ScalarGroupByValue();
-                }
-
-                public override void AddValue(CosmosElement groupByValue)
-                {
-                    if (!this.initialized)
-                    {
-                        this.value = groupByValue;
-                        this.initialized = true;
-                    }
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/PipelinedDocumentQueryExecutionContext.cs
@@ -289,30 +289,15 @@ namespace Microsoft.Azure.Cosmos.Query
                 createComponentFunc = createParallelQueryExecutionContext;
             }
 
-            if (queryInfo.HasGroupBy)
-            {
-                if (!allowGroupBy)
-                {
-                    throw new ArgumentException("Cross Partition GROUP BY is not supported.");
-                }
-
-                Func<string, Task<IDocumentQueryExecutionComponent>> createSourceCallback = createComponentFunc;
-                createComponentFunc = async (continuationToken) =>
-                {
-                    return await GroupByDocumentQueryExecutionComponent.CreateAsync(
-                        continuationToken,
-                        createSourceCallback,
-                        queryInfo.GroupByAliasToAggregateType);
-                };
-            }
-
-            if (queryInfo.HasAggregates)
+            if (queryInfo.HasAggregates && !queryInfo.HasGroupBy)
             {
                 Func<string, Task<IDocumentQueryExecutionComponent>> createSourceCallback = createComponentFunc;
                 createComponentFunc = async (continuationToken) =>
                 {
                     return await AggregateDocumentQueryExecutionComponent.CreateAsync(
                         queryInfo.Aggregates,
+                        queryInfo.GroupByAliasToAggregateType,
+                        queryInfo.HasSelectValue,
                         continuationToken,
                         createSourceCallback);
                 };
@@ -327,6 +312,24 @@ namespace Microsoft.Azure.Cosmos.Query
                         continuationToken,
                         createSourceCallback,
                         queryInfo.DistinctType);
+                };
+            }
+
+            if (queryInfo.HasGroupBy)
+            {
+                if (!allowGroupBy)
+                {
+                    throw new ArgumentException("Cross Partition GROUP BY is not supported.");
+                }
+
+                Func<string, Task<IDocumentQueryExecutionComponent>> createSourceCallback = createComponentFunc;
+                createComponentFunc = async (continuationToken) =>
+                {
+                    return await GroupByDocumentQueryExecutionComponent.CreateAsync(
+                        continuationToken,
+                        createSourceCallback,
+                        queryInfo.GroupByAliasToAggregateType,
+                        queryInfo.HasSelectValue);
                 };
             }
 

--- a/Microsoft.Azure.Cosmos/src/Query/QueryFeature.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryFeature.cs
@@ -18,5 +18,6 @@ namespace Microsoft.Azure.Cosmos
         OffsetAndLimit = 1 << 6,
         OrderBy = 1 << 7,
         Top = 1 << 8,
+        NonValueAggregate = 1 << 9,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/QueryInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryInfo.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Query
 {
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
@@ -108,7 +109,17 @@ namespace Microsoft.Azure.Cosmos.Query
         {
             get
             {
-                return this.Aggregates != null && this.Aggregates.Length > 0;
+                bool aggregatesListNonEmpty = (this.Aggregates != null) && (this.Aggregates.Length > 0);
+                if (aggregatesListNonEmpty)
+                {
+                    return true;
+                }
+
+                bool aggregateAliasMappingNonEmpty = (this.GroupByAliasToAggregateType != null)
+                    && this.GroupByAliasToAggregateType
+                        .Values
+                        .Any(aggregateOperator => aggregateOperator.HasValue);
+                return aggregateAliasMappingNonEmpty;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
@@ -160,6 +160,11 @@ namespace Microsoft.Azure.Cosmos
                             {
                                 exceptions.Value.Add(QueryContainsUnsupportedNonValueAggregate);
                             }
+
+                            if (!supportedQueryFeatures.HasFlag(QueryFeatures.CompositeAggregate))
+                            {
+                                exceptions.Value.Add(QueryContainsUnsupportedCompositeAggregate);
+                            }
                         }
                     }
                     else

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanHandler.cs
@@ -160,11 +160,6 @@ namespace Microsoft.Azure.Cosmos
                             {
                                 exceptions.Value.Add(QueryContainsUnsupportedNonValueAggregate);
                             }
-
-                            if (!supportedQueryFeatures.HasFlag(QueryFeatures.CompositeAggregate))
-                            {
-                                exceptions.Value.Add(QueryContainsUnsupportedCompositeAggregate);
-                            }
                         }
                     }
                     else

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Azure.Cosmos.Query
             | QueryFeatures.MultipleOrderBy
             | QueryFeatures.OffsetAndLimit
             | QueryFeatures.OrderBy
-            | QueryFeatures.Top;
+            | QueryFeatures.Top
+            | QueryFeatures.NonValueAggregate;
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
 

--- a/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/QueryPlanRetriever.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Query
             QueryFeatures.Aggregate
             | QueryFeatures.Distinct
             | QueryFeatures.MultipleOrderBy
+            | QueryFeatures.MultipleAggregates
             | QueryFeatures.OffsetAndLimit
             | QueryFeatures.OrderBy
             | QueryFeatures.Top

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
@@ -3,6 +3,7 @@
     <Input>
       <Description><![CDATA[Any]]></Description>
       <Expression><![CDATA[query.Any(), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -12,12 +13,15 @@ FROM (
     FROM root
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Filter true flag -> Any]]></Description>
       <Expression><![CDATA[query.Where(doc => doc.Flag).Any(), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -28,12 +32,15 @@ FROM (
     WHERE root["Flag"]
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Filter false flag -> Any]]></Description>
       <Expression><![CDATA[query.Where(doc => Not(doc.Flag)).Any(), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -44,12 +51,15 @@ FROM (
     WHERE (NOT root["Flag"])
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Select number -> Any]]></Description>
       <Expression><![CDATA[query.Select(doc => doc.Number).Any(), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -59,12 +69,15 @@ FROM (
     FROM root
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Select many -> Filter -> Select -> Any]]></Description>
       <Expression><![CDATA[query.SelectMany(doc => doc.Multiples.Where(m => ((m % 3) == 0)).Select(m => m)).Any(), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -76,12 +89,15 @@ FROM (
     WHERE ((m0 % 3) = 0)
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Any w/ boolean filter]]></Description>
       <Expression><![CDATA[query.Any(doc => doc.Flag), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -92,12 +108,15 @@ FROM (
     WHERE root["Flag"]
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Any w/ operator filter]]></Description>
       <Expression><![CDATA[query.Any(doc => (doc.Number < -7)), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -108,12 +127,15 @@ FROM (
     WHERE (root["Number"] < -7)
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Select number -> Any w/ operator filter]]></Description>
       <Expression><![CDATA[query.Select(doc => doc.Number).Any(num => (num < -13)), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -124,12 +146,15 @@ FROM (
     WHERE (root["Number"] < -13)
 ) AS v0 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Select(Select) -> Any(Sum)]]></Description>
       <Expression><![CDATA[query.Select(doc => doc.Multiples).Any(array => (array.Sum() > 5)), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -148,12 +173,15 @@ FROM (
     WHERE (v1 > 5)
 ) AS v2 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[Select(Where) -> Any(Sum(map))]]></Description>
       <Expression><![CDATA[query.Select(f => f.Children.Where(c => (c.Pets.Count() > 0))).Any(children => (children.Sum(c => c.Grade) > 150)), Object)]]></Expression>
+      <ErrorMessage><![CDATA[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]></ErrorMessage>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
@@ -180,6 +208,8 @@ FROM (
     WHERE (v1 > 150)
 ) AS v2 
 ]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expecting error message containing [[Cross partition query only supports 'VALUE <AggreateFunc>' for aggregates.]]. Actual: Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <Failed>True</Failed>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1320,12 +1320,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [Ignore]
         public async Task TestUnsupportedQueries()
         {
             await this.CreateIngestQueryDelete(
-                ConnectionModes.Direct,
-                CollectionTypes.MultiPartition,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 NoDocuments,
                 this.TestUnsupportedQueriesHelper);
         }
@@ -1360,7 +1359,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
                 catch (Exception e)
                 {
-                    Assert.IsTrue(e.Message.Contains("Query contains 1 or more unsupported features. Upgrade your SDK to a version that does support the requested features:"),
+                    Assert.IsTrue(e.Message.Contains("Compositions of aggregates and other expressions are not allowed."),
                         e.Message);
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1446,8 +1446,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             object[] values = aggregateTestArgs.Values;
             string partitionKey = aggregateTestArgs.PartitionKey;
 
-            double samePartitionSum = ((numberOfDocumentSamePartitionKey * (numberOfDocumentSamePartitionKey + 1)) / 2);
-            double differentPartitionSum = ((numberOfDocumentsDifferentPartitionKey * (numberOfDocumentsDifferentPartitionKey + 1)) / 2);
+            double samePartitionSum = numberOfDocumentSamePartitionKey * (numberOfDocumentSamePartitionKey + 1) / 2;
+            double differentPartitionSum = numberOfDocumentsDifferentPartitionKey * (numberOfDocumentsDifferentPartitionKey + 1) / 2;
             double partitionSum = samePartitionSum + differentPartitionSum;
             AggregateQueryArguments[] aggregateQueryArgumentsList = new AggregateQueryArguments[]
             {
@@ -1530,12 +1530,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                             if (expected is long)
                             {
-                                expected = (double)((long)expected);
+                                expected = (double)(long)expected;
                             }
 
                             if (actual is long)
                             {
-                                actual = (double)((long)actual);
+                                actual = (double)(long)actual;
                             }
 
                             Assert.AreEqual(expected, actual, message);
@@ -1890,6 +1890,329 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string normalizedOutput = r.Replace(File.ReadAllText(outputPath), ">");
 
             Assert.AreEqual(normalizedBaseline, normalizedOutput);
+        }
+
+        [TestMethod]
+        [Owner("brchon")]
+        public async Task TestNonValueAggregates()
+        {
+            string[] documents = new string[]
+            {
+                @"{""first"":""Good"",""last"":""Trevino"",""age"":23,""height"":61,""income"":59848}",
+                @"{""first"":""Charles"",""last"":""Decker"",""age"":31,""height"":64,""income"":55970}",
+                @"{""first"":""Holden"",""last"":""Cotton"",""age"":30,""height"":66,""income"":57075}",
+                @"{""first"":""Carlene"",""last"":""Cabrera"",""age"":26,""height"":72,""income"":98018}",
+                @"{""first"":""Gates"",""last"":""Spence"",""age"":38,""height"":53,""income"":12338}",
+                @"{""first"":""Camacho"",""last"":""Singleton"",""age"":40,""height"":52,""income"":76973}",
+                @"{""first"":""Rachel"",""last"":""Tucker"",""age"":27,""height"":68,""income"":28116}",
+                @"{""first"":""Kristi"",""last"":""Robertson"",""age"":32,""height"":53,""income"":61687}",
+                @"{""first"":""Poole"",""last"":""Petty"",""age"":22,""height"":75,""income"":53381}",
+                @"{""first"":""Lacey"",""last"":""Carlson"",""age"":38,""height"":78,""income"":63989}",
+                @"{""first"":""Rosario"",""last"":""Mendez"",""age"":21,""height"":64,""income"":20300}",
+                @"{""first"":""Estrada"",""last"":""Collins"",""age"":28,""height"":74,""income"":6926}",
+                @"{""first"":""Ursula"",""last"":""Burton"",""age"":26,""height"":66,""income"":32870}",
+                @"{""first"":""Rochelle"",""last"":""Sanders"",""age"":24,""height"":56,""income"":47564}",
+                @"{""first"":""Darcy"",""last"":""Herring"",""age"":27,""height"":52,""income"":67436}",
+                @"{""first"":""Carole"",""last"":""Booth"",""age"":34,""height"":60,""income"":50177}",
+                @"{""first"":""Cruz"",""last"":""Russell"",""age"":25,""height"":52,""income"":95072}",
+                @"{""first"":""Wilma"",""last"":""Robbins"",""age"":36,""height"":50,""income"":53008}",
+                @"{""first"":""Mcdaniel"",""last"":""Barlow"",""age"":21,""height"":78,""income"":85441}",
+                @"{""first"":""Leann"",""last"":""Blackwell"",""age"":40,""height"":79,""income"":900}",
+                @"{""first"":""Hoffman"",""last"":""Hoffman"",""age"":31,""height"":76,""income"":1208}",
+                @"{""first"":""Pittman"",""last"":""Shepherd"",""age"":35,""height"":61,""income"":26887}",
+                @"{""first"":""Wright"",""last"":""Rojas"",""age"":35,""height"":73,""income"":76487}",
+                @"{""first"":""Lynne"",""last"":""Waters"",""age"":27,""height"":60,""income"":22926}",
+                @"{""first"":""Corina"",""last"":""Shelton"",""age"":29,""height"":78,""income"":67379}",
+                @"{""first"":""Alvarez"",""last"":""Barr"",""age"":29,""height"":59,""income"":34698}",
+                @"{""first"":""Melinda"",""last"":""Mccoy"",""age"":24,""height"":63,""income"":69811}",
+                @"{""first"":""Chelsea"",""last"":""Bolton"",""age"":20,""height"":63,""income"":47698}",
+                @"{""first"":""English"",""last"":""Ingram"",""age"":28,""height"":50,""income"":94977}",
+                @"{""first"":""Vance"",""last"":""Thomas"",""age"":30,""height"":49,""income"":67638}",
+                @"{""first"":""Howell"",""last"":""Joyner"",""age"":34,""height"":78,""income"":65547}",
+                @"{""first"":""Ofelia"",""last"":""Chapman"",""age"":23,""height"":82,""income"":85049}",
+                @"{""first"":""Downs"",""last"":""Adams"",""age"":28,""height"":76,""income"":19373}",
+                @"{""first"":""Terrie"",""last"":""Bryant"",""age"":32,""height"":55,""income"":79024}",
+                @"{""first"":""Jeanie"",""last"":""Carson"",""age"":26,""height"":52,""income"":68293}",
+                @"{""first"":""Hazel"",""last"":""Bean"",""age"":40,""height"":70,""income"":46028}",
+                @"{""first"":""Dominique"",""last"":""Norman"",""age"":25,""height"":50,""income"":59445}",
+                @"{""first"":""Lyons"",""last"":""Patterson"",""age"":36,""height"":64,""income"":71748}",
+                @"{""first"":""Catalina"",""last"":""Cantrell"",""age"":30,""height"":78,""income"":16999}",
+                @"{""first"":""Craft"",""last"":""Head"",""age"":30,""height"":49,""income"":10542}",
+                @"{""first"":""Suzanne"",""last"":""Gilliam"",""age"":36,""height"":77,""income"":7511}",
+                @"{""first"":""Pamela"",""last"":""Merritt"",""age"":30,""height"":81,""income"":80653}",
+                @"{""first"":""Haynes"",""last"":""Ayala"",""age"":38,""height"":65,""income"":85832}",
+                @"{""first"":""Teri"",""last"":""Martin"",""age"":40,""height"":83,""income"":27839}",
+                @"{""first"":""Susanne"",""last"":""Short"",""age"":25,""height"":57,""income"":48957}",
+                @"{""first"":""Rosalie"",""last"":""Camacho"",""age"":24,""height"":83,""income"":30313}",
+                @"{""first"":""Walls"",""last"":""Bray"",""age"":28,""height"":74,""income"":21616}",
+                @"{""first"":""Norris"",""last"":""Bates"",""age"":23,""height"":59,""income"":13631}",
+                @"{""first"":""Wendy"",""last"":""King"",""age"":38,""height"":48,""income"":19845}",
+                @"{""first"":""Deena"",""last"":""Ramsey"",""age"":20,""height"":66,""income"":49665}",
+                @"{""first"":""Richmond"",""last"":""Meadows"",""age"":36,""height"":59,""income"":43244}",
+                @"{""first"":""Burks"",""last"":""Whitley"",""age"":25,""height"":55,""income"":39974}",
+                @"{""first"":""Gilliam"",""last"":""George"",""age"":37,""height"":82,""income"":47114}",
+                @"{""first"":""Marcy"",""last"":""Harding"",""age"":33,""height"":80,""income"":20316}",
+                @"{""first"":""Curtis"",""last"":""Gomez"",""age"":31,""height"":50,""income"":69085}",
+                @"{""first"":""Lopez"",""last"":""Burt"",""age"":34,""height"":79,""income"":37577}",
+                @"{""first"":""Nell"",""last"":""Nixon"",""age"":37,""height"":58,""income"":67999}",
+                @"{""first"":""Sonja"",""last"":""Lamb"",""age"":37,""height"":53,""income"":92553}",
+                @"{""first"":""Owens"",""last"":""Fischer"",""age"":40,""height"":48,""income"":75199}",
+                @"{""first"":""Ortega"",""last"":""Padilla"",""age"":28,""height"":55,""income"":29126}",
+                @"{""first"":""Stacie"",""last"":""Velez"",""age"":20,""height"":56,""income"":45292}",
+                @"{""first"":""Brennan"",""last"":""Craig"",""age"":38,""height"":65,""income"":37445}"
+            };
+
+            await this.CreateIngestQueryDelete(
+                ConnectionModes.Direct,
+                CollectionTypes.SinglePartition,
+                documents,
+                this.TestNonValueAggregates);
+        }
+
+        private async Task TestNonValueAggregates(
+            Container container,
+            IEnumerable<Document> documents)
+        {
+            IEnumerable<JToken> documentsAsJTokens = documents.Select(document => JToken.FromObject(document));
+
+            // ------------------------------------------
+            // Positive
+            // ------------------------------------------
+
+            List<Tuple<string, JToken>> queryAndExpectedAggregation = new List<Tuple<string, JToken>>()
+            {
+                // ------------------------------------------
+                // Simple Aggregates without a value
+                // ------------------------------------------
+
+                new Tuple<string, JToken>(
+                    "SELECT SUM(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Sum(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT COUNT(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Where(document => document["age"] != null).Count()
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT MAX(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT AVG(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Average(document => document["age"].Value<double>())
+                        }
+                    }),
+                
+                // ------------------------------------------
+                // Simple aggregates with alias
+                // ------------------------------------------
+
+                new Tuple<string, JToken>(
+                    "SELECT SUM(c.age) as sum_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "sum_age",
+                            documentsAsJTokens.Sum(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT COUNT(c.age) as count_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "count_age",
+                            documentsAsJTokens.Where(document => document["age"] != null).Count()
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age) as min_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "min_age",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT MAX(c.age) as max_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "max_age",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT AVG(c.age) as avg_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "avg_age",
+                            documentsAsJTokens.Average(document => document["age"].Value<double>())
+                        }
+                    }),
+                
+                // ------------------------------------------
+                // Multiple Aggregates without alias
+                // ------------------------------------------
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age), MAX(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        },
+                        {
+                            "$2",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                // ------------------------------------------
+                // Multiple Aggregates with alias
+                // ------------------------------------------
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age) as min_age, MAX(c.age) as max_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "min_age",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        },
+                        {
+                            "max_age",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                // ------------------------------------------
+                // Multiple Aggregates with and without alias
+                // ------------------------------------------
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age), MAX(c.age) as max_age FROM c",
+                    new JObject
+                    {
+                        {
+                            "$1",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        },
+                        {
+                            "max_age",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+
+                new Tuple<string, JToken>(
+                    "SELECT MIN(c.age) as min_age, MAX(c.age) FROM c",
+                    new JObject
+                    {
+                        {
+                            "min_age",
+                            documentsAsJTokens.Min(document => document["age"].Value<double>())
+                        },
+                        {
+                            "$1",
+                            documentsAsJTokens.Max(document => document["age"].Value<double>())
+                        }
+                    }),
+            };
+
+            // Test query correctness.
+            foreach ((string query, JToken expectedAggregation) in queryAndExpectedAggregation)
+            {
+                foreach (int maxItemCount in new int[] { 1, 5, 10 })
+                {
+                    List<JToken> actual = await QueryWithoutContinuationTokens<JToken>(
+                        container: container,
+                        query: query,
+                        maxConcurrency: 100,
+                        maxItemCount: maxItemCount,
+                        queryRequestOptions: new QueryRequestOptions()
+                        {
+                            MaxBufferedItemCount = 100,
+                        });
+
+                    Assert.AreEqual(1, actual.Count());
+
+                    Assert.IsTrue(
+                       JsonTokenEqualityComparer.Value.Equals(actual.First(), expectedAggregation),
+                       $"Results did not match for query: {query} with maxItemCount: {maxItemCount}" +
+                       $"Actual: {JsonConvert.SerializeObject(actual.First())}" +
+                       $"Expected: {JsonConvert.SerializeObject(expectedAggregation)}");
+                }
+            }
+
+            // ------------------------------------------
+            // Negative
+            // ------------------------------------------
+
+            List<string> notSupportedQueries = new List<string>()
+            {
+                "SELECT MIN(c.age) + MAX(c.age) FROM c",
+                "SELECT MIN(c.age) / 2 FROM c",
+            };
+
+            foreach (string query in notSupportedQueries)
+            {
+                try
+                {
+                    List<JToken> actual = await QueryWithoutContinuationTokens<JToken>(
+                        container: container,
+                        query: query,
+                        maxConcurrency: 100,
+                        queryRequestOptions: new QueryRequestOptions()
+                        {
+                            MaxBufferedItemCount = 100,
+                        });
+
+                    Assert.Fail("Expected Query To Fail");
+                }
+                catch (Exception)
+                {
+                    // Do Nothing
+                }
+            }
         }
 
         [TestMethod]
@@ -2982,7 +3305,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 documents.Add(JsonConvert.SerializeObject(person));
             }
 
-            await CreateIngestQueryDelete(
+            await this.CreateIngestQueryDelete(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
@@ -3856,6 +4179,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         documentsAsJTokens
                             .GroupBy(document => document["age"], JsonTokenEqualityComparer.Value)
                             .Select(grouping => grouping.Key)),
+
+                 // ------------------------------------------
+                // Corner Cases
+                // ------------------------------------------
+
+                new Tuple<string, IEnumerable<JToken>>(
+                    "SELECT AVG(\"asdf\") as avg_asdf FROM c GROUP BY c.age",
+                        documentsAsJTokens
+                            .GroupBy(document => document["age"], JsonTokenEqualityComparer.Value)
+                            .Select(grouping => new JObject(
+                                new JProperty("avg_asdf", new JObject())))),
             };
 
             // Test query correctness.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
@@ -145,7 +145,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Select(new() -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Select(c => c.Grade).Max(),
                     v1 = f.Children.Skip(1).Take(3).Select(c => c.Grade).Max(),
                     v2 = f.Children.Take(3).Skip(1).Select(c => c.Grade).Max(),
@@ -221,7 +222,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Select(new(Skip -> Select -> Min, Skip -> Take -> Select -> Min, Take -> Skip -> Select -> Min) -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Select(c => c.Grade).Min(),
                     v1 = f.Children.Skip(1).Take(3).Select(c => c.Grade).Min(),
                     v2 = f.Children.Take(3).Skip(1).Select(c => c.Grade).Min(),
@@ -293,7 +295,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Select(new() -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Select(c => c.Grade).Sum(),
                     v1 = f.Children.Skip(1).Take(3).Select(c => c.Grade).Sum(),
                     v2 = f.Children.Take(3).Skip(1).Select(c => c.Grade).Sum(),
@@ -369,7 +372,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Select(new(Skip -> Select -> Count, Skip -> Take -> Select -> Count, Take -> Skip -> Select -> Count) -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Select(c => c.Grade).Count(),
                     v1 = f.Children.Skip(1).Take(3).Select(c => c.Grade).Count(),
                     v2 = f.Children.Take(3).Skip(1).Select(c => c.Grade).Count()
@@ -381,7 +385,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Select(new() -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Count(c => c.Grade > 50),
                     v1 = f.Children.Skip(1).Take(3).Count(c => c.Grade > 50),
                     v2 = f.Children.Take(3).Skip(1).Count(c => c.Grade > 50),
@@ -395,6 +400,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             this.ExecuteTestSuite(inputs);
         }
 
+
         [TestMethod]
         [Owner("khdang")]
         public void TestAny()
@@ -407,43 +413,53 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
             inputs.Add(new LinqAggregateInput(
                 "Any", b => getQuery(b)
-                .Any()));
+                .Any(),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Filter true flag -> Any", b => getQuery(b)
-                .Where(doc => doc.Flag).Any()));
+                .Where(doc => doc.Flag).Any(),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Filter false flag -> Any", b => getQuery(b)
-                .Where(doc => !doc.Flag).Any()));
+                .Where(doc => !doc.Flag).Any(),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Select number -> Any", b => getQuery(b)
-                .Select(doc => doc.Number).Any()));
+                .Select(doc => doc.Number).Any(),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Select many -> Filter -> Select -> Any", b => getQuery(b)
-                .SelectMany(doc => doc.Multiples.Where(m => m % 3 == 0).Select(m => m)).Any()));
+                .SelectMany(doc => doc.Multiples.Where(m => m % 3 == 0).Select(m => m)).Any(),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Any w/ boolean filter", b => getQuery(b)
-                .Any(doc => doc.Flag)));
+                .Any(doc => doc.Flag),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Any w/ operator filter", b => getQuery(b)
-                .Any(doc => doc.Number < -7)));
+                .Any(doc => doc.Number < -7),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Select number -> Any w/ operator filter", b => getQuery(b)
-                .Select(doc => doc.Number).Any(num => num < -13)));
+                .Select(doc => doc.Number).Any(num => num < -13),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Select(Select) -> Any(Sum)", b => getQuery(b)
-                .Select(doc => doc.Multiples).Any(array => array.Sum() > 5)));
+                .Select(doc => doc.Multiples).Any(array => array.Sum() > 5),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Select(Where) -> Any(Sum(map))", b => getQueryFamily(b)
-                .Select(f => f.Children.Where(c => c.Pets.Count() > 0)).Any(children => children.Sum(c => c.Grade) > 150)));
+                .Select(f => f.Children.Where(c => c.Pets.Count() > 0)).Any(children => children.Sum(c => c.Grade) > 150),
+                ErrorMessages.CrossPartitionQueriesOnlySupportValueAggregateFunc));
 
             inputs.Add(new LinqAggregateInput(
                 "Skip -> Take -> Any", b => getQueryFamily(b)
@@ -532,7 +548,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 "Skip -> Take -> Select(new() -> Skip -> Take)", b => getQueryFamily(b)
                 .Skip(1).Take(20)
                 .Where(f => f.Children.Count() > 2)
-                .Select(f => new {
+                .Select(f => new
+                {
                     v0 = f.Children.Skip(1).Select(c => c.Grade).Average(),
                     v1 = f.Children.Skip(1).Take(3).Select(c => c.Grade).Average(),
                     v2 = f.Children.Take(3).Skip(1).Select(c => c.Grade).Average(),

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
     <AssemblyName>Microsoft.Azure.Cosmos.EmulatorTests</AssemblyName>
-    <DirectVersion>3.1.4</DirectVersion>
+    <DirectVersion>3.1.5</DirectVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <DirectPackageName Condition=" '$(SignAssembly)' == 'true' ">Microsoft.Azure.Cosmos.Direct</DirectPackageName>
     <DirectPackageName Condition=" '$(SignAssembly)' != 'true' ">Microsoft.Azure.Cosmos.Direct.MyGet</DirectPackageName>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.Aggregates.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.Aggregates.xml
@@ -7,75 +7,81 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <requireFormattableOrderByQuery_true_isContinuationExpected_true>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates />
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[],"Infinity")</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_true_isContinuationExpected_true>
-        <requireFormattableOrderByQuery_true_isContinuationExpected_false>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates>
-              <Aggregate>Average</Aggregate>
-            </Aggregates>
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[],"Infinity")</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
-FROM c]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_true_isContinuationExpected_false>
-        <requireFormattableOrderByQuery_false_isContinuationExpected_true>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates />
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[],"Infinity")</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_false_isContinuationExpected_true>
-        <requireFormattableOrderByQuery_false_isContinuationExpected_false>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates>
-              <Aggregate>Average</Aggregate>
-            </Aggregates>
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[],"Infinity")</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
-FROM c]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_false_isContinuationExpected_false>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Average</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -86,8 +92,91 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -100,25 +189,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Average</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Average</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -131,25 +250,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Min</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Min</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -162,25 +311,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Max</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Max</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -193,25 +372,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Sum</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": SUM(c.blah)}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Sum</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": SUM(c.blah)}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -224,25 +433,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Count</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": COUNT(c.blah)}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Count</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": COUNT(c.blah)}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -255,25 +494,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Count</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": COUNT(1)}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Count</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": COUNT(1)}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -286,25 +555,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Min</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN((c.blah + 1)), "item2": {"min": MIN((c.blah + 1)), "count": COUNT((c.blah + 1))}}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Min</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MIN((c.blah + 1)), "item2": {"min": MIN((c.blah + 1)), "count": COUNT((c.blah + 1))}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -317,25 +616,55 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Min</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN(c.key), "item2": {"min": MIN(c.key), "count": COUNT(c.key)}}]
-FROM c]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Min</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MIN(c.key), "item2": {"min": MIN(c.key), "count": COUNT(c.key)}}]
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -348,77 +677,82 @@ FROM c]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <requireFormattableOrderByQuery_true_isContinuationExpected_true>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates />
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[1.0],[1.0]]</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_true_isContinuationExpected_true>
-        <requireFormattableOrderByQuery_true_isContinuationExpected_false>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates>
-              <Aggregate>Min</Aggregate>
-            </Aggregates>
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[1.0],[1.0]]</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Min</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
 FROM c
-WHERE (c.key = 1)]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_true_isContinuationExpected_false>
-        <requireFormattableOrderByQuery_false_isContinuationExpected_true>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates />
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[1.0],[1.0]]</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_false_isContinuationExpected_true>
-        <requireFormattableOrderByQuery_false_isContinuationExpected_false>
-          <QueryInfo>
-            <DistinctType>None</DistinctType>
-            <Top />
-            <OrderBy />
-            <OrderByExpressions />
-            <Aggregates>
-              <Aggregate>Min</Aggregate>
-            </Aggregates>
-          </QueryInfo>
-          <QueryRanges>
-            <Range>
-              <Range>[[1.0],[1.0]]</Range>
-            </Range>
-          </QueryRanges>
-          <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
-FROM c
-WHERE (c.key = 1)]]></RewrittenQuery>
-        </requireFormattableOrderByQuery_false_isContinuationExpected_false>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+WHERE (c.key = 1)]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -431,26 +765,56 @@ WHERE (c.key = 1)]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Min</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Min</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}]
 FROM c
-WHERE (c.key > 1)]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+WHERE (c.key > 1)]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -463,28 +827,58 @@ WHERE (c.key > 1)]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top />
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Average</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT VALUE [{"item": {"sum": SUM((c.age + 1)), "count": COUNT((c.age + 1))}}]
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Average</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT VALUE [{"item": {"sum": SUM((c.age + 1)), "count": COUNT((c.age + 1))}}]
 FROM Root AS r
 JOIN c IN r.children
 WHERE (c.age > 1)
-ORDER BY c.name]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+ORDER BY c.name]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -497,25 +891,55 @@ ORDER BY c.name]]></RewrittenQuery>
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal>
-        <QueryInfo>
-          <DistinctType>None</DistinctType>
-          <Top>10</Top>
-          <OrderBy />
-          <OrderByExpressions />
-          <Aggregates>
-            <Aggregate>Average</Aggregate>
-          </Aggregates>
-        </QueryInfo>
-        <QueryRanges>
-          <Range>
-            <Range>[[],"Infinity")</Range>
-          </Range>
-        </QueryRanges>
-        <RewrittenQuery><![CDATA[SELECT TOP 10 VALUE [{"item": {"sum": SUM((r.age + 1)), "count": COUNT((r.age + 1))}}]
-FROM Root AS r]]></RewrittenQuery>
-      </PartitionedQueryExecutionInfoInternal>
-      <Error />
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top>10</Top>
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates>
+                  <AggregateOperator>Average</AggregateOperator>
+                </Aggregates>
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>True</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT TOP 10 VALUE [{"item": {"sum": SUM((r.age + 1)), "count": COUNT((r.age + 1))}}]
+FROM Root AS r]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.Negative.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.Negative.xml
@@ -9,8 +9,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"errors":[{"severity":"Error","location":{"start":7,"end":14},"code":"SC2005","message":"'BADFUNC' is not a recognized built-in function name."}]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"errors":[{"severity":"Error","location":{"start":7,"end":14},"code":"SC2005","message":"'BADFUNC' is not a recognized built-in function name."}]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -23,8 +46,50 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"errors":[{"severity":"Error","location":{"start":0,"end":113},"code":"SC3005","message":"The SQL query exceeded the maximum number of user-defined function calls. The allowed limit is 2."}]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -37,8 +102,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"errors":[{"severity":"Error","location":{"start":27,"end":54},"code":"SC2050","message":"The STARTSWITH function requires 2 argument(s)."}]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"errors":[{"severity":"Error","location":{"start":27,"end":54},"code":"SC2050","message":"The STARTSWITH function requires 2 argument(s)."}]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -51,8 +139,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -65,8 +176,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"errors":[{"severity":"Error","location":{"start":13,"end":24},"code":"SC2101","message":"Cannot perform an aggregate function on an expression containing an aggregate or a subquery."}]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"errors":[{"severity":"Error","location":{"start":13,"end":24},"code":"SC2101","message":"Cannot perform an aggregate function on an expression containing an aggregate or a subquery."}]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -79,8 +213,65 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": COUNT(r)}} AS payload
+FROM r]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -93,8 +284,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -107,8 +321,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
   <Result>
@@ -121,8 +358,31 @@
       <PartitionKeyType>Hash</PartitionKeyType>
     </Input>
     <Output>
-      <PartitionedQueryExecutionInfoInternal />
-      <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.NonValueAggregate.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPartitionProviderTest.NonValueAggregate.xml
@@ -1,0 +1,4243 @@
+﻿<Results>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (SUM) Without 'VALUE' and Without alias.</Description>
+      <Query>SELECT SUM(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (COUNT) Without 'VALUE' and Without alias.</Description>
+      <Query>SELECT COUNT(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (MIN) Without 'VALUE' and Without alias.</Description>
+      <Query>SELECT MIN(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (MAX) Without 'VALUE' and Without alias.</Description>
+      <Query>SELECT MAX(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (AVG) Without 'VALUE' and Without alias.</Description>
+      <Query>SELECT AVG(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (SUM) Without 'VALUE' and With alias.</Description>
+      <Query>SELECT SUM(c.blah) as sum_blah FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"sum_blah": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (COUNT) Without 'VALUE' and With alias.</Description>
+      <Query>SELECT COUNT(c.blah) as count_blah FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"count_blah": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (MIN) Without 'VALUE' and With alias.</Description>
+      <Query>SELECT MIN(c.blah) as min_blah FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"min_blah": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (MAX) Without 'VALUE' and With alias.</Description>
+      <Query>SELECT MAX(c.blah) as max_blah FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"max_blah": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate (AVG) Without 'VALUE' and With alias.</Description>
+      <Query>SELECT AVG(c.blah) as avg_blah FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"avg_blah": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (SUM) With alias.</Description>
+      <Query>
+        SELECT
+        SUM(c.blah) as sum_blah,
+        SUM(c.blah) as sum_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah2</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"sum_blah": {"item": SUM(c.blah)}, "sum_blah2": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (COUNT) With alias.</Description>
+      <Query>
+        SELECT
+        COUNT(c.blah) as count_blah,
+        COUNT(c.blah) as count_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah2</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"count_blah": {"item": COUNT(c.blah)}, "count_blah2": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MIN) With alias.</Description>
+      <Query>
+        SELECT
+        MIN(c.blah) as min_blah,
+        MIN(c.blah) as min_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah2</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"min_blah": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "min_blah2": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MAX) With alias.</Description>
+      <Query>
+        SELECT
+        MAX(c.blah) as max_blah,
+        MAX(c.blah) as max_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah2</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"max_blah": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "max_blah2": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (AVG) With alias.</Description>
+      <Query>
+        SELECT
+        AVG(c.blah) as avg_blah,
+        AVG(c.blah) as avg_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah2</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"avg_blah": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "avg_blah2": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (SUM) Without alias.</Description>
+      <Query>
+        SELECT
+        SUM(c.blah),
+        SUM(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": SUM(c.blah)}, "$2": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (COUNT) Without alias.</Description>
+      <Query>
+        SELECT
+        COUNT(c.blah),
+        COUNT(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": COUNT(c.blah)}, "$2": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MIN) Without alias.</Description>
+      <Query>
+        SELECT
+        MIN(c.blah),
+        MIN(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "$2": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MAX) Without alias.</Description>
+      <Query>
+        SELECT
+        MAX(c.blah),
+        MAX(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "$2": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (AVG) Without alias.</Description>
+      <Query>
+        SELECT
+        AVG(c.blah),
+        AVG(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "$2": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (SUM) mixed alias.</Description>
+      <Query>
+        SELECT
+        SUM(c.blah) as sum_blah,
+        SUM(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"sum_blah": {"item": SUM(c.blah)}, "$1": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (SUM) mixed alias.</Description>
+      <Query>
+        SELECT
+        SUM(c.blah),
+        SUM(c.blah) as sum_blah
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": SUM(c.blah)}, "sum_blah": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (COUNT) mixed alias.</Description>
+      <Query>
+        SELECT
+        COUNT(c.blah) as count_blah,
+        COUNT(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"count_blah": {"item": COUNT(c.blah)}, "$1": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (COUNT) mixed alias.</Description>
+      <Query>
+        SELECT
+        COUNT(c.blah),
+        COUNT(c.blah) as count_blah
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": COUNT(c.blah)}, "count_blah": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MIN) mixed alias.</Description>
+      <Query>
+        SELECT
+        MIN(c.blah) as min_blah,
+        MIN(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"min_blah": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MIN) mixed alias.</Description>
+      <Query>
+        SELECT
+        MIN(c.blah),
+        MIN(c.blah) as min_blah
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "min_blah": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MAX) mixed alias.</Description>
+      <Query>
+        SELECT
+        MAX(c.blah) as max_blah,
+        MAX(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"max_blah": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MAX) mixed alias.</Description>
+      <Query>
+        SELECT
+        MAX(c.blah),
+        MAX(c.blah) as max_blah
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "max_blah": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (AVG) mixed alias.</Description>
+      <Query>
+        SELECT
+        AVG(c.blah) as avg_blah,
+        AVG(c.blah)
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"avg_blah": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (AVG) mixed alias.</Description>
+      <Query>
+        SELECT
+        AVG(c.blah),
+        AVG(c.blah) as avg_blah
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "avg_blah": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (SUM) interleaved aliases.</Description>
+      <Query>
+        SELECT
+        SUM(c.blah) as sum_blah,
+        SUM(c.blah),
+        SUM(c.blah) as sum_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>sum_blah2</Alias>
+                    <AggregateOperator>Sum</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"sum_blah": {"item": SUM(c.blah)}, "$1": {"item": SUM(c.blah)}, "sum_blah2": {"item": SUM(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (COUNT) interleaved aliases.</Description>
+      <Query>
+        SELECT
+        COUNT(c.blah) as count_blah,
+        COUNT(c.blah),
+        COUNT(c.blah) as count_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>count_blah2</Alias>
+                    <AggregateOperator>Count</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"count_blah": {"item": COUNT(c.blah)}, "$1": {"item": COUNT(c.blah)}, "count_blah2": {"item": COUNT(c.blah)}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MIN) interleaved aliases.</Description>
+      <Query>
+        SELECT
+        MIN(c.blah) as min_blah,
+        MIN(c.blah),
+        MIN(c.blah) as min_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah2</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>min_blah</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"min_blah": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "min_blah2": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (MAX) interleaved aliases.</Description>
+      <Query>
+        SELECT
+        MAX(c.blah) as max_blah,
+        MAX(c.blah),
+        MAX(c.blah) as max_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>max_blah2</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"max_blah": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}, "max_blah2": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregates (AVG) interleaved aliases.</Description>
+      <Query>
+        SELECT
+        AVG(c.blah) as avg_blah,
+        AVG(c.blah),
+        AVG(c.blah) as avg_blah2
+        FROM c
+      </Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah2</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>avg_blah</Alias>
+                    <AggregateOperator>Average</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"avg_blah": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "$1": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}, "avg_blah2": {"item": {"sum": SUM(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Single Aggregate with partition key</Description>
+      <Query>SELECT MIN(c.blah) FROM c WHERE c.pk = 1</Query>
+      <PartitionKeys>
+        <Key>/pk</Key>
+      </PartitionKeys>
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c
+WHERE (c.pk = 1)]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Aggregate with partition key</Description>
+      <Query>SELECT MIN(c.blah), MAX(c.blah) FROM c WHERE c.pk = 1</Query>
+      <PartitionKeys>
+        <Key>/pk</Key>
+      </PartitionKeys>
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN(c.blah), "item2": {"min": MIN(c.blah), "count": COUNT(c.blah)}}, "$2": {"item": MAX(c.blah), "item2": {"max": MAX(c.blah), "count": COUNT(c.blah)}}} AS payload
+FROM c
+WHERE (c.pk = 1)]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[1.0],[1.0]]</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Composite Single Aggregate Outer</Description>
+      <Query>SELECT MIN(c.blah) / 2 FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Composite Single Aggregate Inner</Description>
+      <Query>SELECT MIN(c.blah / 2) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN((c.blah / 2)), "item2": {"min": MIN((c.blah / 2)), "count": COUNT((c.blah / 2))}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Composite Multiple Aggregates</Description>
+      <Query>SELECT MIN(c.blah) + MAX(c.blah) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Composite Aggregate Outer</Description>
+      <Query>SELECT MIN(c.blah) / 2, MAX(c.blah) / 2 FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Multiple Composite Aggregate Inner</Description>
+      <Query>SELECT MIN(c.blah / 2), MAX(c.blah / 2) FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$1</Alias>
+                    <AggregateOperator>Min</AggregateOperator>
+                  </AliasToAggregateType>
+                  <AliasToAggregateType>
+                    <Alias>$2</Alias>
+                    <AggregateOperator>Max</AggregateOperator>
+                  </AliasToAggregateType>
+                </GroupByAliasToAggregateType>
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery>
+                <![CDATA[SELECT {"$1": {"item": MIN((c.blah / 2)), "item2": {"min": MIN((c.blah / 2)), "count": COUNT((c.blah / 2))}}, "$2": {"item": MAX((c.blah / 2)), "item2": {"max": MAX((c.blah / 2)), "count": COUNT((c.blah / 2))}}} AS payload
+FROM c]]>
+              </RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Mixed Composite Aggregate</Description>
+      <Query>SELECT MIN(c.blah), MAX(c.blah) / 2 FROM c</Query>
+      <PartitionKeys />
+      <PartitionKeyType>Hash</PartitionKeyType>
+    </Input>
+    <Output>
+      <GroupedOutputs>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Cross partition query only supports 'VALUE &lt;AggreateFunc&gt;' for aggregates."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: False	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <Error>Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}</Error>
+          </Output>
+        </GroupedOutput>
+        <GroupedOutput>
+          <OptionsList>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: False</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: False	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: False	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+            <Options>AllowNonValueAggregateQuery: True	HasLogicalPartitionKey: True	IsContinuationExpected: True	RequireFormattableOrderByQuery: True</Options>
+          </OptionsList>
+          <Output>
+            <PartitionedQueryExecutionInfoInternal>
+              <QueryInfo>
+                <DistinctType>None</DistinctType>
+                <Top />
+                <Offset />
+                <Limit />
+                <GroupByExpressions />
+                <OrderBy />
+                <OrderByExpressions />
+                <Aggregates />
+                <GroupByAliasToAggregateType />
+                <HasSelectValue>False</HasSelectValue>
+              </QueryInfo>
+              <QueryRanges>
+                <Range>
+                  <Range>[[],"Infinity")</Range>
+                </Range>
+              </QueryRanges>
+              <RewrittenQuery><![CDATA[]]></RewrittenQuery>
+            </PartitionedQueryExecutionInfoInternal>
+          </Output>
+        </GroupedOutput>
+      </GroupedOutputs>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
@@ -59,7 +59,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return new PartitionKeyRangeBatchExecutionResult(request.PartitionKeyRangeId, request.Operations, batchresponse);
             };
 
-        private BatchAsyncBatcherExecuteDelegate ExecutorWithFailure => throw expectedException;
+        private BatchAsyncBatcherExecuteDelegate ExecutorWithFailure = (PartitionKeyRangeServerBatchRequest request, CancellationToken cancellationToken) =>
+        {
+            throw expectedException;
+        };
 
         private BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, CancellationToken cancellation) =>
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
@@ -59,11 +59,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return new PartitionKeyRangeBatchExecutionResult(request.PartitionKeyRangeId, request.Operations, batchresponse);
             };
 
-        private BatchAsyncBatcherExecuteDelegate ExecutorWithFailure
-            = async (PartitionKeyRangeServerBatchRequest request, CancellationToken cancellationToken) =>
-            {
-                throw expectedException;
-            };
+        private BatchAsyncBatcherExecuteDelegate ExecutorWithFailure => throw expectedException;
 
         private BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, CancellationToken cancellation) =>
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ComparableTaskSchedulerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ComparableTaskSchedulerTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Cosmos.Test
             Assert.AreEqual(true, task.IsCompleted);
             Assert.AreEqual(false, delayedTask.IsCompleted);
             Assert.AreEqual(0, scheduler.CurrentRunningTaskCount);
-            await Task.Delay(200);
+            await Task.Delay(60);
             Assert.AreEqual(true, delayedTask.IsCompleted);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -112,7 +112,10 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             components.Add(await AggregateDocumentQueryExecutionComponent.CreateAsync(
                 operators.ToArray(),
-                null,
+                new Dictionary<string, AggregateOperator?>()
+                {
+                    { "test", AggregateOperator.Count }
+                },
                 false,
                 null,
                 setupContext.func));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -113,6 +113,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             components.Add(await AggregateDocumentQueryExecutionComponent.CreateAsync(
                 operators.ToArray(),
                 null,
+                false,
+                null,
                 setupContext.func));
 
             components.Add(await DistinctDocumentQueryExecutionComponent.CreateAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -114,7 +114,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
             Mock<Database> mockContainers = new Mock<Database>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
+#pragma warning disable CS0612 // Type or member is obsolete
                     It.Is<ContainerProperties>((settings) => settings.TimeToLivePropertyPath.Equals(path)),
+#pragma warning restore CS0612 // Type or member is obsolete
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -134,7 +136,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Fluent
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
+#pragma warning disable CS0612 // Type or member is obsolete
                     It.Is<ContainerProperties>((settings) => settings.TimeToLivePropertyPath.Equals(path)),
+#pragma warning restore CS0612 // Type or member is obsolete
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -22,6 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="BaselineTest\TestBaseline\QueryPartitionProviderTest - Copy (2).Top.xml" />
+    <None Remove="BaselineTest\TestBaseline\QueryPartitionProviderTest - Copy.Top.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="$(DirectPackageName)" Version="[$(DirectVersion)]" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -9,7 +9,7 @@
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
-    <DirectVersion>3.1.4</DirectVersion>
+    <DirectVersion>3.1.5</DirectVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <DirectPackageName Condition=" '$(SignAssembly)' == 'true' ">Microsoft.Azure.Cosmos.Direct</DirectPackageName>
     <DirectPackageName Condition=" '$(SignAssembly)' != 'true' ">Microsoft.Azure.Cosmos.Direct.MyGet</DirectPackageName>


### PR DESCRIPTION
This PR adds cross partition support for non value aggregates.

Before we enforced that a user had to write their cross partition aggregate queries like so:


```
SELECT VALUE MIN(c.age)
FROM c
```
now we are supporting non value aggregates like so:

```
SELECT MIN(c.age)
FROM c

SELECT MIN(c.age) as min_age
FROM c
```
And also multiple aggregates:

```
SELECT MIN(c.age) as min_age, MAX(c.age) as max_age
FROM c

```
This bridges the set of queries that single partition and cross partition can support.

We still do not support composite aggregates like:

```
SELECT (MIN(c.age) + MAX(c.age)) / 2 as mid_point_age
FROM c
```
Baseline tests have been added in QueryPartitionProviderTest.cs to verify the new features and existing features remained unchanged.

Cross partition GROUP BY and AGGREGATES now call into the same code, since one can conceptualize aggregate queries as an aggregation on a single grouping while GROUP BY is the same aggregation on multiple groupings.

Tests have been added to CrossPartitionQueryTests.cs to verify end to end execution.

SDKs should be able to pick up this change without a break by opting in for a feature flag.