### PR TITLE
Fixing build break in master from bad merge 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         public static CosmosElement Parse(string json)
         {
             byte[] buffer = Encoding.UTF8.GetBytes(json);
-            return CosmosElement.Create(buffer);
+            return CosmosElement.CreateFromBuffer(buffer);
         }
 
         public static CosmosElement Dispatch(


### PR DESCRIPTION
# Pull Request Template

## Description

A method was renamed in one PR but not in the other causing a build break.

Error    CS0117    'CosmosElement' does not contain a definition for 'Create'    Microsoft.Azure.Cosmos    C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\CosmosElements\CosmosElement.cs 


https://github.com/Azure/azure-cosmos-dotnet-v3/pull/875/files

https://github.com/Azure/azure-cosmos-dotnet-v3/pull/825/files


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

