### PR TITLE
Don't fail on client for Batch API for large requests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos
 
             int itemByteSize = operation.GetApproximateSerializedLength();
 
-            if (itemByteSize + this.currentSize > this.maxBatchByteSize)
+            if (this.batchOperations.Count > 0 && itemByteSize + this.currentSize > this.maxBatchByteSize)
             {
                 DefaultTrace.TraceInformation($"Batch is full - Max byte size {this.maxBatchByteSize} reached.");
                 return false;

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Cosmos
                                 || itemRequestOptions.PostTriggers != null
                                 || itemRequestOptions.SessionToken != null)
                 {
-                    throw new InvalidOperationException(ClientResources.UnsupportedBatchRequestOptions);
+                    throw new InvalidOperationException(ClientResources.UnsupportedBulkRequestOptions);
                 }
 
                 Debug.Assert(BatchAsyncContainerExecutor.ValidateOperationEPK(operation, itemRequestOptions));

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -135,13 +135,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             await operation.MaterializeResourceAsync(this.cosmosClientContext.CosmosSerializer, cancellationToken);
-
-            int itemByteSize = operation.GetApproximateSerializedLength();
-
-            if (itemByteSize > this.maxServerRequestBodyLength)
-            {
-                throw new ArgumentException(RMResources.RequestTooLarge);
-            }
         }
 
         private static IDocumentClientRetryPolicy GetRetryPolicy(RetryOptions retryOptions)

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchCore.cs
@@ -195,8 +195,6 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             return this.ExecuteAsync(
-                Constants.MaxDirectModeBatchRequestBodySizeInBytes,
-                Constants.MaxOperationsInDirectModeBatchRequest,
                 requestOptions: null,
                 cancellationToken: cancellationToken);
         }
@@ -211,11 +209,9 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.ExecuteAsync(
-                Constants.MaxDirectModeBatchRequestBodySizeInBytes,
-                Constants.MaxOperationsInDirectModeBatchRequest,
-                requestOptions,
-                cancellationToken);
+            BatchExecutor executor = new BatchExecutor(this.container, this.partitionKey, this.operations, requestOptions);
+            this.operations = new List<ItemBatchOperation>();
+            return executor.ExecuteAsync(cancellationToken);
         }
 
         /// <summary>
@@ -238,17 +234,6 @@ namespace Microsoft.Azure.Cosmos
                     requestOptions: requestOptions));
 
             return this;
