### PR TITLE
Removed Duplicate Substatus Code

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/CosmosMessageHeadersInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/CosmosMessageHeadersInternal.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos
 
         public void Clear()
         {
-            foreach (var knownHeader in this.knownHeaders)
+            foreach (KeyValuePair<string, CosmosCustomHeader> knownHeader in this.knownHeaders)
             {
                 knownHeader.Value.Set(null);
             }
@@ -198,12 +198,12 @@ namespace Microsoft.Azure.Cosmos
 
         public IEnumerable<string> Keys()
         {
-            foreach (var knownHeader in this.knownHeaders.Where(header => !string.IsNullOrEmpty(header.Value.Get())))
+            foreach (KeyValuePair<string, CosmosCustomHeader> knownHeader in this.knownHeaders.Where(header => !string.IsNullOrEmpty(header.Value.Get())))
             {
                 yield return knownHeader.Key;
             }
 
-            foreach (var key in this.headers.Value.Keys)
+            foreach (string key in this.headers.Value.Keys)
             {
                 yield return key;
             }
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Cosmos
 
         public IEnumerator<string> GetEnumerator()
         {
-            using (var customHeaderIterator = this.knownHeaders.GetEnumerator())
+            using (Dictionary<string, CosmosCustomHeader>.Enumerator customHeaderIterator = this.knownHeaders.GetEnumerator())
             {
                 while (customHeaderIterator.MoveNext())
                 {
@@ -266,7 +266,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal static KeyValuePair<string, PropertyInfo>[] GetHeaderAttributes<T>()
         {
-            var knownHeaderProperties = typeof(T)
+            IEnumerable<PropertyInfo> knownHeaderProperties = typeof(T)
                     .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     .Where(p => p.GetCustomAttributes(typeof(CosmosKnownHeaderAttribute), false).Any());
 

--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return ((int)this.SubStatusCode).ToString(CultureInfo.InvariantCulture);
+                return this.subStatusCode.HasValue ? ((int)this.SubStatusCode).ToString(CultureInfo.InvariantCulture) : null;
             }
             set
             {

--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos
 
         private string contentLength;
 
-        private string subStatusCodeLiteral;
+        private SubStatusCodes? subStatusCode;
 
         private string retryAfterInternal;
 
@@ -44,7 +44,17 @@ namespace Microsoft.Azure.Cosmos
 
         internal TimeSpan? RetryAfter;
 
-        internal SubStatusCodes SubStatusCode = SubStatusCodes.Unknown;
+        internal SubStatusCodes SubStatusCode
+        {
+            get
+            {
+                return this.subStatusCode.GetValueOrDefault(SubStatusCodes.Unknown);
+            }
+            set
+            {
+                this.subStatusCode = value;
+            }
+        }
 
         internal long ContentLengthAsLong;
 
@@ -126,12 +136,11 @@ namespace Microsoft.Azure.Cosmos
         {
             get
             {
-                return this.subStatusCodeLiteral;
+                return ((int)this.SubStatusCode).ToString(CultureInfo.InvariantCulture);
             }
             set
             {
                 this.SubStatusCode = Headers.GetSubStatusCodes(value);
-                this.subStatusCodeLiteral = value;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
                 Assert.AreEqual(value, (string)knownHeaderProperty.GetValue(Headers)); // Verify getter
 
-                value = "9876543210";
+                value = "987654321";
                 knownHeaderProperty.SetValue(Headers, value);
                 Assert.AreEqual(value, Headers[header]);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             string value1 = Guid.NewGuid().ToString();
             string value2 = Guid.NewGuid().ToString();
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.Add(Key, value1);
             Assert.AreEqual(value1, Headers.Get(Key));
             Headers.Set(Key, value2);
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestIndexer()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             string value = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders[Key] = value;
             Assert.AreEqual(value, Headers[Key]);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestRemove()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             string value = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders[Key] = value;
             Assert.AreEqual(value, Headers[Key]);
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestClear()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders.Clear();
             Assert.IsNull(Headers[Key]);
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestCount()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Assert.AreEqual(1, Headers.CosmosMessageHeaders.Count());
         }
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestGetValues()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             string value1 = Guid.NewGuid().ToString();
             Headers.Add(Key, value1);
             IEnumerable<string> values = Headers.GetValues(Key);
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestAllKeys()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Assert.AreEqual(Key, Headers.AllKeys().First());
         }
@@ -87,10 +87,10 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestGetIEnumerableKeys()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             string value = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders[Key] = value;
-            foreach (var header in Headers)
+            foreach (string header in Headers)
             {
                 Assert.AreEqual(value, Headers[header]);
                 return;
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [ExpectedException(typeof(NotImplementedException))]
         public void TestGetToNameValueCollection()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             string value = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders[Key] = value;
             NameValueCollection anotherCollection = Headers.CosmosMessageHeaders.ToNameValueCollection();
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string value2 = Guid.NewGuid().ToString();
                 string value3 = Guid.NewGuid().ToString();
                 string value4 = Guid.NewGuid().ToString();
-                var Headers = new Headers();
+                Headers Headers = new Headers();
                 Headers.ContinuationToken = value1;
                 Headers.PartitionKey = value2;
                 Headers.PartitionKeyRangeId = value3;
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string value2 = "1002";
                 string value3 = "20";
                 string value4 = "someSession";
-                var requestHeaders = new Headers();
+                Headers requestHeaders = new Headers();
                 requestHeaders.CosmosMessageHeaders[HttpConstants.HttpHeaders.Continuation] = value1;
                 requestHeaders.CosmosMessageHeaders[WFConstants.BackendHeaders.SubStatus] = value2;
                 requestHeaders.CosmosMessageHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds] = value3;
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestClearWithKnownProperties()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Headers.PartitionKey = Guid.NewGuid().ToString();
             Headers.ContinuationToken = Guid.NewGuid().ToString();
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestCountWithKnownProperties()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Headers.PartitionKey = Guid.NewGuid().ToString();
             Headers.ContinuationToken = Guid.NewGuid().ToString();
@@ -192,13 +192,13 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestAllKeysWithKnownProperties()
         {
-            var Headers = new Headers();
+            Headers Headers = new Headers();
             Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
             Headers.ContinuationToken = Guid.NewGuid().ToString();
             Headers.CosmosMessageHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds] = "20";
             Headers.Add(WFConstants.BackendHeaders.SubStatus, "1002");
             Headers.PartitionKey = Guid.NewGuid().ToString();
-            var allKeys = Headers.AllKeys();
+            string[] allKeys = Headers.AllKeys();
             Assert.IsTrue(allKeys.Contains(Key));
             Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.PartitionKey));
             Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
@@ -209,12 +209,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void AllKnownPropertiesHaveGetAndSetAndIndexed()
         {
-            var Headers = new Headers();
-            var knownHeaderProperties = typeof(Headers)
+            Headers Headers = new Headers();
+            IEnumerable<PropertyInfo> knownHeaderProperties = typeof(Headers)
                     .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                     .Where(p => p.GetCustomAttributes(typeof(CosmosKnownHeaderAttribute), false).Any());
 
-            foreach (var knownHeaderProperty in knownHeaderProperties)
+            foreach (PropertyInfo knownHeaderProperty in knownHeaderProperties)
             {
                 string value = "123456789";
                 string header = ((CosmosKnownHeaderAttribute)knownHeaderProperty.GetCustomAttributes(typeof(CosmosKnownHeaderAttribute), false).First()).HeaderName;


### PR DESCRIPTION
# Removed Duplicate Substatus Code

## Description

The SDK has a soft contract with Compute to expose sub status code through a secret header. For some reason the SDK decided that the sub status code should be both stored as an enum and a string and that they could go out of sync. I change it so that we only store the enum and the string is just the .ToString of the enum.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

