### PR TITLE
Max Item Count Fix

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
@@ -146,19 +146,18 @@ namespace Microsoft.Azure.Cosmos.Query
 
             QueryInfo queryInfo = initParams.PartitionedQueryExecutionInfo.QueryInfo;
 
-            int actualPageSize = initParams.InitialPageSize;
             int initialPageSize = initParams.InitialPageSize;
             CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams parameters = initParams;
             if (queryInfo.HasGroupBy)
             {
-                initialPageSize = int.MaxValue;
+                // The query will block until all groupings are gathered so we might as well speed up the process.
                 initParams = new CosmosCrossPartitionQueryExecutionContext.CrossPartitionInitParams(
                     sqlQuerySpec: initParams.SqlQuerySpec,
                     collectionRid: initParams.CollectionRid,
                     partitionedQueryExecutionInfo: initParams.PartitionedQueryExecutionInfo,
                     partitionKeyRanges: initParams.PartitionKeyRanges,
-                    initialPageSize: initialPageSize,
-                    maxConcurrency: initParams.MaxConcurrency,
+                    initialPageSize: int.MaxValue,
+                    maxConcurrency: int.MaxValue,
                     maxItemCount: int.MaxValue,
                     maxBufferedItemCount: initParams.MaxBufferedItemCount);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -4230,7 +4230,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 foreach (int maxItemCount in new int[] { 1, 5, 10 })
                 {
-                    List<JToken> actual = await CrossPartitionQueryTests.RunQuery<JToken>(
+                    List<JToken> actual = await CrossPartitionQueryTests.QueryWithoutContinuationTokens<JToken>(
                         container,
                         query,
                         new QueryRequestOptions()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1324,10 +1324,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             MaxItemCount = maxItemCount,
                         };
 
-                    List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
-                        container,
-                        "SELECT * FROM c ORDER BY c._ts",
-                        feedOptions);
+                        List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
+                            containerWithForcedPlan,
+                            "SELECT * FROM c ORDER BY c._ts",
+                            feedOptions);
 
                         Assert.AreEqual(documents.Count(), queryResults.Count);
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -425,7 +425,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
            string partitionKey = "/id",
            Cosmos.IndexingPolicy indexingPolicy = null)
         {
-            int retryCount = 5;
+            int retryCount = 1;
             AggregateException exceptionHistory = new AggregateException();
             while (retryCount-- > 0)
             {
@@ -574,18 +574,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private static async Task<List<T>> QueryWithContinuationTokens<T>(
             Container container,
             string query,
-            int? maxConcurrency = 2,
-            int? maxItemCount = null,
             QueryRequestOptions queryRequestOptions = null)
         {
-            if (maxConcurrency.HasValue || maxItemCount.HasValue)
+            if (queryRequestOptions == null)
             {
-                if (queryRequestOptions == null)
-                {
-                    queryRequestOptions = new QueryRequestOptions();
-                }
-                queryRequestOptions.MaxConcurrency = maxConcurrency;
-                queryRequestOptions.MaxItemCount = maxItemCount;
+                queryRequestOptions = new QueryRequestOptions();
             }
 
             List<T> results = new List<T>();
@@ -598,6 +591,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                    continuationToken: continuationToken);
 
                 FeedResponse<T> cosmosQueryResponse = await itemQuery.ReadNextAsync();
+                if (queryRequestOptions.MaxItemCount.HasValue)
+                {
+                    Assert.IsTrue(
+                        cosmosQueryResponse.Count <= queryRequestOptions.MaxItemCount.Value,
+                        "Max Item Count is not being honored");
+                }
+
                 results.AddRange(cosmosQueryResponse);
                 continuationToken = cosmosQueryResponse.ContinuationToken;
             } while (continuationToken != null);
@@ -608,17 +608,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private static async Task<List<T>> QueryWithoutContinuationTokens<T>(
             Container container,
             string query,
-            int maxConcurrency = 2,
-            int? maxItemCount = null,
             QueryRequestOptions queryRequestOptions = null)
         {
             if (queryRequestOptions == null)
             {
                 queryRequestOptions = new QueryRequestOptions();
             }
-
-            queryRequestOptions.MaxConcurrency = maxConcurrency;
-            queryRequestOptions.MaxItemCount = maxItemCount;
 
             List<T> results = new List<T>();
             FeedIterator<T> itemQuery = container.GetItemQueryIterator<T>(
@@ -627,7 +622,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             while (itemQuery.HasMoreResults)
             {
-                results.AddRange(await itemQuery.ReadNextAsync());
+                FeedResponse<T> page = await itemQuery.ReadNextAsync();
+                results.AddRange(page);
+
+                if (queryRequestOptions.MaxItemCount.HasValue)
+                {
+                    Assert.IsTrue(
+                        page.Count <= queryRequestOptions.MaxItemCount.Value,
+                        "Max Item Count is not being honored");
+                }
             }
 
             return results;
@@ -651,6 +654,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public void TestContinuationTokenSerialization()
         {
+            CompositeContinuationToken[] tokens = JsonConvert.DeserializeObject<CompositeContinuationToken[]>("[{\"token\":null,\"range\":{\"min\":\"05C1C9CD673398\",\"max\":\"05C1D9CD673398\"}}]");
             CompositeContinuationToken compositeContinuationToken = new CompositeContinuationToken()
             {
                 Token = "asdf",
@@ -786,7 +790,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(0, (await CrossPartitionQueryTests.RunQuery<Document>(
                 container,
                 @"SELECT * FROM Root r WHERE false",
-                maxConcurrency: 1)).Count);
+                new QueryRequestOptions()
+                {
+                    MaxConcurrency = 1,
+                })).Count);
 
             object[] keys = new object[] { "A", 5, Undefined.Value };
             for (int i = 0; i < keys.Length; ++i)
@@ -1259,8 +1266,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
                             container,
                             query,
-                            maxDegreeOfParallelism,
-                            maxItemCount,
                             feedOptions);
 
                         Assert.AreEqual(
@@ -1312,8 +1317,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
                         container,
                         "SELECT * FROM c ORDER BY c._ts",
-                        maxDegreeOfParallelism,
-                        maxItemCount,
                         feedOptions);
 
                     Assert.AreEqual(documents.Count(), queryResults.Count);
@@ -1338,6 +1341,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             QueryRequestOptions feedOptions = new QueryRequestOptions
             {
                 MaxBufferedItemCount = 7000,
+                MaxConcurrency = 10,
+                MaxItemCount = 10,
             };
 
             string compositeAggregate = "SELECT COUNT(1) + 5 FROM c";
@@ -1354,8 +1359,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     await CrossPartitionQueryTests.RunQuery<JToken>(
                         container,
                         unsupportedQuery,
-                        maxConcurrency: 10,
-                        maxItemCount: 10,
                         queryRequestOptions: feedOptions);
                     Assert.Fail("Expected query to fail due it not being supported.");
                 }
