### PR TITLE
Convert QueryException to CosmosException

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Azure.Cosmos
         private const bool DefaultEnableCpuMonitor = true;
 
         private readonly IDictionary<string, List<PartitionKeyAndResourceTokenPair>> resourceTokens;
-        private ConnectionPolicy connectionPolicy;
         private RetryPolicy retryPolicy;
         private bool allowOverrideStrongerConsistency = false;
         private int maxConcurrentConnectionOpenRequests = Environment.ProcessorCount * MaxConcurrentConnectionOpenRequestsPerProcessor;
@@ -144,11 +143,6 @@ namespace Microsoft.Azure.Cosmos
         // This flag is used to allow shared store client factory survive disposition of a document client while other clients continue using it.
         private bool isStoreClientFactoryCreatedInternally;
 
-        //Based on connectivity mode we will either have ServerStoreModel / GatewayStoreModel here.
-        private IStoreModel storeModel;
-        //We will always have GatewayStoreModel for certain Master operations(viz: Collection CRUD)
-        private IStoreModel gatewayStoreModel;
-
         //Id counter.
         private static int idCounter;
         //Trace Id.
@@ -161,19 +155,12 @@ namespace Microsoft.Azure.Cosmos
         private readonly string authKeyResourceToken = string.Empty;
 
         private DocumentClientEventSource eventSource;
-        private GlobalEndpointManager globalEndpointManager;
-        private bool useMultipleWriteLocations;
-
         internal Task initializeTask;
 
         private JsonSerializerSettings serializerSettings;
         private event EventHandler<SendingRequestEventArgs> sendingRequest;
         private event EventHandler<ReceivedResponseEventArgs> receivedResponse;
         private Func<TransportClient, TransportClient> transportClientHandlerFactory;
-
-        //Callback for on execution of scalar LINQ queries event.
-        //This callback is meant for tests only.
-        private Action<IQueryable> onExecuteScalarQueryCallback;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentClient"/> class using the
@@ -724,10 +711,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal GlobalEndpointManager GlobalEndpointManager
-        {
-            get { return this.globalEndpointManager; }
-        }
+        internal GlobalEndpointManager GlobalEndpointManager { get; private set; }
 
         /// <summary>
         /// Open the connection to validate that the client initialization is successful in the Azure Cosmos DB service.
@@ -752,7 +736,7 @@ namespace Microsoft.Azure.Cosmos
         /// </example>
         public Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.InlineIfPossibleAsync(() => OpenPrivateInlineAsync(cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossibleAsync(() => this.OpenPrivateInlineAsync(cancellationToken), null, cancellationToken);
         }
 
         private async Task OpenPrivateInlineAsync(CancellationToken cancellationToken)
@@ -789,8 +773,8 @@ namespace Microsoft.Azure.Cosmos
             catch (DocumentClientException ex)
             {
                 // Clear the caches to ensure that we don't have partial results
-                this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.gatewayStoreModel, this, this.retryPolicy);
-                this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.gatewayStoreModel, this.collectionCache);
+                this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.GatewayStoreModel, this, this.retryPolicy);
+                this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.GatewayStoreModel, this.collectionCache);
 
                 DefaultTrace.TraceWarning("{0} occurred while OpenAsync. Exception Message: {1}", ex.ToString(), ex.Message);
             }
@@ -984,21 +968,21 @@ namespace Microsoft.Azure.Cosmos
 
             this.ServiceEndpoint = serviceEndpoint.OriginalString.EndsWith("/", StringComparison.Ordinal) ? serviceEndpoint : new Uri(serviceEndpoint.OriginalString + "/");
 
-            this.connectionPolicy = connectionPolicy ?? ConnectionPolicy.Default;
+            this.ConnectionPolicy = connectionPolicy ?? ConnectionPolicy.Default;
 
 #if !NETSTANDARD16
             ServicePoint servicePoint = ServicePointManager.FindServicePoint(this.ServiceEndpoint);
-            servicePoint.ConnectionLimit = this.connectionPolicy.MaxConnectionLimit;
+            servicePoint.ConnectionLimit = this.ConnectionPolicy.MaxConnectionLimit;
 #endif
 
-            this.globalEndpointManager = new GlobalEndpointManager(this, this.connectionPolicy);
+            this.GlobalEndpointManager = new GlobalEndpointManager(this, this.ConnectionPolicy);
 
             this.httpMessageHandler = new HttpRequestMessageHandler(this.sendingRequest, this.receivedResponse, handler);
 
             this.mediaClient = new HttpClient(this.httpMessageHandler);
 
             this.mediaClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true };
-            this.mediaClient.AddUserAgentHeader(this.connectionPolicy.UserAgentContainer);
+            this.mediaClient.AddUserAgentHeader(this.ConnectionPolicy.UserAgentContainer);
 
             this.mediaClient.AddApiTypeHeader(this.ApiType);
 
@@ -1019,10 +1003,10 @@ namespace Microsoft.Azure.Cosmos
                 this.sessionContainer = new SessionContainer(this.ServiceEndpoint.Host);
             }
 
-            this.retryPolicy = new RetryPolicy(this.globalEndpointManager, this.connectionPolicy);
+            this.retryPolicy = new RetryPolicy(this.GlobalEndpointManager, this.ConnectionPolicy);
             this.ResetSessionTokenRetryPolicy = this.retryPolicy;
 
-            this.mediaClient.Timeout = this.connectionPolicy.MediaRequestTimeout;
+            this.mediaClient.Timeout = this.ConnectionPolicy.MediaRequestTimeout;
 
             this.desiredConsistencyLevel = desiredConsistencyLevel;
             // Setup the proxy to be  used based on connection mode.
@@ -1035,8 +1019,8 @@ namespace Microsoft.Azure.Cosmos
             this.initializeTask = TaskHelper.InlineIfPossibleAsync(
                 () => this.GetInitializationTaskAsync(storeClientFactory: storeClientFactory),
                 new ResourceThrottleRetryPolicy(
-                    this.connectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests,
-                    this.connectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds));
+                    this.ConnectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests,
+                    this.ConnectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds));
 
             // ContinueWith on the initialization task is needed for handling the UnobservedTaskException
             // if this task throws for some reason. Awaiting inside a constructor is not supported and
@@ -1057,8 +1041,8 @@ namespace Microsoft.Azure.Cosmos
                 "DocumentClient with id {0} initialized at endpoint: {1} with ConnectionMode: {2}, connection Protocol: {3}, and consistency level: {4}",
                 this.traceId,
                 serviceEndpoint.ToString(),
-                this.connectionPolicy.ConnectionMode.ToString(),
-                this.connectionPolicy.ConnectionProtocol.ToString(),
+                this.ConnectionPolicy.ConnectionMode.ToString(),
+                this.ConnectionPolicy.ConnectionProtocol.ToString(),
                 desiredConsistencyLevel != null ? desiredConsistencyLevel.ToString() : "null"));
 
             this.QueryCompatibilityMode = QueryCompatibilityMode.Default;
@@ -1075,25 +1059,25 @@ namespace Microsoft.Azure.Cosmos
             }
 
             GatewayStoreModel gatewayStoreModel = new GatewayStoreModel(
-                    this.globalEndpointManager,
+                    this.GlobalEndpointManager,
                     this.sessionContainer,
-                    this.connectionPolicy.RequestTimeout,
+                    this.ConnectionPolicy.RequestTimeout,
                     (Cosmos.ConsistencyLevel)this.accountServiceConfiguration.DefaultConsistencyLevel,
                     this.eventSource,
                     this.serializerSettings,
-                    this.connectionPolicy.UserAgentContainer,
+                    this.ConnectionPolicy.UserAgentContainer,
                     this.ApiType,
                     this.httpMessageHandler);
 
-            this.gatewayStoreModel = gatewayStoreModel;
+            this.GatewayStoreModel = gatewayStoreModel;
 
-            this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.gatewayStoreModel, this, this.retryPolicy);
-            this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.gatewayStoreModel, this.collectionCache);
+            this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.GatewayStoreModel, this, this.retryPolicy);
+            this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.GatewayStoreModel, this.collectionCache);
             this.ResetSessionTokenRetryPolicy = new ResetSessionTokenRetryPolicyFactory(this.sessionContainer, this.collectionCache, this.retryPolicy);
 
-            if (this.connectionPolicy.ConnectionMode == ConnectionMode.Gateway)
+            if (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway)
             {
-                this.storeModel = this.gatewayStoreModel;
+                this.StoreModel = this.GatewayStoreModel;
             }
             else
             {
@@ -1211,7 +1195,7 @@ namespace Microsoft.Azure.Cosmos
             get; private set;
         }
 
-        internal bool UseMultipleWriteLocations => this.useMultipleWriteLocations;
+        internal bool UseMultipleWriteLocations { get; private set; }
 
         /// <summary>
         /// Gets the endpoint Uri for the service endpoint from the Azure Cosmos DB service.
@@ -1233,7 +1217,7 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return this.globalEndpointManager.WriteEndpoints.FirstOrDefault();
+                return this.GlobalEndpointManager.WriteEndpoints.FirstOrDefault();
             }
         }
 
@@ -1244,7 +1228,7 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return this.globalEndpointManager.ReadEndpoints.FirstOrDefault();
+                return this.GlobalEndpointManager.ReadEndpoints.FirstOrDefault();
             }
         }
 
@@ -1255,13 +1239,7 @@ namespace Microsoft.Azure.Cosmos
         /// The Connection policy used by the client.
         /// </value>
         /// <seealso cref="Microsoft.Azure.Cosmos.ConnectionPolicy"/>
-        public ConnectionPolicy ConnectionPolicy
-        {
-            get
-            {
-                return this.connectionPolicy;
-            }
-        }
+        public ConnectionPolicy ConnectionPolicy { get; private set; }
 
         /// <summary>
         /// Gets a dictionary of resource tokens used by the client from the Azure Cosmos DB service.
@@ -1340,16 +1318,16 @@ namespace Microsoft.Azure.Cosmos
                 return;
             }
 
-            if (this.storeModel != null)
+            if (this.StoreModel != null)
             {
-                this.storeModel.Dispose();
-                this.storeModel = null;
+                this.StoreModel.Dispose();
+                this.StoreModel = null;
             }
 
             if (this.storeClientFactory != null)
             {
                 // Dispose only if this store client factory was created and is owned by this instance of document client, otherwise just release the reference
-                if (isStoreClientFactoryCreatedInternally)
+                if (this.isStoreClientFactoryCreatedInternally)
                 {
                     this.storeClientFactory.Dispose();
                 }
@@ -1375,10 +1353,10 @@ namespace Microsoft.Azure.Cosmos
                 this.authKeyHashFunction = null;
             }
 
-            if (this.globalEndpointManager != null)
+            if (this.GlobalEndpointManager != null)
             {
-                this.globalEndpointManager.Dispose();
-                this.globalEndpointManager = null;
+                this.GlobalEndpointManager.Dispose();
+                this.GlobalEndpointManager = null;
             }
 
             DefaultTrace.TraceInformation("DocumentClient with id {0} disposed.", this.traceId);
