### PR TITLE
Fixed flaky gateway timeout test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -4,15 +4,11 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
-
     using System;
-    using System.Collections.Generic;
     using System.Net.Http;
-    using System.Net.Http.Headers;
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -50,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 HttpClient httpClient = new HttpClient(new TimeOutHttpClientHandler());
                 FieldInfo httpClientProperty = storeClient.GetType().GetField("httpClient", BindingFlags.NonPublic | BindingFlags.Instance);
                 httpClientProperty.SetValue(storeClient, httpClient);
-                
+
                 // Verify the failure has the required info
                 CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
                 try


### PR DESCRIPTION
# Pull Request Template

## Description

The gateway test passes locally, but seems to be flaky in the gates. Changing the test to always throw the timeout exception, and validate the message. This removes the dependency on the HttpClient to throw the timeout exception.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

