### PR TITLE
Updating replace item documentation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -581,8 +581,8 @@ namespace Microsoft.Azure.Cosmos
         /// Replaces a item in the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <remarks>
-        /// The item id and partition key value are immutable. 
-        /// To change an item id or partition key value you must delete the original item and insert a new item.
+        /// The item's partition key value is immutable. 
+        /// To change an item's partition key value you must delete the original item and insert a new item.
         /// </remarks>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the payload.</param>
         /// <param name="id">The cosmos item id</param>
@@ -632,8 +632,8 @@ namespace Microsoft.Azure.Cosmos
         /// Replaces a item in the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <remarks>
-        /// The item id and partition key value are immutable. 
-        /// To change an item id or partition key value you must delete the original item and insert a new item.
+        /// The item's partition key value is immutable. 
+        /// To change an item's partition key value you must delete the original item and insert a new item.
         /// </remarks>
         /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
         /// <param name="id">The cosmos item id, which is expected to match the value within T.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -580,6 +580,10 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Replaces a item in the Azure Cosmos service as an asynchronous operation.
         /// </summary>
+        /// <remarks>
+        /// The item id and partition key value are immutable. 
+        /// To change an item id or partition key value you must delete the original item and insert a new item.
+        /// </remarks>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the payload.</param>
         /// <param name="id">The cosmos item id</param>
         /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
@@ -626,7 +630,11 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// Replaces a item in the Azure Cosmos service as an asynchronous operation.
-        /// </summary>        
+        /// </summary>
+        /// <remarks>
+        /// The item id and partition key value are immutable. 
+        /// To change an item id or partition key value you must delete the original item and insert a new item.
+        /// </remarks>
         /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
         /// <param name="id">The cosmos item id, which is expected to match the value within T.</param>
         /// <param name="partitionKey">Partition key for the item. If not specified will be populated by extracting from {T}</param>


### PR DESCRIPTION
# Pull Request Template

## Description

Added documentation that the partition key value is immutable and can not be changed in a replace operation. I added a test and verified that the id value can be updated during a replace. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

