### PR TITLE
Cache CosmosElements in Nested Lazy Types

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.LazyCosmosArray.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.LazyCosmosArray.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         {
             private readonly IJsonNavigator jsonNavigator;
             private readonly IJsonNavigatorNode jsonNavigatorNode;
-            private readonly Lazy<CosmosElement>[] lazyCosmosElementArray;
+            private readonly Lazy<Lazy<CosmosElement>[]> lazyCosmosElementArray;
             public LazyCosmosArray(
                 IJsonNavigator jsonNavigator,
                 IJsonNavigatorNode jsonNavigatorNode)
@@ -45,21 +45,27 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
                 this.jsonNavigator = jsonNavigator;
                 this.jsonNavigatorNode = jsonNavigatorNode;
 
-                this.lazyCosmosElementArray = new Lazy<CosmosElement>[this.jsonNavigator.GetArrayItemCount(this.jsonNavigatorNode)];
-                int index = 0;
-                // Using foreach instead of indexer, since the navigator doesn't support random seeks efficiently.
-                foreach (IJsonNavigatorNode arrayItem in this.jsonNavigator.GetArrayItems(this.jsonNavigatorNode))
+                this.lazyCosmosElementArray = new Lazy<Lazy<CosmosElement>[]>(() =>
                 {
-                    this.lazyCosmosElementArray[index] = new Lazy<CosmosElement>(() => CosmosElement.Dispatch(this.jsonNavigator, arrayItem));
-                    index++;
-                }
+                    Lazy<CosmosElement>[] lazyArray = new Lazy<CosmosElement>[this.jsonNavigator.GetArrayItemCount(this.jsonNavigatorNode)];
+                    int index = 0;
+                    // Using foreach instead of indexer, since the navigator doesn't support random seeks efficiently.
+                    foreach (IJsonNavigatorNode arrayItem in this.jsonNavigator.GetArrayItems(this.jsonNavigatorNode))
+                    {
+                        lazyArray[index] = new Lazy<CosmosElement>(() => CosmosElement.Dispatch(this.jsonNavigator, arrayItem));
+                        index++;
+                    }
+
+                    return lazyArray;
+                });
+                
             }
 
-            public override int Count => this.lazyCosmosElementArray.Length;
+            public override int Count => this.lazyCosmosElementArray.Value.Length;
 
-            public override CosmosElement this[int index] => this.lazyCosmosElementArray[index].Value;
+            public override CosmosElement this[int index] => this.lazyCosmosElementArray.Value[index].Value;
 
