### PR TITLE
TryGetState

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/AggregateDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/AggregateDocumentQueryExecutionComponent.cs
@@ -153,6 +153,12 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                 responseLengthBytes: responseLengthBytes);
         }
 
+        public override bool TryGetState(out string state)
+        {
+            state = null;
+            return false;
+        }
+
         /// <summary>
         /// Struct for getting the payload out of the rewritten projection.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.cs
@@ -149,6 +149,12 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
                 responseLengthBytes: cosmosQueryResponse.ResponseLengthBytes);
         }
 
+        public override bool TryGetState(out string state)
+        {
+            state = null;
+            return false;
+        }
+
         /// <summary>
         /// Efficiently casts a object to a JToken.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DocumentQueryExecutionComponentBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DocumentQueryExecutionComponentBase.cs
@@ -80,5 +80,7 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
         {
             return this.Source.GetQueryMetrics();
         }
+
+        public abstract bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
@@ -178,6 +178,12 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
             return response;
         }
 
+        public override bool TryGetState(out string state)
+        {
+            state = default(string);
+            return false;
+        }
+
         /// <summary>
         /// When a group by query gets rewritten the projection looks like:
         /// 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/IDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/IDocumentQueryExecutionComponent.cs
@@ -37,5 +37,7 @@ namespace Microsoft.Azure.Cosmos.Query.ExecutionComponent
         /// </summary>
         /// <returns>The QueryMetrics from this component.</returns>
         IReadOnlyDictionary<string, QueryMetrics> GetQueryMetrics();
+
+        bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
@@ -680,26 +680,10 @@ namespace Microsoft.Azure.Cosmos.Query
             }
         }
 
-        /// <summary>
-        /// Gets the formatting for a trace.
-        /// </summary>
-        /// <param name="message">The message to format</param>
-        /// <returns>The formatted message ready for a trace.</returns>
-        private string GetTrace(string message)
+        public bool TryGetState(out string state)
         {
-            const string TracePrefixFormat = "{0}, CorrelatedActivityId: {1}, ActivityId: {2} | {3}";
-            return string.Format(
-                CultureInfo.InvariantCulture,
-                TracePrefixFormat,
-                DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture),
-                this.queryContext.CorrelatedActivityId,
-                this.itemProducerForest.Count != 0 ? this.CurrentItemProducerTree().ActivityId : Guid.Empty,
-                message);
-        }
-
-        private static bool IsMaxBufferedItemCountSet(int maxBufferedItemCount)
-        {
-            return maxBufferedItemCount != default(int);
+            state = this.ContinuationToken;
+            return true;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContext.cs
@@ -29,5 +29,7 @@ namespace Microsoft.Azure.Cosmos.Query
         /// <param name="token">The cancellation token.</param>
         /// <returns>A task to await on, which in return provides a DoucmentFeedResponse of documents.</returns>
         public abstract Task<QueryResponseCore> ExecuteNextAsync(CancellationToken token);
+
+        public abstract bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -142,6 +142,11 @@ namespace Microsoft.Azure.Cosmos.Query
             }
         }
 
+        public override bool TryGetState(out string state)
+        {
+            return this.innerExecutionContext.TryGetState(out state);
+        }
+
         private async Task<CosmosQueryExecutionContext> CreateItemQueryExecutionContextAsync(
             CancellationToken cancellationToken)
         {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
@@ -123,6 +123,11 @@ namespace Microsoft.Azure.Cosmos.Query
             }
         }
 
+        public override bool TryGetState(out string state)
+        {
+            return this.component.TryGetState(out state);
+        }
+
         /// <summary>
         /// Creates a CosmosPipelinedItemQueryExecutionContext.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryContext.cs
@@ -70,5 +70,7 @@ namespace Microsoft.Azure.Cosmos.Query
             bool isContinuationExpected,
             int pageSize,
             CancellationToken cancellationToken);
+
+        internal abstract bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
@@ -63,5 +63,11 @@ namespace Microsoft.Azure.Cosmos.Query
                            pageSize: pageSize,
                            cancellationToken: cancellationToken);
         }
+
+        internal override bool TryGetState(out string state)
+        {
+            state = null;
+            return true;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIterator.cs
@@ -23,5 +23,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A query response from cosmos service</returns>
         public abstract Task<ResponseMessage> ReadNextAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        internal abstract bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
@@ -100,6 +100,12 @@ namespace Microsoft.Azure.Cosmos
             return response;
         }
 
+        internal override bool TryGetState(out string state)
+        {
+            state = this.continuationToken;
+            return true;
+        }
+
         internal static string GetContinuationToken(ResponseMessage httpResponseMessage)
         {
             return httpResponseMessage.Headers.ContinuationToken;
@@ -144,6 +150,11 @@ namespace Microsoft.Azure.Cosmos
 
             ResponseMessage response = await this.feedIterator.ReadNextAsync(cancellationToken);
             return this.responseCreator(response);
+        }
+
+        internal override bool TryGetState(out string state)
+        {
+            return this.feedIterator.TryGetState(out state);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorOfT.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorOfT.cs
@@ -25,5 +25,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A query response from cosmos service</returns>
         public abstract Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        internal abstract bool TryGetState(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -130,5 +130,10 @@ namespace Microsoft.Azure.Cosmos.Query
 
             return response;
         }
+
+        internal override bool TryGetState(out string state)
+        {
+            return this.cosmosQueryExecutionContext.TryGetState(out state);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return ProcessResourceOperationStreamAsync(
+            return this.ProcessResourceOperationStreamAsync(
                 streamPayload: streamPayload,
                 operationType: operationType,
                 linkUri: this.LinkUri,

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -75,6 +75,12 @@ namespace Microsoft.Azure.Cosmos
                 }, cancellationToken);
         }
 
+        internal override bool TryGetState(out string state)
+        {
+            state = this.continuationToken;
+            return true;
+        }
+
         private Task<ResponseMessage> NextResultSetDelegateAsync(
             string continuationToken,
             string partitionKeyRangeId,

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -90,6 +90,12 @@ namespace Microsoft.Azure.Cosmos
             return response;
         }
 
+        internal override bool TryGetState(out string state)
+        {
+            state = this.continuationToken;
+            return true;
+        }
+
         internal async Task<Tuple<string, ResponseMessage>> ReadNextInternalAsync(CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
# TryGetState

## Description

FeedReponse.ContinuationToken is an inherently inefficient API. Returning a continuation token for every page is very expensive and unneeded. Instead we eventually want our users to call `FeedIterator.TryGetState(out string state)` that way they can serialize state only when they are ready to preempt feed iteration. For queries like GROUP BY where we currently can not serialize the state we can just return false. In the future we can wire up options like "state length limit" to configure when `TryGetState` will return true.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
