### PR TITLE
Fixed a bug that caused sortedRanges exception

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -4271,6 +4271,47 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+
+        [TestMethod]
+        [Owner("brchon")]
+        public async Task TestLargePrefixPartitionKeys()
+        {
+            await this.CreateIngestQueryDelete(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition,
+                new List<string>() { },
+                this.TestLargePrefixPartitionKeys);
+        }
+
+        private async Task TestLargePrefixPartitionKeys(
+            Container container,
+            IEnumerable<Document> documents)
+        {
+            // There was a bug where the SDK could not handle collisions in the effective partition key.
+            // Normally this is pretty much impossible, since the epk is 128 bits, 
+            // but in HashV1 we only hash the first 100 bytes.
+            // This means any two strings with the same large prefix will collide. 
+            // This collision caused an assertion error (the query ranges were not sorted and non-overlapping (because there was a perfect overlap)).
+
+            ContainerProperties containerProperties = await container.ReadContainerAsync();
+            string partitionKey = containerProperties.PartitionKeyPath.Substring(1);
+            string largePrefix = new string('a', 1024);
+            string key1 = largePrefix + "abc";
+            string key2 = largePrefix + "xyz";
+
+            string serialQuery = $@"SELECT * FROM c WHERE c.{partitionKey} IN (""{key1}"", ""{key2}"")";
+
+            await CrossPartitionQueryTests.QueryWithContinuationTokens<JToken>(
+                container,
+                serialQuery);
+
+            string crossPartitionQuery = $"{serialQuery} ORDER BY c._ts";
+
+            await CrossPartitionQueryTests.QueryWithContinuationTokens<JToken>(
+                container,
+                crossPartitionQuery);
+        }
+
         private sealed class Headers
         {
             public double TotalRUs { get; set; }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#822](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/822) GROUP BY query support.
 
+### Fixed
+
+- [#835](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/835) Fixed a bug that caused sortedRanges exceptions
+
 ## <a name="3.2.0"/> [3.2.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.2.0) - 2019-09-17
 
 ### Added


### PR DESCRIPTION
# Pull Request Template

## Description

There was a bug where the SDK could not handle collisions in the effective partition key. Normally this is pretty much impossible, since the epk is 128, but in HashV1 we only hash the first 100 bytes. This means any two strings with the same large prefix will collide. This collision caused an assertion error (the query ranges were not sorted and non-overlapping (because there was a perfect overlap)).

The client side solution was to push the invariant into the structure instead of the check. The client now puts all the ranges into a sorted set to avoid this issue. In future this work should be pushed to the backend.

Fix is ported from internal PR: https://msdata.visualstudio.com/DefaultCollection/CosmosDB/_git/CosmosDB/pullrequest/248585

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

closes #833 