-        }
-
-        internal Task<BatchResponse> ExecuteAsync(
-            int maxServerRequestBodyLength,
-            int maxServerRequestOperationCount,
-            RequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken))
-        {
-            BatchExecutor executor = new BatchExecutor(this.container, this.partitionKey, this.operations, requestOptions, maxServerRequestBodyLength, maxServerRequestOperationCount);
-            this.operations = new List<ItemBatchOperation>();
-            return executor.ExecuteAsync(cancellationToken);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
@@ -20,12 +20,11 @@ namespace Microsoft.Azure.Cosmos
         private const int BufferSize = 81920;
 
         /// <summary>
-        /// Converts a Stream to a Memory{byte} wrapping a byte array honoring a provided maximum length for the returned Memory.
+        /// Converts a Stream to a Memory{byte} wrapping a byte array.
         /// </summary>
         /// <param name="stream">Stream to be converted to bytes.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> to cancel the operation.</param>
-        /// <returns>A Memory{byte} with length at most maximumLength.</returns>
-        /// <remarks>Throws CosmosException if the input stream has more bytes than maximumLength.</remarks>
+        /// <returns>A Memory{byte}.</returns>
         public static async Task<Memory<byte>> StreamToMemoryAsync(
             Stream stream,
             CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
@@ -7,12 +7,9 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
     /// Util methods for batch requests.
@@ -26,22 +23,15 @@ namespace Microsoft.Azure.Cosmos
         /// Converts a Stream to a Memory{byte} wrapping a byte array honoring a provided maximum length for the returned Memory.
         /// </summary>
         /// <param name="stream">Stream to be converted to bytes.</param>
-        /// <param name="maximumLength">Desired maximum length of the Memory{byte}.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> to cancel the operation.</param>
         /// <returns>A Memory{byte} with length at most maximumLength.</returns>
         /// <remarks>Throws CosmosException if the input stream has more bytes than maximumLength.</remarks>
         public static async Task<Memory<byte>> StreamToMemoryAsync(
             Stream stream,
-            int maximumLength,
             CancellationToken cancellationToken)
         {
             if (stream.CanSeek)
             {
-                if (stream.Length > maximumLength)
-                {
-                    throw new CosmosException(HttpStatusCode.RequestEntityTooLarge, RMResources.RequestTooLarge);
-                }
-
                 // Some derived implementations of MemoryStream (such as versions of RecyclableMemoryStream prior to 1.2.2 that we may be using)
                 // return an incorrect response from TryGetBuffer. Use TryGetBuffer only on the MemoryStream type and not derived types.
                 MemoryStream memStream = stream as MemoryStream;
@@ -74,10 +64,6 @@ namespace Microsoft.Azure.Cosmos
                     while ((count = await stream.ReadAsync(buffer, 0, bufferSize, cancellationToken)) > 0)
                     {
                         sum += count;
-                        if (sum > maximumLength)
-                        {
-                            throw new CosmosException(HttpStatusCode.RequestEntityTooLarge, RMResources.RequestTooLarge);
-                        }
 
 #pragma warning disable VSTHRD103 // Call async methods when in an async method
                         memoryStream.Write(buffer, 0, count);
@@ -89,39 +75,11 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        public static string GetPartitionKeyRangeId(PartitionKeyInternal partitionKeyInternal, PartitionKeyDefinition partitionKeyDefinition, CollectionRoutingMap collectionRoutingMap)
-        {
-            string effectivePartitionKey = partitionKeyInternal.GetEffectivePartitionKeyString(partitionKeyDefinition);
-            return collectionRoutingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey).Id;
-        }
-
-        public static void GetServerRequestLimits(out int maxServerRequestBodyLength, out int maxServerRequestOperationCount)
-        {
-            maxServerRequestBodyLength = Constants.MaxDirectModeBatchRequestBodySizeInBytes;
-            maxServerRequestOperationCount = Constants.MaxOperationsInDirectModeBatchRequest;
-        }
-
-        public static ResponseMessage EnsureValidStream(
-            IReadOnlyList<ItemBatchOperation> operations,
-            RequestOptions batchOptions,
-            int? maxOperationCount = null)
-        {
-            string errorMessage = BatchExecUtils.EnsureValidInternal(operations, batchOptions, maxOperationCount);
-
-            if (errorMessage != null)
-            {
-                return new ResponseMessage(HttpStatusCode.BadRequest, errorMessage: errorMessage);
-            }
-
-            return new ResponseMessage(HttpStatusCode.OK);
-        }
-
         public static void EnsureValid(
             IReadOnlyList<ItemBatchOperation> operations,
-            RequestOptions batchOptions,
-            int? maxOperationCount = null)
+            RequestOptions batchOptions)
         {
-            string errorMessage = BatchExecUtils.EnsureValidInternal(operations, batchOptions, maxOperationCount);
+            string errorMessage = BatchExecUtils.IsValid(operations, batchOptions);
 
             if (errorMessage != null)
             {
@@ -129,21 +87,15 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        private static string EnsureValidInternal(
+        internal static string IsValid(
             IReadOnlyList<ItemBatchOperation> operations,
-            RequestOptions batchOptions,
-            int? maxOperationCount = null)
+            RequestOptions batchOptions)
         {
             string errorMessage = null;
 
             if (operations.Count == 0)
             {
                 errorMessage = ClientResources.BatchNoOperations;
-            }
-
-            if (maxOperationCount.HasValue && operations.Count > maxOperationCount.Value)
-            {
-                errorMessage = ClientResources.BatchTooLarge;
             }
 
             if (errorMessage == null && batchOptions != null)

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchExecutor.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Diagnostics;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
@@ -26,30 +25,22 @@ namespace Microsoft.Azure.Cosmos
 
         private readonly RequestOptions batchOptions;
 
-        private readonly int maxServerRequestBodyLength;
-
-        private readonly int maxServerRequestOperationCount;
-
         public BatchExecutor(
             ContainerCore container,
             PartitionKey partitionKey,
             IReadOnlyList<ItemBatchOperation> operations,
-            RequestOptions batchOptions,
-            int maxServerRequestBodyLength,
-            int maxServerRequestOperationCount)
+            RequestOptions batchOptions)
         {
             this.container = container;
             this.clientContext = this.container.ClientContext;
             this.inputOperations = operations;
             this.partitionKey = partitionKey;
             this.batchOptions = batchOptions;
-            this.maxServerRequestBodyLength = maxServerRequestBodyLength;
-            this.maxServerRequestOperationCount = maxServerRequestOperationCount;
         }
 
         public async Task<BatchResponse> ExecuteAsync(CancellationToken cancellationToken)
         {
-            BatchExecUtils.EnsureValid(this.inputOperations, this.batchOptions, this.maxServerRequestOperationCount);
+            BatchExecUtils.EnsureValid(this.inputOperations, this.batchOptions);
 
             PartitionKey? serverRequestPartitionKey = this.partitionKey;
             if (this.batchOptions != null && this.batchOptions.IsEffectivePartitionKeyRouting)
@@ -60,15 +51,8 @@ namespace Microsoft.Azure.Cosmos
             SinglePartitionKeyServerBatchRequest serverRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                       serverRequestPartitionKey,
                       new ArraySegment<ItemBatchOperation>(this.inputOperations.ToArray()),
-                      this.maxServerRequestBodyLength,
-                      this.maxServerRequestOperationCount,
-                      serializer: this.clientContext.CosmosSerializer,
-                      cancellationToken: cancellationToken);
-
-            if (serverRequest.Operations.Count != this.inputOperations.Count)
-            {
-                throw new CosmosException(HttpStatusCode.RequestEntityTooLarge, ClientResources.BatchTooLarge);
-            }
+                      this.clientContext.CosmosSerializer,
+                      cancellationToken);
 
             return await this.ExecuteServerRequestAsync(serverRequest, cancellationToken);
         }
@@ -86,7 +70,7 @@ namespace Microsoft.Azure.Cosmos
             using (Stream serverRequestPayload = serverRequest.TransferBodyStream())
             {
                 Debug.Assert(serverRequestPayload != null, "Server request payload expected to be non-null");
-                ResponseMessage responseMessage = await clientContext.ProcessResourceOperationStreamAsync(
+                ResponseMessage responseMessage = await this.clientContext.ProcessResourceOperationStreamAsync(
                     this.container.LinkUri,
                     ResourceType.Document,
                     OperationType.Batch,

--- a/Microsoft.Azure.Cosmos/src/Batch/ItemBatchOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ItemBatchOperation.cs
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.body.IsEmpty && this.ResourceStream != null)
             {
-                this.body = await BatchExecUtils.StreamToMemoryAsync(this.ResourceStream, Constants.MaxResourceSizeInBytes, cancellationToken);
+                this.body = await BatchExecUtils.StreamToMemoryAsync(this.ResourceStream, cancellationToken);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Batch/PartitionKeyRangeServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/PartitionKeyRangeServerBatchRequest.cs
@@ -58,13 +58,6 @@ namespace Microsoft.Azure.Cosmos
         {
             PartitionKeyRangeServerBatchRequest request = new PartitionKeyRangeServerBatchRequest(partitionKeyRangeId, maxBodyLength, maxOperationCount, serializer);
             ArraySegment<ItemBatchOperation> pendingOperations = await request.CreateBodyStreamAsync(operations, cancellationToken, ensureContinuousOperationIndexes);
-
-            if (pendingOperations.Count == operations.Count)
-            {
-                // A single operation was larger than the allowed size for the server request
-                throw new CosmosException(HttpStatusCode.RequestEntityTooLarge, RMResources.RequestTooLarge);
-            }
-
             return new Tuple<PartitionKeyRangeServerBatchRequest, ArraySegment<ItemBatchOperation>>(request, pendingOperations);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
@@ -7,13 +7,11 @@ namespace Microsoft.Azure.Cosmos
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Serialization.HybridRow;
     using Microsoft.Azure.Cosmos.Serialization.HybridRow.IO;
     using Microsoft.Azure.Cosmos.Serialization.HybridRow.RecordIO;
-    using Microsoft.Azure.Documents;
 
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
     internal abstract class ServerBatchRequest
@@ -128,11 +126,6 @@ namespace Microsoft.Azure.Cosmos
             else
             {
                 this.operations = new ArraySegment<ItemBatchOperation>(operations.Array, operations.Offset, this.lastWrittenOperationIndex + 1);
-            }
-
-            if (this.operations.Count == 0)
-            {
-                throw new CosmosException(HttpStatusCode.RequestEntityTooLarge, RMResources.RequestTooLarge);
             }
 
             int overflowOperations = operations.Count - this.operations.Count;

--- a/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ServerBatchRequest.cs
@@ -136,7 +136,13 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.bodyStream.Length > this.maxBodyLength)
             {
-                this.shouldDeleteLastWrittenRecord = true;
+                // If there is only one operation within the request, we will keep it even if it
+                // exceeds the maximum size allowed for the body.
+                if (index > 1)
+                {
+                    this.shouldDeleteLastWrittenRecord = true;
+                }
+
                 buffer = default(ReadOnlyMemory<byte>);
                 return Result.Success;
             }

--- a/Microsoft.Azure.Cosmos/src/Batch/SinglePartitionKeyServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/SinglePartitionKeyServerBatchRequest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos
         private SinglePartitionKeyServerBatchRequest(
             PartitionKey? partitionKey,
             CosmosSerializer serializer)
-            : base(maxBodyLength: int.MaxValue, maxOperationCount: int.MaxValue, serializer)
+            : base(maxBodyLength: int.MaxValue, maxOperationCount: int.MaxValue, serializer: serializer)
         {
             this.PartitionKey = partitionKey;
         }

--- a/Microsoft.Azure.Cosmos/src/Batch/SinglePartitionKeyServerBatchRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/SinglePartitionKeyServerBatchRequest.cs
@@ -15,15 +15,11 @@ namespace Microsoft.Azure.Cosmos
         /// Single partition key server request.
         /// </summary>
         /// <param name="partitionKey">Partition key that applies to all operations in this request.</param>
-        /// <param name="maxBodyLength">Maximum length allowed for the request body.</param>
-        /// <param name="maxOperationCount">Maximum number of operations allowed in the request.</param>
         /// <param name="serializer">Serializer to serialize user provided objects to JSON.</param>
         private SinglePartitionKeyServerBatchRequest(
             PartitionKey? partitionKey,
-            int maxBodyLength,
-            int maxOperationCount,
             CosmosSerializer serializer)
-            : base(maxBodyLength, maxOperationCount, serializer)
+            : base(maxBodyLength: int.MaxValue, maxOperationCount: int.MaxValue, serializer)
         {
             this.PartitionKey = partitionKey;
         }
@@ -39,20 +35,16 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="partitionKey">Partition key of the request.</param>
         /// <param name="operations">Operations to be added into this batch request.</param>
-        /// <param name="maxBodyLength">Desired maximum length of the request body.</param>
-        /// <param name="maxOperationCount">Maximum number of operations allowed in the request.</param>
         /// <param name="serializer">Serializer to serialize user provided objects to JSON.</param>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A newly created instance of <see cref="SinglePartitionKeyServerBatchRequest"/>.</returns>
         public static async Task<SinglePartitionKeyServerBatchRequest> CreateAsync(
             PartitionKey? partitionKey,
             ArraySegment<ItemBatchOperation> operations,
-            int maxBodyLength,
-            int maxOperationCount,
             CosmosSerializer serializer,
             CancellationToken cancellationToken)
         {
-            SinglePartitionKeyServerBatchRequest request = new SinglePartitionKeyServerBatchRequest(partitionKey, maxBodyLength, maxOperationCount, serializer);
+            SinglePartitionKeyServerBatchRequest request = new SinglePartitionKeyServerBatchRequest(partitionKey, serializer);
             await request.CreateBodyStreamAsync(operations, cancellationToken);
             return request;
         }

--- a/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
@@ -565,11 +565,11 @@ namespace Microsoft.Azure.Cosmos {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consistency, Session, and Triggers are not allowed when using the Batch streaming feature..
+        ///   Looks up a localized string similar to Consistency, Session, and Triggers are not allowed when AllowBulkExecution is set to true..
         /// </summary>
-        internal static string UnsupportedBatchRequestOptions {
+        internal static string UnsupportedBulkRequestOptions {
             get {
-                return ResourceManager.GetString("UnsupportedBatchRequestOptions", resourceCulture);
+                return ResourceManager.GetString("UnsupportedBulkRequestOptions", resourceCulture);
             }
         }
         

--- a/Microsoft.Azure.Cosmos/src/ClientResources.resx
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.resx
@@ -291,7 +291,7 @@
   <data name="ValueAndAnonymousTypesAndGeometryOnly" xml:space="preserve">
     <value>Instantiation of only value types, anonymous types and spatial types are supported.</value>
   </data>
-  <data name="UnsupportedBatchRequestOptions" xml:space="preserve">
-    <value>Consistency, Session, and Triggers are not allowed when using the Batch streaming feature.</value>
+  <data name="UnsupportedBulkRequestOptions" xml:space="preserve">
+    <value>Consistency, Session, and Triggers are not allowed when AllowBulkExecution is set to true.</value>
   </data>
 </root>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -77,18 +77,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => executor.ValidateOperationAsync(new ItemBatchOperation(OperationType.Replace, 0, new Cosmos.PartitionKey(id), id, cosmosDefaultJsonSerializer.ToStream(myDocument)), new ItemRequestOptions() { SessionToken = "something" }));
         }
 
-        [TestMethod]
-        [Owner("maquaran")]
-        public async Task ValidateInvalidDocumentSizeAsync()
-        {
-            BatchAsyncContainerExecutor executor = new BatchAsyncContainerExecutor(this.cosmosContainer, this.cosmosContainer.ClientContext, 50, 2);
-
-            string id = Guid.NewGuid().ToString();
-            MyDocument myDocument = new MyDocument() { id = id, Status = id };
-
-            await Assert.ThrowsExceptionAsync<ArgumentException>(() => executor.ValidateOperationAsync(new ItemBatchOperation(OperationType.Replace, 0, new Cosmos.PartitionKey(id), id, cosmosDefaultJsonSerializer.ToStream(myDocument))));
-        }
-
         private static ItemBatchOperation CreateItem(string id)
         {
             MyDocument myDocument = new MyDocument() { id = id, Status = id };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
@@ -230,6 +230,45 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [Owner("abpai")]
+        public async Task BatchLargerThanServerRequestAsync()
+        {
+            Container container = BatchTestBase.JsonContainer;
+
+            const int operationCount = 20;
+            int appxDocSize = Constants.MaxDirectModeBatchRequestBodySizeInBytes / operationCount;
+
+            // Increase the doc size by a bit so all docs won't fit in one server request.
+            appxDocSize = (int)(appxDocSize * 1.05);
+            Batch batch = new BatchCore((ContainerCore)container, new Cosmos.PartitionKey(this.PartitionKey1));
+            for (int i = 0; i < operationCount; i++)
+            {
+                TestDoc doc = BatchTestBase.PopulateTestDoc(this.PartitionKey1, minDesiredSize: appxDocSize);
+                batch.CreateItem(doc);
+            }
+
+            BatchResponse batchResponse = await batch.ExecuteAsync();
+            Assert.AreEqual(HttpStatusCode.RequestEntityTooLarge, batchResponse.StatusCode);
+        }
+
+        [TestMethod]
+        [Owner("abpai")]
+        public async Task BatchWithTooManyOperationsAsync()
+        {
+            Container container = BatchTestBase.JsonContainer;
+            const int operationCount = Constants.MaxOperationsInDirectModeBatchRequest + 1;
+
+            Batch batch = new BatchCore((ContainerCore)container, new Cosmos.PartitionKey(this.PartitionKey1));
+            for (int i = 0; i < operationCount; i++)
+            {
+                batch.ReadItem("someId");
+            }
+
+            BatchResponse batchResponse = await batch.ExecuteAsync();
+            Assert.AreEqual(HttpStatusCode.BadRequest, batchResponse.StatusCode);
+        }
+
+        [TestMethod]
+        [Owner("abpai")]
         public async Task BatchServerResponseTooLargeAsync()
         {
             Container container = BatchTestBase.JsonContainer;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
@@ -54,8 +54,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                     partitionKey: null,
                     operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                    maxBodyLength: (int)responseContent.Length * request.Operations.Count,
-                    maxOperationCount: request.Operations.Count,
                     serializer: new CosmosJsonDotNetSerializer(),
                 cancellationToken: cancellationToken);
 
@@ -102,8 +100,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                     partitionKey: null,
                     operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                    maxBodyLength: (int)responseContent.Length * request.Operations.Count,
-                    maxOperationCount: request.Operations.Count,
                     serializer: new CosmosJsonDotNetSerializer(),
                 cancellationToken: cancellationToken);
 
@@ -155,8 +151,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                     partitionKey: null,
                     operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                    maxBodyLength: (int)responseContent.Length * operationCount,
-                    maxOperationCount: operationCount,
                     serializer: new CosmosJsonDotNetSerializer(),
                 cancellationToken: cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -291,8 +291,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: CancellationToken.None);
 
@@ -331,8 +329,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: CancellationToken.None);
 
@@ -370,8 +366,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: CancellationToken.None);
 
@@ -408,8 +402,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: CancellationToken.None);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
@@ -46,8 +46,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                     partitionKey: null,
                     operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                    maxBodyLength: (int)responseContent.Length * request.Operations.Count,
-                    maxOperationCount: request.Operations.Count,
                     serializer: new CosmosJsonDotNetSerializer(),
                 cancellationToken: cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchExecUtilsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchExecUtilsUnitTests.cs
@@ -25,22 +25,21 @@ namespace Microsoft.Azure.Cosmos.Tests
             const int bytesLength = 10;
             byte[] bytes = new byte[bytesLength];
             this.random.NextBytes(bytes);
-            const int maximumLength = 100;
             {
                 Stream stream = new MemoryStream(bytes);
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength, CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes));
             }
 
             {
                 Stream stream = new MemoryStream(bytes, 2, 5, writable: false, publiclyVisible: true);
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength, CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes.Skip(2).Take(5).ToArray()));
             }
 
             {
                 Stream stream = new MemoryStream(bytes, 2, 5, writable: false, publiclyVisible: false);
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength, CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes.Skip(2).Take(5).ToArray()));
             }
 
