### PR TITLE
Query Core serialization options

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             if (cosmosSerializationOptions != null)
             {
-                memberName = cosmosSerializationOptions.GetStrWithPropertyNamingPolicy(memberName);
+                memberName = CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(cosmosSerializationOptions, memberName);
             }
 
             return memberName;

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public sealed class CosmosSerializationOptions
     {
-        private CamelCaseNamingStrategy camelCaseNamingStrategy { get; }
-
         /// <summary>
         /// Create an instance of CosmosSerializationOptions
         /// with the default values for the Cosmos SDK
@@ -23,7 +21,6 @@ namespace Microsoft.Azure.Cosmos
             this.IgnoreNullValues = false;
             this.Indented = false;
             this.PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default;
-            this.camelCaseNamingStrategy = new CamelCaseNamingStrategy();
         }
 
         /// <summary>
@@ -50,15 +47,5 @@ namespace Microsoft.Azure.Cosmos
         /// The default value is CosmosPropertyNamingPolicy.Default
         /// </remarks>
         public CosmosPropertyNamingPolicy PropertyNamingPolicy { get; set; }
-
-        internal string GetStrWithPropertyNamingPolicy(string str)
-        {
-            if (this.PropertyNamingPolicy == CosmosPropertyNamingPolicy.CamelCase)
-            {
-                return this.camelCaseNamingStrategy.GetPropertyName(str, false);
-            }
-
-            return str;
-        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationUtil.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationUtil.cs
@@ -1,0 +1,28 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using Newtonsoft.Json.Serialization;
+
+    internal static class CosmosSerializationUtil
+    {
+        private static CamelCaseNamingStrategy camelCaseNamingStrategy = new CamelCaseNamingStrategy();
+
+        internal static string ToCamelCase(string name)
+        {
+            return CosmosSerializationUtil.camelCaseNamingStrategy.GetPropertyName(name, false);
+        }
+
+        internal static string GetStringWithPropertyNamingPolicy(CosmosSerializationOptions options, string name)
+        {
+            if (options != null && options.PropertyNamingPolicy == CosmosPropertyNamingPolicy.CamelCase)
+            {
+                return CosmosSerializationUtil.ToCamelCase(name);
+            }
+
+            return name;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

The query core logic works with the serializer. The serializer uses the CamelCaseNamingStrategy which is not support in Netwonsoft 6.0.8. The code has been refactored to make it an external util class to avoid the conflict when doing the v2 submodule.

