### PR TITLE
Fix azure-pipelines-official

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         }
 
         [TestMethod]
-        [TestCategory("Quarantine")]
         public async Task TestWithFixedLeaseContainer()
         {
             await NonPartitionedContainerHelper.CreateNonPartitionedContainer(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         }
 
         [TestMethod]
+        [TestCategory("Quarantine")]
         public async Task TestWithFixedLeaseContainer()
         {
             await NonPartitionedContainerHelper.CreateNonPartitionedContainer(

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -53,6 +53,7 @@ stages:
         inputs: 
           command: custom
           projects: 'Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj'
+          custom: pack
           arguments: '-v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"'
 
       - task: AzureFileCopy@2

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -40,112 +40,26 @@ stages:
           arguments: --configuration $(BuildConfiguration) /p:Optimize=true 
           versioningScheme: OFF
 
-#      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-#        displayName: 'ESRP CodeSigning - binaries'
-#        ConnectedServiceName: 'ESRP Code Signing 2019'
-#        FolderPath: Microsoft.Azure.Cosmos
-#        Pattern: Microsoft.Azure.Cosmos.Client.dll
-#        signConfigType: inlineSignParams
-#        inlineOperation: |
-#            [
-#                {
-#                    "keyCode": "CP-233863-SN",
-#                    "operationSetCode": "StrongNameSign",
-#                    "parameters": [],
-#                    "toolName": "sign",
-#                    "toolVersion": "1.0"
-#                },    {
-#                    "keyCode": "CP-230012",
-#                    "operationSetCode": "SigntoolSign",
-#                    "parameters": [
-#                    {
-#                        "parameterName": "OpusName",
-#                        "parameterValue": "Microsoft"
-#                    },
-#                    {
-#                        "parameterName": "OpusInfo",
-#                        "parameterValue": "http://www.microsoft.com"
-#                    },
-#                    {
-#                        "parameterName": "FileDigest",
-#                        "parameterValue": "/fd \"SHA256\""
-#                    },
-#                    {
-#                        "parameterName": "PageHash",
-#                        "parameterValue": "/NPH"
-#                    },
-#                    {
-#                        "parameterName": "TimeStamp",
-#                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-#                    }
-#                    ],
-#                    "toolName": "sign",
-#                    "toolVersion": "1.0"
-#                }, {
-#                    "keyCode": "CP-233863-SN",
-#                    "operationSetCode": "StrongNameVerify",
-#                    "parameters": [ ],
-#                    "toolName": "sign",
-#                    "toolVersion": "1.0"
-#                }, {
-#                    "keyCode": "CP-230012",
-#                    "operationSetCode": "SigntoolVerify",
-#                    "parameters": [{
-#                        "parameterName": "VerifyAll",
-#                        "parameterValue": "/all"
-#                    }],
-#                    "toolName": "sign",
-#                    "toolVersion": "1.0"
-#                }
-#            ]
-#        SessionTimeout: 20
-#
-#      - task: DotNetCoreCLI@2
-#        displayName: Pack Microsoft.Azure.Cosmos
-#        inputs: 
-#          command: pack 
-#          configuration: $(BuildConfiguration)
-#          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-#          arguments: -v detailed -c $(BuildConfiguration) --no-build --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
-#          versioningScheme: OFF
-#
-#      - task: DotNetCoreCLI@2
-#        displayName: Pack Microsoft.Azure.Cosmos Symbols
-#        inputs: 
-#          command: pack 
-#          configuration: $(BuildConfiguration)
-#          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-#          arguments: -v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
-#          versioningScheme: OFF
-#
-#       - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-#         displayName: 'ESRP CodeSigning - nuget'
-#         inputs:
-#         ConnectedServiceName: 'ESRP Code Signing 2019'
-#         FolderPath: $(Build.ArtifactStagingDirectory)\bin
-#         Pattern: 'Microsoft.Azure.Cosmos*.nupkg'
-#         signConfigType: inlineSignParams
-#         inlineOperation: |
-#             [ 
-#                 {
-#                     "keyCode": "CP-401405",
-#                     "operationSetCode": "NuGetSign",
-#                     "parameters": [ ],
-#                     "toolName": "sign",
-#                     "toolVersion": "1.0"
-#                 },
-#                 {
-#                     "keyCode": "CP-401405",
-#                     "operationSetCode": "NuGetVerify",
-#                     "parameters": [ ],
-#                     "toolName": "sign",
-#                     "toolVersion": "1.0"
-#                 }
-#             ]
-#          SessionTimeout: 20
-#
-#      - task: PublishBuildArtifacts@1
-#        displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
-#        inputs:
-#          artifactName: Microsoft.Azure.Cosmos
+      - task: DotNetCoreCLI@2
+        displayName: Pack Microsoft.Azure.Cosmos
+        inputs: 
+          command: pack 
+          configuration: $(BuildConfiguration)
+          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+          arguments: -v detailed -c $(BuildConfiguration) --no-build --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
+          versioningScheme: OFF
+
+      - task: DotNetCoreCLI@2
+        displayName: Pack Microsoft.Azure.Cosmos Symbols
+        inputs: 
+          command: pack 
+          configuration: $(BuildConfiguration)
+          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+          arguments: -v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
+          versioningScheme: OFF
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
+        inputs:
+          artifactName: Microsoft.Azure.Cosmos
 #

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -41,22 +41,19 @@ stages:
           versioningScheme: OFF
 
       - task: DotNetCoreCLI@2
-        displayName: Pack Microsoft.Azure.Cosmos
-        inputs: 
-          command: pack 
-          configuration: $(BuildConfiguration)
-          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-          arguments: -v detailed -c $(BuildConfiguration) --no-build --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
-          versioningScheme: OFF
+        displayName: 'Create SDK NuGet Package'
+        inputs:
+          command: custom
+          projects: 'Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj'
+          custom: pack
+          arguments: '-v detailed -c $(BuildConfiguration) --no-build --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"'
 
       - task: DotNetCoreCLI@2
-        displayName: Pack Microsoft.Azure.Cosmos Symbols
+        displayName: 'Create SDK NuGet Symbols Package'
         inputs: 
-          command: pack 
-          configuration: $(BuildConfiguration)
-          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-          arguments: -v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
-          versioningScheme: OFF
+          command: custom
+          projects: 'Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj'
+          arguments: '-v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"'
 
       - task: AzureFileCopy@2
         displayName: ' Copy Artifacts to Azure SDK Release blob storage'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -61,12 +61,12 @@ stages:
       - task: AzureFileCopy@2
         displayName: ' Copy Artifacts to Azure SDK Release blob storage'
         inputs:
-        SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        azureSubscription: azuresdkpartnerdrops
-        Destination: AzureBlob
-        storage: azuresdkpartnerdrops
-        ContainerName: 'https://azuresdkpartnerdrops.blob.core.windows.net/drops'
-        BlobPrefix: 'cosmosdb/cshar/$(Version)'
+          SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
+          azureSubscription: azuresdkpartnerdrops
+          Destination: AzureBlob
+          storage: azuresdkpartnerdrops
+          ContainerName: 'https://azuresdkpartnerdrops.blob.core.windows.net/drops'
+          BlobPrefix: 'cosmosdb/cshar/$(Version)'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -58,6 +58,16 @@ stages:
           arguments: -v detailed -c $(BuildConfiguration) --no-build --include-symbols /p:SymbolPackageFormat=snupkg --no-restore -o "$(Build.ArtifactStagingDirectory)\bin\AnyCPU\$(BuildConfiguration)\Microsoft.Azure.Cosmos"
           versioningScheme: OFF
 
+      - task: AzureFileCopy@2
+        displayName: ' Copy Artifacts to Azure SDK Release blob storage'
+        inputs:
+        SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
+        azureSubscription: azuresdkpartnerdrops
+        Destination: AzureBlob
+        storage: azuresdkpartnerdrops
+        ContainerName: 'https://azuresdkpartnerdrops.blob.core.windows.net/drops'
+        BlobPrefix: 'cosmosdb/cshar/$(Version)'
+
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
         inputs:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -65,8 +65,8 @@ stages:
           azureSubscription: azuresdkpartnerdrops
           Destination: AzureBlob
           storage: azuresdkpartnerdrops
-          ContainerName: 'https://azuresdkpartnerdrops.blob.core.windows.net/drops'
-          BlobPrefix: 'cosmosdb/cshar/$(Version)'
+          ContainerName: 'drops'
+          BlobPrefix: 'cosmosdb/csharp/$(Version)'
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'


### PR DESCRIPTION
Removing ESRP signing and going to use the partner release pipeline to do signing and publishing package to nuget.org. The partner release pipeline step will be separate from this pipeline. 