@@ -1408,11 +1386,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// Test hook to enable unit test of DocumentClient.
         /// </remarks>
-        internal IStoreModel StoreModel
-        {
-            get { return this.storeModel; }
-            set { this.storeModel = value; }
-        }
+        internal IStoreModel StoreModel { get; set; }
 
         /// <summary>
         /// Gets and sets the gateway IStoreModel object.
@@ -1420,11 +1394,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// Test hook to enable unit test of DocumentClient.
         /// </remarks>
-        internal IStoreModel GatewayStoreModel
-        {
-            get { return this.gatewayStoreModel; }
-            set { this.gatewayStoreModel = value; }
-        }
+        internal IStoreModel GatewayStoreModel { get; set; }
 
         /// <summary>
         /// Gets and sets on execute scalar query callback
@@ -1432,11 +1402,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// Test hook to enable unit test for scalar queries
         /// </remarks>
-        internal Action<IQueryable> OnExecuteScalarQueryCallback
-        {
-            get { return this.onExecuteScalarQueryCallback; }
-            set { this.onExecuteScalarQueryCallback = value; }
-        }
+        internal Action<IQueryable> OnExecuteScalarQueryCallback { get; set; }
 
         internal virtual async Task<IDictionary<string, object>> GetQueryEngineConfigurationAsync()
         {
@@ -1703,7 +1669,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="System.Threading.Tasks.Task"/>
         public Task<ResourceResponse<Documents.Database>> CreateDatabaseIfNotExistsAsync(Documents.Database database, Documents.Client.RequestOptions options = null)
         {
-            return TaskHelper.InlineIfPossible(() => CreateDatabaseIfNotExistsPrivateAsync(database, options), null);
+            return TaskHelper.InlineIfPossible(() => this.CreateDatabaseIfNotExistsPrivateAsync(database, options), null);
         }
 
         private async Task<ResourceResponse<Documents.Database>> CreateDatabaseIfNotExistsPrivateAsync(Documents.Database database,
@@ -1847,7 +1813,7 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken))
         {
             // This call is to just run CreateDocumentInlineAsync in a SynchronizationContext aware environment
-            return TaskHelper.InlineIfPossible(() => CreateDocumentInlineAsync(documentsFeedOrDatabaseLink, document, options, disableAutomaticIdGeneration, cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossible(() => this.CreateDocumentInlineAsync(documentsFeedOrDatabaseLink, document, options, disableAutomaticIdGeneration, cancellationToken), null, cancellationToken);
         }
 
         private async Task<ResourceResponse<Document>> CreateDocumentInlineAsync(string documentsFeedOrDatabaseLink, object document, Documents.Client.RequestOptions options, bool disableAutomaticIdGeneration, CancellationToken cancellationToken)
@@ -2045,7 +2011,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="System.Threading.Tasks.Task"/>
         public Task<ResourceResponse<DocumentCollection>> CreateDocumentCollectionIfNotExistsAsync(string databaseLink, DocumentCollection documentCollection, Documents.Client.RequestOptions options = null)
         {
-            return TaskHelper.InlineIfPossible(() => CreateDocumentCollectionIfNotExistsPrivateAsync(databaseLink, documentCollection, options), null);
+            return TaskHelper.InlineIfPossible(() => this.CreateDocumentCollectionIfNotExistsPrivateAsync(databaseLink, documentCollection, options), null);
         }
 
         private async Task<ResourceResponse<DocumentCollection>> CreateDocumentCollectionIfNotExistsPrivateAsync(
@@ -3076,7 +3042,7 @@ namespace Microsoft.Azure.Cosmos
         public Task<ResourceResponse<Document>> ReplaceDocumentAsync(string documentLink, object document, Documents.Client.RequestOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // This call is to just run ReplaceDocumentInlineAsync in a SynchronizationContext aware environment
-            return TaskHelper.InlineIfPossible(() => ReplaceDocumentInlineAsync(documentLink, document, options, cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossible(() => this.ReplaceDocumentInlineAsync(documentLink, document, options, cancellationToken), null, cancellationToken);
         }
 
         private async Task<ResourceResponse<Document>> ReplaceDocumentInlineAsync(string documentLink, object document, Documents.Client.RequestOptions options, CancellationToken cancellationToken)
@@ -4877,7 +4843,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="System.Threading.Tasks.Task"/>
         public Task<DocumentFeedResponse<dynamic>> ReadDocumentFeedAsync(string documentsLink, FeedOptions options = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.InlineIfPossible(() => ReadDocumentFeedInlineAsync(documentsLink, options, cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossible(() => this.ReadDocumentFeedInlineAsync(documentsLink, options, cancellationToken), null, cancellationToken);
         }
 
         private async Task<DocumentFeedResponse<dynamic>> ReadDocumentFeedInlineAsync(string documentsLink, FeedOptions options, CancellationToken cancellationToken)
@@ -4952,7 +4918,7 @@ namespace Microsoft.Azure.Cosmos
         /// <seealso cref="System.Threading.Tasks.Task"/>
         public Task<DocumentFeedResponse<Conflict>> ReadConflictFeedAsync(string conflictsLink, FeedOptions options = null)
         {
-            return TaskHelper.InlineIfPossible(() => ReadConflictFeedInlineAsync(conflictsLink, options), null);
+            return TaskHelper.InlineIfPossible(() => this.ReadConflictFeedInlineAsync(conflictsLink, options), null);
         }
 
         private async Task<DocumentFeedResponse<Conflict>> ReadConflictFeedInlineAsync(string conflictsLink, FeedOptions options)
@@ -5512,7 +5478,7 @@ namespace Microsoft.Azure.Cosmos
         public Task<ResourceResponse<Document>> UpsertDocumentAsync(string documentsFeedOrDatabaseLink, object document, Documents.Client.RequestOptions options = null, bool disableAutomaticIdGeneration = false, CancellationToken cancellationToken = default(CancellationToken))
         {
             // This call is to just run UpsertDocumentInlineAsync in a SynchronizationContext aware environment
-            return TaskHelper.InlineIfPossible(() => UpsertDocumentInlineAsync(documentsFeedOrDatabaseLink, document, options, disableAutomaticIdGeneration, cancellationToken), null, cancellationToken);
+            return TaskHelper.InlineIfPossible(() => this.UpsertDocumentInlineAsync(documentsFeedOrDatabaseLink, document, options, disableAutomaticIdGeneration, cancellationToken), null, cancellationToken);
         }
 
         private async Task<ResourceResponse<Document>> UpsertDocumentInlineAsync(string documentsFeedOrDatabaseLink, object document, Documents.Client.RequestOptions options, bool disableAutomaticIdGeneration, CancellationToken cancellationToken)
@@ -6296,7 +6262,7 @@ namespace Microsoft.Azure.Cosmos
         private async Task<AccountProperties> GetDatabaseAccountPrivateAsync(Uri serviceEndpoint, CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.EnsureValidClientAsync();
-            GatewayStoreModel gatewayModel = this.gatewayStoreModel as GatewayStoreModel;
+            GatewayStoreModel gatewayModel = this.GatewayStoreModel as GatewayStoreModel;
             if (gatewayModel != null)
             {
                 using (HttpRequestMessage request = new HttpRequestMessage())
@@ -6329,7 +6295,7 @@ namespace Microsoft.Azure.Cosmos
 
                     AccountProperties databaseAccount = await gatewayModel.GetDatabaseAccountAsync(request);
 
-                    this.useMultipleWriteLocations = this.connectionPolicy.UseMultipleWriteLocations && databaseAccount.EnableMultipleWriteLocations;
+                    this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && databaseAccount.EnableMultipleWriteLocations;
 
                     return databaseAccount;
                 }
@@ -6352,7 +6318,7 @@ namespace Microsoft.Azure.Cosmos
             // we return the Gateway store model
             if (request.UseGatewayMode)
             {
-                return this.gatewayStoreModel;
+                return this.GatewayStoreModel;
             }
 
             ResourceType resourceType = request.ResourceType;
@@ -6362,7 +6328,7 @@ namespace Microsoft.Azure.Cosmos
                 (resourceType.IsScript() && operationType != OperationType.ExecuteJavaScript) ||
                 resourceType == ResourceType.PartitionKeyRange)
             {
-                return this.gatewayStoreModel;
+                return this.GatewayStoreModel;
             }
 
             if (operationType == OperationType.Create
@@ -6373,11 +6339,11 @@ namespace Microsoft.Azure.Cosmos
                     resourceType == ResourceType.Collection ||
                     resourceType == ResourceType.Permission)
                 {
-                    return this.gatewayStoreModel;
+                    return this.GatewayStoreModel;
                 }
                 else
                 {
-                    return this.storeModel;
+                    return this.StoreModel;
                 }
             }
             else if (operationType == OperationType.Delete)
@@ -6386,45 +6352,45 @@ namespace Microsoft.Azure.Cosmos
                     resourceType == ResourceType.User ||
                     resourceType == ResourceType.Collection)
                 {
-                    return this.gatewayStoreModel;
+                    return this.GatewayStoreModel;
                 }
                 else
                 {
-                    return this.storeModel;
+                    return this.StoreModel;
                 }
             }
             else if (operationType == OperationType.Replace)
             {
                 if (resourceType == ResourceType.Collection)
                 {
-                    return this.gatewayStoreModel;
+                    return this.GatewayStoreModel;
                 }
                 else
                 {
-                    return this.storeModel;
+                    return this.StoreModel;
                 }
             }
             else if (operationType == OperationType.Read)
             {
                 if (resourceType == ResourceType.Collection)
                 {
-                    return this.gatewayStoreModel;
+                    return this.GatewayStoreModel;
                 }
                 else
                 {
-                    return this.storeModel;
+                    return this.StoreModel;
                 }
             }
             else
             {
-                return this.storeModel;
+                return this.StoreModel;
             }
         }
 
         /// <summary>
         /// The preferred link used in replace operation in SDK.
         /// </summary>
-        private string GetLinkForRouting(Resource resource)
+        private string GetLinkForRouting(Documents.Resource resource)
         {
             // we currently prefer the selflink
             return resource.SelfLink ?? resource.AltLink;
@@ -6465,10 +6431,10 @@ namespace Microsoft.Azure.Cosmos
             else
             {
                 StoreClientFactory newClientFactory = new StoreClientFactory(
-                    this.connectionPolicy.ConnectionProtocol,
-                    (int)this.connectionPolicy.RequestTimeout.TotalSeconds,
+                    this.ConnectionPolicy.ConnectionProtocol,
+                    (int)this.ConnectionPolicy.RequestTimeout.TotalSeconds,
                     this.maxConcurrentConnectionOpenRequests,
-                    this.connectionPolicy.UserAgentContainer,
+                    this.ConnectionPolicy.UserAgentContainer,
                     this.eventSource,
                     null,
                     this.openConnectionTimeoutInSeconds,
@@ -6480,7 +6446,7 @@ namespace Microsoft.Azure.Cosmos
                     receiveHangDetectionTimeSeconds: this.rntbdReceiveHangDetectionTimeSeconds,
                     sendHangDetectionTimeSeconds: this.rntbdSendHangDetectionTimeSeconds,
                     enableCpuMonitor: this.enableCpuMonitor,
-                    retryWithConfiguration: this.connectionPolicy.RetryOptions?.GetRetryWithConfiguration());
+                    retryWithConfiguration: this.ConnectionPolicy.RetryOptions?.GetRetryWithConfiguration());
 
                 if (this.transportClientHandlerFactory != null)
                 {
@@ -6492,15 +6458,15 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.AddressResolver = new GlobalAddressResolver(
-                this.globalEndpointManager,
-                this.connectionPolicy.ConnectionProtocol,
+                this.GlobalEndpointManager,
+                this.ConnectionPolicy.ConnectionProtocol,
                 this,
                 this.collectionCache,
                 this.partitionKeyRangeCache,
-                this.connectionPolicy.UserAgentContainer,
+                this.ConnectionPolicy.UserAgentContainer,
                 this.accountServiceConfiguration,
                 this.httpMessageHandler,
-                this.connectionPolicy,
+                this.ConnectionPolicy,
                 this.ApiType);
 
             this.CreateStoreModel(subscribeRntbdStatus: true);
@@ -6517,9 +6483,9 @@ namespace Microsoft.Azure.Cosmos
                 this.accountServiceConfiguration,
                 this,
                 true,
-                this.connectionPolicy.EnableReadRequestsFallback ?? (this.accountServiceConfiguration.DefaultConsistencyLevel != Documents.ConsistencyLevel.BoundedStaleness),
+                this.ConnectionPolicy.EnableReadRequestsFallback ?? (this.accountServiceConfiguration.DefaultConsistencyLevel != Documents.ConsistencyLevel.BoundedStaleness),
                 !this.enableRntbdChannel,
-                this.useMultipleWriteLocations && (this.accountServiceConfiguration.DefaultConsistencyLevel != Documents.ConsistencyLevel.Strong),
+                this.UseMultipleWriteLocations && (this.accountServiceConfiguration.DefaultConsistencyLevel != Documents.ConsistencyLevel.Strong),
                 true);
 
             if (subscribeRntbdStatus)
@@ -6529,7 +6495,7 @@ namespace Microsoft.Azure.Cosmos
 
             storeClient.SerializerSettings = this.serializerSettings;
 
-            this.storeModel = new ServerStoreModel(storeClient, this.sendingRequest, this.receivedResponse);
+            this.StoreModel = new ServerStoreModel(storeClient, this.sendingRequest, this.receivedResponse);
         }
 
         private void DisableRntbdChannel()
@@ -6546,7 +6512,7 @@ namespace Microsoft.Azure.Cosmos
                     this.authKeyHashFunction,
                     this.hasAuthKeyResourceToken,
                     this.authKeyResourceToken,
-                    this.connectionPolicy,
+                    this.ConnectionPolicy,
                     this.ApiType,
                     this.httpMessageHandler);
 
@@ -6554,9 +6520,9 @@ namespace Microsoft.Azure.Cosmos
 
             await this.accountServiceConfiguration.InitializeAsync();
             AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
-            this.useMultipleWriteLocations = this.connectionPolicy.UseMultipleWriteLocations && accountProperties.EnableMultipleWriteLocations;
+            this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && accountProperties.EnableMultipleWriteLocations;
 
-            await this.globalEndpointManager.RefreshLocationAsync(accountProperties);
+            await this.GlobalEndpointManager.RefreshLocationAsync(accountProperties);
         }
 
         internal void CaptureSessionToken(DocumentServiceRequest request, DocumentServiceResponse response)
@@ -6590,7 +6556,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal void ValidateResource(Resource resource)
+        internal void ValidateResource(Documents.Resource resource)
         {
             this.ValidateResource(resource.Id);
         }
@@ -6683,7 +6649,7 @@ namespace Microsoft.Azure.Cosmos
 
             INameValueCollection headers = new DictionaryNameValueCollection();
 
-            if (this.useMultipleWriteLocations)
+            if (this.UseMultipleWriteLocations)
             {
                 headers.Set(HttpConstants.HttpHeaders.AllowTentativeWrites, bool.TrueString);
             }
@@ -6866,7 +6832,7 @@ namespace Microsoft.Azure.Cosmos
 
             public IDocumentClientRetryPolicy GetRequestPolicy()
             {
-                return new RenameCollectionAwareClientRetryPolicy(this.sessionContainer, this.collectionCache, retryPolicy.GetRequestPolicy());
+                return new RenameCollectionAwareClientRetryPolicy(this.sessionContainer, this.collectionCache, this.retryPolicy.GetRequestPolicy());
             }
         }
 
