### PR TITLE
BatchResponse should return MultiStatus

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
@@ -343,27 +343,9 @@ namespace Microsoft.Azure.Cosmos
                 return null;
             }
 
-            HttpStatusCode responseStatusCode = responseMessage.StatusCode;
-            SubStatusCodes responseSubStatusCode = responseMessage.Headers.SubStatusCode;
-
-            // Promote the operation error status as the Batch response error status if we have a MultiStatus response
-            // to provide users with status codes they are used to.
-            if ((int)responseMessage.StatusCode == (int)StatusCodes.MultiStatus)
-            {
-                foreach (TransactionalBatchOperationResult result in results)
-                {
-                    if ((int)result.StatusCode != (int)StatusCodes.FailedDependency)
-                    {
-                        responseStatusCode = result.StatusCode;
-                        responseSubStatusCode = result.SubStatusCode;
-                        break;
-                    }
-                }
-            }
-
             TransactionalBatchResponse response = new TransactionalBatchResponse(
-                responseStatusCode,
-                responseSubStatusCode,
+                responseMessage.StatusCode,
+                responseMessage.Headers.SubStatusCode,
                 responseMessage.ErrorMessage,
                 responseMessage.Headers.RequestCharge,
                 responseMessage.Headers.RetryAfter,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task NegativeCreateDropItemTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.Serializer.ToStream(testItem), new Cosmos.PartitionKey("BadKey"));
+            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.Serializer.ToStream(testItem), partitionKey: new Cosmos.PartitionKey("BadKey"));
             Assert.IsNotNull(response);
             Assert.IsNull(response.Content);
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 serializer);
 
             Assert.IsNotNull(batchRequest);
-            Assert.AreEqual(HttpStatusCode.Conflict, batchResponse.StatusCode);
+            Assert.AreEqual((HttpStatusCode)207, batchResponse.StatusCode);
+            Assert.AreEqual(HttpStatusCode.Conflict, batchResponse[0].StatusCode);
             Assert.AreEqual(2, batchResponse.Count);
 
             CosmosBatchOperationResultEqualityComparer comparer = new CosmosBatchOperationResultEqualityComparer();


### PR DESCRIPTION
# BatchResponse should return MultiStatus

## Description

BatchResponse should return MultiStatus. It doesn't make sense to put the child status code on top, since they could have different failure reasons. It also hides whether the batch failed because a child failed or because the whole batch failed. 

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

