### PR TITLE
Fixed invalid user agent format exception for Mac OS.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -4,11 +4,8 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
-    using System.Runtime.Versioning;
-    using System.Text.RegularExpressions;
 
     internal sealed class EnvironmentInformation
     {

--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal sealed class EnvironmentInformation
     {
-        private const int MaxOperatingSystemString = 50;
         private static readonly string clientSDKVersion;
         private static readonly string directPackageVersion;
         private static readonly string framework;

--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override string ToString()
         {
-            return $"{this.OperatingSystem}/{this.ProcessArchitecture} {this.ClientVersion}/{this.DirectVersion}-{this.RuntimeFramework} {this.ClientId}";
+            return $"{this.OperatingSystem}|{this.ProcessArchitecture} {this.ClientVersion}|{this.DirectVersion}|{this.RuntimeFramework} {this.ClientId}|";
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -4,12 +4,15 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
+    using System.Runtime.Versioning;
+    using System.Text.RegularExpressions;
 
     internal sealed class EnvironmentInformation
     {
-        private static readonly string clientId;
+        private const int MaxOperatingSystemString = 50;
         private static readonly string clientSDKVersion;
         private static readonly string directPackageVersion;
         private static readonly string framework;
@@ -25,14 +28,18 @@ namespace Microsoft.Azure.Cosmos
             EnvironmentInformation.framework = RuntimeInformation.FrameworkDescription;
             EnvironmentInformation.architecture = RuntimeInformation.ProcessArchitecture.ToString();
             EnvironmentInformation.os = RuntimeInformation.OSDescription;
+        }
+
+        public EnvironmentInformation()
+        {
             string now = DateTime.UtcNow.Ticks.ToString();
-            EnvironmentInformation.clientId = now.Substring(now.Length - 5); // 5 most significative digits
+            this.ClientId = now.Substring(now.Length - 5); // 5 most significative digits
         }
 
         /// <summary>
         /// Unique identifier of a client
         /// </summary>
-        public string ClientId => EnvironmentInformation.clientId;
+        public string ClientId { get; }
 
         /// <summary>
         /// Version of the current direct package.
@@ -61,10 +68,5 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <seealso cref="RuntimeInformation.ProcessArchitecture"/>
         public string ProcessArchitecture => EnvironmentInformation.architecture;
-
-        public override string ToString()
-        {
-            return $"{this.OperatingSystem}|{this.ProcessArchitecture} {this.ClientVersion}|{this.DirectVersion}|{this.RuntimeFramework} {this.ClientId}|";
-        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -1,24 +1,17 @@
 ﻿// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
-
 namespace Microsoft.Azure.Cosmos
 {
+    using System.Text.RegularExpressions;
+
     /// <summary>
     /// Contains information about the user environment and helps identify requests.
     /// </summary>
     internal class UserAgentContainer : Documents.UserAgentContainer
     {
-        private static readonly string cosmosBaseUserAgent;
-
-        static UserAgentContainer()
-        {
-            EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            string infoString = environmentInformation.ToString();
-
-            // Two Backslashes in the same string without a space will cause the HTTP to throw a format exception 
-            UserAgentContainer.cosmosBaseUserAgent = infoString.Replace("/", "-");
-        }
+        private const int MaxOperatingSystemString = 30;
+        private string cosmosBaseUserAgent;
 
         public UserAgentContainer()
             : base()
@@ -29,8 +22,26 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return UserAgentContainer.cosmosBaseUserAgent;
+                if (this.cosmosBaseUserAgent == null)
+                {
+                    this.cosmosBaseUserAgent = this.CreateBaseUserAgentString();
+                }
+
+                return this.cosmosBaseUserAgent;
             }
+        }
+
+        private string CreateBaseUserAgentString()
+        {
+            EnvironmentInformation environmentInformation = new EnvironmentInformation();
+            string operatingSystem = environmentInformation.OperatingSystem;
+            if (operatingSystem.Length > MaxOperatingSystemString)
+            {
+                operatingSystem = operatingSystem.Substring(0, MaxOperatingSystemString);
+            }
+
+            // Regex replaces all special characters with empty space except . - | since they do not cause format exception for the user agent string.
+            return Regex.Replace($"cosmos-net|{environmentInformation.ClientVersion}|{environmentInformation.DirectVersion}|{environmentInformation.ClientId}|{environmentInformation.ProcessArchitecture}|{operatingSystem}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos
 
             // Regex replaces all special characters with empty space except . - | since they do not cause format exception for the user agent string.
             // Do not change the cosmos-netstandard-sdk as it is required for reporting
-            return $"cosmos-netstandard-sdk/{environmentInformation.ClientVersion} " + Regex.Replace($"|{environmentInformation.DirectVersion}|{environmentInformation.ClientId}|{environmentInformation.ProcessArchitecture}|{operatingSystem}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
+            return $"cosmos-netstandard-sdk/{environmentInformation.ClientVersion}" + Regex.Replace($"|{environmentInformation.DirectVersion}|{environmentInformation.ClientId}|{environmentInformation.ProcessArchitecture}|{operatingSystem}|{environmentInformation.RuntimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -41,7 +41,8 @@ namespace Microsoft.Azure.Cosmos
             }
 
             // Regex replaces all special characters with empty space except . - | since they do not cause format exception for the user agent string.
-            return Regex.Replace($"cosmos-net|{environmentInformation.ClientVersion}|{environmentInformation.DirectVersion}|{environmentInformation.ClientId}|{environmentInformation.ProcessArchitecture}|{operatingSystem}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
+            // Do not change the cosmos-netstandard-sdk as it is required for reporting
+            return $"cosmos-netstandard-sdk/{environmentInformation.ClientVersion} " + Regex.Replace($"|{environmentInformation.DirectVersion}|{environmentInformation.ClientId}|{environmentInformation.ProcessArchitecture}|{operatingSystem}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -14,7 +14,10 @@ namespace Microsoft.Azure.Cosmos
         static UserAgentContainer()
         {
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            UserAgentContainer.cosmosBaseUserAgent = environmentInformation.ToString();
+            string infoString = environmentInformation.ToString();
+
+            // Two Backslashes in the same string without a space will cause the HTTP to throw a format exception 
+            UserAgentContainer.cosmosBaseUserAgent = infoString.Replace("/", "-");
         }
 
         public UserAgentContainer()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -1,0 +1,88 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Reflection;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Collections;
+    using Microsoft.Azure.Documents.Routing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class UserAgentTests
+    {
+        [TestMethod]
+        public void ValidateCustomUserAgentHeader()
+        {
+            const string suffix = " MyCustomUserAgent/1.0";
+            ConnectionPolicy policy = new ConnectionPolicy();
+            policy.UserAgentSuffix = suffix;
+            Assert.IsTrue(policy.UserAgentContainer.UserAgent.EndsWith(suffix));
+
+            byte[] expectedUserAgentUTF8 = Encoding.UTF8.GetBytes(policy.UserAgentContainer.UserAgent);
+            CollectionAssert.AreEqual(expectedUserAgentUTF8, policy.UserAgentContainer.UserAgentUTF8);
+        }
+
+        [TestMethod]
+        public void ValidateUniqueClientIdHeader()
+        {
+            using (CosmosClient client = TestCommon.CreateCosmosClient())
+            {
+                string firstClientId = this.GetClientIdFromCosmosClient(client);
+
+                using (CosmosClient innerClient = TestCommon.CreateCosmosClient())
+                {
+                    string secondClientId = this.GetClientIdFromCosmosClient(innerClient);
+                    Assert.AreNotEqual(firstClientId, secondClientId);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task ValidateUserAgentHeaderWithCustomOs()
+        {
+            //This changes the runtime information to simulate a max os x response
+            const string invalidOsField = "Darwin 18.0.0: Darwin/Kernel/Version 18.0.0: Wed Aug 22 20:13:40 PDT 2018; root:xnu-4903.201.2~1/RELEASE_X86_64";
+            FieldInfo fieldInfo = typeof(RuntimeInformation).GetField("s_osDescription", BindingFlags.Static | BindingFlags.NonPublic);
+            fieldInfo.SetValue(null, invalidOsField);
+            string updatedRuntime = RuntimeInformation.OSDescription;
+            Assert.AreEqual(invalidOsField, updatedRuntime);
+
+            const string suffix = " MyCustomUserAgent/1.0";
+
+            using (CosmosClient client = TestCommon.CreateCosmosClient(builder => builder.WithApplicationName(suffix)))
+            {
+                Cosmos.UserAgentContainer userAgentContainer = client.ClientOptions.GetConnectionPolicy().UserAgentContainer;
+
+                string userAgentString = userAgentContainer.UserAgent;
+                Assert.IsTrue(userAgentString.Contains(suffix));
+                Assert.IsTrue(userAgentString.Contains("Darwin 18.0.0"));
+                Cosmos.Database db = await client.CreateDatabaseIfNotExistsAsync(Guid.NewGuid().ToString());
+                Assert.IsNotNull(db);
+                await db.DeleteAsync();
+            }
+        }
+
+        private string GetClientIdFromCosmosClient(CosmosClient client)
+        {
+            Cosmos.UserAgentContainer userAgentContainer = client.ClientOptions.GetConnectionPolicy().UserAgentContainer;
+            string userAgentString = userAgentContainer.UserAgent;
+            string clientId = userAgentString.Split('|')[3];
+            Assert.AreEqual(5, clientId.Length);
+            return clientId;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void UserAgentContainsEnvironmentInformation()
         {
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            string expectedValue = "cosmos-net|" + environmentInformation.ClientVersion;
+            string expectedValue = "cosmos-netstandard-sdk/" + environmentInformation.ClientVersion;
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void UserAgentContainsEnvironmentInformation()
         {
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
-            string expectedValue = environmentInformation.ToString();
+            string expectedValue = "cosmos-net|" + environmentInformation.ClientVersion;
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/EnvironmentInformationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/EnvironmentInformationTests.cs
@@ -41,16 +41,5 @@ namespace Microsoft.Azure.Cosmos.Tests
             var envInfo = new EnvironmentInformation();
             Assert.IsNotNull(envInfo.ClientId);
         }
-
-        [TestMethod]
-        public void ToStringContainsAll()
-        {
-            var envInfo = new EnvironmentInformation();
-            var serialization = envInfo.ToString();
-            Assert.IsTrue(serialization.Contains(envInfo.ClientVersion));
-            Assert.IsTrue(serialization.Contains(envInfo.ProcessArchitecture));
-            Assert.IsTrue(serialization.Contains(envInfo.RuntimeFramework));
-            Assert.IsTrue(serialization.Contains(envInfo.ClientId));
-        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

The http headers only allow certain formats. The Mac OS creates a operating system string that causes the validation to fail. The / are converted | so it does not hit the same issue. 
 
Examples:
`cosmos-netstandard-sdk/3.3.0|3.3.0|60526|X64|Darwin 18.0.0 Darwin Kernel V|.NET Core 4.6.28008.01| UserApplicationName/1.0`

`cosmos-netstandard-sdk/3.3.0|3.3.0|28400|X64|Microsoft Windows 10.0.18362 |.NET Core 4.6.28008.01| UserApplicationName/1.0`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put fixes #891

