### PR TITLE
ORDER BY Undefined

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/OrderByItem.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/OrderByItem.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 if (!this.cosmosObject.TryGetValue(ItemName, out CosmosElement cosmosElement))
                 {
-                    throw new InvalidOperationException($"Underlying object does not have an 'item' field.");
+                    cosmosElement = null;
                 }
 
                 return cosmosElement;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/OrderByQuery/OrderByConsumeComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/OrderByQuery/OrderByConsumeComparer.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Azure.Cosmos.Query.ParallelQuery
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Globalization;
-    using Microsoft.Azure.Cosmos.CosmosElements;
-    using RMResources = Documents.RMResources;
 
     /// <summary>
     /// For cross partition order by queries we serve documents from the partition
@@ -17,12 +14,6 @@ namespace Microsoft.Azure.Cosmos.Query.ParallelQuery
     /// </summary>
     internal sealed class OrderByConsumeComparer : IComparer<ItemProducerTree>
     {
-        /// <summary>
-        /// This flag used to determine whether we should support mixed type order by.
-        /// For testing purposes we might turn it on to test mixed type order by on index v2.
-        /// </summary>
-        public static bool AllowMixedTypeOrderByTestFlag = false;
-
         /// <summary>
         /// The sort orders for the query (1 for each order by in the query).
         /// Until composite indexing is released this will just be an array of length 1.
@@ -132,11 +123,6 @@ namespace Microsoft.Azure.Cosmos.Query.ParallelQuery
                 this.sortOrders.Count == items1.Count,
                 "SortOrders must match size of order-by items.");
 
-            if (!AllowMixedTypeOrderByTestFlag)
-            {
-                this.CheckTypeMatching(items1, items2);
-            }
-
             for (int i = 0; i < this.sortOrders.Count; ++i)
             {
                 int cmp = ItemComparer.Instance.Compare(
@@ -150,40 +136,6 @@ namespace Microsoft.Azure.Cosmos.Query.ParallelQuery
             }
 
             return 0;
-        }
-
-        /// <summary>
-        /// With index V1 collections we have the check the types of the items since it is impossible to support mixed typed order by for V1 collections.
-        /// The reason for this is, since V1 does not order types.
-        /// The only constraint is that all the numbers will be sorted with respect to each other and same for the strings, but strings and numbers might get interleaved.
-        /// Take the following example:
-        /// Partition 1: "A", 1, "B", 2
-        /// Partition 2: 42, "Z", 0x5F3759DF
-        /// Step 1: Compare "A" to 42 and WLOG 42 comes first
-        /// Step 2: Compare "A" to "Z" and "A" comes first
-        /// Step 3: Compare "Z" to 1 and WLOG 1 comes first
-        /// Whoops: We have 42, "A", 1 and 1 should come before 42.
-        /// </summary>
-        /// <param name="items1">The items relevant to the sort for the first partition.</param>
-        /// <param name="items2">The items relevant to the sort for the second partition.</param>
-        private void CheckTypeMatching(IList<OrderByItem> items1, IList<OrderByItem> items2)
-        {
-            for (int i = 0; i < items1.Count; ++i)
-            {
-                CosmosElementType itemType1 = items1[i].Item.Type;
-                CosmosElementType itemType2 = items2[i].Item.Type;
-
-                if (itemType1 != itemType2)
-                {
-                    throw new NotSupportedException(
-                        string.Format(
-                            CultureInfo.InvariantCulture,
-                            RMResources.UnsupportedCrossPartitionOrderByQueryOnMixedTypes,
-                            itemType1,
-                            itemType2,
-                            items1[i]));
-                }
-            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -2775,7 +2775,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     },
                     new Cosmos.IncludedPath()
                     {
-                        Path = "/MixedTypeField/?",
+                        Path = $"/{nameof(MixedTypedDocument.MixedTypeField)}/?",
                     }
                 },
 
@@ -2928,23 +2928,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private sealed class MockOrderByComparer : IComparer<object>
+        private sealed class MockOrderByComparer : IComparer<CosmosElement>
         {
             public static readonly MockOrderByComparer Value = new MockOrderByComparer();
 
-            public int Compare(object x, object y)
+            public int Compare(CosmosElement element1, CosmosElement element2)
             {
-                CosmosElement element1 = ObjectToCosmosElement(x);
-                CosmosElement element2 = ObjectToCosmosElement(y);
-
                 return ItemComparer.Instance.Compare(element1, element2);
-            }
-
-            private static CosmosElement ObjectToCosmosElement(object obj)
-            {
-                string json = JsonConvert.SerializeObject(obj != null ? JToken.FromObject(obj) : JValue.CreateNull());
-                byte[] bytes = Encoding.UTF8.GetBytes(json);
-                return CosmosElement.CreateFromBuffer(bytes);
             }
         }
 
@@ -3068,14 +3058,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         IEnumerable<CosmosObject> expected = new List<CosmosObject>();
 
                         // Filter based on the mixedOrderByType enum
-                        if (orderByTypes.HasFlag(OrderByTypes.Array))
-                        {
-                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosArray value)));
-                        }
 
-                        if (orderByTypes.HasFlag(OrderByTypes.Bool))
+                        if (orderByTypes.HasFlag(OrderByTypes.Undefined))
                         {
-                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosBoolean value)));
+                            expected = expected.Concat(insertedDocs.Where(x => !x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosElement value)));
                         }
 
                         if (orderByTypes.HasFlag(OrderByTypes.Null))
@@ -3083,14 +3069,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosNull value)));
                         }
 
+                        if (orderByTypes.HasFlag(OrderByTypes.Bool))
+                        {
+                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosBoolean value)));
+                        }
+
                         if (orderByTypes.HasFlag(OrderByTypes.Number))
                         {
                             expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosNumber value)));
-                        }
-
-                        if (orderByTypes.HasFlag(OrderByTypes.Object))
-                        {
-                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosObject value)));
                         }
 
                         if (orderByTypes.HasFlag(OrderByTypes.String))
@@ -3098,9 +3084,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosString value)));
                         }
 
-                        if (orderByTypes.HasFlag(OrderByTypes.Undefined))
+                        if (orderByTypes.HasFlag(OrderByTypes.Array))
                         {
-                            expected = expected.Concat(insertedDocs.Where(x => !x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosElement value)));
+                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosArray value)));
+                        }
+
+                        if (orderByTypes.HasFlag(OrderByTypes.Object))
+                        {
+                            expected = expected.Concat(insertedDocs.Where(x => x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosObject value)));
                         }
 
                         // Order using the mock order by comparer

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- [#952](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/952) ORDER BY Undefined and Mixed Type ORDER BY support.
+
 ### Added
 
 - [#853](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/853) ORDER BY Arrays and Object support.


### PR DESCRIPTION
# ORDER BY Undefined

## Description

Allows for ordering by undefined fields. The fix was just to allow nulls to propagate through the sort code. 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

