### PR TITLE
Fix typo (perhaps due to API change) in exception message

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             if (!this.allowSynchronousQueryExecution)
             {
                 throw new NotSupportedException("To execute LINQ query please set " + nameof(this.allowSynchronousQueryExecution) + " true or" +
-                    " use GetItemsQueryIterator to execute asynchronously");
+                    " use GetItemQueryIterator to execute asynchronously");
             }
 
             FeedIterator<T> localFeedIterator = this.CreateFeedIterator(false);


### PR DESCRIPTION
## Description

When this exception is thrown, it refers to `GetItemsQueryIterator` but it should be `GetItemQueryIterator`:

```
Unhandled Exception: System.NotSupportedException: To execute LINQ query please set allowSynchronousQueryExecution true or use GetItemsQueryIterator to execute asynchronously
   at Microsoft.Azure.Cosmos.Linq.CosmosLinqQuery`1.GetEnumerator()+MoveNext()
   at System.Collections.Generic.List`1.AddEnumerable(IEnumerable`1 enumerable)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)