### PR TITLE
Fixed LINQ with camel case.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -86,8 +86,8 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <returns>The corresponding SQL query.</returns>
         public static SqlQuery TranslateQuery(
             Expression inputExpression,
-            IDictionary<object, string> parameters = null,
-            CosmosSerializationOptions serializationOptions = null)
+            IDictionary<object, string> parameters,
+            CosmosSerializationOptions serializationOptions)
         {
             TranslationContext context = new TranslationContext(serializationOptions, parameters);
             ExpressionToSql.Translate(inputExpression, context); // ignore result here

--- a/Microsoft.Azure.Cosmos/src/Linq/SQLTranslator.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/SQLTranslator.cs
@@ -42,11 +42,11 @@ namespace Microsoft.Azure.Cosmos.Linq
 
         internal static SqlQuerySpec TranslateQuery(
             Expression inputExpression,
-            CosmosSerializationOptions serializationOptions = null,
-            IDictionary<object, string> parameters = null)
+            CosmosSerializationOptions serializationOptions,
+            IDictionary<object, string> parameters)
         {
             inputExpression = ConstantEvaluator.PartialEval(inputExpression);
-            SqlQuery query = ExpressionToSql.TranslateQuery(inputExpression, parameters);
+            SqlQuery query = ExpressionToSql.TranslateQuery(inputExpression, parameters, serializationOptions);
             string queryText = null;
             SqlParameterCollection sqlParameters = new SqlParameterCollection();
             if (parameters != null && parameters.Count > 0)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -404,6 +404,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [DataRow(false)]
         [DataRow(true)]
+        [TestMethod]
         public async Task ItemLINQWithCamelCaseSerializerOptions(bool isGatewayMode)
         {
             Action<CosmosClientBuilder> builder = action =>
@@ -411,8 +412,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 action.WithSerializerOptions(new CosmosSerializationOptions()
                 {
                     PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
-                }
-                    );
+                });
                 if (isGatewayMode)
                 {
                     action.WithConnectionModeGateway();

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [#905](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/909) Fixed linq camel case bug
+
 ## <a name="3.3.1"/> [3.3.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.3.1) - 2019-10-11
 
 ### Fixed


### PR DESCRIPTION
# Pull Request Template

## Description

Camel case with LINQ was not being tested because of a missing tag in the test. LINQ was not honoring camel case because the serialization settings did not get passed to the inner method. I removed all the default nulls to avoid the missing parameter in the future.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

fixes #905