### PR TITLE
Fixed query responses to return null Content if it is a failure.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Azure.Cosmos.Query
                     count: responseCore.CosmosElements.Count,
                     responseLengthBytes: responseCore.ResponseLengthBytes,
                     diagnostics: diagnostics,
+                    serializationOptions: this.cosmosSerializationFormatOptions,
                     responseHeaders: new CosmosQueryResponseMessageHeaders(
                         responseCore.ContinuationToken,
                         responseCore.DisallowContinuationTokenMessage,
@@ -128,8 +129,6 @@ namespace Microsoft.Azure.Cosmos.Query
                         SubStatusCode = responseCore.SubStatusCode ?? Documents.SubStatusCodes.Unknown
                     });
             }
-
-            queryResponse.CosmosSerializationOptions = this.cosmosSerializationFormatOptions;
 
             return queryResponse;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
@@ -35,7 +35,9 @@ namespace Microsoft.Azure.Cosmos
             RequestMessage requestMessage,
             CosmosDiagnostics diagnostics,
             string errorMessage,
-            Error error)
+            Error error,
+            Lazy<MemoryStream> memoryStream,
+            CosmosSerializationFormatOptions serializationOptions)
             : base(
                 statusCode: statusCode,
                 requestMessage: requestMessage,
@@ -47,11 +49,8 @@ namespace Microsoft.Azure.Cosmos
             this.CosmosElements = result;
             this.Count = count;
             this.ResponseLengthBytes = responseLengthBytes;
-            this.memoryStream = new Lazy<MemoryStream>(() => CosmosElementSerializer.ToStream(
-                        this.QueryHeaders.ContainerRid,
-                        this.CosmosElements,
-                        this.QueryHeaders.ResourceType,
-                        this.CosmosSerializationOptions));
+            this.memoryStream = memoryStream;
+            this.CosmosSerializationOptions = serializationOptions;
         }
 
         public int Count { get; }
@@ -60,7 +59,7 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return this.memoryStream.Value;
+                return this.memoryStream?.Value;
             }
         }
 
@@ -76,7 +75,7 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         internal long ResponseLengthBytes { get; }
 
-        internal virtual CosmosSerializationFormatOptions CosmosSerializationOptions { get; set; }
+        internal virtual CosmosSerializationFormatOptions CosmosSerializationOptions { get; }
 
         internal bool GetHasMoreResults()
         {
@@ -88,7 +87,8 @@ namespace Microsoft.Azure.Cosmos
             int count,
             long responseLengthBytes,
             CosmosQueryResponseMessageHeaders responseHeaders,
-            CosmosDiagnostics diagnostics)
+            CosmosDiagnostics diagnostics,
+            CosmosSerializationFormatOptions serializationOptions)
         {
             if (count < 0)
             {
@@ -100,6 +100,12 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentOutOfRangeException("responseLengthBytes must be positive");
             }
 
+            Lazy<MemoryStream> memoryStream = new Lazy<MemoryStream>(() => CosmosElementSerializer.ToStream(
+                       responseHeaders.ContainerRid,
+                       result,
+                       responseHeaders.ResourceType,
+                       serializationOptions));
+
             QueryResponse cosmosQueryResponse = new QueryResponse(
                result: result,
                count: count,
@@ -109,7 +115,9 @@ namespace Microsoft.Azure.Cosmos
                statusCode: HttpStatusCode.OK,
                errorMessage: null,
                error: null,
-               requestMessage: null);
+               requestMessage: null,
+               memoryStream: memoryStream,
+               serializationOptions: serializationOptions);
 
             return cosmosQueryResponse;
         }