@@ -1507,16 +1510,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         string query = string.Format(CultureInfo.InvariantCulture, queryFormat, argument.AggregateOperator, partitionKey, argument.Predicate);
                         string message = string.Format(CultureInfo.InvariantCulture, "query: {0}, data: {1}", query, JsonConvert.SerializeObject(argument));
-                        List<dynamic> items = new List<dynamic>();
 
-                        FeedIterator<dynamic> resultSetIterator = container.GetItemQueryIterator<dynamic>(
+                        List<dynamic> items = await CrossPartitionQueryTests.RunQuery<dynamic>(
+                            container,
                             query,
-                            requestOptions: new QueryRequestOptions() { MaxConcurrency = maxDoP });
-                        while (resultSetIterator.HasMoreResults)
-                        {
-                            items.AddRange(await resultSetIterator.ReadNextAsync());
-                        }
-
+                            new QueryRequestOptions()
+                            {
+                                MaxConcurrency = maxDoP,
+                            });
                         if (Undefined.Value.Equals(argument.ExpectedValue))
                         {
                             Assert.AreEqual(0, items.Count, message);
@@ -1660,9 +1661,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 try
                 {
                     List<dynamic> items = await CrossPartitionQueryTests.RunQuery<dynamic>(
-                    container,
-                    query,
-                    maxConcurrency: 10);
+                        container,
+                        query,
+                        new QueryRequestOptions()
+                        {
+                            MaxConcurrency = 10,
+                        });
 
                     Assert.AreEqual(valueOfInterest, items.Single());
                 }
@@ -1864,8 +1868,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     List<dynamic> items = await CrossPartitionQueryTests.RunQuery<dynamic>(
                         container,
                         query,
-                        10,
-                        null);
+                        new QueryRequestOptions()
+                        {
+                            MaxItemCount = 10,
+                        });
 
                     writer.WriteStartElement("Result");
                     writer.WriteStartElement("Query");
