### PR TITLE
Fixed flaky TestAsyncDeadlock

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AsyncCacheTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AsyncCacheTest.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Common;
@@ -240,12 +241,23 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Timeout(500)]
+        [Timeout(60000)]
         public async Task TestAsyncDeadlock()
         {
             AsyncCache<int, int> cache = new AsyncCache<int, int>();
+            Stopwatch stopwatch = new Stopwatch();
 
-            await Task.Factory.StartNew(() => cache.Set(0, 42), CancellationToken.None, TaskCreationOptions.None, new SingleTaskScheduler());
+            stopwatch.Start();
+            await Task.Factory.StartNew(() =>
+            {
+                stopwatch.Stop();
+                Logger.LogLine($"TestAsyncDeadlock Factory started in {stopwatch.ElapsedMilliseconds} ms");
+                cache.Set(0, 42);
+            },
+            CancellationToken.None,
+            TaskCreationOptions.None,
+            new SingleTaskScheduler()
+            );
         }
 
         private int GenerateIntFuncThatThrows()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/Logger.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/Logger.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System.Diagnostics;
+    using System.Globalization;
+
+    /// <summary>
+    /// Placeholder for VST Logger.
+    /// </summary>
+    internal static class Logger
+    {
+        public static void LogLine(string message)
+        {
+            Debug.WriteLine(message);
+            Trace.WriteLine(message);
+        }
+
+        public static void LogLine(string format, params object[] parameters)
+        {
+            Debug.WriteLine(string.Format(CultureInfo.InvariantCulture, format, parameters));
+            Trace.WriteLine(string.Format(CultureInfo.InvariantCulture, format, parameters));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Increased the timeout to 1 minute and added info on how long it takes the factory to start to see if the factory is causing the timeouts.

