### PR TITLE
Refactored AsyncCollection

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncConcurrentQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncConcurrentQueue.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.Collections.Generic
 {
+    using System;
     using System.Collections.Concurrent;
 
     internal sealed class AsyncConcurrentQueue<T> : AsyncCollectionBase<T>
@@ -26,8 +27,13 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         }
 
         public AsyncConcurrentQueue(ConcurrentQueue<T> initialCollection, int boundingCapacity)
-            : base(initialCollection.Count, boundingCapacity)
+            : base(initialCollection?.Count ?? 0, boundingCapacity)
         {
+            if (initialCollection == null)
+            {
+                throw new ArgumentNullException("initialCollection");
+            }
+
             this.concurrentQueue = initialCollection;
             base.collection = this.concurrentQueue;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncConcurrentQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncConcurrentQueue.cs
@@ -1,0 +1,40 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Collections.Generic
+{
+    using System.Collections.Concurrent;
+
+    internal sealed class AsyncConcurrentQueue<T> : AsyncCollectionBase<T>
+    {
+        private readonly ConcurrentQueue<T> concurrentQueue;
+
+        public AsyncConcurrentQueue()
+           : this(new ConcurrentQueue<T>(), int.MaxValue)
+        {
+        }
+
+        public AsyncConcurrentQueue(int boundingCapacity)
+            : this(new ConcurrentQueue<T>(), boundingCapacity)
+        {
+        }
+
+        public AsyncConcurrentQueue(ConcurrentQueue<T> initialCollection)
+          : this(initialCollection, int.MaxValue)
+        {
+        }
+
+        public AsyncConcurrentQueue(ConcurrentQueue<T> initialCollection, int boundingCapacity)
+            : base(initialCollection.Count, boundingCapacity)
+        {
+            this.concurrentQueue = initialCollection;
+            base.collection = this.concurrentQueue;
+        }
+
+        public override bool TryPeek(out T item)
+        {
+            return this.concurrentQueue.TryPeek(out item);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncPriorityQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncPriorityQueue.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.Azure.Cosmos.Collections.Generic
 {
+    using System;
+
     internal sealed class AsyncPriorityQueue<T> : AsyncCollectionBase<T>
     {
         private readonly PriorityQueue<T> priorityQueue;
@@ -24,8 +26,13 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         }
 
         public AsyncPriorityQueue(PriorityQueue<T> initialCollection, int boundingCapacity)
-            : base(initialCollection.Count, boundingCapacity)
+            : base(initialCollection?.Count ?? 0, boundingCapacity)
         {
+            if (initialCollection == null)
+            {
+                throw new ArgumentNullException("initialCollection");
+            }
+
             this.priorityQueue = initialCollection;
             base.collection = this.priorityQueue;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncPriorityQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Collections/AsyncPriorityQueue.cs
@@ -1,0 +1,38 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Collections.Generic
+{
+    internal sealed class AsyncPriorityQueue<T> : AsyncCollectionBase<T>
+    {
+        private readonly PriorityQueue<T> priorityQueue;
+
+        public AsyncPriorityQueue()
+           : this(new PriorityQueue<T>(), int.MaxValue)
+        {
+        }
+
+        public AsyncPriorityQueue(int boundingCapacity)
+            : this(new PriorityQueue<T>(), boundingCapacity)
+        {
+        }
+
+        public AsyncPriorityQueue(PriorityQueue<T> initialCollection)
+          : this(initialCollection, int.MaxValue)
+        {
+        }
+
+        public AsyncPriorityQueue(PriorityQueue<T> initialCollection, int boundingCapacity)
+            : base(initialCollection.Count, boundingCapacity)
+        {
+            this.priorityQueue = initialCollection;
+            base.collection = this.priorityQueue;
+        }
+
+        public override bool TryPeek(out T item)
+        {
+            return this.priorityQueue.TryPeek(out item);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ComparableTask/ComparableTaskScheduler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ComparableTask/ComparableTaskScheduler.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class ComparableTaskScheduler : IDisposable
     {
         private const int MinimumBatchSize = 1;
-        private readonly AsyncCollection<IComparableTask> taskQueue;
+        private readonly AsyncPriorityQueue<IComparableTask> taskQueue;
         private readonly ConcurrentDictionary<IComparableTask, Task> delayedTasks;
         private readonly CancellationTokenSource tokenSource;
         private readonly SemaphoreSlim canRunTaskSemaphoreSlim;
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos
 
         public ComparableTaskScheduler(IEnumerable<IComparableTask> tasks, int maximumConcurrencyLevel)
         {
-            this.taskQueue = new AsyncCollection<IComparableTask>(new PriorityQueue<IComparableTask>(tasks, true));
+            this.taskQueue = new AsyncPriorityQueue<IComparableTask>(new PriorityQueue<IComparableTask>(tasks, true));
             this.delayedTasks = new ConcurrentDictionary<IComparableTask, Task>();
             this.maximumConcurrencyLevel = maximumConcurrencyLevel;
             this.tokenSource = new CancellationTokenSource();

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ItemProducerTree/ItemProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ItemProducerTree/ItemProducer.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// We buffer TryMonad of DoucmentFeedResponse of T, since we want to buffer exceptions,
         /// so that the exception is thrown on the consumer thread (instead of the background producer thread), thus observing the exception.
         /// </summary>
-        private readonly AsyncCollection<QueryResponseCore> bufferedPages;
+        private readonly AsyncConcurrentQueue<QueryResponseCore> bufferedPages;
 
         /// <summary>
         /// The document producer can only be fetching one page at a time.
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Query
             long initialPageSize = 50,
             string initialContinuationToken = null)
         {
-            this.bufferedPages = new AsyncCollection<QueryResponseCore>();
+            this.bufferedPages = new AsyncConcurrentQueue<QueryResponseCore>();
 
             // We use a binary semaphore to get the behavior of a mutex,
             // since fetching documents from the backend using a continuation token is a critical section.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Collections/Concurrent/AsyncCollectionTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Collections/Concurrent/AsyncCollectionTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         {
             var queue = new ConcurrentQueue<int>();
             queue.Enqueue(0);
-            var asyncCollection = new AsyncCollection<int>(queue, 1);
+            var asyncCollection = new AsyncConcurrentQueue<int>(queue, 1);
             int item = 1;
             Task task = asyncCollection.AddAsync(item);
             await Task.Delay(DelayInMilliSeconds);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         [TestMethod]
         public async Task TestAddRangeAsync()
         {
-            var asyncCollection = new AsyncCollection<int>(2);
+            var asyncCollection = new AsyncConcurrentQueue<int>(2);
             Task task = asyncCollection.AddRangeAsync(new[] { 0, 1, 2 });
             await Task.Delay(DelayInMilliSeconds);
             Assert.AreEqual(false, task.IsCompleted);
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         [TestMethod]
         public async Task TestTakeAsync()
         {
-            var asyncCollection = new AsyncCollection<int>();
+            var asyncCollection = new AsyncConcurrentQueue<int>();
             Task<int> task = asyncCollection.TakeAsync();
             await Task.Delay(DelayInMilliSeconds);
             Assert.AreEqual(false, task.IsCompleted);
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         [TestMethod]
         public async Task TestPeekAsync()
         {
-            var asyncCollection = new AsyncCollection<int>();
+            var asyncCollection = new AsyncConcurrentQueue<int>();
             Task<int> task = asyncCollection.PeekAsync();
             await Task.Delay(DelayInMilliSeconds);
             Assert.AreEqual(false, task.IsCompleted);
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
         public async Task SimpleTest()
         {
             int size = 100;
-            var asyncCollection = new AsyncCollection<int>();
+            var asyncCollection = new AsyncConcurrentQueue<int>();
             Assert.AreEqual(0, asyncCollection.Count);
             List<int> list = new List<int>();
             for (int i = 0; i < size; ++i)
@@ -130,69 +130,6 @@ namespace Microsoft.Azure.Cosmos.Collections.Generic
                             string.Join(",", await asyncCollection.DrainAsync()));
                     }
                 }
-            }
-        }
-
-        /// <summary>
-        /// Test for AsyncCollection.PeekAsync NotImplementedException
-        /// </summary>
-        [TestMethod]
-        [ExpectedException(typeof(NotImplementedException))]
-        public async Task TestNotImplmenetedPeekAsync()
-        {
-            await new AsyncCollection<int>(new TestProducerConsumerCollection<int>()).PeekAsync();
-        }
-
-        private class TestProducerConsumerCollection<T> : IProducerConsumerCollection<T>
-        {
-            public void CopyTo(T[] array, int index)
-            {
-                throw new NotImplementedException();
-            }
-
-            public T[] ToArray()
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool TryAdd(T item)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool TryTake(out T item)
-            {
-                throw new NotImplementedException();
-            }
-
-            public IEnumerator<T> GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
-
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-            {
-                throw new NotImplementedException();
-            }
-
-            public void CopyTo(Array array, int index)
-            {
-                throw new NotImplementedException();
-            }
-
-            public int Count
-            {
-                get { throw new NotImplementedException(); }
-            }
-
-            public bool IsSynchronized
-            {
-                get { throw new NotImplementedException(); }
-            }
-
-            public object SyncRoot
-            {
-                get { throw new NotImplementedException(); }
             }
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Refactored AsyncCollection to remove the need for the TryPeek Delegate. Created separate Async implementations for ConcurrentCollection and PriorityQueue to make it more clear what your AsyncCollection is backed by and eliminate the need for type casting and TryPeek delegates.

## Type of change

Refactoring. No impact to outside callers.

## Closing issues

Closes #836 