@@ -6880,7 +6846,7 @@ namespace Microsoft.Azure.Cosmos
                 this.sendingRequest = sendingRequest;
                 this.receivedResponse = receivedResponse;
 
-                InnerHandler = innerHandler ?? new HttpClientHandler();
+                this.InnerHandler = innerHandler ?? new HttpClientHandler();
             }
 
             protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/FeedResponseBinder.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedResponseBinder.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.InteropServices;
-    using System.Text;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Documents;
@@ -84,7 +82,7 @@ namespace Microsoft.Azure.Cosmos
             // If the resource type is an offer and the requested type is either a Offer or OfferV2 or dynamic
             // create a OfferV2 object and cast it to T. This is a temporary fix until offers is moved to v3 API. 
             if (resourceType == ResourceType.Offer &&
-                (typeof(T).IsSubclassOf(typeof(Resource)) || typeof(T) == typeof(object)))
+                (typeof(T).IsSubclassOf(typeof(Documents.Resource)) || typeof(T) == typeof(object)))
             {
                 typedResults = JsonConvert.DeserializeObject<List<OfferV2>>(jsonText, settings).Cast<T>();
             }

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Cosmos
             if (string.Equals(responseMessage.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase))
             {
                 Stream readStream = await responseMessage.Content.ReadAsStreamAsync();
-                Error error = Resource.LoadFrom<Error>(readStream);
+                Error error = Documents.Resource.LoadFrom<Error>(readStream);
                 return new DocumentClientException(
                     error,
                     responseMessage.Headers,

--- a/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 try
                 {
-                    Error error = Resource.LoadFrom<Error>(this.content);
+                    Error error = Documents.Resource.LoadFrom<Error>(this.content);
                     if (error != null)
                     {
                         // Error format is not consistent across modes

--- a/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
@@ -1269,7 +1269,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Database if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Database if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="databaseLink"/> is always "/dbs/{db identifier}" only
         /// the values within the {} change depending on which method you wish to use to address the resource.
@@ -1364,7 +1364,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the DocumentCollection if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the DocumentCollection if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="documentCollectionLink"/> is always "/dbs/{db identifier}/colls/{coll identifier}" only
         /// the values within the {} change depending on which method you wish to use to address the resource.
@@ -1462,7 +1462,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Document if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Document if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="documentLink"/> is always "dbs/{db identifier}/colls/{coll identifier}/docs/{doc identifier}" only
         /// the values within the {} change depending on which method you wish to use to address the resource.
@@ -1562,7 +1562,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Document if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Document if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="documentLink"/> is always "dbs/{db identifier}/colls/{coll identifier}/docs/{doc identifier}" only
         /// the values within the {} change depending on which method you wish to use to address the resource.
@@ -1661,7 +1661,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Stored Procedure if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Stored Procedure if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="storedProcedureLink"/> is always "/dbs/{db identifier}/colls/{coll identifier}/sprocs/{sproc identifier}"
         /// only the values within the {...} change depending on which method you wish to use to address the resource.
@@ -1759,7 +1759,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Trigger if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Trigger if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="triggerLink"/> is always "/dbs/{db identifier}/colls/{coll identifier}/triggers/{trigger identifier}"
         /// only the values within the {...} change depending on which method you wish to use to address the resource.
@@ -1857,7 +1857,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the User Defined Function if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the User Defined Function if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="functionLink"/> is always "/dbs/{db identifier}/colls/{coll identifier}/udfs/{udf identifier}"
         /// only the values within the {...} change depending on which method you wish to use to address the resource.
@@ -1955,7 +1955,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// <para>
         /// The example shown uses ID-based links, where the link is composed of the ID properties used when the resources were created.
-        /// You can still use the <see cref="Resource.SelfLink"/> property of the Conflict if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
+        /// You can still use the <see cref="Documents.Resource.SelfLink"/> property of the Conflict if you prefer. A self-link is a URI for a resource that is made up of Resource Identifiers  (or the _rid properties).
         /// ID-based links and SelfLink will both work.
         /// The format for <paramref name="conflictLink"/> is always "/dbs/{db identifier}/colls/{collectioon identifier}/conflicts/{conflict identifier}"
         /// only the values within the {...} change depending on which method you wish to use to address the resource.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/AverageAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/AverageAggregator.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
 {
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
@@ -58,7 +59,8 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
             {
                 if (!AverageInfo.TryParse(continuationToken, out averageInfo))
                 {
-                    return TryCatch<IAggregator>.FromException(new ArgumentException($"Invalid continuation token: {continuationToken}"));
+                    return TryCatch<IAggregator>.FromException(
+                        new MalformedContinuationTokenException($"Invalid continuation token: {continuationToken}"));
                 }
             }
             else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/CountAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/CountAggregator.cs
@@ -5,8 +5,8 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
 {
     using System;
     using System.Globalization;
-    using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
                 if (!long.TryParse(continuationToken, out partialCount))
                 {
                     return TryCatch<IAggregator>.FromException(
-                        new Exception($@"Invalid count continuation token: ""{continuationToken}""."));
+                        new MalformedContinuationTokenException($@"Invalid count continuation token: ""{continuationToken}""."));
                 }
             }
             else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/MinMaxAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/MinMaxAggregator.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
 {
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
@@ -194,7 +195,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
                     if (!CosmosElement.TryParse(continuationToken, out globalMinMax))
                     {
                         return TryCatch<IAggregator>.FromException(
-                            new Exception($"Malformed continuation token: {continuationToken}"));
+                            new MalformedContinuationTokenException($"Malformed continuation token: {continuationToken}"));
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SingleGroupAggregator.cs
@@ -6,10 +6,10 @@ namespace Microsoft.Azure.Cosmos.Query
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Aggregation;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
@@ -188,7 +188,8 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!CosmosElement.TryParse(continuationToken, out aliasToContinuationToken))
                     {
                         return TryCatch<SingleGroupAggregator>.FromException(
-                            new Exception($"{nameof(SelectListAggregateValues)} continuation token is malformed: {continuationToken}."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(SelectListAggregateValues)} continuation token is malformed: {continuationToken}."));
                     }
                 }
                 else
@@ -207,7 +208,8 @@ namespace Microsoft.Azure.Cosmos.Query
                         if (!(aliasToContinuationToken[alias] is CosmosString parsedAliasContinuationToken))
                         {
                             return TryCatch<SingleGroupAggregator>.FromException(
-                                new Exception($"{nameof(SelectListAggregateValues)} continuation token is malformed: {continuationToken}."));
+                                new MalformedContinuationTokenException(
+                                    $"{nameof(SelectListAggregateValues)} continuation token is malformed: {continuationToken}."));
                         }
 
                         aliasContinuationToken = parsedAliasContinuationToken.Value;
@@ -406,7 +408,7 @@ namespace Microsoft.Azure.Cosmos.Query
                             out CosmosObject rawContinuationToken))
                         {
                             return TryCatch<AggregateValue>.FromException(
-                                new ArgumentException($"Invalid {nameof(ScalarAggregateValue)}: {continuationToken}"));
+                                new MalformedContinuationTokenException($"Invalid {nameof(ScalarAggregateValue)}: {continuationToken}"));
                         }
 
                         if (!rawContinuationToken.TryGetValue<CosmosBoolean>(
@@ -414,7 +416,7 @@ namespace Microsoft.Azure.Cosmos.Query
                             out CosmosBoolean rawInitialized))
                         {
                             return TryCatch<AggregateValue>.FromException(
-                                new ArgumentException($"Invalid {nameof(ScalarAggregateValue)}: {continuationToken}"));
+                                new MalformedContinuationTokenException($"Invalid {nameof(ScalarAggregateValue)}: {continuationToken}"));
                         }
 
                         if (!rawContinuationToken.TryGetValue(nameof(ScalarAggregateValue.value), out value))

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SumAggregator.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
     using System;
     using System.Globalization;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global sum from the local sum of multiple partitions and continuations.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Aggregation/SumAggregator.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
     using System.Globalization;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global sum from the local sum of multiple partitions and continuations.
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.Query.Aggregation
                 if (!double.TryParse(continuationToken, out partialSum))
                 {
                     return TryCatch<IAggregator>.FromException(
-                        new Exception($"Malformed {nameof(SumAggregator)} continuation token: {continuationToken}"));
+                        new MalformedContinuationTokenException($"Malformed {nameof(SumAggregator)} continuation token: {continuationToken}"));
                 }
             }
             else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/DistinctMap.OrderedDistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/DistinctMap.OrderedDistinctMap.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!UInt128.TryParse(continuationToken, out lastHash))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new Exception($"Malformed {nameof(OrderedDistinctMap)} continuation token: {continuationToken}."));
