### PR TITLE
Fixed cross partition query force gateway plan tests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -35,12 +35,6 @@ namespace Microsoft.Azure.Cosmos.Query
         /// </summary>
         private Exception exception;
 
-        /// <summary>
-        /// Test flag for making the query use the opposite code path for query plan retrieval.
-        /// If the SDK would have went to Gateway, then it will use ServiceInterop and visa versa.
-        /// </summary>
-        public static bool TestFlag = true;
-
         public CosmosQueryExecutionContextFactory(
             CosmosQueryContext cosmosQueryContext,
             InputParameters inputParameters)
@@ -162,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Query
             this.CosmosQueryContext.ContainerResourceId = containerQueryProperties.ResourceId;
 
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo;
-            if (this.CosmosQueryContext.QueryClient.ByPassQueryParsing() && TestFlag)
+            if (this.CosmosQueryContext.QueryClient.ByPassQueryParsing())
             {
                 // For non-Windows platforms(like Linux and OSX) in .NET Core SDK, we cannot use ServiceInterop, so need to bypass in that case.
                 // We are also now bypassing this for 32 bit host process running even on Windows as there are many 32 bit apps that will not work without this

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Scripts;
     using Microsoft.Azure.Documents;
@@ -30,7 +31,8 @@ namespace Microsoft.Azure.Cosmos
         internal ContainerCore(
             CosmosClientContext clientContext,
             DatabaseCore database,
-            string containerId)
+            string containerId,
+            CosmosQueryClient cosmosQueryClient = null)
         {
             this.Id = containerId;
             this.ClientContext = clientContext;
@@ -43,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
             this.Conflicts = new ConflictsCore(this.ClientContext, this);
             this.Scripts = new ScriptsCore(this, this.ClientContext);
             this.cachedUriSegmentWithoutId = this.GetResourceSegmentUriWithoutId();
-            this.queryClient = queryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
+            this.queryClient = cosmosQueryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
             this.BatchExecutor = this.InitializeBatchExecutorForContainer();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -1280,43 +1280,63 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             QueryOracle.QueryOracleUtil util = new QueryOracle.QueryOracle2(seed);
             IEnumerable<string> documents = util.GetDocuments(numberOfDocuments);
 
-            bool originalTestFlag = CosmosQueryExecutionContextFactory.TestFlag;
-
-            foreach (bool testFlag in new bool[] { true, false })
-            {
-                CosmosQueryExecutionContextFactory.TestFlag = testFlag;
-                await this.CreateIngestQueryDelete(
-                    ConnectionModes.Direct,
-                    CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
-                    documents,
-                    this.TestQueryPlanGatewayAndServiceInteropHelper);
-                CosmosQueryExecutionContextFactory.TestFlag = originalTestFlag;
-            }
+            await this.CreateIngestQueryDelete(
+                ConnectionModes.Direct,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                documents,
+                this.TestQueryPlanGatewayAndServiceInteropHelper);
         }
 
         private async Task TestQueryPlanGatewayAndServiceInteropHelper(
             Container container,
             IEnumerable<Document> documents)
         {
-            foreach (int maxDegreeOfParallelism in new int[] { 1, 100 })
+            ContainerCore containerCore = (ContainerCore)container;
+
+            foreach (bool isGatewayQueryPlan in new bool[] { true, false })
             {
-                foreach (int maxItemCount in new int[] { 10, 100 })
+                MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
+                    containerCore.ClientContext,
+                    containerCore,
+                    isGatewayQueryPlan);
+
+                ContainerCore containerWithForcedPlan = new ContainerCore(
+                    containerCore.ClientContext,
+                    (DatabaseCore)containerCore.Database,
+                    containerCore.Id,
+                    cosmosQueryClientCore);
+
+                int numOfQueries = 0;
+                foreach (int maxDegreeOfParallelism in new int[] { 1, 100 })
                 {
-                    QueryRequestOptions feedOptions = new QueryRequestOptions
+                    foreach (int maxItemCount in new int[] { 10, 100 })
                     {
-                        MaxBufferedItemCount = 7000,
-                        MaxConcurrency = maxDegreeOfParallelism,
-                        MaxItemCount = maxItemCount,
-                    };
+                        numOfQueries++;
+                        QueryRequestOptions feedOptions = new QueryRequestOptions
+                        {
+                            MaxBufferedItemCount = 7000,
+                            MaxConcurrency = maxDegreeOfParallelism,
+                            MaxItemCount = maxItemCount,
+                        };
 
-                    List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
-                        container,
-                        "SELECT * FROM c ORDER BY c._ts",
-                        maxDegreeOfParallelism,
-                        maxItemCount,
-                        feedOptions);
+                        List<JToken> queryResults = await CrossPartitionQueryTests.RunQuery<JToken>(
+                            containerWithForcedPlan,
+                            "SELECT * FROM c ORDER BY c._ts",
+                            maxDegreeOfParallelism,
+                            maxItemCount,
+                            feedOptions);
 
-                    Assert.AreEqual(documents.Count(), queryResults.Count);
+                        Assert.AreEqual(documents.Count(), queryResults.Count);
+                    }
+                }
+
+                if (isGatewayQueryPlan)
+                {
+                    Assert.IsTrue(cosmosQueryClientCore.QueryPlanCalls > numOfQueries);
+                }
+                else
+                {
+                    Assert.AreEqual(0, cosmosQueryClientCore.QueryPlanCalls, "ServiceInterop mode should not be calling gateway plan retriever");
                 }
             }
         }
