### PR TITLE
GROUP BY OOM Fix

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupByDocumentQueryExecutionComponent.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent
             public IReadOnlyList<CosmosElement> Drain(int maxItemCount)
             {
                 List<UInt128> keys = this.table.Keys.Take(maxItemCount).ToList();
-                List<SingleGroupAggregator> singleGroupAggregators = new List<SingleGroupAggregator>(maxItemCount);
+                List<SingleGroupAggregator> singleGroupAggregators = new List<SingleGroupAggregator>(keys.Count);
                 foreach (UInt128 key in keys)
                 {
                     SingleGroupAggregator singleGroupAggregator = this.table[key];


### PR DESCRIPTION
# GROUP BY OOM Fix

## Description

We had an OOM due to the way we were draining from the grouping table. The initial list size if the user page size instead of the actual grouping table size. I start the list off as the min of the two sizes. 

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