+                            new MalformedContinuationTokenException(
+                                $"Malformed {nameof(OrderedDistinctMap)} continuation token: {continuationToken}."));
                     }
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/DistinctMap.UnorderedDistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/DistinctMap.UnorderedDistinctMap.cs
@@ -450,14 +450,16 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!(cosmosElement is CosmosObject hashDictionary))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
 
                     // Numbers
                     if (!hashDictionary.TryGetValue(UnorderdDistinctMap.NumbersName, out CosmosArray numbersArray))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawNumber in numbersArray)
@@ -465,7 +467,8 @@ namespace Microsoft.Azure.Cosmos.Query
                         if (!(rawNumber is CosmosNumber64 number))
                         {
                             return TryCatch<DistinctMap>.FromException(
-                                new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                new MalformedContinuationTokenException(
+                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                         }
 
                         numbers.Add(number.GetValue());
@@ -475,7 +478,8 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!hashDictionary.TryGetValue(UnorderdDistinctMap.StringsLength4Name, out CosmosArray stringsLength4Array))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                                new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                new MalformedContinuationTokenException(
+                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawStringLength4 in stringsLength4Array)
@@ -483,7 +487,8 @@ namespace Microsoft.Azure.Cosmos.Query
                         if (!(rawStringLength4 is CosmosUInt32 stringlength4))
                         {
                             return TryCatch<DistinctMap>.FromException(
-                                new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                new MalformedContinuationTokenException(
+                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                         }
 
                         stringsLength4.Add(stringlength4.GetValue());
@@ -493,7 +498,8 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!hashDictionary.TryGetValue(UnorderdDistinctMap.StringsLength8Name, out CosmosArray stringsLength8Array))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawStringLength8 in stringsLength8Array)
@@ -501,7 +507,8 @@ namespace Microsoft.Azure.Cosmos.Query
                         if (!(rawStringLength8 is CosmosInt64 stringlength8))
                         {
                             return TryCatch<DistinctMap>.FromException(
-                                new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                new MalformedContinuationTokenException(
+                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                         }
 
                         stringsLength8.Add((ulong)stringlength8.GetValue());
@@ -524,13 +531,15 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (!(rawSimpleValues is CosmosString simpleValuesString))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
 
                     if (!Enum.TryParse<SimpleValues>(simpleValuesString.Value, out simpleValues))
                     {
                         return TryCatch<DistinctMap>.FromException(
-                            new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                            new MalformedContinuationTokenException(
+                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
                     }
                 }
 
@@ -550,14 +559,16 @@ namespace Microsoft.Azure.Cosmos.Query
                 HashSet<UInt128> hashSet = new HashSet<UInt128>();
                 if (!hashDictionary.TryGetValue(propertyName, out CosmosArray array))
                 {
-                    throw new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
+                    throw new MalformedContinuationTokenException(
+                        $"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
                 }
 
                 foreach (CosmosElement item in array)
                 {
                     if (!(item is CosmosBinary binary))
                     {
-                        throw new ArgumentException($"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
+                        throw new MalformedContinuationTokenException(
+                            $"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
                     }
 
                     // Todo have this method work with span<byte> instead to avoid the allocation.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/MalformedContinuationTokenException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/MalformedContinuationTokenException.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core
+{
+    using System;
+
+    internal sealed class MalformedContinuationTokenException : QueryException
+    {
+        public MalformedContinuationTokenException()
+            : base()
+        {
+        }
+
+        public MalformedContinuationTokenException(string message)
+            : base(message)
+        {
+        }
+
+        public MalformedContinuationTokenException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public override TResult Accept<TResult>(QueryExceptionVisitor<TResult> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryException.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core
+{
+    using System;
+
+    internal abstract class QueryException : Exception
+    {
+        protected QueryException()
+            : base()
+        {
+        }
+
+        protected QueryException(string message)
+            : base(message)
+        {
+        }
+
+        protected QueryException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public abstract TResult Accept<TResult>(QueryExceptionVisitor<TResult> visitor);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryExceptionVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryExceptionVisitor.cs
@@ -1,0 +1,15 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core
+{
+    using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
+
+    internal abstract class QueryExceptionVisitor<TResult>
+    {
+        public abstract TResult Visit(MalformedContinuationTokenException malformedContinuationTokenException);
+        public abstract TResult Visit(UnexpectedQueryPartitionProviderException unexpectedQueryPartitionProviderException);
+        public abstract TResult Visit(ExpectedQueryPartitionProviderException expectedQueryPartitionProviderException);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryPartitionProviderException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Exceptions/QueryPartitionProviderException.cs
@@ -1,0 +1,72 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core.Exceptions
+{
+    using System;
+
+    internal abstract class QueryPartitionProviderException : QueryException
+    {
+        protected QueryPartitionProviderException()
+            : base()
+        {
+        }
+
+        protected QueryPartitionProviderException(string message)
+            : base(message)
+        {
+        }
+
+        protected QueryPartitionProviderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+
+    internal sealed class UnexpectedQueryPartitionProviderException : QueryPartitionProviderException
+    {
+        public UnexpectedQueryPartitionProviderException()
+            : base()
+        {
+        }
+
+        public UnexpectedQueryPartitionProviderException(string message)
+            : base(message)
+        {
+        }
+
+        public UnexpectedQueryPartitionProviderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public override TResult Accept<TResult>(QueryExceptionVisitor<TResult> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+
+    internal sealed class ExpectedQueryPartitionProviderException : QueryPartitionProviderException
+    {
+        public ExpectedQueryPartitionProviderException()
+            : base()
+        {
+        }
+
+        public ExpectedQueryPartitionProviderException(string message)
+            : base(message)
+        {
+        }
+
+        public ExpectedQueryPartitionProviderException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public override TResult Accept<TResult>(QueryExceptionVisitor<TResult> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/AggregateDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/AggregateDocumentQueryExecutionComponent.Compute.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
 
     internal abstract partial class AggregateDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {
@@ -41,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                     if (!AggregateContinuationToken.TryParse(requestContinuation, out AggregateContinuationToken aggregateContinuationToken))
                     {
                         return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                            new Exception($"Malfomed {nameof(AggregateContinuationToken)}: '{requestContinuation}'"));
+                            new MalformedContinuationTokenException($"Malfomed {nameof(AggregateContinuationToken)}: '{requestContinuation}'"));
                     }
 
                     sourceContinuationToken = aggregateContinuationToken.SourceContinuationToken;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.Client.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
 
     internal abstract partial class DistinctDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {
@@ -48,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                     if (!DistinctContinuationToken.TryParse(requestContinuation, out distinctContinuationToken))
                     {
                         return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                            new Exception($"Invalid {nameof(DistinctContinuationToken)}: {requestContinuation}"));
+                            new MalformedContinuationTokenException($"Invalid {nameof(DistinctContinuationToken)}: {requestContinuation}"));
                     }
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/DistinctDocumentQueryExecutionComponent.Compute.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
 
     internal abstract partial class DistinctDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                     if (!DistinctContinuationToken.TryParse(requestContinuation, out distinctContinuationToken))
                     {
                         return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                            new Exception($"Invalid {nameof(DistinctContinuationToken)}: {requestContinuation}"));
+                            new MalformedContinuationTokenException($"Invalid {nameof(DistinctContinuationToken)}: {requestContinuation}"));
                     }
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.Compute.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                     if (!GroupByContinuationToken.TryParse(requestContinuation, out groupByContinuationToken))
                     {
                         return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                            new Exception($"Invalid {nameof(GroupByContinuationToken)}: '{requestContinuation}'"));
+                            new MalformedContinuationTokenException($"Invalid {nameof(GroupByContinuationToken)}: '{requestContinuation}'"));
                     }
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
@@ -284,7 +284,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                         groupingTableContinuationToken,
                         out CosmosObject parsedGroupingTableContinuations))
                     {
-                        return TryCatch<GroupingTable>.FromException(new Exception($"Invalid GroupingTableContinuationToken"));
+                        return TryCatch<GroupingTable>.FromException(
+                            new MalformedContinuationTokenException($"Invalid GroupingTableContinuationToken"));
                     }
 
                     foreach (KeyValuePair<string, CosmosElement> kvp in parsedGroupingTableContinuations)
@@ -294,12 +295,14 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
 
                         if (!UInt128.TryParse(key, out UInt128 groupByKey))
                         {
-                            return TryCatch<GroupingTable>.FromException(new Exception($"Invalid GroupingTableContinuationToken"));
+                            return TryCatch<GroupingTable>.FromException(
+                                new MalformedContinuationTokenException($"Invalid GroupingTableContinuationToken"));
                         }
 
                         if (!(value is CosmosString singleGroupAggregatorContinuationToken))
                         {
-                            return TryCatch<GroupingTable>.FromException(new Exception($"Invalid GroupingTableContinuationToken"));
+                            return TryCatch<GroupingTable>.FromException(
+                                new MalformedContinuationTokenException($"Invalid GroupingTableContinuationToken"));
                         }
 
                         TryCatch<SingleGroupAggregator> tryCreateSingleGroupAggregator = SingleGroupAggregator.TryCreate(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipDocumentQueryExecutionComponent.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                 if (!OffsetContinuationToken.TryParse(continuationToken, out offsetContinuationToken))
                 {
                     return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new Exception($"Invalid {nameof(SkipDocumentQueryExecutionComponent)}: {continuationToken}."));
+                        new MalformedContinuationTokenException($"Invalid {nameof(SkipDocumentQueryExecutionComponent)}: {continuationToken}."));
                 }
             }
             else
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
             if (offsetContinuationToken.Offset > offsetCount)
             {
                 return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new Exception("offset count in continuation token can not be greater than the offsetcount in the query."));
+                        new MalformedContinuationTokenException("offset count in continuation token can not be greater than the offsetcount in the query."));
             }
 
             return (await tryCreateSourceAsync(offsetContinuationToken.SourceToken))

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/TakeDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/TakeDocumentQueryExecutionComponent.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                 if (!LimitContinuationToken.TryParse(continuationToken, out limitContinuationToken))
                 {
                     return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new ArgumentException($"Malformed {nameof(LimitContinuationToken)}: {continuationToken}."));
+                        new MalformedContinuationTokenException($"Malformed {nameof(LimitContinuationToken)}: {continuationToken}."));
                 }
             }
             else
@@ -56,13 +56,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
             if (limitContinuationToken.Limit > limitCount)
             {
                 return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                    new ArgumentOutOfRangeException($"{nameof(LimitContinuationToken.Limit)} in {nameof(LimitContinuationToken)}: {continuationToken}: {limitContinuationToken.Limit} can not be greater than the limit count in the query: {limitCount}."));
+                    new MalformedContinuationTokenException($"{nameof(LimitContinuationToken.Limit)} in {nameof(LimitContinuationToken)}: {continuationToken}: {limitContinuationToken.Limit} can not be greater than the limit count in the query: {limitCount}."));
             }
 
             if (limitCount < 0)
             {
                 return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new ArgumentException($"{nameof(limitCount)}: {limitCount} must be a non negative number."));
+                        new MalformedContinuationTokenException($"{nameof(limitCount)}: {limitCount} must be a non negative number."));
             }
 
             return (await tryCreateSourceAsync(limitContinuationToken.SourceToken))
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
                 if (!TopContinuationToken.TryParse(continuationToken, out topContinuationToken))
                 {
                     return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new ArgumentException($"Malformed {nameof(LimitContinuationToken)}: {continuationToken}."));
+                        new MalformedContinuationTokenException($"Malformed {nameof(LimitContinuationToken)}: {continuationToken}."));
                 }
             }
             else