@@ -48,49 +47,16 @@ namespace Microsoft.Azure.Cosmos.Tests
                 Stream stream = new MemoryStream(bytes.Length * 2);
                 await stream.WriteAsync(bytes, 0, bytes.Length);
                 stream.Position = 0;
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength, CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes));
             }
 
             {
                 Stream stream = new TestSeekableStream(bytes, maxLengthToReturnPerRead: 3);
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength, CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes));
             }
         }
-
-        [TestMethod]
-        [Owner("abpai")]
-        public async Task StreamToBytesAsyncSeekableMaximumLengthAsync()
-        {
-            byte[] bytes = new byte[10];
-            this.random.NextBytes(bytes);
-
-            Stream stream = new MemoryStream(bytes);
-            {
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 100, cancellationToken: CancellationToken.None);
-                Assert.IsTrue(actual.Span.SequenceEqual(bytes));
-            }
-
-            {
-                stream.Position = 0;
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 10, cancellationToken: CancellationToken.None);
-                Assert.IsTrue(actual.Span.SequenceEqual(bytes));
-            }
-
-            {
-                stream.Position = 0;
-                try
-                {
-                    Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 9, cancellationToken: CancellationToken.None);
-                    Assert.Fail("Expected " + nameof(CosmosException));
-                }
-                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.RequestEntityTooLarge)
-                {
-                }
-            }
-        }
-
 
         [TestMethod]
         [Owner("abpai")]
