### PR TITLE
Converted all aggregate linq queries to return Response<T> 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Linq
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query;
 
     /// <summary>
     /// This class provides extension methods for cosmos LINQ code.
@@ -171,14 +172,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to determine the maximum of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The maximum value in the sequence.</returns>
-        public static Task<TSource> MaxAsync<TSource>(
+        public static Task<Response<TSource>> MaxAsync<TSource>(
             this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Max());
+                 return ResponseHelperAsync(source.Max());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<TSource>(
@@ -195,14 +196,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to determine the minimum of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The minimum value in the sequence.</returns>
-        public static Task<TSource> MinAsync<TSource>(
+        public static Task<Response<TSource>> MinAsync<TSource>(
             this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Min());
+                 return ResponseHelperAsync(source.Min());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<TSource>(
@@ -218,14 +219,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<decimal> AverageAsync(
+        public static Task<Response<decimal>> AverageAsync(
             this IQueryable<decimal> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<decimal>(
@@ -241,14 +242,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<decimal?> AverageAsync(
+        public static Task<Response<decimal?>> AverageAsync(
             this IQueryable<decimal?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<decimal?>(
@@ -264,14 +265,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double> AverageAsync(
+        public static Task<Response<double>> AverageAsync(
             this IQueryable<double> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double>(
@@ -287,14 +288,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double?> AverageAsync(
+        public static Task<Response<double?>> AverageAsync(
             this IQueryable<double?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double?>(
@@ -310,14 +311,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<float> AverageAsync(
+        public static Task<Response<float>> AverageAsync(
             this IQueryable<float> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<float>(
@@ -333,14 +334,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<float?> AverageAsync(
+        public static Task<Response<float?>> AverageAsync(
             this IQueryable<float?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<float?>(
@@ -356,14 +357,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double> AverageAsync(
+        public static Task<Response<double>> AverageAsync(
             this IQueryable<int> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double>(
@@ -379,14 +380,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double?> AverageAsync(
+        public static Task<Response<double?>> AverageAsync(
             this IQueryable<int?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double?>(
@@ -402,14 +403,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double> AverageAsync(
+        public static Task<Response<double>> AverageAsync(
             this IQueryable<long> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double>(
@@ -425,14 +426,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double?> AverageAsync(
+        public static Task<Response<double?>> AverageAsync(
             this IQueryable<long?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Average());
+                 return ResponseHelperAsync(source.Average());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double?>(
@@ -448,14 +449,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<decimal> SumAsync(
+        public static Task<Response<decimal>> SumAsync(
             this IQueryable<decimal> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<decimal>(
@@ -471,14 +472,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<decimal?> SumAsync(
+        public static Task<Response<decimal?>> SumAsync(
             this IQueryable<decimal?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<decimal?>(
@@ -494,14 +495,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double> SumAsync(
+        public static Task<Response<double>> SumAsync(
             this IQueryable<double> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double>(
@@ -517,14 +518,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<double?> SumAsync(
+        public static Task<Response<double?>> SumAsync(
             this IQueryable<double?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<double?>(
@@ -540,14 +541,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<float> SumAsync(
+        public static Task<Response<float>> SumAsync(
             this IQueryable<float> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<float>(
@@ -563,14 +564,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<float?> SumAsync(
+        public static Task<Response<float?>> SumAsync(
             this IQueryable<float?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<float?>(
@@ -586,14 +587,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<int> SumAsync(
+        public static Task<Response<int>> SumAsync(
             this IQueryable<int> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<int>(
@@ -609,14 +610,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<int?> SumAsync(
+        public static Task<Response<int?>> SumAsync(
             this IQueryable<int?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return ((CosmosLinqQueryProvider)source.Provider).ExecuteAggregateAsync<int?>(
@@ -632,14 +633,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<long> SumAsync(
+        public static Task<Response<long>> SumAsync(
             this IQueryable<long> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                 return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<long>(
@@ -655,14 +656,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">A sequence of values to calculate the average of.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The average value in the sequence.</returns>
-        public static Task<long?> SumAsync(
+        public static Task<Response<long?>> SumAsync(
             this IQueryable<long?> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Sum());
+                return ResponseHelperAsync(source.Sum());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<long?>(
@@ -679,14 +680,14 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <param name="source">The sequence that contains the elements to be counted.</param>
         /// <param name="cancellationToken">The cancellation token.</param>
         /// <returns>The number of elements in the input sequence.</returns>
-        public static Task<int> CountAsync<TSource>(
+        public static Task<Response<int>> CountAsync<TSource>(
             this IQueryable<TSource> source,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             CosmosLinqQueryProvider cosmosLinqQueryProvider = source.Provider as CosmosLinqQueryProvider;
             if (cosmosLinqQueryProvider == null)
             {
-                return Task.FromResult(source.Count());
+                return ResponseHelperAsync(source.Count());
             }
 
             return cosmosLinqQueryProvider.ExecuteAggregateAsync<int>(
@@ -694,6 +695,16 @@ namespace Microsoft.Azure.Cosmos.Linq
                     GetMethodInfoOf<IQueryable<TSource>, int>(Queryable.Count),
                     source.Expression),
                 cancellationToken);
+        }
+
+        private static Task<Response<T>> ResponseHelperAsync<T>(T value)
+        {
+            return Task.FromResult<Response<T>>(
+                       new ItemResponse<T>(
+                           System.Net.HttpStatusCode.OK,
+                           new Headers(),
+                           value,
+                           new CosmosDiagnosticsAggregate()));
         }
 
         private static MethodInfo GetMethodInfoOf<T1, T2>(Func<T1, T2> func)

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQueryProvider.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             return cosmosLINQQuery.ToList().FirstOrDefault();
         }
 
-        public async Task<TResult> ExecuteAggregateAsync<TResult>(
+        public async Task<Response<TResult>> ExecuteAggregateAsync<TResult>(
             Expression expression,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -123,8 +123,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 expression,
                 this.allowSynchronousQueryExecution,
                 this.serializationOptions);
-            IList<TResult> result = await cosmosLINQQuery.AggregateResultAsync();
-            return result.FirstOrDefault();
+            return await cosmosLINQQuery.AggregateResultAsync();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/CosmosDiagnosticsAggregate.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/CosmosDiagnosticsAggregate.cs
@@ -1,0 +1,19 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    internal class CosmosDiagnosticsAggregate : CosmosDiagnostics
+    {
+        public IList<CosmosDiagnostics> Diagnostics = new List<CosmosDiagnostics>();
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -267,65 +267,125 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             int count = await linqQueryable.CountAsync();
             Assert.AreEqual(10, count);
 
-            int intSum = await linqQueryable.Select(item => item.taskNum).SumAsync();
+            Response<int> intSum = await linqQueryable.Select(item => item.taskNum).SumAsync();
+            Assert.AreEqual(420, intSum.Resource);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            string diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
+
+            Response<int?> intNullableSum = await linqQueryable.Select(item => (int?)item.taskNum).SumAsync();
+            Assert.AreEqual<int?>(420, intNullableSum);
+            Assert.IsTrue(intNullableSum.RequestCharge > 0);
+            diagnostics = intNullableSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
+
+            Response<float> floatSum = await linqQueryable.Select(item => (float)item.taskNum).SumAsync();
             Assert.AreEqual(420, intSum);
+            Assert.IsTrue(floatSum.RequestCharge > 0);
+            diagnostics = floatSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            int? intNullableSum = await linqQueryable.Select(item => item.taskNum).SumAsync();
-            Assert.AreEqual(420, intNullableSum);
+            Response<float?> floatNullableSum = await linqQueryable.Select(item => (float?)item.taskNum).SumAsync();
+            Assert.AreEqual<float?>(420, intNullableSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            float floatSum = await linqQueryable.Select(item => (float)item.taskNum).SumAsync();
-            Assert.AreEqual(420, intSum);
+            Response<double> doubleSum = await linqQueryable.Select(item => (double)item.taskNum).SumAsync();
+            Assert.AreEqual(420.0, doubleSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            float? floatNullableSum = await linqQueryable.Select(item => (float?)item.taskNum).SumAsync();
-            Assert.AreEqual(420, intNullableSum);
+            Response<double?> doubleNullableSum = await linqQueryable.Select(item => (double?)item.taskNum).SumAsync();
+            Assert.AreEqual<double?>(420.0, doubleNullableSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double doubleSum = await linqQueryable.Select(item => (double)item.taskNum).SumAsync();
-            Assert.AreEqual(420, doubleSum);
+            Response<long> longSum = await linqQueryable.Select(item => (long)item.taskNum).SumAsync();
+            Assert.AreEqual<long>(420, longSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double? doubleNullableSum = await linqQueryable.Select(item => (double?)item.taskNum).SumAsync();
-            Assert.AreEqual(420, doubleNullableSum);
+            Response<long?> longNullableSum = await linqQueryable.Select(item => (long?)item.taskNum).SumAsync();
+            Assert.AreEqual<long?>(420, longNullableSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            long longSum = await linqQueryable.Select(item => (long)item.taskNum).SumAsync();
-            Assert.AreEqual(420, longSum);
+            Response<decimal> decimalSum = await linqQueryable.Select(item => (decimal)item.taskNum).SumAsync();
+            Assert.AreEqual<decimal>(420, decimalSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            long? longNullableSum = await linqQueryable.Select(item => (long?)item.taskNum).SumAsync();
-            Assert.AreEqual(420, longNullableSum);
+            Response<decimal?> decimalNullableSum = await linqQueryable.Select(item => (decimal?)item.taskNum).SumAsync();
+            Assert.AreEqual<decimal?>(420, decimalNullableSum);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            decimal decimalSum = await linqQueryable.Select(item => (decimal)item.taskNum).SumAsync();
-            Assert.AreEqual(420, decimalSum);
+            Response<double> intToDoubleAvg = await linqQueryable.Select(item => item.taskNum).AverageAsync();
+            Assert.AreEqual<double>(42, intToDoubleAvg);
+            Assert.IsTrue(intSum.RequestCharge > 0);
+            diagnostics = intSum.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            decimal? decimalNullableSum = await linqQueryable.Select(item => (decimal?)item.taskNum).SumAsync();
-            Assert.AreEqual(420, decimalNullableSum);
+            Response<double?> intToDoubleNulableAvg = await linqQueryable.Select(item => (double?)item.taskNum).AverageAsync();
+            Assert.AreEqual<double?>(42, intToDoubleNulableAvg);
+            Assert.IsTrue(intToDoubleNulableAvg.RequestCharge > 0);
+            diagnostics = intToDoubleNulableAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double intToDoubleAvg = await linqQueryable.Select(item => item.taskNum).AverageAsync();
-            Assert.AreEqual(42, intToDoubleAvg);
+            Response<float> floatAvg = await linqQueryable.Select(item => (float)item.taskNum).AverageAsync();
+            Assert.AreEqual<float>(42, floatAvg);
+            Assert.IsTrue(floatAvg.RequestCharge > 0);
+            diagnostics = floatAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double? intToDoubleNulableAvg = await linqQueryable.Select(item => item.taskNum).AverageAsync();
-            Assert.AreEqual(42, intToDoubleNulableAvg);
+            Response<float?> floatNullableAvg = await linqQueryable.Select(item => (float?)item.taskNum).AverageAsync();
+            Assert.AreEqual<float?>(42, floatNullableAvg);
+            Assert.IsTrue(floatNullableAvg.RequestCharge > 0);
+            diagnostics = floatNullableAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            float floatAvg = await linqQueryable.Select(item => (float)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, floatAvg);
+            Response<double> doubleAvg = await linqQueryable.Select(item => (double)item.taskNum).AverageAsync();
+            Assert.AreEqual<double>(42, doubleAvg);
+            Assert.IsTrue(doubleAvg.RequestCharge > 0);
+            diagnostics = doubleAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            float? floatNullableAvg = await linqQueryable.Select(item => (float?)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, floatNullableAvg);
+            Response<double?> doubleNullableAvg = await linqQueryable.Select(item => (double?)item.taskNum).AverageAsync();
+            Assert.AreEqual<double?>(42, doubleNullableAvg);
+            Assert.IsTrue(doubleNullableAvg.RequestCharge > 0);
+            diagnostics = doubleNullableAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double doubleAvg = await linqQueryable.Select(item => (double)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, doubleAvg);
+            Response<double> longToDoubleAvg = await linqQueryable.Select(item => (long)item.taskNum).AverageAsync();
+            Assert.AreEqual<double>(42, longToDoubleAvg);
+            Assert.IsTrue(longToDoubleAvg.RequestCharge > 0);
+            diagnostics = longToDoubleAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double? doubleNullableAvg = await linqQueryable.Select(item => (double?)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, doubleNullableAvg);
+            Response<double?> longToNullableDoubleAvg = await linqQueryable.Select(item => (long?)item.taskNum).AverageAsync();
+            Assert.AreEqual<double?>(42, longToNullableDoubleAvg);
+            Assert.IsTrue(longToNullableDoubleAvg.RequestCharge > 0);
+            diagnostics = longToNullableDoubleAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double longToDoubleAvg = await linqQueryable.Select(item => (long)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, longToDoubleAvg);
+            Response<decimal> decimalAvg = await linqQueryable.Select(item => (decimal)item.taskNum).AverageAsync();
+            Assert.AreEqual<decimal>(42, decimalAvg);
+            Assert.IsTrue(decimalAvg.RequestCharge > 0);
+            diagnostics = decimalAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
-            double? longToNullableDoubleAvg = await linqQueryable.Select(item => (long?)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, longToNullableDoubleAvg);
-
-            decimal decimalAvg = await linqQueryable.Select(item => (decimal)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, decimalAvg);
-
-            decimal? decimalNullableAvg = await linqQueryable.Select(item => (decimal?)item.taskNum).AverageAsync();
-            Assert.AreEqual(42, decimalNullableAvg);
+            Response<decimal?> decimalNullableAvg = await linqQueryable.Select(item => (decimal?)item.taskNum).AverageAsync();
+            Assert.AreEqual<decimal?>(42, decimalNullableAvg);
+            Assert.IsTrue(decimalNullableAvg.RequestCharge > 0);
+            diagnostics = decimalNullableAvg.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("queryMetrics"));
 
             //Adding more items to test min and max function
             ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
@@ -336,10 +396,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             toDoActivity.id = "maxTaskNum";
             await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.status));
 
-            int minTaskNum = await linqQueryable.Select(item => item.taskNum).MinAsync();
+            Response<int> minTaskNum = await linqQueryable.Select(item => item.taskNum).MinAsync();
             Assert.AreEqual(20, minTaskNum);
 
-            int maxTaskNum = await linqQueryable.Select(item => item.taskNum).MaxAsync();
+            Response<int> maxTaskNum = await linqQueryable.Select(item => item.taskNum).MaxAsync();
             Assert.AreEqual(100, maxTaskNum);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -3084,166 +3084,166 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T])"
         },
-        "System.Threading.Tasks.Task`1[System.Decimal] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Decimal] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Decimal] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Decimal] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Double] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Double] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Double] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Int32] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Int32] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Int32] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Int32] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Int64] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Int64] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int32]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int32]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int64]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int64]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Single] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Single] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Single] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Single] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[TSource] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[TSource] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[TSource] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[TSource] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
         }
       },
       "NestedTypes": {}

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#716](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/716) Added camel case serialization on LINQ query generation
 - [#729](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/729) Added aggregate(CountAsync/SumAsync etc.) extensions for LINQ query
 - [#743](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/743) Added WebProxy to CosmosClientOptions
+- [#776](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/776) Converted all aggregate linq queries to return Response<T> to allow access to request charge and diagnostics
 
 ### Fixed
 


### PR DESCRIPTION
…ccess to diagnostics.

# Pull Request Template

## Description

Converted all aggregate linq queries like CountAsync to return a Response<T>. This will allow users to access the request charge and diagnostics information for the request.

Only the request charge and diagnostics is aggregated. All other fields on Response<T> such as activity id will be null since they can not be aggregated.

Response<T> does have an implicit conversion to type T so users can still do the following:
```
int intSum = await linqQueryable.Select(item => item.taskNum).SumAsync();
```
Or
```
Response<int> intSum = await linqQueryable.Select(item => item.taskNum).SumAsync();
string totalCharge = intSum.RequestCharge;
string diagnosticis = intSum.Diagnostics.ToString();
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

