### PR TITLE
Prerequisites for mono repo emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     /// Tests for CrossPartitionQueryTests.
     /// </summary>
     [TestClass]
+    [TestCategory("Query")]
     public class CrossPartitionQueryTests
     {
         private static readonly string[] NoDocuments = new string[] { };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -8,6 +8,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
     <AssemblyName>Microsoft.Azure.Cosmos.EmulatorTests</AssemblyName>
+    <IsEmulatorTest>true</IsEmulatorTest>
+    <EmulatorFlavor>master</EmulatorFlavor>
+    <DisableCopyEmulator>True</DisableCopyEmulator>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Microsoft.Azure.Documents.Routing;
 
     [TestClass]
+    [TestCategory("Query")]
     public class QueryTests
     {
         private DocumentClient client;


### PR DESCRIPTION
Add test category for query tests so test can be split to adhere to 30min max test duration.
Add properties needed to run emulator in cloud test.