@@ -100,26 +66,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             this.random.NextBytes(bytes);
             TestNonSeekableStream stream = new TestNonSeekableStream(bytes, maxLengthToReturnPerRead: 3);
             {
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 100, cancellationToken: CancellationToken.None);
+                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, cancellationToken: CancellationToken.None);
                 Assert.IsTrue(actual.Span.SequenceEqual(bytes));
-            }
-
-            {
-                stream.Reset();
-                Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 10, cancellationToken: CancellationToken.None);
-                Assert.IsTrue(actual.Span.SequenceEqual(bytes));
-            }
-
-            {
-                stream.Reset();
-                try
-                {
-                    Memory<byte> actual = await BatchExecUtils.StreamToMemoryAsync(stream, maximumLength: 9, cancellationToken: CancellationToken.None);
-                    Assert.Fail("Expected " + nameof(CosmosException));
-                }
-                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.RequestEntityTooLarge)
-                {
-                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         [Owner("abpai")]
         public async Task BatchRequestSerializationAsync()
         {
-            const int maxBodySize = 5 * 1024;
-            const int maxOperationCount = 10;
             const string partitionKey1 = "pk1";
 
             ItemBatchOperation[] operations = new ItemBatchOperation[]
@@ -47,8 +45,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             ServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 new Cosmos.PartitionKey(partitionKey1),
                 new ArraySegment<ItemBatchOperation>(operations),
-                maxBodySize,
-                maxOperationCount,
                 serializer: new CosmosJsonDotNetSerializer(),
                 cancellationToken: CancellationToken.None);
 
@@ -60,66 +56,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
                 List<ItemBatchOperation> readOperations = await new BatchRequestPayloadReader().ReadPayloadAsync(payload);
                 Assert.AreEqual(2, readOperations.Count);
-                ItemBatchOperationEqualityComparer comparer = new ItemBatchOperationEqualityComparer();
-                Assert.IsTrue(comparer.Equals(operations[0], readOperations[0]));
-                Assert.IsTrue(comparer.Equals(operations[1], readOperations[1]));
-            }
-        }
-
-        [TestMethod]
-        [Owner("abpai")]
-        public async Task BatchRequestSerializationFillAsync()
-        {
-            const int maxBodySize = 5 * 1024;
-            const int maxOperationCount = 10;
-            const int operationBodySize = 2 * 1024;
-            const string partitionKey1 = "pk1";
-            const string id = "random";
-            ItemBatchOperation[] operations = new ItemBatchOperation[]
-            {
-                new ItemBatchOperation(
-                    operationType: OperationType.Replace,
-                    id: id,
-                    operationIndex: 0)
-                {
-                    ResourceBody = Encoding.UTF8.GetBytes(new string('w', operationBodySize))
-                },
-                new ItemBatchOperation(
-                    operationType: OperationType.Create,
-                    operationIndex: 1)
-                {
-                    ResourceBody = Encoding.UTF8.GetBytes(new string('x', operationBodySize))
-                },
-                new ItemBatchOperation(
-                    operationType: OperationType.Upsert,
-                    operationIndex: 2)
-                {
-                    ResourceBody = Encoding.UTF8.GetBytes(new string('y', operationBodySize))
-                },
-                new ItemBatchOperation(
-                    operationType: OperationType.Create,
-                    operationIndex: 3)
-                {
-                    ResourceBody = Encoding.UTF8.GetBytes(new string('z', operationBodySize))
-                }
-            };
-            ServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
-                new Cosmos.PartitionKey(partitionKey1), 
-                new ArraySegment<ItemBatchOperation>(operations), 
-                maxBodySize,
-                maxOperationCount,
-                serializer: new CosmosJsonDotNetSerializer(),
-                cancellationToken: CancellationToken.None);
-
-            Assert.AreEqual(2, batchRequest.Operations.Count);
-
-            using (MemoryStream payload = batchRequest.TransferBodyStream())
-            {
-                Assert.IsNotNull(payload);
-
-                List<ItemBatchOperation> readOperations = await new BatchRequestPayloadReader().ReadPayloadAsync(payload);
-                Assert.AreEqual(2, readOperations.Count);
-
                 ItemBatchOperationEqualityComparer comparer = new ItemBatchOperationEqualityComparer();
                 Assert.IsTrue(comparer.Equals(operations[0], readOperations[0]));
                 Assert.IsTrue(comparer.Equals(operations[1], readOperations[1]));
@@ -159,8 +95,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                     {
                         new ItemBatchOperation(OperationType.Read, operationIndex: 0, id: "someId")
                     }),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: serializer,
                 cancellationToken: CancellationToken.None);
             BatchResponse batchresponse = await BatchResponse.PopulateFromContentAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
