### PR TITLE
QueryDefinition: Add Expose QueryDefinition parameters

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns the query definition's parameters.
         /// </summary>
-        /// <returns>A dictionary with the names and values of the parameters.</returns>
+        /// <returns>A dictionary with the name and value of the parameters.</returns>
         public IReadOnlyDictionary<string, object> Parameters => this.parameters;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Defines a Cosmos SQL query
@@ -88,9 +89,41 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
+        /// <summary>
+        /// Add parameters to the SQL query
+        /// </summary>
+        /// <param name="parameters">The parameters to add, in the form of a list of key-value pairs (can be a dictionary).</param>
+        /// <remarks>
+        /// If the same name is added again it will replace the original value
+        /// </remarks>
+        /// <returns>An instance of <see cref="QueryDefinition"/>.</returns>
+        public QueryDefinition WithParameters(IEnumerable<KeyValuePair<string, object>> parameters)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            foreach (var keyValuePair in parameters)
+            {
+                this.SqlParameters[keyValuePair.Key] = new SqlParameter(keyValuePair.Key, keyValuePair.Value);
+            }
+            
+            return this;
+        }
+
         internal SqlQuerySpec ToSqlQuerySpec()
         {
             return new SqlQuerySpec(this.QueryText, new SqlParameterCollection(this.SqlParameters.Values));
+        }
+
+        /// <summary>
+        /// Returns a copy of the query definition's parameters.
+        /// </summary>
+        /// <returns>A dictionary with the names and values of the parameters.</returns>
+        public IReadOnlyDictionary<string, object> GetParameters()
+        {
+            return SqlParameters.ToDictionary(p => p.Key, p => p.Value.Value);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -3745,6 +3745,16 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)"
         },
+        "Microsoft.Azure.Cosmos.QueryDefinition WithParameters(System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,System.Object]])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition WithParameters(System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,System.Object]])"
+        },
+        "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] GetParameters()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] GetParameters()"
+        },
         "System.String get_QueryText()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -3750,10 +3750,15 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition WithParameters(System.Collections.Generic.IEnumerable`1[System.Collections.Generic.KeyValuePair`2[System.String,System.Object]])"
         },
-        "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] GetParameters()": {
+        "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] get_Parameters()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] GetParameters()"
+          "MethodInfo": "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] get_Parameters()"
+        },
+        "System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.Object] Parameters": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
         },
         "System.String get_QueryText()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -54,22 +54,22 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void GetParametersReturnsCopyOfQueryParameters()
+        public void ParametersReturnsQueryParameters()
         {
             var queryDefinition = new QueryDefinition("select * from s where s.Account = @account and s.Name = @name")
                 .WithParameter("@account", "12345")
                 .WithParameter("@name", "ABC");
 
-            var parameters = queryDefinition.GetParameters();
+            var parameters = queryDefinition.Parameters;
             Assert.IsTrue(parameters.TryGetValue("@account", out var account));
             Assert.AreEqual("12345", account);
             Assert.IsTrue(parameters.TryGetValue("@name", out var name));
             Assert.AreEqual("ABC", name);
 
-            // Ensure the returned dictionary is a copy, so modifications to the query
-            // definition are not reflected in the dictionary.
+            // Ensure the returned dictionary is not a copy, so modifications to the query
+            // definition are reflected in the returned dictionary.
             queryDefinition.WithParameter("@foo", "bar");
-            Assert.IsFalse(parameters.ContainsKey("@foo"));
+            Assert.IsTrue(parameters.ContainsKey("@foo"));
         }
 
         [TestMethod]
@@ -86,8 +86,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             };
 
             queryDefinition.WithParameters(parametersToAdd);
-            
-            var parameters = queryDefinition.GetParameters();
+
+            var parameters = queryDefinition.Parameters;
             Assert.IsTrue(parameters.TryGetValue("@account", out var account));
             Assert.AreEqual("12345", account);
             Assert.IsTrue(parameters.TryGetValue("@name", out var name));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -56,14 +56,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void ParametersReturnsQueryParameters()
         {
-            var queryDefinition = new QueryDefinition("select * from s where s.Account = @account and s.Name = @name")
+            QueryDefinition queryDefinition = new QueryDefinition("select * from s where s.Account = @account and s.Name = @name")
                 .WithParameter("@account", "12345")
                 .WithParameter("@name", "ABC");
 
-            var parameters = queryDefinition.Parameters;
-            Assert.IsTrue(parameters.TryGetValue("@account", out var account));
+            IReadOnlyDictionary<string, object> parameters = queryDefinition.Parameters;
+            Assert.IsTrue(parameters.TryGetValue("@account", out object account));
             Assert.AreEqual("12345", account);
-            Assert.IsTrue(parameters.TryGetValue("@name", out var name));
+            Assert.IsTrue(parameters.TryGetValue("@name", out object name));
             Assert.AreEqual("ABC", name);
 
             // Ensure the returned dictionary is not a copy, so modifications to the query
@@ -75,11 +75,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void WithParametersCombinesWithExistingParameters()
         {
-            var queryDefinition = new QueryDefinition("select * from s where s.Account = @account and s.Name = @name")
+            QueryDefinition queryDefinition = new QueryDefinition("select * from s where s.Account = @account and s.Name = @name")
                 .WithParameter("@account", "12345")
                 .WithParameter("@name", "ABC");
 
-            var parametersToAdd = new Dictionary<string, object>
+            Dictionary<string, object> parametersToAdd = new Dictionary<string, object>
             {
                 ["@name"] = "XYZ",
                 ["@foo"] = "bar"
@@ -87,12 +87,12 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             queryDefinition.WithParameters(parametersToAdd);
 
-            var parameters = queryDefinition.Parameters;
-            Assert.IsTrue(parameters.TryGetValue("@account", out var account));
+            IReadOnlyDictionary<string, object> parameters = queryDefinition.Parameters;
+            Assert.IsTrue(parameters.TryGetValue("@account", out object account));
             Assert.AreEqual("12345", account);
-            Assert.IsTrue(parameters.TryGetValue("@name", out var name));
+            Assert.IsTrue(parameters.TryGetValue("@name", out object name));
             Assert.AreEqual("XYZ", name);
-            Assert.IsTrue(parameters.TryGetValue("@foo", out var foo));
+            Assert.IsTrue(parameters.TryGetValue("@foo", out object foo));
             Assert.AreEqual("bar", foo);
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [#796](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/796) Expose QueryDefinition parameters
+
 ### Fixed
 
 - [#944](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/944) Change Feed Processor won't use user serializer for internal operations
@@ -84,6 +88,7 @@ flow.
 - [#716](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/716) Added camel case serialization on LINQ query generation
 - [#729](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/729), [#776](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/776) Added aggregate(CountAsync/SumAsync etc.) extensions for LINQ query
 - [#743](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/743) Added WebProxy to CosmosClientOptions
+
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Public API:
* ~~Add a `QueryDefinition.GetParameters` method. It's a method rather than a property, because it returns a new dictionary with a copy of the parameters every time it's called. The parameters can't be returned directly, because they're stored as a dictionary of `SqlParameter`, and that type isn't public.~~
* Add a `QueryDefinition.Parameters` property.
* Add a `QueryDefinition.WithParameters`. This allows the user to add multiple parameters as a dictionary, rather than one by one.

Private implementation:
Changed how the parameters are stored in `QueryDefinition`. They're now stored as a `Dictionary<string, object>`; the `SqlParameter`s are constructed on the fly in `ToSqlQuerySpec`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Closes #796 
