### PR TITLE
Fix ThroughputResponse.IsReplacePending

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -109,7 +109,7 @@
   <PropertyGroup>
     <DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
     <DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
-    <DefineConstants Condition=" '$(DelaySign)' == 'true' ">DelaySignKeys</DefineConstants>
+    <DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
     <DefineConstants>$(DefineConstants);DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20</DefineConstants>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Microsoft.Azure.Cosmos/src/Resource/Throughput/ThroughputResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Throughput/ThroughputResponse.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 if (this.Headers.GetHeaderValue<string>(WFConstants.BackendHeaders.OfferReplacePending) != null)
                 {
-                    return Boolean.Parse(this.Headers.GetHeaderValue<string>(WFConstants.BackendHeaders.MinimumRUsForOffer));
+                    return Boolean.Parse(this.Headers.GetHeaderValue<string>(WFConstants.BackendHeaders.OfferReplacePending));
                 }
                 return null;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Resource/Throughput/ThroughputResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Resource/Throughput/ThroughputResponseTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Net;
+using Microsoft.Azure.Documents;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Azure.Cosmos.Resource.Throughput
+{
+    [TestClass]
+    public class ThroughputResponseTests
+    {
+        [TestMethod]
+        public void OfferReplacePendingHeaderNotSetReturnsNull()
+        {
+            ThroughputResponse throughputResponse =
+                new ThroughputResponse(HttpStatusCode.OK, new Headers(), null, null);
+
+            Assert.IsNull(throughputResponse.IsReplacePending);
+        }
+
+        [TestMethod]
+        public void OfferReplacePendingHeaderSetTrueReturnsTrue()
+        {
+            ThroughputResponse throughputResponse = new ThroughputResponse(HttpStatusCode.OK, new Headers
+            {
+                {WFConstants.BackendHeaders.OfferReplacePending, "true"}
+            }, null, null);
+
+            Assert.IsNotNull(throughputResponse.IsReplacePending);
+            Assert.IsTrue(throughputResponse.IsReplacePending.Value);
+        }
+
+        [TestMethod]
+        public void OfferReplacePendingHeaderSetFalseReturnsFalse()
+        {
+            ThroughputResponse throughputResponse = new ThroughputResponse(HttpStatusCode.OK, new Headers
+            {
+                {WFConstants.BackendHeaders.OfferReplacePending, "false"}
+            }, null, null);
+
+            Assert.IsNotNull(throughputResponse.IsReplacePending);
+            Assert.IsFalse(throughputResponse.IsReplacePending.Value);
+        }
+    }
+}


### PR DESCRIPTION
fix the value that is being retrieved when mapping ThoughputResponse.IsReplacePending

# Pull Request Template

## Description

This PR is to fix the value that is being retrieved when mapping ThoughputResponse.IsReplacePending as it is currently incorrectly attempting to read `WFConstants.BackendHeaders.MinimumRUsForOffer`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues
Closes #1024 