@@ -99,13 +99,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
             if (topContinuationToken.Top > topCount)
             {
                 return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                    new ArgumentOutOfRangeException($"{nameof(TopContinuationToken.Top)} in {nameof(TopContinuationToken)}: {continuationToken}: {topContinuationToken.Top} can not be greater than the top count in the query: {topCount}."));
+                    new MalformedContinuationTokenException($"{nameof(TopContinuationToken.Top)} in {nameof(TopContinuationToken)}: {continuationToken}: {topContinuationToken.Top} can not be greater than the top count in the query: {topCount}."));
             }
 
             if (topCount < 0)
             {
                 return TryCatch<IDocumentQueryExecutionComponent>.FromException(
-                        new ArgumentException($"{nameof(topCount)}: {topCount} must be a non negative number."));
+                        new MalformedContinuationTokenException($"{nameof(topCount)}: {topCount} must be a non negative number."));
             }
 
             return (await tryCreateSourceAsync(topContinuationToken.SourceToken))

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using Collections.Generic;
     using Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using ParallelQuery;
     using PartitionKeyRange = Documents.PartitionKeyRange;
@@ -559,7 +560,7 @@ namespace Microsoft.Azure.Cosmos.Query
             if (minIndex < 0)
             {
                 return TryCatch<InitInfo<TContinuationToken>>.FromException(
-                    new ArgumentException(
+                    new MalformedContinuationTokenException(
                         $"{RMResources.InvalidContinuationToken} - Could not find continuation token: {firstContinuationToken}"));
             }
 
@@ -579,7 +580,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 if (replacementRanges.Count() == 0)
                 {
                     return TryCatch<InitInfo<TContinuationToken>>.FromException(
-                        new ArgumentException(
+                        new MalformedContinuationTokenException(
                             $"{RMResources.InvalidContinuationToken} - Could not find continuation token: {continuationToken}"));
                 }
 
@@ -598,7 +599,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     child1Min == parentMin))
                 {
                     return TryCatch<InitInfo<TContinuationToken>>.FromException(
-                        new ArgumentException(
+                        new MalformedContinuationTokenException(
                             $"{RMResources.InvalidContinuationToken} - PMax = C2Max > C2Min > C1Max > C1Min = PMin: {continuationToken}"));
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosOrderByItemQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosOrderByItemQueryExecutionContext.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Threading.Tasks;
     using Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Newtonsoft.Json;
     using ParallelQuery;
@@ -428,7 +429,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 if (suppliedOrderByContinuationTokens.Length == 0)
                 {
                     return TryCatch<OrderByContinuationToken[]>.FromException(
-                        new Exception($"Order by continuation token cannot be empty: {requestContinuation}."));
+                        new MalformedContinuationTokenException($"Order by continuation token cannot be empty: {requestContinuation}."));
                 }
 
                 foreach (OrderByContinuationToken suppliedOrderByContinuationToken in suppliedOrderByContinuationTokens)
@@ -436,7 +437,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     if (suppliedOrderByContinuationToken.OrderByItems.Count != sortOrders.Length)
                     {
                         return TryCatch<OrderByContinuationToken[]>.FromException(
-                            new Exception($"Invalid order-by items in continuation token {requestContinuation} for OrderBy~Context."));
+                            new MalformedContinuationTokenException($"Invalid order-by items in continuation token {requestContinuation} for OrderBy~Context."));
                     }
                 }
 
@@ -445,7 +446,7 @@ namespace Microsoft.Azure.Cosmos.Query
             catch (JsonException ex)
             {
                 return TryCatch<OrderByContinuationToken[]>.FromException(
-                    new Exception($"Invalid JSON in continuation token {requestContinuation} for OrderBy~Context: {ex.Message}"));
+                    new MalformedContinuationTokenException($"Invalid JSON in continuation token {requestContinuation} for OrderBy~Context: {ex.Message}"));
             }
         }
 
