### PR TITLE
Gateway OperationCanceledException are now returned as request timeouts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -324,19 +324,21 @@ namespace Microsoft.Azure.Cosmos
                     DateTime sendTimeUtc = DateTime.UtcNow;
                     Guid localGuid = Guid.NewGuid();  // For correlating HttpRequest and HttpResponse Traces
 
+                    Guid requestedActivityId = Trace.CorrelationManager.ActivityId;
                     this.eventSource.Request(
-                        Guid.Empty,
+                        requestedActivityId,
                         localGuid,
                         requestMessage.RequestUri.ToString(),
                         resourceType.ToResourceTypeString(),
                         requestMessage.Headers);
 
+                    TimeSpan durationTimeSpan;
                     try
                     {
                         HttpResponseMessage responseMessage = await this.httpClient.SendAsync(requestMessage, cancellationToken);
 
                         DateTime receivedTimeUtc = DateTime.UtcNow;
-                        double durationInMilliSeconds = (receivedTimeUtc - sendTimeUtc).TotalMilliseconds;
+                        durationTimeSpan = receivedTimeUtc - sendTimeUtc;
 
                         IEnumerable<string> headerValues;
                         Guid activityId = Guid.Empty;
@@ -350,7 +352,7 @@ namespace Microsoft.Azure.Cosmos
                             activityId,
                             localGuid,
                             (short)responseMessage.StatusCode,
-                            durationInMilliSeconds,
+                            durationTimeSpan.TotalMilliseconds,
                             responseMessage.Headers);
 
                         return responseMessage;
@@ -360,7 +362,23 @@ namespace Microsoft.Azure.Cosmos
                         if (!cancellationToken.IsCancellationRequested)
                         {
                             // throw timeout if the cancellationToken is not canceled (i.e. httpClient timed out)
-                            throw new RequestTimeoutException(ex, requestMessage.RequestUri);
+                            durationTimeSpan = DateTime.UtcNow - sendTimeUtc;
+                            string message = $"GatewayStoreClient Request Timeout. Start Time:{sendTimeUtc}; Total Duration:{durationTimeSpan}; Http Client Timeout:{this.httpClient.Timeout}; Activity id: {requestedActivityId}; Inner Message: {ex.Message};";
+                            throw new RequestTimeoutException(message, ex, requestMessage.RequestUri);
+                        }
+                        else
+                        {
+                            throw;
+                        }
+                    }
+                    catch (OperationCanceledException ex)
+                    {
+                        if (!cancellationToken.IsCancellationRequested)
+                        {
+                            // throw timeout if the cancellationToken is not canceled (i.e. httpClient timed out)
+                            durationTimeSpan = DateTime.UtcNow - sendTimeUtc;
+                            string message = $"GatewayStoreClient Request Timeout. Start Time:{sendTimeUtc}; Total Duration:{durationTimeSpan}; Http Client Timeout:{this.httpClient.Timeout}; Activity id: {requestedActivityId}; Inner Message: {ex.Message};";
+                            throw new RequestTimeoutException(message, ex, requestMessage.RequestUri);
                         }
                         else
                         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -1,0 +1,73 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+ 
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CosmosGatewayTimeoutTests
+    { 
+        [TestMethod]
+        public async Task GatewayStoreClientTimeout()
+        {
+            HttpClient httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromMilliseconds(20);
+            httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true };
+
+            httpClient.AddApiTypeHeader(ApiType.None);
+
+            // Set requested API version header that can be used for
+            // version enforcement.
+            httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Version,
+                HttpConstants.Versions.CurrentVersion);
+
+            httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Accept, RuntimeConstants.MediaTypes.Json);
+
+            GatewayStoreClient gatewayStoreClient = new GatewayStoreClient(
+                httpClient,
+                DocumentClientEventSource.Instance,
+                null);
+
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            try
+            {
+                using (new ActivityScope(Guid.NewGuid()))
+                {
+                    using (DocumentServiceRequest serviceRequest = new DocumentServiceRequest(
+                            operationType: OperationType.Read,
+                            resourceIdOrFullName: null,
+                            resourceType: ResourceType.Database,
+                            body: null,
+                            headers: null,
+                            isNameBased: false,
+                            authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey))
+                    {
+                        await gatewayStoreClient.InvokeAsync(
+                            serviceRequest,
+                            ResourceType.Database,
+                            new Uri("https://127.0.0.1:8081/dbs/97c0b8d0-9c6f-462f-8ea8-3374ab788273"),
+                            cancellationTokenSource.Token);
+                    }
+                }
+            }catch(RequestTimeoutException rte)
+            {
+                string message = rte.ToString();
+                Assert.IsTrue(message.Contains("Start Time"));
+                Assert.IsTrue(message.Contains("Total Duration"));
+                Assert.IsTrue(message.Contains("Http Client Timeout"));
+                Assert.IsTrue(message.Contains("Activity id"));
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -21,52 +21,67 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task GatewayStoreClientTimeout()
         {
-            HttpClient httpClient = new HttpClient();
-            httpClient.Timeout = TimeSpan.FromMilliseconds(20);
-            httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true };
-
-            httpClient.AddApiTypeHeader(ApiType.None);
-
-            // Set requested API version header that can be used for
-            // version enforcement.
-            httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Version,
-                HttpConstants.Versions.CurrentVersion);
-
-            httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Accept, RuntimeConstants.MediaTypes.Json);
-
-            GatewayStoreClient gatewayStoreClient = new GatewayStoreClient(
-                httpClient,
-                DocumentClientEventSource.Instance,
-                null);
-
-            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            try
+            using (CosmosClient client = TestCommon.CreateCosmosClient())
             {
-                using (new ActivityScope(Guid.NewGuid()))
+                HttpClient httpClient = new HttpClient();
+                httpClient.Timeout = TimeSpan.FromMilliseconds(50);
+                httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true };
+
+                httpClient.AddApiTypeHeader(ApiType.None);
+
+                // Set requested API version header that can be used for
+                // version enforcement.
+                httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Version,
+                    HttpConstants.Versions.CurrentVersion);
+
+                httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Accept, RuntimeConstants.MediaTypes.Json);
+
+                GatewayStoreClient gatewayStoreClient = new GatewayStoreClient(
+                    httpClient,
+                    DocumentClientEventSource.Instance,
+                    null);
+
+                CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+                try
                 {
-                    using (DocumentServiceRequest serviceRequest = new DocumentServiceRequest(
-                            operationType: OperationType.Read,
-                            resourceIdOrFullName: null,
-                            resourceType: ResourceType.Database,
-                            body: null,
-                            headers: null,
-                            isNameBased: false,
-                            authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey))
+
+                    using (new ActivityScope(Guid.NewGuid()))
                     {
-                        await gatewayStoreClient.InvokeAsync(
-                            serviceRequest,
-                            ResourceType.Database,
-                            new Uri("https://127.0.0.1:8081/dbs/97c0b8d0-9c6f-462f-8ea8-3374ab788273"),
-                            cancellationTokenSource.Token);
+                        using (DocumentServiceRequest serviceRequest = new DocumentServiceRequest(
+                                operationType: OperationType.Read,
+                                resourceIdOrFullName: null,
+                                resourceType: ResourceType.Database,
+                                body: null,
+                                headers: null,
+                                isNameBased: false,
+                                authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey))
+                        {
+                            string authorization = ((IAuthorizationTokenProvider)client.DocumentClient).GetUserAuthorizationToken(
+                                serviceRequest.ResourceAddress,
+                                PathsHelper.GetResourcePath(serviceRequest.ResourceType),
+                                HttpMethod.Get.ToString(),
+                                serviceRequest.Headers,
+                                AuthorizationTokenType.PrimaryMasterKey,
+                                payload: out _);
+
+                            serviceRequest.Headers[HttpConstants.HttpHeaders.Authorization] = authorization;
+
+                            await gatewayStoreClient.InvokeAsync(
+                                serviceRequest,
+                                ResourceType.Database,
+                                new Uri("https://127.0.0.1:8081/dbs/97c0b8d0-9c6f-462f-8ea8-3374ab788273"),
+                                cancellationTokenSource.Token);
+                        }
                     }
                 }
