### PR TITLE
Fix mocking for FeedIterator and Response classes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIterator.cs
@@ -23,14 +23,5 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A query response from cosmos service</returns>
         public abstract Task<ResponseMessage> ReadNextAsync(CancellationToken cancellationToken = default(CancellationToken));
-
-        /// <summary>
-        /// Tries to get the continuation token for the feed iterator.
-        /// Useful to avoid exceptions.
-        /// Useful to avoid the cost serialization until needed.
-        /// </summary>
-        /// <param name="continuationToken">The continuation to resume from.</param>
-        /// <returns>Whether or not we can get the continuaiton token.</returns>
-        internal abstract bool TryGetContinuationToken(out string continuationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
     using static Microsoft.Azure.Documents.RuntimeConstants;
 
@@ -154,7 +155,19 @@ namespace Microsoft.Azure.Cosmos
 
         internal override bool TryGetContinuationToken(out string state)
         {
-            return ((FeedIteratorCore)this.feedIterator).TryGetContinuationToken(out state);
+            QueryIterator queryIterator = this.feedIterator as QueryIterator;
+            if (queryIterator != null)
+            {
+                return queryIterator.TryGetContinuationToken(out state);
+            }
+
+            FeedIteratorCore feedIteratorCore = this.feedIterator as FeedIteratorCore;
+            if (feedIteratorCore != null)
+            {
+                return feedIteratorCore.TryGetContinuationToken(out state);
+            }
+
+            throw new ArgumentException($"Unsupported  iterator type of {this.feedIterator.GetType().Name}");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos
             return response;
         }
 
-        internal override bool TryGetContinuationToken(out string state)
+        internal bool TryGetContinuationToken(out string state)
         {
             state = this.continuationToken;
             return true;
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal override bool TryGetContinuationToken(out string state)
         {
-            return this.feedIterator.TryGetContinuationToken(out state);
+            return ((FeedIteratorCore)this.feedIterator).TryGetContinuationToken(out state);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorCore.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Cosmos
             return this.responseCreator(response);
         }
 
-        internal override bool TryGetContinuationToken(out string state)
+        internal bool TryGetContinuationToken(out string state)
         {
             QueryIterator queryIterator = this.feedIterator as QueryIterator;
             if (queryIterator != null)

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorOfT.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedIteratorOfT.cs
@@ -25,7 +25,5 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A query response from cosmos service</returns>
         public abstract Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default(CancellationToken));
-
-        internal abstract bool TryGetContinuationToken(out string state);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/FeedResponse.cs
@@ -29,12 +29,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Gets the continuation token to be used for continuing enumeration of the Azure Cosmos DB service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Cosmos.Query
             return response;
         }
 
-        internal override bool TryGetContinuationToken(out string state)
+        internal bool TryGetContinuationToken(out string state)
         {
             return this.cosmosQueryExecutionContext.TryGetContinuationToken(out state);
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerResponse.cs
@@ -65,12 +65,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="Cosmos.Container"/> implicitly from <see cref="ContainerResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
@@ -56,12 +56,5 @@ namespace Microsoft.Azure.Cosmos
 
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
-
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseResponse.cs
@@ -65,12 +65,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="Cosmos.Database"/> implicitly from <see cref="DatabaseResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionResponse.cs
@@ -65,12 +65,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="Cosmos.Permission"/> implicitly from <see cref="PermissionResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -75,6 +75,12 @@ namespace Microsoft.Azure.Cosmos
                 }, cancellationToken);
         }
 
+        internal bool TryGetContinuationToken(out string state)
+        {
+            state = this.continuationToken;
+            return true;
+        }
+
         private Task<ResponseMessage> NextResultSetDelegateAsync(
             string continuationToken,
             string partitionKeyRangeId,

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -75,12 +75,6 @@ namespace Microsoft.Azure.Cosmos
                 }, cancellationToken);
         }
 
-        internal override bool TryGetContinuationToken(out string state)
-        {
-            state = this.continuationToken;
-            return true;
-        }
-
         private Task<ResponseMessage> NextResultSetDelegateAsync(
             string continuationToken,
             string partitionKeyRangeId,

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos
             return response;
         }
 
