### PR TITLE
Wire up gateway with transportClientHandlerFactory

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1083,7 +1083,8 @@ namespace Microsoft.Azure.Cosmos
                     this.serializerSettings,
                     this.connectionPolicy.UserAgentContainer,
                     this.ApiType,
-                    this.httpMessageHandler);
+                    this.httpMessageHandler,
+                    this.transportClientHandlerFactory);
 
             this.gatewayStoreModel = gatewayStoreModel;
 

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Azure.Cosmos
             JsonSerializerSettings serializerSettings,
             UserAgentContainer userAgent,
             ApiType apiType = ApiType.None,
-            HttpMessageHandler messageHandler = null)
+            HttpMessageHandler messageHandler = null,
+            Func<TransportClient, TransportClient> transportClientHandlerFactory = null)
         {
             // CookieContainer is not really required, but is helpful in debugging.
             this.cookieJar = new CookieContainer();
@@ -71,6 +72,10 @@ namespace Microsoft.Azure.Cosmos
                 this.eventSource,
                 serializerSettings);
 
+            if (transportClientHandlerFactory != null)
+            {
+                this.gatewayStoreClient = (GatewayStoreClient)transportClientHandlerFactory(this.gatewayStoreClient);
+            }
         }
 
         public virtual async Task<DocumentServiceResponse> ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
## Description

Wire up gateway with transportClientHandlerFactory so that the TransportClient can be decorated to customize the DocumentServiceRequest.

The uncontrolled usage transportClientHandlerFactory is scary, it can be used as a factory, it can be used as an interceptor. And if used as an interceptor you can override properties and behavior, and in this scenario you can decorate the TransportClient to change behavior. I think to add custom requests headers, the contract should be clear, explicit and easy to discover, as an option on CosmosClientOptions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

closes #919