@@ -2164,11 +2170,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     List<JToken> actual = await QueryWithoutContinuationTokens<JToken>(
                         container: container,
                         query: query,
-                        maxConcurrency: 100,
-                        maxItemCount: maxItemCount,
                         queryRequestOptions: new QueryRequestOptions()
                         {
                             MaxBufferedItemCount = 100,
+                            MaxConcurrency = 100,
+                            MaxItemCount = maxItemCount,
                         });
 
                     Assert.AreEqual(1, actual.Count());
@@ -2198,10 +2204,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     List<JToken> actual = await QueryWithoutContinuationTokens<JToken>(
                         container: container,
                         query: query,
-                        maxConcurrency: 100,
                         queryRequestOptions: new QueryRequestOptions()
                         {
                             MaxBufferedItemCount = 100,
+                            MaxConcurrency = 100,
                         });
 
                     Assert.Fail("Expected Query To Fail");
@@ -2566,8 +2572,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Document> query = await CrossPartitionQueryTests.RunQuery<Document>(
                 container,
                 "SELECT r.id FROM r ORDER BY r.prop DESC",
-                maxItemCount: 1,
-                maxConcurrency: 1);
+                new QueryRequestOptions()
+                {
+                    MaxItemCount = 1,
+                    MaxConcurrency = 1,
+                });
 
             Assert.AreEqual(string.Join(", ", expected), string.Join(", ", query.Select(doc => doc.Id)));
         }
@@ -2621,14 +2630,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     QueryRequestOptions feedOptions = new QueryRequestOptions
                     {
                         MaxBufferedItemCount = 7000,
-                        MaxConcurrency = maxDegreeOfParallelism
+                        MaxConcurrency = maxDegreeOfParallelism,
+                        MaxItemCount = maxItemCount,
                     };
 
                     List<JToken> actualFromQueryWithoutContinutionTokens = await QueryWithContinuationTokens<JToken>(
                         container,
                         "SELECT * FROM c ORDER BY c.field",
-                        maxDegreeOfParallelism,
-                        maxItemCount,
                         feedOptions);
 
                     Assert.AreEqual(documents.Count(), actualFromQueryWithoutContinutionTokens.Count);
@@ -2919,14 +2927,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         QueryRequestOptions feedOptions = new QueryRequestOptions()
                         {
                             MaxBufferedItemCount = 1000,
+                            MaxItemCount = 16,
+                            MaxConcurrency = 10,
                         };
 
                         List<JToken> actualFromQueryWithoutContinutionTokens;
                         actualFromQueryWithoutContinutionTokens = await CrossPartitionQueryTests.QueryWithoutContinuationTokens<JToken>(
                             container,
                             query,
-                            maxItemCount: 16,
-                            maxConcurrency: 10,
                             queryRequestOptions: feedOptions);
 #if false
                         For now we can not serve the query through continuation tokens correctly.
@@ -3080,15 +3088,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<string> computedResults = new List<string>();
 
             string emptyQueryText = @"SELECT TOP 5 * FROM Root r WHERE r.partitionKey = 9991123 OR r.partitionKey = 9991124 OR r.partitionKey = 99991125";
-            FeedOptions feedOptionsEmptyResult = new FeedOptions
-            {
-                EnableCrossPartitionQuery = true
-            };
-
             List<Document> queryEmptyResult = await CrossPartitionQueryTests.RunQuery<Document>(
                 container,
-                emptyQueryText,
-                maxConcurrency: 1);
+                emptyQueryText);
 
             computedResults = queryEmptyResult.Select(doc => doc.Id).ToList();
             computedResults.Sort();
@@ -3581,14 +3583,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 List<Document> queryResultsWithoutContinuationTokens = await QueryWithoutContinuationTokens<Document>(
                     container,
-                    query,
-                    maxConcurrency: 0);
+                    query);
 
                 foreach (int pageSize in new int[] { 1, documentCount / 2, documentCount })
                 {
                     List<Document> queryResultsWithContinuationTokens = await QueryWithContinuationTokens<Document>(
                         container,
-                        query);
+                        query,
+                        new QueryRequestOptions()
+                        {
+                            MaxItemCount = pageSize,
+                        });
 
                     Assert.AreEqual(
                         string.Join(", ", queryResultsWithoutContinuationTokens.Select(doc => doc.GetPropertyValue<int>(partitionKey))),
@@ -3945,13 +3950,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             QueryRequestOptions feedOptions = new QueryRequestOptions()
                             {
                                 MaxBufferedItemCount = 1000,
+                                MaxItemCount = 3,
+                                MaxConcurrency = 10,
                             };
 
                             List<List<object>> actual = await CrossPartitionQueryTests.RunQuery<List<object>>(
                                 container,
                                 query,
-                                maxItemCount: 3,
-                                maxConcurrency: 10,
                                 queryRequestOptions: feedOptions);
                             this.AssertMultiOrderByResults(expected, actual, query);
                         }