@@ -476,7 +477,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 if (!ResourceId.TryParse(continuationToken.Rid, out ResourceId continuationRid))
                 {
                     return TryCatch<bool>.FromException(
-                        new Exception($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context."));
+                        new MalformedContinuationTokenException($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context."));
                 }
 
                 Dictionary<string, ResourceId> resourceIds = new Dictionary<string, ResourceId>();
@@ -514,7 +515,7 @@ namespace Microsoft.Azure.Cosmos.Query
                             if (!ResourceId.TryParse(orderByResult.Rid, out rid))
                             {
                                 return TryCatch<bool>.FromException(
-                                    new Exception($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context~TryParse."));
+                                    new MalformedContinuationTokenException($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context~TryParse."));
 
                             }
 
@@ -526,7 +527,7 @@ namespace Microsoft.Azure.Cosmos.Query
                             if (continuationRid.Database != rid.Database || continuationRid.DocumentCollection != rid.DocumentCollection)
                             {
                                 return TryCatch<bool>.FromException(
-                                    new Exception($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context."));
+                                    new MalformedContinuationTokenException($"Invalid Rid in the continuation token {continuationToken.CompositeContinuationToken.Token} for OrderBy~Context."));
                             }
 
                             continuationRidVerified = true;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosParallelItemQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosParallelItemQueryExecutionContext.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Threading.Tasks;
     using Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Newtonsoft.Json;
     using PartitionKeyRange = Documents.PartitionKeyRange;
@@ -237,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 if (!TryParseContinuationToken(continuationToken, out CompositeContinuationToken[] tokens))
                 {
                     return TryCatch<ParallelInitInfo>.FromException(
-                        new Exception($"Invalid format for continuation token {continuationToken} for {nameof(CosmosParallelItemQueryExecutionContext)}"));
+                        new MalformedContinuationTokenException($"Invalid format for continuation token {continuationToken} for {nameof(CosmosParallelItemQueryExecutionContext)}"));
                 }
 
                 return CosmosCrossPartitionQueryExecutionContext.TryFindTargetRangeAndExtractContinuationTokens(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -114,14 +114,7 @@ namespace Microsoft.Azure.Cosmos.Query
                         TryCatch<CosmosQueryExecutionContext> tryCreateItemQueryExecutionContext = await this.TryCreateItemQueryExecutionContextAsync(cancellationToken);
                         if (!tryCreateItemQueryExecutionContext.Succeeded)
                         {
-                            // Failed to create pipeline (due to a bad request).
-                            return QueryResponseCore.CreateFailure(
-                                HttpStatusCode.BadRequest,
-                                subStatusCodes: null,
-                                errorMessage: tryCreateItemQueryExecutionContext.Exception.ToString(),
-                                requestCharge: 0,
-                                activityId: this.CosmosQueryContext.CorrelatedActivityId.ToString(),
-                                diagnostics: QueryResponseCore.EmptyDiagnostics);
+                            return QueryResponseFactory.CreateFromException(tryCreateItemQueryExecutionContext.Exception);
                         }
 
                         this.innerExecutionContext = tryCreateItemQueryExecutionContext.Result;
@@ -145,14 +138,7 @@ namespace Microsoft.Azure.Cosmos.Query
                         TryCatch<CosmosQueryExecutionContext> tryCreateItemQueryExecutionContext = await this.TryCreateItemQueryExecutionContextAsync(cancellationToken);
                         if (!tryCreateItemQueryExecutionContext.Succeeded)
                         {
-                            // Failed to create pipeline (due to a bad request).
-                            return QueryResponseCore.CreateFailure(
-                                HttpStatusCode.BadRequest,
-                                subStatusCodes: null,
-                                errorMessage: tryCreateItemQueryExecutionContext.Exception.ToString(),
-                                requestCharge: 0,
-                                activityId: this.CosmosQueryContext.CorrelatedActivityId.ToString(),
-                                diagnostics: QueryResponseCore.EmptyDiagnostics);
+                            return QueryResponseFactory.CreateFromException(tryCreateItemQueryExecutionContext.Exception);
                         }
 
                         this.innerExecutionContext = tryCreateItemQueryExecutionContext.Result;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
@@ -213,13 +214,14 @@ namespace Microsoft.Azure.Cosmos.Query
                     out PipelineContinuationToken pipelineContinuationToken))
                 {
                     return TryCatch<CosmosQueryExecutionContext>.FromException(
-                        new Exception($"Malformed {nameof(PipelineContinuationToken)}: {continuationToken}."));
+                        new MalformedContinuationTokenException(
+                            $"Malformed {nameof(PipelineContinuationToken)}: {continuationToken}."));
                 }
 
                 if (PipelineContinuationToken.IsTokenFromTheFuture(pipelineContinuationToken))
                 {
                     return TryCatch<CosmosQueryExecutionContext>.FromException(
-                        new Exception(
+                        new MalformedContinuationTokenException(
                             $"{nameof(PipelineContinuationToken)} Continuation token is from a newer version of the SDK. " +
                             $"Upgrade the SDK to avoid this issue." +
                             $"{continuationToken}."));
@@ -230,7 +232,8 @@ namespace Microsoft.Azure.Cosmos.Query
                     out PipelineContinuationTokenV1_1 latestVersionPipelineContinuationToken))
                 {
                     return TryCatch<CosmosQueryExecutionContext>.FromException(
-                        new Exception($"{nameof(PipelineContinuationToken)}: '{continuationToken}' is no longer supported."));
+                        new MalformedContinuationTokenException(
+                            $"{nameof(PipelineContinuationToken)}: '{continuationToken}' is no longer supported."));
                 }
 
                 continuationToken = latestVersionPipelineContinuationToken.SourceContinuationToken;
@@ -363,7 +366,7 @@ namespace Microsoft.Azure.Cosmos.Query
             if (initialPageSize < -1 || initialPageSize == 0)
             {
                 return TryCatch<CosmosQueryExecutionContext>.FromException(
-                    new Exception($"Invalid MaxItemCount {initialPageSize}"));
+                    new MalformedContinuationTokenException($"Invalid MaxItemCount {initialPageSize}"));
             }
 
             QueryInfo queryInfo = partitionedQueryExecutionInfo.QueryInfo;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
@@ -5,15 +5,14 @@ namespace Microsoft.Azure.Cosmos.Query
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using IClientSideRequestStatistics = Documents.IClientSideRequestStatistics;
     using SubStatusCodes = Documents.SubStatusCodes;
 
     internal struct QueryResponseCore
     {
         private static readonly IReadOnlyList<CosmosElement> EmptyList = new List<CosmosElement>().AsReadOnly();
+        internal static readonly string EmptyGuidString = Guid.Empty.ToString();
         internal static readonly IReadOnlyCollection<QueryPageDiagnostics> EmptyDiagnostics = new List<QueryPageDiagnostics>();
 
         private QueryResponseCore(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPartitionProvider.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 }
                 else
                 {
-                    queryPartitionProviderException = new UnexpectedQueryPartitionProviderException(
+                    queryPartitionProviderException = new ExpectedQueryPartitionProviderException(
                         serializedQueryExecutionInfo,
                         exception);
                 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
@@ -1,0 +1,102 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core
+{
+    using System;
+    using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
+
+    internal static class QueryResponseFactory
+    {
+        private static readonly string EmptyGuidString = Guid.Empty.ToString();
+
+        public static QueryResponseCore CreateFromException(Exception exception)
+        {
+            QueryResponseCore queryResponseCore;
+            if (exception is CosmosException cosmosException)
+            {
+                queryResponseCore = CreateFromCosmosException(cosmosException);
+            }
+            else if (exception is Microsoft.Azure.Documents.DocumentClientException documentClientException)
+            {
+                queryResponseCore = CreateFromDocumentClientException(documentClientException);
+            }
+            else if (exception is QueryException queryException)
+            {
+                CosmosException convertedException = queryException.Accept(QueryExceptionConverter.Singleton);
+                queryResponseCore = CreateFromCosmosException(convertedException);
+            }
+            else
+            {
+                // Unknown exception type should become a 500
+                queryResponseCore = QueryResponseCore.CreateFailure(
+                    statusCode: System.Net.HttpStatusCode.InternalServerError,
+                    subStatusCodes: null,
+                    errorMessage: exception.ToString(),
+                    requestCharge: 0,
+                    activityId: QueryResponseCore.EmptyGuidString,
+                    diagnostics: QueryResponseCore.EmptyDiagnostics);
+            }
+
+            return queryResponseCore;
+        }
+
+        private static QueryResponseCore CreateFromCosmosException(CosmosException cosmosException)
+        {
+            QueryResponseCore queryResponseCore = QueryResponseCore.CreateFailure(
+                statusCode: cosmosException.StatusCode,
+                subStatusCodes: (Microsoft.Azure.Documents.SubStatusCodes)cosmosException.SubStatusCode,
+                errorMessage: cosmosException.Message,
+                requestCharge: 0,
+                activityId: cosmosException.ActivityId,
+                diagnostics: QueryResponseCore.EmptyDiagnostics);
+
+            return queryResponseCore;
+        }
+
+        private static QueryResponseCore CreateFromDocumentClientException(Microsoft.Azure.Documents.DocumentClientException documentClientException)
+        {
+            QueryResponseCore queryResponseCore = QueryResponseCore.CreateFailure(
+                statusCode: documentClientException.StatusCode.GetValueOrDefault(System.Net.HttpStatusCode.InternalServerError),
+                subStatusCodes: null,
+                errorMessage: documentClientException.Message,
+                requestCharge: 0,
+                activityId: documentClientException.ActivityId,
+                diagnostics: QueryResponseCore.EmptyDiagnostics);
+
+            return queryResponseCore;
+        }
+
+        private sealed class QueryExceptionConverter : QueryExceptionVisitor<CosmosException>
+        {
+            public static readonly QueryExceptionConverter Singleton = new QueryExceptionConverter();
+
+            private QueryExceptionConverter()
+            {
+            }
+
+            public override CosmosException Visit(MalformedContinuationTokenException malformedContinuationTokenException)
+            {
+                return new BadRequestException(
+                    $"{nameof(BadRequestException)} due to {nameof(MalformedContinuationTokenException)}",
+                    malformedContinuationTokenException);
+            }
+
+            public override CosmosException Visit(UnexpectedQueryPartitionProviderException unexpectedQueryPartitionProviderException)
+            {
+                return new InternalServerErrorException(
+                    $"{nameof(InternalServerErrorException)} due to {nameof(UnexpectedQueryPartitionProviderException)}",
+                    unexpectedQueryPartitionProviderException);
+            }
+
+            public override CosmosException Visit(ExpectedQueryPartitionProviderException expectedQueryPartitionProviderException)
+            {
+                return new BadRequestException(
+                    $"{nameof(BadRequestException)} due to {nameof(ExpectedQueryPartitionProviderException)}",
+                    expectedQueryPartitionProviderException);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosException.cs
@@ -17,8 +17,9 @@ namespace Microsoft.Azure.Cosmos
         internal CosmosException(
             HttpStatusCode statusCode,
             string message,
-            Error error = null)
-            : base(message)
+            Error error = null,
+            Exception inner = null)
+            : base(message, inner)
         {
             this.StatusCode = statusCode;
             this.Error = error;

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 {
     using System;
 
-    internal sealed class BadRequestException : CosmosException
+    internal sealed class BadRequestException : CosmosHttpException
     {
         public BadRequestException()
             : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: null)
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
         {
         }
 
-        public BadRequestException(string message, Exception inner)
-            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message, inner: inner)
+        public BadRequestException(string message, Exception innerException)
+            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message, innerException: innerException)
         {
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
@@ -1,0 +1,26 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
+{
+    using System;
+
+    internal sealed class BadRequestException : CosmosException
+    {
+        public BadRequestException()
+            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: null)
+        {
+        }
+
+        public BadRequestException(string message)
+            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message)
+        {
+        }
+
+        public BadRequestException(string message, Exception inner)
+            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message, inner: inner)
+        {
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/BadRequestException.cs
@@ -5,21 +5,22 @@
 namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 {
     using System;
+    using System.Net;
 
     internal sealed class BadRequestException : CosmosHttpException
     {
         public BadRequestException()
-            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: null)
+            : base(statusCode: HttpStatusCode.BadRequest, message: null)
         {
         }
 
         public BadRequestException(string message)
-            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message)
+            : base(statusCode: HttpStatusCode.BadRequest, message: message)
         {
         }
 
         public BadRequestException(string message, Exception innerException)
-            : base(statusCode: System.Net.HttpStatusCode.BadRequest, message: message, innerException: innerException)
+            : base(statusCode: HttpStatusCode.BadRequest, message: message, innerException: innerException)
         {
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosHttpException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosHttpException.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
+{
+    using System;
+    using System.Net;
+
+    internal abstract class CosmosHttpException : Exception
+    {
+        protected CosmosHttpException(HttpStatusCode statusCode)
+            : this(statusCode, message: null, innerException: null)
+        {
+        }
+
+        protected CosmosHttpException(HttpStatusCode statusCode, string message)
+            : this(statusCode, message: message, innerException: null)
+        {
+        }
+
+        protected CosmosHttpException(HttpStatusCode statusCode, string message, Exception innerException)
+            : base(message: message, innerException: innerException)
+        {
+            this.StatusCode = statusCode;
+        }
+
+        public HttpStatusCode StatusCode { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosHttpException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosHttpException.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
     using System;
     using System.Net;
 
-    internal abstract class CosmosHttpException : Exception
+    internal abstract class CosmosHttpException : CosmosException
     {
         protected CosmosHttpException(HttpStatusCode statusCode)
             : this(statusCode, message: null, innerException: null)
@@ -20,11 +20,8 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
         }
 
         protected CosmosHttpException(HttpStatusCode statusCode, string message, Exception innerException)
-            : base(message: message, innerException: innerException)
+            : base(statusCode: statusCode, message: message, inner: innerException)
         {
-            this.StatusCode = statusCode;
         }
-
-        public HttpStatusCode StatusCode { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/InternalServerErrorException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/InternalServerErrorException.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
+{
+    using System;
+    using System.Net;
+
+    internal sealed class InternalServerErrorException : CosmosHttpException
+    {
+        public InternalServerErrorException()
+            : base(statusCode: HttpStatusCode.InternalServerError, message: null)
+        {
+        }
+
+        public InternalServerErrorException(string message)
+            : base(statusCode: HttpStatusCode.InternalServerError, message: message)
+        {
+        }
+
+        public InternalServerErrorException(string message, Exception innerException)
+            : base(statusCode: HttpStatusCode.InternalServerError, message: message, innerException: innerException)
+        {
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// <para>
         /// Every resource within an Azure Cosmos DB database account needs to have a unique identifier. 
-        /// Unlike <see cref="Resource.ResourceId"/>, which is set internally, this Id is settable by the user and is not immutable.
+        /// Unlike <see cref="Documents.Resource.ResourceId"/>, which is set internally, this Id is settable by the user and is not immutable.
         /// </para>
         /// <para>
         /// When working with document resources, they too have this settable Id property. 

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// <para>
         /// Every resource within an Azure Cosmos DB database account needs to have a unique identifier. 
-        /// Unlike <see cref="Resource.ResourceId"/>, which is set internally, this Id is settable by the user and is not immutable.
+        /// Unlike <see cref="Documents.Resource.ResourceId"/>, which is set internally, this Id is settable by the user and is not immutable.
         /// </para>
         /// <para>
         /// When working with document resources, they too have this settable Id property. 

--- a/Microsoft.Azure.Cosmos/src/StoredProcedureResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/StoredProcedureResponse.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Azure.Cosmos
                 // load resource
                 if (typeof(TValue) == typeof(Document) || typeof(Document).IsAssignableFrom(typeof(TValue)))
                 {
-                    this.responseBody = Resource.LoadFromWithConstructor<TValue>(response.ResponseBody, () => (TValue)(object)new Document(), this.serializerSettings);
+                    this.responseBody = Documents.Resource.LoadFromWithConstructor<TValue>(response.ResponseBody, () => (TValue)(object)new Document(), this.serializerSettings);
                 }
                 else if (typeof(TValue) == typeof(Attachment) || typeof(Attachment).IsAssignableFrom(typeof(TValue)))
                 {
-                    this.responseBody = Resource.LoadFromWithConstructor<TValue>(response.ResponseBody, () => (TValue)(object)new Attachment(), this.serializerSettings);
+                    this.responseBody = Documents.Resource.LoadFromWithConstructor<TValue>(response.ResponseBody, () => (TValue)(object)new Attachment(), this.serializerSettings);
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
@@ -111,7 +111,7 @@ FROM (
     OFFSET 90 LIMIT 2147483647
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -128,7 +128,7 @@ FROM (
     OFFSET 90 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -145,7 +145,7 @@ FROM (
     OFFSET 5 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -167,7 +167,7 @@ FROM (
     OFFSET 10 LIMIT 20
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -253,7 +253,7 @@ FROM (
     ) AS r8
 ) AS r9 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":230,"end":247},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":367,"end":392},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":522,"end":538},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":653},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":707,"end":732},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":879,"end":904},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":905,"end":923},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1079,"end":1103},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1104,"end":1129},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1190,"end":1207},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":230,"end":247},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":367,"end":392},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":522,"end":538},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":653},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":707,"end":732},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":879,"end":904},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":905,"end":923},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1079,"end":1103},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1104,"end":1129},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1190,"end":1207},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
@@ -108,7 +108,7 @@ FROM (
     OFFSET 90 LIMIT 2147483647
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":63,"end":89},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":63,"end":89},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -125,7 +125,7 @@ FROM (
     OFFSET 90 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -142,7 +142,7 @@ FROM (
     OFFSET 5 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":63,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":63,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -164,7 +164,7 @@ FROM (
     OFFSET 10 LIMIT 20
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":87,"end":103},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":138,"end":156},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":87,"end":103},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":138,"end":156},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -215,7 +215,7 @@ FROM (
     OFFSET 1 LIMIT 10
 ) AS r5 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":202,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":341,"end":357},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":446,"end":451},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":507,"end":532},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":550,"end":567},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":576,"end":593},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":202,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":341,"end":357},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":446,"end":451},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":507,"end":532},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":550,"end":567},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":576,"end":593},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -291,7 +291,7 @@ FROM (
 ) AS r8 
 WHERE ((r8["v0"] + r8["v1"]) > (r8["v2"] + r8["v3"])) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":215,"end":240},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":370,"end":386},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":491,"end":496},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":552,"end":577},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":733,"end":758},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":759,"end":777},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":917,"end":941},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":942,"end":967},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":985,"end":1002},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1011,"end":1028},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":215,"end":240},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":370,"end":386},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":491,"end":496},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":552,"end":577},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":733,"end":758},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":759,"end":777},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":917,"end":941},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":942,"end":967},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":985,"end":1002},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1011,"end":1028},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
