### PR TITLE
Fixed substatuscode so it gets set on query response.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1438,7 +1438,7 @@ namespace Microsoft.Azure.Cosmos
             set { this.onExecuteScalarQueryCallback = value; }
         }
 
-        internal async Task<IDictionary<string, object>> GetQueryEngineConfigurationAsync()
+        internal virtual async Task<IDictionary<string, object>> GetQueryEngineConfigurationAsync()
         {
             await this.EnsureValidClientAsync();
             return this.accountServiceConfiguration.QueryEngineConfiguration;

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Azure.Cosmos.Query
                             cosmosQueryContext.ContainerResourceId)
                         {
                             RequestCharge = responseCore.RequestCharge,
-                            ActivityId = responseCore.ActivityId
+                            ActivityId = responseCore.ActivityId,
+                            SubStatusCode = responseCore.SubStatusCode ?? Documents.SubStatusCodes.Unknown
                         });
                 }
                 else
@@ -118,7 +119,8 @@ namespace Microsoft.Azure.Cosmos.Query
                             cosmosQueryContext.ContainerResourceId)
                         {
                             RequestCharge = responseCore.RequestCharge,
-                            ActivityId = responseCore.ActivityId
+                            ActivityId = responseCore.ActivityId,
+                            SubStatusCode = responseCore.SubStatusCode ?? Documents.SubStatusCodes.Unknown
                         });
                 }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MockDocumentClient.cs
@@ -125,6 +125,12 @@ namespace Microsoft.Azure.Cosmos.Client.Core.Tests
             return Task.FromResult(this.partitionKeyRangeCache.Object);
         }
 
+        internal override Task<IDictionary<string, object>> GetQueryEngineConfigurationAsync()
+        {
+            Dictionary<string, object> queryEngineConfiguration = JsonConvert.DeserializeObject< Dictionary<string, object>>("{\"maxSqlQueryInputLength\":262144,\"maxJoinsPerSqlQuery\":5,\"maxLogicalAndPerSqlQuery\":500,\"maxLogicalOrPerSqlQuery\":500,\"maxUdfRefPerSqlQuery\":10,\"maxInExpressionItemsCount\":16000,\"queryMaxInMemorySortDocumentCount\":500,\"maxQueryRequestTimeoutFraction\":0.9,\"sqlAllowNonFiniteNumbers\":false,\"sqlAllowAggregateFunctions\":true,\"sqlAllowSubQuery\":true,\"sqlAllowScalarSubQuery\":true,\"allowNewKeywords\":true,\"sqlAllowLike\":false,\"sqlAllowGroupByClause\":false,\"maxSpatialQueryCells\":12,\"spatialMaxGeometryPointCount\":256,\"sqlAllowTop\":true,\"enableSpatialIndexing\":true}");
+            return Task.FromResult((IDictionary<string, object>)queryEngineConfiguration);
+        }
+
         string IAuthorizationTokenProvider.GetUserAuthorizationToken(
             string resourceAddress,
             string resourceType,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryNegativeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryNegativeTests.cs
@@ -1,0 +1,39 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Client.Core.Tests;
+    using Microsoft.Azure.Cosmos.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class MockQueryNegativeTests
+    {
+        [TestMethod]
+        public async Task TestSubStatusCode()
+        {
+            ResponseMessage failedResponse = new ResponseMessage(statusCode: System.Net.HttpStatusCode.BadRequest);
+            failedResponse.Headers.SubStatusCode = Documents.SubStatusCodes.ReadSessionNotAvailable;
+            failedResponse.Headers.ActivityId = new Guid("A9F6D58B-8F9A-45B4-9887-F5C710E025DD").ToString();
+
+            Mock<RequestHandler> mockHandler = new Mock<RequestHandler>();
+            mockHandler.Setup(x => x.SendAsync(It.IsAny<RequestMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(failedResponse));
+            
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient(builder => builder.AddCustomHandlers(mockHandler.Object));
+            Container container = client.GetContainer("TestDb", "TestContainer");
+            FeedIterator feedIterator = container.GetItemQueryStreamIterator("select * from t");
+            Assert.IsTrue(feedIterator.HasMoreResults);
+            ResponseMessage responseMessage = await feedIterator.ReadNextAsync();
+            Assert.AreEqual(failedResponse.StatusCode, responseMessage.StatusCode);
+            Assert.AreEqual(Documents.SubStatusCodes.ReadSessionNotAvailable, responseMessage.Headers.SubStatusCode);
+            Assert.AreEqual(failedResponse.Headers.ActivityId, responseMessage.Headers.ActivityId);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Internal teams depend on the substatuscode to be populated. This fixes a bug where the substatuscode was not getting set on the conversion to the public type.

Test will be added in future iterations. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

