### PR TITLE
add preview pipeline

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -35,12 +35,6 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         private Exception exception;
 
-        /// <summary>
-        /// Test flag for making the query use the opposite code path for query plan retrieval.
-        /// If the SDK would have went to Gateway, then it will use ServiceInterop and visa versa.
-        /// </summary>
-        public static bool TestFlag = true;
-
         public CosmosQueryExecutionContextFactory(
             CosmosQueryContext cosmosQueryContext,
             InputParameters inputParameters)
@@ -162,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Query
             this.CosmosQueryContext.ContainerResourceId = containerQueryProperties.ResourceId;
 
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo;
-            if (this.CosmosQueryContext.QueryClient.ByPassQueryParsing() && TestFlag)
+            if (this.CosmosQueryContext.QueryClient.ByPassQueryParsing())
             {
                 // For non-Windows platforms(like Linux and OSX) in .NET Core SDK, we cannot use ServiceInterop, so need to bypass in that case.
                 // We are also now bypassing this for 32 bit host process running even on Windows as there are many 32 bit apps that will not work without this

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Scripts;
     using Microsoft.Azure.Documents;
@@ -30,7 +31,8 @@ namespace Microsoft.Azure.Cosmos
         internal ContainerCore(
             CosmosClientContext clientContext,
             DatabaseCore database,
-            string containerId)
+            string containerId,
+            CosmosQueryClient cosmosQueryClient = null)
         {
             this.Id = containerId;
             this.ClientContext = clientContext;
@@ -43,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
             this.Conflicts = new ConflictsCore(this.ClientContext, this);
             this.Scripts = new ScriptsCore(this, this.ClientContext);
             this.cachedUriSegmentWithoutId = this.GetResourceSegmentUriWithoutId();
-            this.queryClient = queryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
+            this.queryClient = cosmosQueryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
             this.BatchExecutor = this.InitializeBatchExecutorForContainer();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1273,6 +1273,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [TestCategory("Preview")]
         public async Task TestQueryPlanGatewayAndServiceInterop()
         {
             int seed = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
@@ -4004,6 +4005,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [TestCategory("Preview")]
+
         public async Task TestGroupByQuery()
         {
             string[] documents = new string[]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1280,43 +1280,63 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             QueryOracle.QueryOracleUtil util = new QueryOracle.QueryOracle2(seed);
             IEnumerable<string> documents = util.GetDocuments(numberOfDocuments);
 
-            bool originalTestFlag = CosmosQueryExecutionContextFactory.TestFlag;
-
-            foreach (bool testFlag in new bool[] { true, false })
-            {
-                CosmosQueryExecutionContextFactory.TestFlag = testFlag;
-                await this.CreateIngestQueryDelete(
-                    ConnectionModes.Direct,
-                    CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
-                    documents,
-                    this.TestQueryPlanGatewayAndServiceInteropHelper);
-                CosmosQueryExecutionContextFactory.TestFlag = originalTestFlag;
-            }
+            await this.CreateIngestQueryDelete(
+                ConnectionModes.Direct,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                documents,
+                this.TestQueryPlanGatewayAndServiceInteropHelper);
         }
 
         private async Task TestQueryPlanGatewayAndServiceInteropHelper(
             Container container,
             IEnumerable<Document> documents)
         {
-            foreach (int maxDegreeOfParallelism in new int[] { 1, 100 })
+            ContainerCore containerCore = (ContainerCore)container;
+
+            foreach (bool isGatewayQueryPlan in new bool[] { true, false })
             {
-                foreach (int maxItemCount in new int[] { 10, 100 })
+                MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
+                    containerCore.ClientContext,
+                    containerCore,
+                    isGatewayQueryPlan);
+
+                ContainerCore containerWithForcedPlan = new ContainerCore(
+                    containerCore.ClientContext,
+                    (DatabaseCore)containerCore.Database,
+                    containerCore.Id,
+                    cosmosQueryClientCore);
+
+                int numOfQueries = 0;
+                foreach (int maxDegreeOfParallelism in new int[] { 1, 100 })
                 {
-                    QueryRequestOptions feedOptions = new QueryRequestOptions
+                    foreach (int maxItemCount in new int[] { 10, 100 })
                     {
-                        MaxBufferedItemCount = 7000,
-                        MaxConcurrency = maxDegreeOfParallelism,
-                        MaxItemCount = maxItemCount,
-                    };
+                        numOfQueries++;
+                        QueryRequestOptions feedOptions = new QueryRequestOptions
+                        {
+                            MaxBufferedItemCount = 7000,
+                            MaxConcurrency = maxDegreeOfParallelism,
+                            MaxItemCount = maxItemCount,
+                        };
 
-                    List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
-                        container,
-                        "SELECT * FROM c ORDER BY c._ts",
-                        maxDegreeOfParallelism,
-                        maxItemCount,
-                        feedOptions);
+                        List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
+                            containerWithForcedPlan,
+                            "SELECT * FROM c ORDER BY c._ts",
+                            maxDegreeOfParallelism,
+                            maxItemCount,
+                            feedOptions);
 
-                    Assert.AreEqual(documents.Count(), queryResults.Count);
+                        Assert.AreEqual(documents.Count(), queryResults.Count);
+                    }
+                }
+
+                if (isGatewayQueryPlan)
+                {
+                    Assert.IsTrue(cosmosQueryClientCore.QueryPlanCalls > numOfQueries);
+                }
+                else
+                {
+                    Assert.AreEqual(0, cosmosQueryClientCore.QueryPlanCalls, "ServiceInterop mode should not be calling gateway plan retriever");
                 }
             }
         }