@@ -105,7 +105,7 @@ FROM (
     OFFSET 90 LIMIT 2147483647
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -122,7 +122,7 @@ FROM (
     OFFSET 90 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -139,7 +139,7 @@ FROM (
     OFFSET 5 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -161,7 +161,7 @@ FROM (
     OFFSET 10 LIMIT 20
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -243,7 +243,7 @@ FROM (
     OFFSET 1 LIMIT 10
 ) AS r8 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":459,"end":475},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":585,"end":590},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":673},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":824,"end":849},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":850,"end":868},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1028,"end":1052},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1053,"end":1078},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1098,"end":1115},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1124,"end":1141},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":459,"end":475},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":585,"end":590},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":673},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":824,"end":849},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":850,"end":868},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1028,"end":1052},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1053,"end":1078},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1098,"end":1115},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1124,"end":1141},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
@@ -105,7 +105,7 @@ FROM (
     OFFSET 90 LIMIT 2147483647
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -122,7 +122,7 @@ FROM (
     OFFSET 90 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -139,7 +139,7 @@ FROM (
     OFFSET 5 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -161,7 +161,7 @@ FROM (
     OFFSET 10 LIMIT 20
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -243,7 +243,7 @@ FROM (
     OFFSET 1 LIMIT 10
 ) AS r8 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":459,"end":475},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":585,"end":590},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":673},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":824,"end":849},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":850,"end":868},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1028,"end":1052},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1053,"end":1078},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1098,"end":1115},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1124,"end":1141},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":459,"end":475},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":585,"end":590},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":648,"end":673},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":824,"end":849},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":850,"end":868},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1028,"end":1052},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1053,"end":1078},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1098,"end":1115},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1124,"end":1141},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
@@ -104,7 +104,7 @@ FROM (
     OFFSET 90 LIMIT 2147483647
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -121,7 +121,7 @@ FROM (
     OFFSET 90 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -138,7 +138,7 @@ FROM (
     OFFSET 5 LIMIT 5
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -160,7 +160,7 @@ FROM (
     OFFSET 10 LIMIT 20
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -232,7 +232,7 @@ FROM (
     OFFSET 1 LIMIT 10
 ) AS r8 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":268,"end":293},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":406,"end":422},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":511,"end":516},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":574,"end":599},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":729,"end":754},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":755,"end":773},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":912,"end":936},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":937,"end":962},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":980,"end":997},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1006,"end":1023},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":268,"end":293},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":406,"end":422},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":511,"end":516},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":574,"end":599},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":729,"end":754},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":755,"end":773},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":912,"end":936},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":937,"end":962},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":980,"end":997},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1006,"end":1023},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
@@ -12,7 +12,7 @@ FROM (
     FROM root
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -29,7 +29,7 @@ FROM (
     WHERE root["Flag"]
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -46,7 +46,7 @@ FROM (
     WHERE (NOT root["Flag"])
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -62,7 +62,7 @@ FROM (
     FROM root
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -80,7 +80,7 @@ FROM (
     WHERE ((m0 % 3) = 0)
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -97,7 +97,7 @@ FROM (
     WHERE root["Flag"]
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -114,7 +114,7 @@ FROM (
     WHERE (root["Number"] < -7)
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -131,7 +131,7 @@ FROM (
     WHERE (root["Number"] < -13)
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ FROM (
     WHERE (v1 > 5)
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -189,7 +189,7 @@ FROM (
     WHERE (v1 > 150)
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"Errors":["Compositions of aggregates and other expressions are not allowed."]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -206,7 +206,7 @@ FROM (
     OFFSET 20 LIMIT 1
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -224,7 +224,7 @@ FROM (
     OFFSET 4 LIMIT 2147483647
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":89,"end":114},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":89,"end":114},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -311,7 +311,7 @@ FROM (
     OFFSET 1 LIMIT 10
 ) AS v26 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":285,"end":310},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":410,"end":426},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":501,"end":506},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":562,"end":587},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":704,"end":729},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":730,"end":748},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":874,"end":898},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":899,"end":924},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1070,"end":1094},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1095,"end":1120},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1211,"end":1227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":969,"end":974},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":1248,"end":1265},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1274,"end":1291},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":285,"end":310},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":410,"end":426},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":501,"end":506},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":562,"end":587},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":704,"end":729},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":730,"end":748},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":874,"end":898},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":899,"end":924},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1070,"end":1094},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1095,"end":1120},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1211,"end":1227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":969,"end":974},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":1248,"end":1265},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1274,"end":1291},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
@@ -148,7 +148,7 @@ FROM (
     FROM root
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -189,7 +189,7 @@ FROM (
 ) AS r1 
 ORDER BY r1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -206,7 +206,7 @@ FROM (
     ORDER BY root["Int"] ASC
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":73,"end":97},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":73,"end":97},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -477,7 +477,7 @@ FROM (
     ORDER BY v2 ASC
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":224,"end":239},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":224,"end":239},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -520,7 +520,7 @@ FROM (
     ORDER BY v2 ASC
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":186,"end":201},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":186,"end":201},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -560,7 +560,7 @@ FROM (
     WHERE (LENGTH(v2["FamilyName"]) > 10)
 ) AS r0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
@@ -236,7 +236,7 @@ JOIN (
     WHERE (LENGTH(r0["FamilyName"]) > 10)
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -259,7 +259,7 @@ JOIN (
     WHERE (LENGTH(r0["FamilyName"]) > 10)
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":114,"end":138},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":114,"end":138},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
@@ -37,7 +37,7 @@ FROM (
 ) AS r1 
 ORDER BY LENGTH(r1) ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":75,"end":92},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":75,"end":92},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -55,7 +55,7 @@ FROM (
 ) AS r1 
 ORDER BY ARRAY_LENGTH(r1["Parents"]) ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -73,7 +73,7 @@ FROM (
 ) AS r0 
 ORDER BY ARRAY_LENGTH(r0["Parents"]) ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -90,7 +90,7 @@ FROM (
 ) AS r0 
 ORDER BY r0["FamilyId"] ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -115,7 +115,7 @@ FROM (
 ) AS r2 
 WHERE (LENGTH(r2["FamilyId"]) > 10) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":85,"end":91},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":57,"end":62},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":85,"end":91},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":57,"end":62},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -139,7 +139,7 @@ FROM (
 ) AS r2 
 WHERE (LENGTH(r2["f"]["FamilyId"]) > 10) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":95,"end":101},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":95,"end":101},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -163,7 +163,7 @@ FROM (
 ) AS r2 
 WHERE (ARRAY_LENGTH(r2["f"]["Parents"]) > 0) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":57,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":57,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