-        internal override bool TryGetContinuationToken(out string state)
+        internal bool TryGetContinuationToken(out string state)
         {
             state = this.continuationToken;
             return true;

--- a/Microsoft.Azure.Cosmos/src/Resource/Response.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Response.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos
         /// To get public access to the quota information do the following
         /// cosmosResponse.Headers.GetHeaderValue("x-ms-resource-quota")
         /// </remarks>
-        internal abstract string MaxResourceQuota { get; }
+        internal string MaxResourceQuota { get; }
 
         /// <summary>
         /// Gets the current size of this entity from the Azure Cosmos DB service.
@@ -92,6 +92,6 @@ namespace Microsoft.Azure.Cosmos
         /// To get public access to the quota information do the following
         /// cosmosResponse.Headers.GetHeaderValue("x-ms-resource-usage")
         /// </remarks>
-        internal abstract string CurrentResourceQuotaUsage { get; }
+        internal string CurrentResourceQuotaUsage { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Response.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Response.cs
@@ -67,31 +67,5 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the cosmos diagnostics information for the current request to Azure Cosmos DB service
         /// </summary>
         public abstract CosmosDiagnostics Diagnostics { get; }
-
-        /// <summary>
-        /// Gets the maximum size limit for this entity from the Azure Cosmos DB service.
-        /// </summary>
-        /// <value>
-        /// The maximum size limit for this entity. Measured in kilobytes for document resources 
-        /// and in counts for other resources.
-        /// </value>
-        /// <remarks>
-        /// To get public access to the quota information do the following
-        /// cosmosResponse.Headers.GetHeaderValue("x-ms-resource-quota")
-        /// </remarks>
-        internal string MaxResourceQuota { get; }
-
-        /// <summary>
-        /// Gets the current size of this entity from the Azure Cosmos DB service.
-        /// </summary>
-        /// <value>
-        /// The current size for this entity. Measured in kilobytes for document resources 
-        /// and in counts for other resources.
-        /// </value>
-        /// <remarks>
-        /// To get public access to the quota information do the following
-        /// cosmosResponse.Headers.GetHeaderValue("x-ms-resource-usage")
-        /// </remarks>
-        internal string CurrentResourceQuotaUsage { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/StoredProcedureExecuteResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/StoredProcedureExecuteResponse.cs
@@ -58,12 +58,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Gets the token for use with session consistency requests from the Azure Cosmos DB service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/StoredProcedureResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/StoredProcedureResponse.cs
@@ -57,12 +57,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Gets the token for use with session consistency requests from the Azure Cosmos DB service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/TriggerResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/TriggerResponse.cs
@@ -57,12 +57,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="TriggerProperties"/> implicitly from <see cref="TriggerResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/UserDefinedFunctionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/UserDefinedFunctionResponse.cs
@@ -57,12 +57,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="UserDefinedFunctionProperties"/> implicitly from <see cref="UserDefinedFunctionResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Throughput/ThroughputResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Throughput/ThroughputResponse.cs
@@ -58,12 +58,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Gets minimum throughput in measurement of request units per second in the Azure Cosmos service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/User/UserResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/UserResponse.cs
@@ -65,12 +65,6 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ETag => this.Headers?.ETag;
 
-        /// <inheritdoc/>
-        internal override string MaxResourceQuota => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.MaxResourceQuota);
-
-        /// <inheritdoc/>
-        internal override string CurrentResourceQuotaUsage => this.Headers?.GetHeaderValue<string>(HttpConstants.HttpHeaders.CurrentResourceQuotaUsage);
-
         /// <summary>
         /// Get <see cref="Cosmos.User"/> implicitly from <see cref="UserResponse"/>
         /// </summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
             ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync<ToDoActivity>(item: testItem);
             Assert.IsNotNull(response);
-            Assert.IsNotNull(response.MaxResourceQuota);
-            Assert.IsNotNull(response.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
             ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id);
             Assert.IsNotNull(deleteResponse);
         }
@@ -124,8 +124,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<dynamic> response = await this.Container.CreateItemAsync<dynamic>(item: testItem, partitionKey: new Cosmos.PartitionKey(Undefined.Value));
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
-            Assert.IsNotNull(response.MaxResourceQuota);
-            Assert.IsNotNull(response.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
 
             ItemResponse<dynamic> deleteResponse = await this.Container.DeleteItemAsync<dynamic>(id: testItem.id, partitionKey: new Cosmos.PartitionKey(Undefined.Value));
             Assert.IsNotNull(deleteResponse);
@@ -143,8 +143,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<dynamic> response = await this.Container.CreateItemAsync<dynamic>(item: testItem);
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
-            Assert.IsNotNull(response.MaxResourceQuota);
-            Assert.IsNotNull(response.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
 
             ItemResponse<dynamic> readResponse = await this.Container.ReadItemAsync<dynamic>(id: testItem.id, partitionKey: Cosmos.PartitionKey.None);
             Assert.IsNotNull(readResponse);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -615,7 +615,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 QueryRequestOptions computeRequestOptions = queryRequestOptions.Clone();
                 computeRequestOptions.ExecutionEnvironment = Cosmos.Query.Core.ExecutionContext.ExecutionEnvironment.Compute;
 
-                FeedIterator<T> itemQuery = container.GetItemQueryIterator<T>(
+                FeedIteratorCore<T> itemQuery = (FeedIteratorCore<T>)container.GetItemQueryIterator<T>(
                    queryText: query,
                    requestOptions: computeRequestOptions,
                    continuationToken: state);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -453,8 +453,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(storedProcedureSettings.Id, settings.Id,
                 "Stored Procedure id do not match");
             Assert.IsTrue(cosmosResponse.RequestCharge > 0);
-            Assert.IsNotNull(cosmosResponse.MaxResourceQuota);
-            Assert.IsNotNull(cosmosResponse.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
         }
 
         private class FaultySerializer : CosmosSerializer

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -284,8 +284,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(triggerSettings.Id, settings.Id,
                 "Trigger id do not match");
             Assert.IsTrue(cosmosResponse.RequestCharge > 0);
-            Assert.IsNotNull(cosmosResponse.MaxResourceQuota);
-            Assert.IsNotNull(cosmosResponse.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
         }
 
         private class Job

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -186,8 +186,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(udfSettings.Id, settings.Id,
                 "User defined function id do not match");
             Assert.IsTrue(cosmosResponse.RequestCharge > 0);
-            Assert.IsNotNull(cosmosResponse.MaxResourceQuota);
-            Assert.IsNotNull(cosmosResponse.CurrentResourceQuotaUsage);
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
+            Assert.IsNotNull(cosmosResponse.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
         }
 
         private async Task<UserDefinedFunctionResponse> CreateRandomUdf()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
@@ -50,6 +50,36 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string.Join(";", nonVirtualPublic.Select(x => $"Class:{x.Item1}; Member:{x.Item2}")));
         }
 
+        [TestMethod]
+        public void VerifyAllPublicClassesCanBeMockedUnitTesting()
+        {
+            // All of the public classes should not contain an internal abstract method
+            // create unit tests by mocking the different types. Data Contracts do not support mocking so exclude all types that end with Settings.
+            IEnumerable<Type> allClasses = from t in Assembly.GetAssembly(typeof(CosmosClient)).GetTypes()
+                                           where t.IsClass && t.Namespace == "Microsoft.Azure.Cosmos" && t.IsPublic
+                                           select t;
+
+            // Get the entire list to prevent running the test for each method/property
+            List<Tuple<string, string>> nonVirtualPublic = new List<Tuple<string, string>>();
+            foreach (Type publiClass in allClasses)
+            {
+                // DeclaredOnly flag gets only the properties declared in the current class. 
+                // This ignores inherited properties to prevent duplicate findings.
+                IEnumerable<Tuple<string, string>> allProps = publiClass.GetProperties(BindingFlags.DeclaredOnly)
+                    .Where(x => x.GetGetMethod().IsAbstract && !x.GetGetMethod().IsPublic)
+                    .Select(x => new Tuple<string, string>(publiClass.FullName, x.Name));
+                nonVirtualPublic.AddRange(allProps);
+
+                IEnumerable<Tuple<string, string>> allMethods = publiClass.GetMethods(BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .Where(x => x.IsAbstract && !x.IsPublic)
+                    .Select(x => new Tuple<string, string>(publiClass.FullName, x.Name));
+                nonVirtualPublic.AddRange(allMethods);
+            }
+
+            Assert.AreEqual(0, nonVirtualPublic.Count,
+                "The following methods and properties should be virtual to allow unit testing:" +
+                string.Join(";", nonVirtualPublic.Select(x => $"Class:{x.Item1}; Member:{x.Item2}")));
+        }
 
         [TestMethod]
         public async Task VerifyClientMock()

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
+
+### Fixed
+
+- [#978](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/978) Fixed FeedIterator mocking
+
 ## <a name="3.4.0"/> [3.4.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.0) - 2019-11-04
+
 ### Added
 
 - [#853](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/853) ORDER BY Arrays and Object support.

--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#978](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/978) Fixed FeedIterator mocking
+- [#978](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/978) Fix mocking for FeedIterator and Response classes
 
 ## <a name="3.4.0"/> [3.4.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.0) - 2019-11-04
 


### PR DESCRIPTION
# Pull Request Template

## Description

Users can't mock an internal abstract method. Removing the internal abstract method to fix unit testing.

Fixes #977 