### PR TITLE
Fix for an async deadlock, reported in #758 (and probably #717)

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/AsyncCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AsyncCache.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Common
 
         public void Set(TKey key, TValue value)
         {
-            AsyncLazy<TValue> lazyValue = new AsyncLazy<TValue>(() => value, CancellationToken.None);
+            AsyncLazy<TValue> lazyValue = new AsyncLazy<TValue>(value);
 
             // Access it to mark as created+completed, so that further calls to getasync do not overwrite.
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits

--- a/Microsoft.Azure.Cosmos/src/Routing/AsyncLazy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AsyncLazy.cs
@@ -11,6 +11,11 @@ namespace Microsoft.Azure.Cosmos.Common
 
     internal sealed class AsyncLazy<T> : Lazy<Task<T>>
     {
+        public AsyncLazy(T value)
+            : base(() => Task.FromResult(value))
+        {
+        }
+
         public AsyncLazy(Func<T> valueFactory, CancellationToken cancellationToken)
             : base(() => Task.Factory.StartNewOnCurrentTaskSchedulerAsync(valueFactory, cancellationToken)) // Task.Factory.StartNew() allows specifying task scheduler to use which is critical for compute gateway to track physical consumption.
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AsyncCacheTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AsyncCacheTest.cs
@@ -239,6 +239,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(2, getTaskResult2);
         }
 
+        [TestMethod]
+        [Timeout(200)]
+        public async Task TestAsyncDeadlock()
+        {
+            AsyncCache<int, int> cache = new AsyncCache<int, int>();
+
+            await Task.Factory.StartNew(() => cache.Set(0, 42), CancellationToken.None, TaskCreationOptions.None, new SingleTaskScheduler());
+        }
+
         private int GenerateIntFuncThatThrows()
         {
             throw new InvalidOperationException();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SingleTaskScheduler.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SingleTaskScheduler.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Cosmos
+{
+    /// <summary>
+    /// A task scheduler that processes a single task at a time.
+    /// It is used for testing async deadlocks
+    /// </summary>
+    /// <see cref="https://github.com/Azure/azure-cosmos-dotnet-v3/issues/758"/>
+    internal sealed class SingleTaskScheduler : TaskScheduler
+    {
+        private readonly Queue<Task> TaskQueue = new Queue<Task>();
+        private readonly object SyncObject = new object();
+        private bool IsActive = false;
+
+        public override int MaximumConcurrencyLevel => 1;
+
+        protected override IEnumerable<Task> GetScheduledTasks() { throw new NotSupportedException(); }
+
+        protected override bool TryExecuteTaskInline(Task task, bool taskWasPreviouslyQueued) => false;
+
+        protected override void QueueTask(Task task)
+        {
+            lock (this.SyncObject)
+            {
+                this.TaskQueue.Enqueue(task);
+
+                if (!this.IsActive)
+                {
+                    this.IsActive = true;
+                    ThreadPool.QueueUserWorkItem(
+                        _ =>
+                        {
+                            Task nextTask = null;
+                            while ((nextTask = this.TryGetNextTask()) != null)
+                            {
+                                this.TryExecuteTask(nextTask);
+                            }
+                        });
+                }
+            }
+        }
+
+        private Task TryGetNextTask()
+        {
+            lock (this.SyncObject)
+            {
+                if (this.TaskQueue.Count > 0)
+                {
+                    return this.TaskQueue.Dequeue();
+                }
+                else
+                {
+                    this.IsActive = false;
+                    return null;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Resolving an async deadlock caused by `AsyncCache` performing a blocking wait.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #758 and probably #717


