### PR TITLE
Ensure diagnostics are set even for failed requests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
@@ -52,14 +52,14 @@ namespace Microsoft.Azure.Cosmos
 
         internal static ResponseMessage ToCosmosResponseMessage(this DocumentClientException dce, RequestMessage request)
         {
-            // if StatusCode is not set, it is a client business logic error and it never hit the backend, so throw
-            if (!dce.StatusCode.HasValue)
+            // if StatusCode is null it is a client business logic error and it never hit the backend, so throw
+            if (dce.StatusCode == null)
             {
                 throw dce;
             }
 
             // if there is a status code then it came from the backend, return error as http error instead of throwing the exception
-            ResponseMessage cosmosResponse = new ResponseMessage(dce.StatusCode.Value, request);
+            ResponseMessage cosmosResponse = new ResponseMessage(dce.StatusCode ?? HttpStatusCode.InternalServerError, request);
             string reasonPhraseString = string.Empty;
             if (!string.IsNullOrEmpty(dce.Message))
             {
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos
                 errorMessage: cosmosResponse.ErrorMessage,
                 method: request?.Method,
                 requestUri: request?.RequestUri,
-                clientSideRequestStatistics: null);
+                clientSideRequestStatistics: dce.RequestStatistics as CosmosClientSideRequestStatistics);
 
             if (request != null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -80,6 +80,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                id: testItem.id,
                partitionKey: new PartitionKey(testItem.status));
             Assert.IsNotNull(deleteStreamResponse.Diagnostics);
+
+            // Ensure diagnostics are set even on failed operations
+            testItem.description = new string('x', Microsoft.Azure.Documents.Constants.MaxResourceSizeInBytes + 1);
+            ResponseMessage createTooBigStreamResponse = await this.Container.CreateItemStreamAsync(
+                partitionKey: new PartitionKey(testItem.status),
+                streamPayload: TestCommon.Serializer.ToStream<ToDoActivity>(testItem));
+            Assert.IsFalse(createTooBigStreamResponse.IsSuccessStatusCode);
+            Assert.IsNotNull(createTooBigStreamResponse.Diagnostics);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Diagnostics were not set in the CosmosResponse for failed requests; set them.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

