### PR TITLE
Reduce request timeout to 10s from 60s

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class ConnectionPolicy
     {
         internal UserAgentContainer UserAgentContainer;
-        private const int defaultRequestTimeout = 60;
+        private const int defaultRequestTimeout = 10;
         // defaultMediaRequestTimeout is based upon the blob client timeout and the retry policy.
         private const int defaultMediaRequestTimeout = 300;
         private const int defaultMaxConcurrentFanoutRequests = 32;
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets or sets the request timeout in seconds when connecting to the Azure Cosmos DB service.
         /// The number specifies the time to wait for response to come back from network peer.
         /// </summary>
-        /// <value>Default value is 60 seconds.</value>
+        /// <value>Default value is 10 seconds.</value>
         public TimeSpan RequestTimeout
         {
             get;

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#846](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/846) Statistics not getting populated correctly on CosmosException.
 - [#857](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/857) Fixed reusability of the Bulk support across Container instances
 - [#860](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/860) Fixed base user agent string
+- [#876](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/876) Default connection timeout reduced from 60s to 10s
 
 ## <a name="3.2.0"/> [3.2.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.2.0) - 2019-09-17
 


### PR DESCRIPTION
This value is used to denote the maximum timeout per network request, rather than the overall request. Cosmos SDK's availability resiliency is heavily reliant on failure detection and retries, both within a partition as well as between regions. However, this requires us to not wait indefinitely (which, honestly, 60 seconds is) for a response from the server, and timeout such network calls and let our retry logic kick in.

Hence.. this change decreases the timeout from 60s to 10s.