### PR TITLE
Add mocking constructors to TransactionalBatchOperationResult

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
@@ -31,7 +31,10 @@ namespace Microsoft.Azure.Cosmos
             this.RetryAfter = other.RetryAfter;
         }
 
-        private TransactionalBatchOperationResult()
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionalBatchOperationResult"/> class.
+        /// </summary>
+        protected TransactionalBatchOperationResult()
         {
         }
 
@@ -225,6 +228,13 @@ namespace Microsoft.Azure.Cosmos
             : base(result)
         {
             this.Resource = resource;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransactionalBatchOperationResult{T}"/> class.
+        /// </summary>
+        protected TransactionalBatchOperationResult()
+        {
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
@@ -84,5 +84,24 @@ namespace Microsoft.Azure.Cosmos
                 Assert.AreEqual(success, result.IsSuccessStatusCode);
             }
         }
+
+        [TestMethod]
+        public void CanBeMocked()
+        {
+            Mock<TransactionalBatchOperationResult> mockResult = new Mock<TransactionalBatchOperationResult>();
+            TransactionalBatchOperationResult result = mockResult.Object;
+
+            Assert.AreEqual(default(HttpStatusCode), result.StatusCode);
+        }
+
+        [TestMethod]
+        public void GenericCanBeMocked()
+        {
+            Mock<TransactionalBatchOperationResult<object>> mockResult = new Mock<TransactionalBatchOperationResult<object>>();
+            TransactionalBatchOperationResult<object> result = mockResult.Object;
+
+            Assert.AreEqual(default(HttpStatusCode), result.StatusCode);
+            Assert.AreEqual(default(object), result.Resource);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+
+namespace Microsoft.Azure.Cosmos
+{
+    [TestClass]
+    public class BatchOperationResultTests
+    {
+        static readonly Mock<CosmosDiagnostics> MockCosmosDiagnostics = new Mock<CosmosDiagnostics>(MockBehavior.Strict);
+        static TransactionalBatchOperationResult CreateTestResult() => new TransactionalBatchOperationResult(HttpStatusCode.Unused)
+        {
+            SubStatusCode = Documents.SubStatusCodes.CanNotAcquireOfferOwnerLock,
+            ETag = "TestETag",
+            ResourceStream = new MemoryStream(),
+            RequestCharge = 1.5,
+            RetryAfter = TimeSpan.FromMilliseconds(1234),
+            Diagnostics = MockCosmosDiagnostics.Object
+        };
+
+        [TestMethod]
+        public void StatusCodeIsSetThroughCtor()
+        {
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Unused);
+
+            Assert.AreEqual(HttpStatusCode.Unused, result.StatusCode);
+        }
+
+        [TestMethod]
+        public void PropertiesAreSetThroughCopyCtor()
+        {
+            TransactionalBatchOperationResult other = CreateTestResult();
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(other);
+
+            Assert.AreEqual(other.StatusCode, result.StatusCode);
+            Assert.AreEqual(other.SubStatusCode, result.SubStatusCode);
+            Assert.AreEqual(other.ETag, result.ETag);
+            Assert.AreEqual(other.RequestCharge, result.RequestCharge);
+            Assert.AreEqual(other.RetryAfter, result.RetryAfter);
+            Assert.AreSame(other.ResourceStream, result.ResourceStream);
+        }
+        
+        [TestMethod]
+        public void PropertiesAreSetThroughGenericCtor()
+        {
+            TransactionalBatchOperationResult other = CreateTestResult();
+            object testObject = new object();
+            TransactionalBatchOperationResult<object> result = new TransactionalBatchOperationResult<object>(other, testObject);
+
+            Assert.AreEqual(other.StatusCode, result.StatusCode);
+            Assert.AreEqual(other.SubStatusCode, result.SubStatusCode);
+            Assert.AreEqual(other.ETag, result.ETag);
+            Assert.AreEqual(other.RequestCharge, result.RequestCharge);
+            Assert.AreEqual(other.RetryAfter, result.RetryAfter);
+            Assert.AreSame(other.ResourceStream, result.ResourceStream);
+            Assert.AreSame(testObject, result.Resource);
+        }
+
+        [TestMethod]
+        public void ToResponseMessageHasPropertiesMapped()
+        {
+            TransactionalBatchOperationResult result = CreateTestResult();
+
+            ResponseMessage response = result.ToResponseMessage();
+
+            Assert.AreEqual(result.StatusCode, response.StatusCode);
+            Assert.AreEqual(result.SubStatusCode, response.Headers.SubStatusCode);
+            Assert.AreEqual(result.ETag, response.Headers.ETag);
+            Assert.AreEqual(result.RequestCharge, response.Headers.RequestCharge);
+            Assert.AreEqual(result.RetryAfter, response.Headers.RetryAfter);
+            Assert.AreSame(result.ResourceStream, response.Content);
+            Assert.AreSame(result.Diagnostics, response.Diagnostics);
+        }
+
+        [TestMethod]
+        public void IsSuccessStatusCodeTrueFor200to299()
+        {
+            for (int x = 100; x < 999; ++x)
+            {
+                TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)x);
+                bool success = x >= 200 && x <= 299;
+                Assert.AreEqual(success, result.IsSuccessStatusCode);
+            }
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#1050](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1050) Add mocking constructors to TransactionalBatchOperationResult
+
 ## <a name="3.5.0"/> [3.5.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.0) - 2019-11-21
 
 ### Added


### PR DESCRIPTION
# Pull Request Template

## Description

https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1048

Mocking constructors were missing from TransactionalBatchOperationResult.  Probably by accident.  This pull request adds them back in.

Other public classes in this project support mocking.  It's also consistent with guidance here: https://azure.github.io/azure-sdk/dotnet_introduction.html

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

closes #1048 

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.