@@ -108,48 +108,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         [TestMethod]
         [Owner("abpai")]
-        public async Task BatchLargerThanServerRequestAsync()
-        {
-            Container container = BatchUnitTests.GetContainer();
-            const int operationCount = 20;
-            int appxDocSize = Constants.MaxDirectModeBatchRequestBodySizeInBytes / operationCount;
-
-            // Increase the doc size by a bit so all docs won't fit in one server request.
-            appxDocSize = (int)(appxDocSize * 1.05);
-            Batch batch = new BatchCore((ContainerCore)container, new Cosmos.PartitionKey(BatchUnitTests.PartitionKey1));
-            for (int i = 0; i < operationCount; i++)
-            {
-                TestItem testItem = new TestItem(new string('x', appxDocSize));
-                batch.CreateItem(testItem);
-            }
-
-            await BatchUnitTests.VerifyExceptionThrownOnExecuteAsync(
-                batch,
-                typeof(CosmosException),
-                ClientResources.BatchTooLarge);
-        }
-
-        [TestMethod]
-        [Owner("abpai")]
-        public async Task BatchWithTooManyOperationsAsync()
-        {
-            Container container = BatchUnitTests.GetContainer();
-            const int operationCount = Constants.MaxOperationsInDirectModeBatchRequest + 1;
-
-            Batch batch = new BatchCore((ContainerCore)container, new Cosmos.PartitionKey(BatchUnitTests.PartitionKey1));
-            for (int i = 0; i < operationCount; i++)
-            {
-                batch.ReadItem("someId");
-            }
-
-            await BatchUnitTests.VerifyExceptionThrownOnExecuteAsync(
-                batch,
-                typeof(ArgumentException),
-                ClientResources.BatchTooLarge);
-        }
-
-        [TestMethod]
-        [Owner("abpai")]
         public async Task BatchCrudRequestAsync()
         {
             Random random = new Random();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyBatchResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyBatchResponseTests.cs
@@ -49,8 +49,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: default(CancellationToken));
 
@@ -85,8 +83,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
@@ -54,8 +54,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: default(CancellationToken));
 
@@ -112,8 +110,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
                 partitionKey: null,
                 operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
-                maxBodyLength: 100,
-                maxOperationCount: 1,
                 serializer: new CosmosJsonDotNetSerializer(),
             cancellationToken: default(CancellationToken));
 

--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#901](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/901) Fix a bug causing query response to create a new stream for each content call
 - [#918](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/918) Fixed serializer being used for Scripts, Permissions, and Conflict related iterators
 - [#927](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/927) Fixed query returning partial results instead of error
+- [#936](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/936) Fixed bulk requests with large resources to have natural exception flow.
+
 
 ## <a name="3.3.2"/> [3.3.2](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.3.2) - 2019-10-16
 


### PR DESCRIPTION
## Description

We had an optimization to not make Batch requests to the server if we think they are too large - removing this since making server requests allows for the natural error handling flow (similar to regular point operations where we don't check the max size of input on the client) among other benefits.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