-            }catch(RequestTimeoutException rte)
-            {
-                string message = rte.ToString();
-                Assert.IsTrue(message.Contains("Start Time"));
-                Assert.IsTrue(message.Contains("Total Duration"));
-                Assert.IsTrue(message.Contains("Http Client Timeout"));
-                Assert.IsTrue(message.Contains("Activity id"));
+                catch (RequestTimeoutException rte)
+                {
+                    string message = rte.ToString();
+                    Assert.IsTrue(message.Contains("Start Time"));
+                    Assert.IsTrue(message.Contains("Total Duration"));
+                    Assert.IsTrue(message.Contains("Http Client Timeout"));
+                    Assert.IsTrue(message.Contains("Activity id"));
+                }
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -49,14 +49,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 // Set the http request timeout to 10 ms to cause a timeout exception
                 FieldInfo httpClientProperty = storeClient.GetType().GetField("httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
                 HttpClient gatewayStoreHttpClient = (HttpClient)httpClientProperty.GetValue(storeClient);
-                gatewayStoreHttpClient.Timeout = TimeSpan.FromMilliseconds(10);
+                gatewayStoreHttpClient.Timeout = TimeSpan.FromMilliseconds(1);
 
                 // Verify the failure has the required info
                 CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
                 try
                 {
-                    await client.CreateDatabaseAsync("TestGatewayTimeoutDb");
-                    Assert.Fail("Operation should have timed out");
+                    await client.CreateDatabaseAsync("TestGatewayTimeoutDb" + Guid.NewGuid().ToString());
+                    Assert.Fail("Operation should have timed out:" + gatewayStoreHttpClient.Timeout);
                 }
                 catch (CosmosException rte)
                 {

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#944](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/944) Change Feed Processor won't use user serializer for internal operations
-
+- [#1013](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1013) Gateway OperationCanceledException are now returned as request timeouts
 
 ## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
 


### PR DESCRIPTION
# Pull Request Template

## Description

Added additional context to the request time out exception in gateway. It was discovered during testing that the HttpClient can throw a OperationCanceledException or TaskCancelledException 
 during a request timeout. Added additional logic to handle both exceptions.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