-            public override IEnumerator<CosmosElement> GetEnumerator() => this.lazyCosmosElementArray.Select(lazyItem => lazyItem.Value).GetEnumerator();
+            public override IEnumerator<CosmosElement> GetEnumerator() => this.lazyCosmosElementArray.Value.Select(lazyItem => lazyItem.Value).GetEnumerator();
 
             public override void WriteTo(IJsonWriter jsonWriter)
             {

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.LazyCosmosArray.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.LazyCosmosArray.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             private readonly IJsonNavigator jsonNavigator;
             private readonly IJsonNavigatorNode jsonNavigatorNode;
             private readonly Lazy<Lazy<CosmosElement>[]> lazyCosmosElementArray;
+
             public LazyCosmosArray(
                 IJsonNavigator jsonNavigator,
                 IJsonNavigatorNode jsonNavigatorNode)

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.LazyCosmosObject.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.LazyCosmosObject.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         {
             private readonly IJsonNavigator jsonNavigator;
             private readonly IJsonNavigatorNode jsonNavigatorNode;
+            private readonly Dictionary<string, CosmosElement> cachedElements;
+            private readonly Lazy<int> lazyCount;
 
             public LazyCosmosObject(IJsonNavigator jsonNavigator, IJsonNavigatorNode jsonNavigatorNode)
             {
@@ -42,21 +44,23 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
                 this.jsonNavigator = jsonNavigator;
                 this.jsonNavigatorNode = jsonNavigatorNode;
+                this.cachedElements = new Dictionary<string, CosmosElement>();
+                this.lazyCount = new Lazy<int>(() => this.jsonNavigator.GetObjectPropertyCount(this.jsonNavigatorNode));
             }
 
+            // This method is not efficient (but that's the expectation of IEnumerable ... A user should call ToList() if they are calling multiple times).
             public override IEnumerable<string> Keys => this
                 .jsonNavigator
                 .GetObjectProperties(this.jsonNavigatorNode)
                 .Select((objectProperty) => this.jsonNavigator.GetStringValue(objectProperty.NameNode));
 
+            // This method is not efficient (but that's the expectation of IEnumerable ... A user should call ToList() if they are calling multiple times).
             public override IEnumerable<CosmosElement> Values => this
                 .jsonNavigator
                 .GetObjectProperties(this.jsonNavigatorNode)
                 .Select((objectProperty) => CosmosElement.Dispatch(this.jsonNavigator, objectProperty.ValueNode));
 
-            public override int Count => this
-                .jsonNavigator
-                .GetObjectPropertyCount(this.jsonNavigatorNode);
+            public override int Count => this.lazyCount.Value;
 
             public override CosmosElement this[string key]
             {
@@ -88,15 +92,23 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
             public override bool TryGetValue(string key, out CosmosElement value)
             {
-                value = default(CosmosElement);
+                value = default;
                 bool gotValue;
-                if (this.jsonNavigator.TryGetObjectProperty(
+                if (this.cachedElements.TryGetValue(
+                    key,
+                    out CosmosElement cosmosElemet))
+                {
+                    value = cosmosElemet;
+                    gotValue = true;
+                }
+                else if (this.jsonNavigator.TryGetObjectProperty(
                     this.jsonNavigatorNode,
                     key,
                     out ObjectProperty objectProperty))
                 {
                     value = CosmosElement.Dispatch(this.jsonNavigator, objectProperty.ValueNode);
                     gotValue = true;
+                    this.cachedElements[key] = value;
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosElements/LazyCosmosElementTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosElements/LazyCosmosElementTests.cs
@@ -184,6 +184,30 @@ namespace Microsoft.Azure.Cosmos.NetFramework.Tests.CosmosElements
             Assert.AreEqual(bufferedSerializedPeopleString, bufferedResultString);
         }
 
+        [TestMethod]
+        [Owner("brchon")]
+        public void TestCaching()
+        {
+            CosmosArray lazilyDeserializedPeople = CosmosElement.CreateFromBuffer(LazyCosmosElementTests.bufferedSerializedPeople) as CosmosArray;
+            Assert.IsTrue(
+                object.ReferenceEquals(lazilyDeserializedPeople[0], lazilyDeserializedPeople[0]),
+                "Array did not return the item from the cache.");
+
+            CosmosObject lazilyDeserializedPerson = lazilyDeserializedPeople[0] as CosmosObject;
+            Assert.IsTrue(
+                object.ReferenceEquals(lazilyDeserializedPerson[nameof(Person.Age)], lazilyDeserializedPerson[nameof(Person.Age)]),
+                "Object did not return the property from the cache.");
+
+            CosmosString personName = lazilyDeserializedPerson[nameof(Person.Name)] as CosmosString;
+            Assert.IsTrue(
+                object.ReferenceEquals(personName.Value, personName.Value),
+                "Did not return the string from the cache.");
+
+            // Numbers is a value type so we don't need to test for the cache.
+            // Booleans are multitons so we don't need to test for the cache.
+            // Nulls are singletons so we don't need to test for the cache.
+        }
+
         #region CurratedDocs
         [TestMethod]
         [Owner("brchon")]


### PR DESCRIPTION
# Cache CosmosElements in Nested Types

## Description

Added a caching layer for nested lazy `CosmosElements` (`CosmosObject`, `CosmosArray`). 

### CosmosArray
* Has an array that starts off as the size of the list
* Each element is a `Lazy<CosmosElement>`
* `Count()` is now O(1) instead of O(n)

### CosmosObject
* Has a concrete dictionary to store key value pairs that the user asks for (so subsequent results can be served from the cache).
* `Count()` is backed by a `Lazy<int>`.
* I chose not to do anything special for `Keys`, `Values`, `IEnumerator<KeyValuePair>`, since those are all `IEnumerable` and it the expectation that the user caches the result using `.ToList()` if they are calling it multiple times.
