### PR TITLE
Cassandra Name Cache Is Stale Retry Hack

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             }
 
             CosmosQueryExecutionContext cosmosQueryExecutionContext;
-            if (inputParameters.Properties.ContainsKey("x-ms-schema-owner-rid"))
+            if ((inputParameters.Properties != null) && inputParameters.Properties.ContainsKey("x-ms-schema-owner-rid"))
             {
                 // For Cassandra we can not automatically retry the query on gone exception.
                 // Scenario:

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
 
             CatchAllCosmosQueryExecutionContext catchAllCosmosQueryExecutionContext = new CatchAllCosmosQueryExecutionContext(cosmosQueryExecutionContext);
 
-            return cosmosQueryExecutionContext;
+            return catchAllCosmosQueryExecutionContext;
         }
 
         private static async Task<TryCatch<CosmosQueryExecutionContext>> TryCreateCoreContextAsync(


### PR DESCRIPTION
# Cassandra Name Cache Is Stale Retry Hack

## Description

Cassandra has a soft contract where they add a secret header for collection _rid. The problem is that the SDK will retry the query if it gets a name cache is stale exception. When this happens we will retry the query against the new collection with new _rid, but with the old (provided) _rid in the header. This leads to a schema owner _rid exception. The hack is to just bubble up the not found exception in these cases to let cassandra retry the request with the updated _rid. In the future we should come up with a better contract. Personally I don't think we should be retrying at all. 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