@@ -4853,6 +4873,47 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.Age = age;
                 this.Pet = pet;
                 this.Guid = guid;
+            }
+        }
+
+        /// <summary>
+        /// A helper that forces the SDK to use the gateway or the service interop for the query plan
+        /// </summary>
+        private class MockCosmosQueryClient : CosmosQueryClientCore
+        {
+            /// <summary>
+            /// True it will use the gateway query plan.
+            /// False it will use the service interop
+            /// </summary>
+            private readonly bool forceQueryPlanGatewayElseServiceInterop;
+
+            public MockCosmosQueryClient(
+                CosmosClientContext clientContext,
+                ContainerCore cosmosContainerCore,
+                bool forceQueryPlanGatewayElseServiceInterop) : base(
+                    clientContext,
+                    cosmosContainerCore)
+            {
+                this.forceQueryPlanGatewayElseServiceInterop = forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            public int QueryPlanCalls { get; private set; }
+
+            internal override bool ByPassQueryParsing()
+            {
+                return this.forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(Uri resourceUri, ResourceType resourceType, OperationType operationType, SqlQuerySpec sqlQuerySpec, string supportedQueryFeatures, CancellationToken cancellationToken)
+            {
+                this.QueryPlanCalls++;
+                return base.ExecuteQueryPlanRequestAsync(resourceUri, resourceType, operationType, sqlQuerySpec, supportedQueryFeatures, cancellationToken);
+            }
+
+            internal override Task<QueryResponseCore> ExecuteItemQueryAsync<RequestOptionType>(Uri resourceUri, ResourceType resourceType, OperationType operationType, RequestOptionType requestOptions, SqlQuerySpec sqlQuerySpec, string continuationToken, PartitionKeyRangeIdentity partitionKeyRange, bool isContinuationExpected, int pageSize, CancellationToken cancellationToken)
+            {
+                Assert.IsFalse(this.forceQueryPlanGatewayElseServiceInterop && this.QueryPlanCalls == 0, "Query Plan is force gateway mode, but no ExecuteQueryPlanRequestAsync have been called");
+                return base.ExecuteItemQueryAsync(resourceUri, resourceType, operationType, requestOptions, sqlQuerySpec, continuationToken, partitionKeyRange, isContinuationExpected, pageSize, cancellationToken);
             }
         }
     }

--- a/azure-pipelines-preview.yml
+++ b/azure-pipelines-preview.yml
@@ -12,9 +12,10 @@ pr:
     - NuGet.config
 
 variables:
-  DebugArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Preview" --verbosity normal '
-  ReleaseArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Preview" --verbosity normal '
-  VmImage: vs2017-win2016 # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+  DebugArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory=Preview" --verbosity normal '
+  ReleaseArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory=Preview" --verbosity normal '
+  VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+  Preview: 1
 
 
 jobs:

--- a/templates/emulator-setup.yml
+++ b/templates/emulator-setup.yml
@@ -2,16 +2,27 @@
 
 steps:
   - pwsh:  |
-        Write-Host "Downloading Cosmos Emulator - $env:EMULATORMSIURL" -ForegroundColor green 
-        Invoke-WebRequest "$env:EMULATORMSIURL" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
-        Write-Host "Finished Downloading Cosmos Emulator - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
+        If ($env:Preview -eq 1) {
+          Write-Host "Downloading Cosmos Emulator - https://aka.ms/cosmosdb-emulator" -ForegroundColor green 
+          Invoke-WebRequest "https://aka.ms/cosmosdb-emulator" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
+          Write-Host "Finished Downloading Cosmos Emulator - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
+        } else {
+          Write-Host "Downloading Cosmos Emulator - $env:EMULATORMSIURL" -ForegroundColor green 
+          Invoke-WebRequest "$env:EMULATORMSIURL" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
+          Write-Host "Finished Downloading Cosmos Emulator - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
+        }
         dir "$env:temp" 
         choco install lessmsi
         choco upgrade lessmsi
         mkdir "$env:temp\Azure Cosmos DB Emulator"
         lessmsi x "$env:temp\azure-cosmosdb-emulator.msi" "$env:temp\Azure Cosmos DB Emulator\"
         Write-Host "Starting Comsos DB Emulator" -ForegroundColor green 
-        Start-Process "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=100 /Consistency=Strong /enableRio /overrides=sqlAllowGroupByClause:true" -Verb RunAs
+        If ($env:Preview -eq 1) {
+          Write-Host "Preview = $env:Preview" -ForegroundColor green 
+          Start-Process "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=100 /Consistency=Strong /enableRio /overrides=sqlAllowGroupByClause:true" -Verb RunAs
+        } else {
+          Start-Process "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=100 /Consistency=Strong /enableRio" -Verb RunAs
+        }
         Import-Module "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
         Get-Item env:* | Sort-Object -Property Name
         for ($i=0; $i -lt 10; $i++) {

--- a/templates/emulator-setup.yml
+++ b/templates/emulator-setup.yml
@@ -3,13 +3,13 @@
 steps:
   - pwsh:  |
         If ($env:Preview -eq 1) {
+          Write-Host "Downloading Cosmos Emulator - $env:EMULATORMSIURL" -ForegroundColor green 
+          Invoke-WebRequest "$env:EMULATORMSIURL" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
+          Write-Host "Finished Downloading Cosmos Emulator nightly build - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green
+        } else {
           Write-Host "Downloading Cosmos Emulator - https://aka.ms/cosmosdb-emulator" -ForegroundColor green 
           Invoke-WebRequest "https://aka.ms/cosmosdb-emulator" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
           Write-Host "Finished Downloading Cosmos Emulator - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
-        } else {
-          Write-Host "Downloading Cosmos Emulator - $env:EMULATORMSIURL" -ForegroundColor green 
-          Invoke-WebRequest "$env:EMULATORMSIURL" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
-          Write-Host "Finished Downloading Cosmos Emulator nightly build - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
         }
         dir "$env:temp" 
         choco install lessmsi

--- a/templates/emulator-setup.yml
+++ b/templates/emulator-setup.yml
@@ -9,7 +9,7 @@ steps:
         } else {
           Write-Host "Downloading Cosmos Emulator - $env:EMULATORMSIURL" -ForegroundColor green 
           Invoke-WebRequest "$env:EMULATORMSIURL" -OutFile "$env:temp\azure-cosmosdb-emulator.msi"
-          Write-Host "Finished Downloading Cosmos Emulator - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
+          Write-Host "Finished Downloading Cosmos Emulator nightly build - $env:temp\azure-cosmosdb-emulator.msi" -ForegroundColor green 
         }
         dir "$env:temp" 
         choco install lessmsi


### PR DESCRIPTION
There are test running without the service interop. The issue is we using the nightly emulator with several FS enabled to test new paths. What we came up with as a solution to cover this gap is to have two test pipelines. We will mark a test with preview and it will build with the nightly emulator and the custom emulator flags. All other tests will run against the public emulator without any emulator flags. That way we can catch regressions like this, and still allow people to add features based on the latest nightly emulator. 