@@ -4225,14 +4230,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 foreach (int maxItemCount in new int[] { 1, 5, 10 })
                 {
-                    int maxConcurrency = 2;
-                    List<JToken> actual = await QueryWithoutContinuationTokens<JToken>(
+                    List<JToken> actual = await CrossPartitionQueryTests.RunQuery<JToken>(
                         container,
                         query,
-                        maxConcurrency,
-                        maxItemCount,
                         new QueryRequestOptions()
                         {
+                            MaxConcurrency = 2,
                             MaxItemCount = maxItemCount,
                             MaxBufferedItemCount = 100,
                         });
@@ -4254,16 +4257,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 try
                 {
-                    int maxConcurrency = 2;
-                    int maxItemCount = 1;
-
-                    List<JToken> actual = await QueryWithContinuationTokens<JToken>(
+                    List<JToken> actual = await CrossPartitionQueryTests.QueryWithContinuationTokens<JToken>(
                         container,
                         "SELECT c.age FROM c GROUP BY c.age",
-                        maxConcurrency,
-                        maxItemCount,
                         new QueryRequestOptions()
                         {
+                            MaxConcurrency = 2,
+                            MaxItemCount = 1
                         });
                     Assert.Fail("Expected an error when trying to drain a GROUP BY query with continuation tokens.");
                 }
@@ -4271,47 +4271,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                 }
             }
-        }
-
-
-        [TestMethod]
-        [Owner("brchon")]
-        public async Task TestLargePrefixPartitionKeys()
-        {
-            await this.CreateIngestQueryDelete(
-                ConnectionModes.Direct | ConnectionModes.Gateway,
-                CollectionTypes.MultiPartition,
-                new List<string>() { },
-                this.TestLargePrefixPartitionKeys);
-        }
-
-        private async Task TestLargePrefixPartitionKeys(
-            Container container,
-            IEnumerable<Document> documents)
-        {
-            // There was a bug where the SDK could not handle collisions in the effective partition key.
-            // Normally this is pretty much impossible, since the epk is 128 bits, 
-            // but in HashV1 we only hash the first 100 bytes.
-            // This means any two strings with the same large prefix will collide. 
-            // This collision caused an assertion error (the query ranges were not sorted and non-overlapping (because there was a perfect overlap)).
-
-            ContainerProperties containerProperties = await container.ReadContainerAsync();
-            string partitionKey = containerProperties.PartitionKeyPath.Substring(1);
-            string largePrefix = new string('a', 1024);
-            string key1 = largePrefix + "abc";
-            string key2 = largePrefix + "xyz";
-
-            string serialQuery = $@"SELECT * FROM c WHERE c.{partitionKey} IN (""{key1}"", ""{key2}"")";
-
-            await CrossPartitionQueryTests.QueryWithContinuationTokens<JToken>(
-                container,
-                serialQuery);
-
-            string crossPartitionQuery = $"{serialQuery} ORDER BY c._ts";
-
-            await CrossPartitionQueryTests.QueryWithContinuationTokens<JToken>(
-                container,
-                crossPartitionQuery);
         }
 
         private sealed class Headers
@@ -4505,21 +4464,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private static async Task<List<T>> RunQuery<T>(
             Container container,
             string query,
-            int maxConcurrency = 2,
-            int? maxItemCount = null,
             QueryRequestOptions queryRequestOptions = null)
         {
             List<T> queryResultsWithoutContinuationToken = await QueryWithoutContinuationTokens<T>(
                 container,
                 query,
-                maxConcurrency,
-                maxItemCount,
                 queryRequestOptions);
             List<T> queryResultsWithContinuationTokens = await QueryWithContinuationTokens<T>(
                 container,
                 query,
-                maxConcurrency,
-                maxItemCount,
                 queryRequestOptions);
 
             List<JToken> queryResultsWithoutContinuationTokenAsJTokens = queryResultsWithoutContinuationToken


### PR DESCRIPTION
# Max Item Count Fix

## Description

GROUP BY queries were not honoring `MaxItemCount`. None of the tests caught it. I updated the tests to assert that max item count is honored. The bug was a simple fix. 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update