@@ -36,7 +36,7 @@ JOIN (
     )
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":105,"end":142},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":105,"end":142},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -56,7 +56,7 @@ JOIN (
     )
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -188,7 +188,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -207,7 +207,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -227,7 +227,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -285,7 +285,7 @@ JOIN (
     )
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":124,"end":162},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":124,"end":162},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -345,7 +345,7 @@ JOIN (
     )
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":136,"end":173},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":136,"end":173},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -366,7 +366,7 @@ JOIN (
     )
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -387,7 +387,7 @@ JOIN (
     )
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -428,7 +428,7 @@ JOIN (
     )
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":121,"end":145},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":121,"end":145},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -452,7 +452,7 @@ JOIN (
     )
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":150,"end":187},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":88,"end":93},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":150,"end":187},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":88,"end":93},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -533,7 +533,7 @@ JOIN (
 ) AS v1 
 WHERE (v1 > 0) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":159,"end":183},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":69,"end":74},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":159,"end":183},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":69,"end":74},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -555,7 +555,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -575,7 +575,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -594,7 +594,7 @@ JOIN (
 ) AS v1 
 ORDER BY v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -617,7 +617,7 @@ JOIN (
 ) AS v1 
 ORDER BY v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":130,"end":167},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":77,"end":82},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":130,"end":167},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":77,"end":82},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1023,7 +1023,7 @@ JOIN (
 ) AS v1 
 WHERE (v0 >= 2) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":13,"end":53},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":13,"end":53},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1096,7 +1096,7 @@ JOIN (
 ) AS v0 
 ORDER BY LOG(v0) ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1145,7 +1145,7 @@ FROM (
 WHERE ((r0["FamilyId"] > "ABC") AND (ARRAY_LENGTH(r0["SmartChildren"]) > 0)) 
 ORDER BY r0["ChildrenCount"] ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1198,7 +1198,7 @@ JOIN (
 ) AS v6 
 WHERE (r0["FirstChild"] != null) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":403,"end":408},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":403,"end":408},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1359,7 +1359,7 @@ JOIN (
 WHERE (v0 AND root["IsRegistered"]) 
 ORDER BY v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1465,7 +1465,7 @@ JOIN (
 ) AS v3 
 WHERE (ARRAY_LENGTH(root["Children"]) > 0) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":110,"end":115},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":252,"end":276},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":110,"end":115},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":252,"end":276},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1972,7 +1972,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1990,7 +1990,7 @@ JOIN (
     JOIN v0 IN root["Children"]
 ) AS v2 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -2009,7 +2009,7 @@ JOIN (
     ORDER BY c0["Grade"] ASC
 ) AS v0 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":86,"end":110},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":86,"end":110},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -2028,7 +2028,7 @@ JOIN (
     WHERE (LENGTH(c0["FamilyName"]) > 10)
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -2047,7 +2047,7 @@ JOIN (
     WHERE (LENGTH(c0["FamilyName"]) > 10)
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
@@ -64,7 +64,7 @@ JOIN (
 ) AS v0 
 ORDER BY v0 ASC, root["Int"] DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -84,7 +84,7 @@ JOIN (
 ) AS v0 
 ORDER BY root["FamilyId"] ASC, v0 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -110,7 +110,7 @@ JOIN (
 ) AS v1 
 ORDER BY v0 DESC, v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -162,7 +162,7 @@ JOIN (
 ) AS v1 
 ORDER BY v0 DESC, v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -175,7 +175,7 @@ ORDER BY v0 DESC, v1 ASC
 SELECT VALUE root 
 FROM root 
 ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -188,7 +188,7 @@ ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC ]]></SqlQu
 SELECT VALUE root 
 FROM root 
 ORDER BY (NOT IS_DEFINED(root["NullableInt"])) ASC, (ARRAY_LENGTH(root["Tags"]) % 2) DESC ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -209,7 +209,7 @@ JOIN (
 ) AS v0 
 ORDER BY (root["IsRegistered"] ? root["FamilyId"] : root["Int"]) DESC, (v0[0] % 1000) ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -259,7 +259,7 @@ JOIN (
 ) AS v1 
 ORDER BY v0 ASC, v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -285,7 +285,7 @@ JOIN (
 ) AS v1 
 ORDER BY root["FamilyId"] ASC, v0 DESC, v1 ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -307,7 +307,7 @@ JOIN (
 ) AS v0 
 ORDER BY root["FamilyId"] ASC, v0 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":141,"end":192},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":141,"end":192},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -337,7 +337,7 @@ JOIN (
 ) AS v1 
 ORDER BY v0 ASC, v1 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":107,"end":156},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":280,"end":331},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":107,"end":156},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":280,"end":331},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -359,7 +359,7 @@ JOIN (
 ) AS v1 
 ORDER BY root["FamilyId"] ASC, v1 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":147,"end":198},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":65},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":147,"end":198},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":65},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -393,7 +393,7 @@ JOIN (
 ) AS v2 
 ORDER BY v1 ASC, v2 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":136,"end":186},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":82,"end":88},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":195,"end":242},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":366,"end":417},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":136,"end":186},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":82,"end":88},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":195,"end":242},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":366,"end":417},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -443,7 +443,7 @@ JOIN (
     ORDER BY r0["FamilyId"] ASC, r0["FamilyNumber"] ASC
 ) AS v1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":374,"end":425},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":374,"end":425},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -497,7 +497,7 @@ FROM (
 ) AS r0 
 ORDER BY ARRAY_LENGTH(r0["ChildrenWithPets"]) DESC, r0["TotalExpenses"] DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -536,7 +536,7 @@ FROM (
 ) AS r2 
 ORDER BY r2["GoodChildrenCount"] DESC, r2["UniquePetsNameCount"] ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -564,7 +564,7 @@ FROM root
 JOIN f0 IN root["Children"] 
 WHERE (ARRAY_LENGTH(root["Children"]) > 0) 
 ORDER BY f0["Grade"] ASC, ARRAY_LENGTH(f0["Pets"]) DESC ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -594,7 +594,7 @@ FROM (
     WHERE (v2 > 0)
 ) AS r1 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":163,"end":209},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":210,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":163,"end":209},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":210,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -618,7 +618,7 @@ FROM (
 ) AS r2 
 ORDER BY r2["Length"] ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":170,"end":225},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":234,"end":259},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":170,"end":225},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":234,"end":259},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -650,7 +650,7 @@ FROM (
 ) AS r0 
 ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -668,7 +668,7 @@ FROM (
 ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC 
 OFFSET 5 LIMIT 2147483647 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -705,7 +705,7 @@ FROM (
 ) AS r0 
 ORDER BY r0["Name"] DESC, r0["PetWithLongNames"] ASC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -735,7 +735,7 @@ JOIN (
 ) AS v1 
 ORDER BY v0 ASC, v1 DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -775,7 +775,7 @@ JOIN (
 ) AS v3 
 ORDER BY v0[0] ASC, v1[0] DESC, v2 ASC, v3[0] DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
@@ -169,7 +169,7 @@ FROM root ]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3)) ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -226,7 +226,7 @@ FROM root ]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3)) ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
@@ -107,7 +107,7 @@ FROM (
 JOIN number0 IN r0["EnumerableField"] 
 WHERE (number0 > 10) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":95,"end":127},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":34,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":95,"end":127},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":34,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
@@ -84,7 +84,7 @@ FROM (
 ) AS r0 
 WHERE (r0["NumericField"] > 100) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -101,7 +101,7 @@ FROM (
 ) AS r0 
 WHERE (r0["NumericField"] > 100) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":45,"end":50},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":45,"end":50},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -118,7 +118,7 @@ FROM (
 ) AS r0 
 WHERE (r0 > 100) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -135,7 +135,7 @@ FROM (
 ) AS r0 
 WHERE (r0 > 100) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -153,7 +153,7 @@ FROM (
 WHERE (r0["NumericField"] > 100) 
 ORDER BY r0["NumericField"] DESC 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":45,"end":51},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":45,"end":51},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -203,7 +203,7 @@ FROM (
 ) AS r0 
 WHERE (r0["NumericField"] > 100) 
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Response status code does not indicate success: 400 Substatus: 0 Reason: ({"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]}).]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -781,7 +781,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             catch (CosmosException exception) when (exception.StatusCode == HttpStatusCode.BadRequest)
             {
-                Assert.IsTrue(exception.Message.StartsWith("Response status code does not indicate success: 400 Substatus: 0 Reason: (Message: {\"errors\":[{\"severity\":\"Error\",\"location\":{\"start\":27,\"end\":28},\"code\":\"SC2001\",\"message\":\"Identifier 'a' could not be resolved.\"}]}"),
+                Assert.IsTrue(exception.Message.StartsWith(@"Response status code does not indicate success: 400 Substatus: 0 Reason: ({""errors"":[{""severity"":""Error"",""location"":{""start"":27,""end"":28},""code"":""SC2001"",""message"":""Identifier 'a' could not be resolved.""}]})."),
                     exception.Message);
             }
         }

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -2,19 +2,19 @@
 
 parameters:
   BuildConfiguration: ''
-  VmImage: '' 
+  VmImage: ''
 
-jobs: 
-- job: 
-  displayName: Static Analysis 
+jobs:
+- job:
+  displayName: Static Analysis
   pool:
-    vmImage: '${{ parameters.VmImage }}' 
-    
+    vmImage: '${{ parameters.VmImage }}'
+
   steps:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
-      
-  #Analyze source code for type of content and target types to help determine which tools to run 
+
+  #Analyze source code for type of content and target types to help determine which tools to run
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
     displayName: 'AutoApplicability'
     inputs:
@@ -22,47 +22,47 @@ jobs:
       ExternalRelease: true
       InternalRelease: true
       IsService: true
-      IsSoftware: true    
-    
+      IsSoftware: true
+
   # Analyze source and build output text files for credentials
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
     displayName: 'CredScan'
     inputs:
       scanFolder: $(Build.SourcesDirectory)
-      suppressionsFile: CredScanSuppressions.json 
+      suppressionsFile: CredScanSuppressions.json
       debugMode: true
-  
+
   # Scan text elements including code, code comments, and content/web pages, for sensitive terms based on legal, cultural, or geopolitical reasons
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
     displayName: 'PoliCheck'
     inputs:
       targetType: F
-      
+
   # AntiMalware scan
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
-    displayName: 'AntiMalware'
-    continueOnError: true # signature refresh failing resulting in tasks failures 
-    inputs:
-      EnableServices: true
-  
+  #- task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+  #  displayName: 'AntiMalware'
+  #  continueOnError: true # signature refresh failing resulting in tasks failures
+  #  inputs:
+  #    EnableServices: true
+
   # Run checks for recently discovered vulnerabilities which are not yet incorporated to another tool
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-vulnerabilityassessment.VulnerabilityAssessment@0
     displayName: 'Vulnerability Assessment'
-    
+
   - task: DotNetCoreCLI@2
     displayName: Build Microsoft.Azure.Cosmos.sln
     inputs:
-      command: build 
+      command: build
       projects: 'Microsoft.Azure.Cosmos.sln'
       configuration: '${{ parameters.BuildConfiguration }}'
-      publishTestResults: true 
+      publishTestResults: true
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection' #https://docs.opensource.microsoft.com/tools/cg.html
     inputs:
       alertWarningLevel: Medium
-      failOnAlert: true    
-      
+      failOnAlert: true
+
 #  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
 #    displayName: 'BinSkim'
 #    inputs:


### PR DESCRIPTION
# Convert QueryException to CosmosException

## Description

Query was returning generic exceptions that we were converting to a bad request. This does not work in cases where the query encounters gone exceptions / 429s / etc. The solution was to implement a QueryResponseFactory that converts known exceptions to their corresponding CosmosException. If it's an unknown exception then it gets converted to a CosmosException with status code 500. As for the query code it would have been wrong to return a bad request exception for a malformed continuation token, since the query code could be used independently of the SDK. The solution was to return a QueryException and create a mapping from QueryException to CosmosException. In order to avoid the mapping from going out to sync QueryException implements the visitor pattern so a visitor can convert a QueryException to CosmosException. For utility I added some of the Http error types as children of CosmosException to serve as a factory pattern. 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update