### PR TITLE
Adding tests to cover Batch request overflow

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Azure.Cosmos
                 throw new RequestEntityTooLargeException(RMResources.RequestTooLarge);
             }
 
-            return new ArraySegment<ItemBatchOperation>(operations.Array, this.operations.Count, operations.Count - this.operations.Count);
+            int overflowOperations = operations.Count - this.operations.Count;
+            return new ArraySegment<ItemBatchOperation>(operations.Array, this.operations.Count + operations.Offset, overflowOperations);
         }
 
         private Result WriteOperation(long index, out ReadOnlyMemory<byte> buffer)

--- a/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new RequestEntityTooLargeException(RMResources.RequestTooLarge);
             }
 
-            return new ArraySegment<ItemBatchOperation>(operations.Array, materializedCount, operations.Count - materializedCount);
+            return new ArraySegment<ItemBatchOperation>(operations.Array, this.operations.Count, operations.Count - this.operations.Count);
         }
 
         private Result WriteOperation(long index, out ReadOnlyMemory<byte> buffer)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeServerBatchRequestTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeServerBatchRequestTests.cs
@@ -60,46 +60,70 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(operations[2].Id, pendingOperations[1].Id);
         }
 
+        /// <summary>
+        /// Verifies that the pending operations algorithm takes into account Offset
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Task OverflowsBasedOnCount_WithOffset()
+        {
+            List<ItemBatchOperation> operations = new List<ItemBatchOperation>()
+            {
+                CreateItemBatchOperation("1"),
+                CreateItemBatchOperation("2"),
+                CreateItemBatchOperation("3")
+            };
+
+            // Setting max count to 1
+            (PartitionKeyRangeServerBatchRequest request, ArraySegment<ItemBatchOperation> pendingOperations) = await PartitionKeyRangeServerBatchRequest.CreateAsync("0", new ArraySegment<ItemBatchOperation>(operations.ToArray(), 1, 2), 200000, 1, false, new CosmosJsonDotNetSerializer(), default(CancellationToken));
+
+            Assert.AreEqual(1, request.Operations.Count);
+            // The first element is not taken into account due to an Offset of 1
+            Assert.AreEqual(operations[1].Id, request.Operations[0].Id);
+            Assert.AreEqual(1, pendingOperations.Count);
+            Assert.AreEqual(operations[2].Id, pendingOperations[0].Id);
+        }
+
         [TestMethod]
         public async Task PartitionKeyRangeServerBatchRequestSizeTests()
         {
             const int docSizeInBytes = 250;
             const int operationCount = 10;
 
-            foreach (int expectedRequestCount in new int[] { 1, 2, 5, 10 })
+            foreach (int expectedOperationCount in new int[] { 1, 2, 5, 10 })
             {
-                await PartitionKeyRangeServerBatchRequestTests.VerifyServerRequestCreationsBySizeAsync(expectedRequestCount, operationCount, docSizeInBytes);
-                await PartitionKeyRangeServerBatchRequestTests.VerifyServerRequestCreationsByCountAsync(expectedRequestCount, operationCount, docSizeInBytes);
+                await PartitionKeyRangeServerBatchRequestTests.VerifyServerRequestCreationsBySizeAsync(expectedOperationCount, operationCount, docSizeInBytes);
+                await PartitionKeyRangeServerBatchRequestTests.VerifyServerRequestCreationsByCountAsync(expectedOperationCount, operationCount, docSizeInBytes);
             }
         }
 
         private static async Task VerifyServerRequestCreationsBySizeAsync(
-            int expectedRequestCount,
+            int expectedOperationCount,
             int operationCount,
             int docSizeInBytes)
         {
             const int perRequestOverheadEstimateInBytes = 30;
             const int perDocOverheadEstimateInBytes = 50;
-            int maxServerRequestBodyLength = ((docSizeInBytes + perDocOverheadEstimateInBytes) * expectedRequestCount) + perRequestOverheadEstimateInBytes;
+            int maxServerRequestBodyLength = ((docSizeInBytes + perDocOverheadEstimateInBytes) * expectedOperationCount) + perRequestOverheadEstimateInBytes;
             int maxServerRequestOperationCount = int.MaxValue;
 
             (PartitionKeyRangeServerBatchRequest request, ArraySegment<ItemBatchOperation> overflow) = await PartitionKeyRangeServerBatchRequestTests.GetBatchWithCreateOperationsAsync(operationCount, maxServerRequestBodyLength, maxServerRequestOperationCount, docSizeInBytes);
 
-            Assert.AreEqual(expectedRequestCount, request.Operations.Count);
+            Assert.AreEqual(expectedOperationCount, request.Operations.Count);
             Assert.AreEqual(overflow.Count, operationCount - request.Operations.Count);
         }
 
         private static async Task VerifyServerRequestCreationsByCountAsync(
-            int expectedRequestCount,
+            int expectedOperationCount,
             int operationCount,
             int docSizeInBytes)
         {
             int maxServerRequestBodyLength = int.MaxValue;
-            int maxServerRequestOperationCount = expectedRequestCount;
+            int maxServerRequestOperationCount = expectedOperationCount;
 
             (PartitionKeyRangeServerBatchRequest request, ArraySegment<ItemBatchOperation> overflow) = await PartitionKeyRangeServerBatchRequestTests.GetBatchWithCreateOperationsAsync(operationCount, maxServerRequestBodyLength, maxServerRequestOperationCount, docSizeInBytes);
 
-            Assert.AreEqual(expectedRequestCount, request.Operations.Count);
+            Assert.AreEqual(expectedOperationCount, request.Operations.Count);
             Assert.AreEqual(overflow.Count, operationCount - request.Operations.Count);
         }
 


### PR DESCRIPTION
## Description

As part of the work for https://github.com/Azure/azure-cosmos-dotnet-v3/issues/584, this PR adds new tests to cover possible batch request overflow due to materialization.