### PR TITLE
Refactored cosmos element serializer to remove v3 serializer dependency

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementSerializer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         internal static CosmosArray ToCosmosElements(
             MemoryStream memoryStream,
             ResourceType resourceType,
-            CosmosSerializationFormatOptions.CreateCustomNavigator createJsonNavigator)
+            CosmosSerializationFormatOptions.CreateCustomNavigator createJsonNavigator = null)
         {
             if (!memoryStream.CanRead)
             {

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementSerializer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
             IJsonNavigator jsonNavigator = null;
             // Use the users custom navigator
-            if (createJsonNavigator == null)
+            if (createJsonNavigator != null)
             {
                 jsonNavigator = createJsonNavigator(content);
             }
@@ -165,6 +165,11 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             CosmosSerializer jsonSerializer,
             IJsonWriter jsonWriter = null)
         {
+            if (jsonSerializer == null)
+            {
+                throw new ArgumentNullException(nameof(jsonSerializer));
+            }
+
             if (!cosmosElements.Any())
             {
                 return Enumerable.Empty<T>();

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Cosmos
                 CosmosArray cosmosArray = CosmosElementSerializer.ToCosmosElements(
                     memoryStream,
                     resourceType,
-                    requestOptions.CosmosSerializationFormatOptions);
+                    requestOptions.CosmosSerializationFormatOptions?.CreateCustomNavigatorCallback);
 
                 int itemCount = cosmosArray.Count;
                 return QueryResponseCore.CreateSuccess(


### PR DESCRIPTION
# Pull Request Template

## Description

The v3 serializer code has public types which get leaked in the query core which is used in the v2 SDK. This removes those dependencies, and prevents the v2 SDK from needing to build the Cosmos Serializer code.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