@@ -123,15 +131,17 @@ namespace Microsoft.Azure.Cosmos
             CosmosDiagnostics diagnostics)
         {
             QueryResponse cosmosQueryResponse = new QueryResponse(
-                result: Enumerable.Empty<CosmosElement>(),
-                count: 0,
-                responseLengthBytes: 0,
-                responseHeaders: responseHeaders,
-                diagnostics: diagnostics,
-                statusCode: statusCode,
-                errorMessage: errorMessage,
-                error: error,
-                requestMessage: requestMessage);
+                    result: Enumerable.Empty<CosmosElement>(),
+                    count: 0,
+                    responseLengthBytes: 0,
+                    responseHeaders: responseHeaders,
+                    diagnostics: diagnostics,
+                    statusCode: statusCode,
+                    errorMessage: errorMessage,
+                    error: error,
+                    requestMessage: requestMessage,
+                    memoryStream: null,
+                    serializationOptions: null);
 
             return cosmosQueryResponse;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -69,6 +69,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task NegativeCreateDropItemTest()
+        {
+            ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.Serializer.ToStream(testItem), new Cosmos.PartitionKey("BadKey"));
+            Assert.IsNotNull(response);
+            Assert.IsNull(response.Content);
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
+        [TestMethod]
         public async Task CustomSerilizerTest()
         {
             string id1 = "MyCustomSerilizerTestId1";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ComparableTaskSchedulerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ComparableTaskSchedulerTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Test
                     }
                 }
 
-                bool completionStatus = Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(1));
+                bool completionStatus = Task.WaitAll(tasks.ToArray(), TimeSpan.FromSeconds(10));
                 Assert.IsTrue(completionStatus);
 
                 foreach (Task task in tasks)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         result: cosmosElements,
                         count: cosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
+                        serializationOptions: null,
                         responseHeaders: new CosmosQueryResponseMessageHeaders(
                             responseCore.ContinuationToken,
                             responseCore.DisallowContinuationTokenMessage,
@@ -151,6 +152,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         result: cosmosElements,
                         count: cosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
+                        serializationOptions: null,
                         responseHeaders: new CosmosQueryResponseMessageHeaders(
                             responseCore.ContinuationToken,
                             responseCore.DisallowContinuationTokenMessage,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Scenarios/GremlinScenarioTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Scenarios/GremlinScenarioTests.cs
@@ -642,6 +642,7 @@ namespace Microsoft.Azure.Cosmos.Scenarios
                 vertexArray,
                 count: 2,
                 responseLengthBytes: vertex1JsonWriterResult.Length + vertex2JsonWriterResult.Length,
+                serializationOptions: null,
                 responseHeaders: CosmosQueryResponseMessageHeaders.ConvertToQueryHeaders(
                     sourceHeaders: null,
                     resourceType: ResourceType.Document,
@@ -723,6 +724,7 @@ namespace Microsoft.Azure.Cosmos.Scenarios
                 vertexArray,
                 count: 2,
                 responseLengthBytes: vertex1JsonWriterResult.Length + vertex2JsonWriterResult.Length,
+                serializationOptions: null,
                 responseHeaders: CosmosQueryResponseMessageHeaders.ConvertToQueryHeaders(
                     sourceHeaders: null,
                     resourceType: ResourceType.Document,

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#988](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/988) Fixed query mutating due to retry of gone / name cache is stale.
 - [#999](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/999) Fixed grabbing extra page and updated continuation token on exception path.
 - [#1013](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1013) Gateway OperationCanceledException are now returned as request timeouts
+- [#1036](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1036) Fixed query responses to return null Content if it is a failure
 
 ## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
 
@@ -41,13 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#918](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/918) Fixed serializer being used for Scripts, Permissions, and Conflict related iterators
 - [#936](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/936) Fixed bulk requests with large resources to have natural exception 
 
-
 ## <a name="3.3.3"/> [3.3.3](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.3.3) - 2019-10-30
 
 - [#837](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/837) Fixed group by bug for non-Windows platforms
 - [#927](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/927) Fixed query returning partial results instead of error
-flow.
-
 
 ## <a name="3.3.2"/> [3.3.2](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.3.2) - 2019-10-16
 


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a bug where query stream iterator response message would return a stream on failure scenario. It now returns null for the content if the query failed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

closes #1034