@@ -4853,6 +4873,47 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.Age = age;
                 this.Pet = pet;
                 this.Guid = guid;
+            }
+        }
+
+        /// <summary>
+        /// A helper that forces the SDK to use the gateway or the service interop for the query plan
+        /// </summary>
+        private class MockCosmosQueryClient : CosmosQueryClientCore
+        {
+            /// <summary>
+            /// True it will use the gateway query plan.
+            /// False it will use the service interop
+            /// </summary>
+            private readonly bool forceQueryPlanGatewayElseServiceInterop;
+
+            public MockCosmosQueryClient(
+                CosmosClientContext clientContext,
+                ContainerCore cosmosContainerCore,
+                bool forceQueryPlanGatewayElseServiceInterop) : base(
+                    clientContext,
+                    cosmosContainerCore)
+            {
+                this.forceQueryPlanGatewayElseServiceInterop = forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            public int QueryPlanCalls { get; private set; }
+
+            internal override bool ByPassQueryParsing()
+            {
+                return this.forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(Uri resourceUri, ResourceType resourceType, OperationType operationType, SqlQuerySpec sqlQuerySpec, string supportedQueryFeatures, CancellationToken cancellationToken)
+            {
+                this.QueryPlanCalls++;
+                return base.ExecuteQueryPlanRequestAsync(resourceUri, resourceType, operationType, sqlQuerySpec, supportedQueryFeatures, cancellationToken);
+            }
+
+            internal override Task<QueryResponseCore> ExecuteItemQueryAsync<RequestOptionType>(Uri resourceUri, ResourceType resourceType, OperationType operationType, RequestOptionType requestOptions, SqlQuerySpec sqlQuerySpec, string continuationToken, PartitionKeyRangeIdentity partitionKeyRange, bool isContinuationExpected, int pageSize, CancellationToken cancellationToken)
+            {
+                Assert.IsFalse(this.forceQueryPlanGatewayElseServiceInterop && this.QueryPlanCalls == 0, "Query Plan is force gateway mode, but no ExecuteQueryPlanRequestAsync have been called");
+                return base.ExecuteItemQueryAsync(resourceUri, resourceType, operationType, requestOptions, sqlQuerySpec, continuationToken, partitionKeyRange, isContinuationExpected, pageSize, cancellationToken);
             }
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

There was a bug in the previous logic that was preventing the test from validating gateway mode. Also having a static variable caused conflicts since the test run async. Converted the test to use a local value to override, and added additional validation that the gateway is getting called when gateway mode is forced.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


