### PR TITLE
Cosmos.PartitionKey.TryParse

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 Content = streamPayload
             };
 
-            if (partitionKey != null)
+            if (partitionKey.HasValue)
             {
-                if (cosmosContainerCore == null && Object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.None))
+                if (cosmosContainerCore == null && object.ReferenceEquals(partitionKey, Cosmos.PartitionKey.None))
                 {
                     throw new ArgumentException($"{nameof(cosmosContainerCore)} can not be null with partition key as PartitionKey.None");
                 }
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 else
                 {
-                    request.Headers.PartitionKey = partitionKey.ToString();
+                    request.Headers.PartitionKey = partitionKey.Value.ToJsonString();
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
@@ -112,6 +113,34 @@ namespace Microsoft.Azure.Cosmos
         public override string ToString()
         {
             return this.InternalKey.ToJsonString();
+        }
+
+        internal static bool TryParse(string partitionKeyString, out PartitionKey partitionKey)
+        {
+            if (partitionKeyString == null)
+            {
+                throw new ArgumentNullException(partitionKeyString);
+            }
+
+            try
+            {
+                PartitionKeyInternal partitionKeyInternal = PartitionKeyInternal.FromJsonString(partitionKeyString);
+                if (partitionKeyInternal.Components == null)
+                {
+                    partitionKey = PartitionKey.None;
+                }
+                else
+                {
+                    partitionKey = new PartitionKey(partitionKeyInternal, isNone: false);
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                partitionKey = default(PartitionKey);
+                return false;
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -115,7 +115,12 @@ namespace Microsoft.Azure.Cosmos
             return this.InternalKey.ToJsonString();
         }
 
-        internal static bool TryParse(string partitionKeyString, out PartitionKey partitionKey)
+        internal string ToJsonString()
+        {
+            return this.InternalKey.ToJsonString();
+        }
+
+        internal static bool TryParseJsonString(string partitionKeyString, out PartitionKey partitionKey)
         {
             if (partitionKeyString == null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -582,8 +582,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 JToken.Parse(Documents.Routing.PartitionKeyInternal.Undefined.ToString());
                 Assert.IsTrue(new JTokenEqualityComparer().Equals(
                         JToken.Parse(Documents.Routing.PartitionKeyInternal.Undefined.ToString()),
-                        JToken.Parse(request.Headers.PartitionKey.ToString())),
-                        "Arguments {0} {1} ", Documents.Routing.PartitionKeyInternal.Undefined.ToString(), request.Headers.PartitionKey.ToString());
+                        JToken.Parse(request.Headers.PartitionKey)),
+                        "Arguments {0} {1} ", Documents.Routing.PartitionKeyInternal.Undefined.ToString(), request.Headers.PartitionKey);
 
                 return Task.FromResult(new ResponseMessage(HttpStatusCode.OK));
             });

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -87,5 +87,29 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Assert.IsTrue(PartitionKeyDefinition.AreEquivalent(definition1, definition2));
         }
+
+        [TestMethod]
+        public void RoundTripTests()
+        {
+            Cosmos.PartitionKey[] partitionKeys = new Cosmos.PartitionKey[]
+            {
+                // None partition key is not serializable.
+                // Cosmos.PartitionKey.None,
+                Cosmos.PartitionKey.Null,
+                new Cosmos.PartitionKey(true),
+                new Cosmos.PartitionKey(false),
+                new Cosmos.PartitionKey(42),
+                new Cosmos.PartitionKey("asdf"),
+            };
+
+            foreach (Cosmos.PartitionKey partitionKey in partitionKeys)
+            {
+                string serializedPartitionKey = partitionKey.ToString();
+                Assert.IsTrue(Cosmos.PartitionKey.TryParse(serializedPartitionKey, out Cosmos.PartitionKey parsedPartitionKey));
+                Assert.AreEqual(parsedPartitionKey.ToString(), serializedPartitionKey);
+            }
+
+            Assert.IsFalse(Cosmos.PartitionKey.TryParse("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -104,12 +104,12 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             foreach (Cosmos.PartitionKey partitionKey in partitionKeys)
             {
-                string serializedPartitionKey = partitionKey.ToString();
-                Assert.IsTrue(Cosmos.PartitionKey.TryParse(serializedPartitionKey, out Cosmos.PartitionKey parsedPartitionKey));
-                Assert.AreEqual(parsedPartitionKey.ToString(), serializedPartitionKey);
+                string serializedPartitionKey = partitionKey.ToJsonString();
+                Assert.IsTrue(Cosmos.PartitionKey.TryParseJsonString(serializedPartitionKey, out Cosmos.PartitionKey parsedPartitionKey));
+                Assert.AreEqual(parsedPartitionKey.ToJsonString(), serializedPartitionKey);
             }
 
-            Assert.IsFalse(Cosmos.PartitionKey.TryParse("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
+            Assert.IsFalse(Cosmos.PartitionKey.TryParseJsonString("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
         }
     }
 }


### PR DESCRIPTION
# Cosmos.PartitionKey.TryParse

## Description

Added ability to TryParse a partition key. This feature is needed for compute gateway to parse the partition key from a header.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

