### PR TITLE
Stand By Feed iterator cleanup

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -16,9 +16,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal class ChangeFeedResultSetIteratorCore : FeedIterator
     {
-        private const int DefaultMaxItemCount = 100;
-        private const string PageSizeErrorOnChangeFeedText = "Reduce page size and try again.";
-
         internal StandByFeedContinuationToken compositeContinuationToken;
 
         private readonly CosmosClientContext clientContext;

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -122,6 +122,11 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage response,
             CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (response.IsSuccessStatusCode || response.StatusCode == HttpStatusCode.NotModified)
+            {
+                return false;
+            }
+
             bool partitionSplit = response.StatusCode == HttpStatusCode.Gone
                 && (response.Headers.SubStatusCode == Documents.SubStatusCodes.PartitionKeyRangeGone || response.Headers.SubStatusCode == Documents.SubStatusCodes.CompletingSplit);
             if (partitionSplit)


### PR DESCRIPTION
# Pull Request Template

## Description

The current StandByFeedIterator is checking for a scenario that no longer happens in the backend (a page size error reading the Change Feed), and this check implies a `Contains` evaluation on the failed response. We can safely remove this overhead.