### PR TITLE
Batch sample project rename and other doc fixes

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
@@ -31,7 +31,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BulkSupport", "BulkSupport\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IndexManagement", "IndexManagement\IndexManagement.csproj", "{BDAA451B-C9C8-4D29-AF1E-1748B8720BEC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Batch", "Batch\Batch.csproj", "{2F124644-761C-4DD8-9C4D-229AC71E6C3A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TransactionalBatch", "TransactionalBatch\TransactionalBatch.csproj", "{2F124644-761C-4DD8-9C4D-229AC71E6C3A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/Program.cs
@@ -1,4 +1,4 @@
-﻿namespace Cosmos.Samples
+﻿namespace Cosmos.Samples.TransactionalBatch
 {
     using System;
     using System.Collections.Generic;

--- a/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/TransactionalBatch.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/TransactionalBatch.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <AssemblyName>Cosmos.Samples.Batch</AssemblyName>
-    <RootNamespace>Cosmos.Samples.Batch</RootNamespace>
+    <AssemblyName>Cosmos.Samples.TransactionalBatch</AssemblyName>
+    <RootNamespace>Cosmos.Samples.TransactionalBatch</RootNamespace>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    /// <seealso href="https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits">Limits on TransactionalBatch requests</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/concepts-limits">Limits on TransactionalBatch requests</seealso>
     public abstract class TransactionalBatch
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
@@ -5,20 +5,105 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System.IO;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Represents a batch of requests that will be performed atomically against the Azure Cosmos DB service.
+    /// Represents a batch of operations against items with the same <see cref="PartitionKey"/> in a container that
+    /// will be performed in a transactional manner at the Azure Cosmos DB service.
+    /// Use <see cref="Container.CreateTransactionalBatch(PartitionKey)"/> to create an instance of TransactionalBatch.
     /// </summary>
+    /// <example>
+    /// This example atomically modifies a set of documents as a batch.
+    /// <code language="c#">
+    /// <![CDATA[
+    /// public class ToDoActivity
+    /// {
+    ///     public string type { get; set; }
+    ///     public string id { get; set; }
+    ///     public string status { get; set; }
+    /// }
+    ///
+    /// string activityType = "personal";
+    /// ToDoActivity test1 = new ToDoActivity()
+    /// {
+    ///     type = activityType,
+    ///     id = "learning",
+    ///     status = "ToBeDone"
+    /// };
+    ///
+    /// ToDoActivity test2 = new ToDoActivity()
+    /// {
+    ///     type = activityType,
+    ///     id = "shopping",
+    ///     status = "Done"
+    /// };
+    ///
+    /// ToDoActivity test3 = new ToDoActivity()
+    /// {
+    ///     type = activityType,
+    ///     id = "swimming",
+    ///     status = "ToBeDone"
+    /// };
+    ///
+    /// using (TransactionalBatchResponse batchResponse = await container.CreateTransactionalBatch(new Cosmos.PartitionKey(activityType))
+    ///     .CreateItem<ToDoActivity>(test1)
+    ///     .ReplaceItem<ToDoActivity>(test2.id, test2)
+    ///     .UpsertItem<ToDoActivity>(test3)
+    ///     .DeleteItem("reading")
+    ///     .CreateItemStream(streamPayload1)
+    ///     .ReplaceItemStream("eating", streamPayload2)
+    ///     .UpsertItemStream(streamPayload3)
+    ///     .ExecuteAsync())
+    /// {
+    ///    if (!batchResponse.IsSuccessStatusCode)
+    ///    {
+    ///        // Handle and log exception
+    ///        return;
+    ///    }
+    ///
+    ///    // Look up interested results - eg. via typed access on operation results
+    ///    TransactionalBatchOperationResult<ToDoActivity> replaceResult = batchResponse.GetOperationResultAtIndex<ToDoActivity>(0);
+    ///    ToDoActivity readActivity = replaceResult.Resource;
+    /// }
+    /// ]]>
+    /// </code>
+    /// </example>
+    /// <example>
+    /// This example atomically reads a set of documents as a batch.
+    /// <code language="c#">
+    /// <![CDATA[
+    /// string activityType = "personal";
+    /// using (TransactionalBatchResponse batchResponse = await container.CreateTransactionalBatch(new Cosmos.PartitionKey(activityType))
+    ///    .ReadItem("playing")
+    ///    .ReadItem("walking")
+    ///    .ReadItem("jogging")
+    ///    .ReadItem("running")
+    ///    .ExecuteAsync())
+    /// {
+    ///     // Look up interested results - eg. via direct access to operation result stream
+    ///     List<string> resultItems = new List<string>();
+    ///     foreach (TransactionalBatchOperationResult operationResult in batchResponse)
+    ///     {
+    ///         using (StreamReader streamReader = new StreamReader(operationResult.ResourceStream))
+    ///         {
+    ///             resultItems.Add(await streamReader.ReadToEndAsync());
+    ///         }
+    ///     }
+    /// }
+    /// ]]>
+    /// </code>
+    /// </example>
+    /// <seealso href="https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits">Limits on TransactionalBatch requests</seealso>
     public abstract class TransactionalBatch
     {
         /// <summary>
         /// Adds an operation to create an item into the batch.
         /// </summary>
-        /// <param name="item">A JSON serializable object that must contain an id property.<see cref="CosmosSerializer"/> to implement a custom serializer.</param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="item">A JSON serializable object that must contain an id property. See <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         /// <typeparam name="T">The type of item to be created.</typeparam>
         public abstract TransactionalBatch CreateItem<T>(
             T item,
@@ -28,11 +113,11 @@ namespace Microsoft.Azure.Cosmos
         /// Adds an operation to create an item into the batch.
         /// </summary>
         /// <param name="streamPayload">
-        /// A <see cref="Stream"/> containing the payload of the item.
+        /// A Stream containing the payload of the item.
         /// The stream must have a UTF-8 encoded JSON object which contains an id property.
         /// </param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         public abstract TransactionalBatch CreateItemStream(
             Stream streamPayload,
             TransactionalBatchItemRequestOptions requestOptions = null);
@@ -40,9 +125,9 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds an operation to read an item into the batch.
         /// </summary>
-        /// <param name="id">The cosmos item id.</param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="id">The unique id of the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         public abstract TransactionalBatch ReadItem(
             string id,
             TransactionalBatchItemRequestOptions requestOptions = null);
@@ -50,9 +135,9 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds an operation to upsert an item into the batch.
         /// </summary>
-        /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="item">A JSON serializable object that must contain an id property. See <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         /// <typeparam name="T">The type of item to be created.</typeparam>
         public abstract TransactionalBatch UpsertItem<T>(
             T item,
@@ -62,11 +147,11 @@ namespace Microsoft.Azure.Cosmos
         /// Adds an operation to upsert an item into the batch.
         /// </summary>
         /// <param name="streamPayload">
-        /// A <see cref="Stream"/> containing the payload of the item.
+        /// A Stream containing the payload of the item.
         /// The stream must have a UTF-8 encoded JSON object which contains an id property.
         /// </param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         public abstract TransactionalBatch UpsertItemStream(
             Stream streamPayload,
             TransactionalBatchItemRequestOptions requestOptions = null);
@@ -74,10 +159,10 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds an operation to replace an item into the batch.
         /// </summary>
-        /// <param name="id">The cosmos item id.</param>
-        /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="id">The unique id of the item.</param>
+        /// <param name="item">A JSON serializable object that must contain an id property. See <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         /// <typeparam name="T">The type of item to be created.</typeparam>
         public abstract TransactionalBatch ReplaceItem<T>(
             string id,
@@ -87,13 +172,13 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds an operation to replace an item into the batch.
         /// </summary>
-        /// <param name="id">The cosmos item id.</param>
+        /// <param name="id">The unique id of the item.</param>
         /// <param name="streamPayload">
-        /// A <see cref="Stream"/> containing the payload of the item.
+        /// A Stream containing the payload of the item.
         /// The stream must have a UTF-8 encoded JSON object which contains an id property.
         /// </param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         public abstract TransactionalBatch ReplaceItemStream(
             string id,
             Stream streamPayload,
@@ -102,18 +187,40 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds an operation to delete an item into the batch.
         /// </summary>
-        /// <param name="id">The cosmos item id.</param>
-        /// <param name="requestOptions">(Optional) The options for the item request. <see cref="TransactionalBatchItemRequestOptions"/>.</param>
-        /// <returns>The <see cref="TransactionalBatch"/> instance with the operation added.</returns>
+        /// <param name="id">The unique id of the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
+        /// <returns>The transactional batch instance with the operation added.</returns>
         public abstract TransactionalBatch DeleteItem(
             string id,
             TransactionalBatchItemRequestOptions requestOptions = null);
 
         /// <summary>
-        /// Executes the batch at the Azure Cosmos service as an asynchronous operation.
+        /// Executes the transactional batch at the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An awaitable <see cref="TransactionalBatchResponse"/> which contains the completion status and results of each operation.</returns>
+        /// <param name="cancellationToken">(Optional) Cancellation token representing request cancellation.</param>
+        /// <returns>An awaitable response which contains details of execution of the transactional batch.
+        /// <para>
+        /// If the transactional batch executes successfully, the <see cref="TransactionalBatchResponse.StatusCode"/> on the response returned
+        /// will be set to <see cref="HttpStatusCode.OK"/>.
+        /// </para>
+        /// <para>
+        /// If an operation within the transactional batch fails during execution, no changes from the batch will be committed
+        /// and the status of the failing operation is made available in the <see cref="TransactionalBatchResponse.StatusCode"/>.
+        /// To get more details about the operation that failed, the response can be enumerated - this returns <see cref="TransactionalBatchOperationResult" />
+        /// instances corresponding to each operation in the transactional batch in the order they were added into the transactional batch.
+        /// For a result corresponding to an operation within the transactional batch, the <see cref="TransactionalBatchOperationResult.StatusCode"/> indicates
+        /// the status of the operation - if the operation was not executed or it was aborted due to the failure of another operation within the transactional batch,
+        /// the value of this field will be HTTP 424 (Failed Dependency); for the operation that caused the batch to abort, the value of this field will indicate
+        /// the cause of failure as a HTTP status code.
+        /// </para>
+        /// <para>
+        /// The <see cref="TransactionalBatchResponse.StatusCode"/> on the response returned may also have values such as HTTP 5xx in case of server errors and HTTP 429 (Too Many Requests).
+        /// </para>
+        /// </returns>
+        /// <remarks>
+        /// This API only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions.
+        /// Use <see cref="TransactionalBatchResponse.IsSuccessStatusCode"/> on the response returned to ensure that the transactional batch succeeded.
+        /// </remarks>
         public abstract Task<TransactionalBatchResponse> ExecuteAsync(
             CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -12,9 +12,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Handlers;
-    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -22,8 +20,8 @@ namespace Microsoft.Azure.Cosmos
     /// This client can be used to configure and execute requests in the Azure Cosmos DB database service.
     /// 
     /// CosmosClient is thread-safe. Its recommended to maintain a single instance of CosmosClient per lifetime 
-    /// of the application which enables efficient connection management and performance. Please refer to 
-    /// performance guide at <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>.
+    /// of the application which enables efficient connection management and performance. Please refer to the
+    /// <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">performance guide</see>.
     /// </summary>
     /// <example>
     /// This example create a <see cref="CosmosClient"/>, <see cref="Database"/>, and a <see cref="Container"/>.
@@ -47,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
     /// </code>
     /// </example>
     /// <example>
-    /// This example create a <see cref="CosmosClient"/>, <see cref="Database"/>, and a <see cref="Container"/>.
+    /// This example creates a <see cref="CosmosClient"/>, <see cref="Database"/>, and a <see cref="Container"/>.
     /// The CosmosClient is created with the AccountEndpoint, AccountKey or ResourceToken and configured to use "East US 2" region.
     /// <code language="c#">
     /// <![CDATA[
@@ -69,8 +67,8 @@ namespace Microsoft.Azure.Cosmos
     /// </code>
     /// </example>
     /// <example>
-    /// This example create a <see cref="CosmosClient"/>, <see cref="Database"/>, and a <see cref="Container"/>.
-    /// The CosmosClient is created through builder pattern <see cref="Fluent.CosmosClientBuilder"/>.
+    /// This example creates a <see cref="CosmosClient"/>, <see cref="Database"/>, and a <see cref="Container"/>.
+    /// The CosmosClient is created through builder pattern using <see cref="Fluent.CosmosClientBuilder"/>.
     /// <code language="c#">
     /// <![CDATA[
     /// using Microsoft.Azure.Cosmos;
@@ -87,15 +85,13 @@ namespace Microsoft.Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    /// <remarks>
     /// <seealso cref="CosmosClientOptions"/>
     /// <seealso cref="Fluent.CosmosClientBuilder"/>
-    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>
-    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk"/>
-    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/distribute-data-globally" />
-    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/partitioning-overview" />
-    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units" />
-    /// </remarks>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">Performance Tips</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk">Diagnose and troubleshoot issues</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/distribute-data-globally">Global data distribution</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/partitioning-overview">Partitioning and horizontal scaling</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
     public class CosmosClient : IDisposable
     {
         private readonly Uri DatabaseRootUri = new Uri(Paths.Databases_Root, UriKind.Relative);
@@ -119,11 +115,11 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Create a new CosmosClient with the connection string
+        /// Creates a new CosmosClient with the connection string.
         /// 
         /// CosmosClient is thread-safe. Its recommended to maintain a single instance of CosmosClient per lifetime 
-        /// of the application which enables efficient connection management and performance. Please refer to 
-        /// performance guide at <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>.
+        /// of the application which enables efficient connection management and performance. Please refer to the
+        /// <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">performance guide</see>.
         /// </summary>
         /// <param name="connectionString">The connection string to the cosmos account. ex: https://mycosmosaccount.documents.azure.com:443/;AccountKey=SuperSecretKey; </param>
         /// <param name="clientOptions">(Optional) client options</param>
@@ -145,12 +141,10 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
         /// <seealso cref="CosmosClientOptions"/>
         /// <seealso cref="Fluent.CosmosClientBuilder"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk"/>
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">Performance Tips</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk">Diagnose and troubleshoot issues</seealso>
         public CosmosClient(
             string connectionString,
             CosmosClientOptions clientOptions = null)
@@ -162,11 +156,11 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Create a new CosmosClient with the account endpoint URI string and account key
+        /// Creates a new CosmosClient with the account endpoint URI string and account key.
         /// 
         /// CosmosClient is thread-safe. Its recommended to maintain a single instance of CosmosClient per lifetime 
-        /// of the application which enables efficient connection management and performance. Please refer to 
-        /// performance guide at <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>.
+        /// of the application which enables efficient connection management and performance. Please refer to the
+        /// <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">performance guide</see>.
         /// </summary>
         /// <param name="accountEndpoint">The cosmos service endpoint to use</param>
         /// <param name="authKeyOrResourceToken">The cosmos account key or resource token to use to create the client.</param>
@@ -189,12 +183,10 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
         /// <seealso cref="CosmosClientOptions"/>
         /// <seealso cref="Fluent.CosmosClientBuilder"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk"/>
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips">Performance Tips</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk">Diagnose and troubleshoot issues</seealso>
         public CosmosClient(
             string accountEndpoint,
             string authKeyOrResourceToken,
@@ -273,7 +265,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// The <see cref="Cosmos.CosmosClientOptions"/> used initialize CosmosClient
+        /// The <see cref="Cosmos.CosmosClientOptions"/> used initialize CosmosClient.
         /// </summary>
         public virtual CosmosClientOptions ClientOptions { get; private set; }
 
@@ -301,7 +293,7 @@ namespace Microsoft.Azure.Cosmos
         internal BatchAsyncContainerExecutorCache BatchExecutorCache { get; private set; } = new BatchAsyncContainerExecutorCache();
 
         /// <summary>
-        /// Read Azure Cosmos DB account properties <see cref="Microsoft.Azure.Cosmos.AccountProperties"/>
+        /// Reads the <see cref="Microsoft.Azure.Cosmos.AccountProperties"/> for the Azure Cosmos DB account.
         /// </summary>
         /// <returns>
         /// A <see cref="AccountProperties"/> wrapped in a <see cref="System.Threading.Tasks.Task"/> object.
@@ -314,7 +306,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns a proxy reference to a database. 
         /// </summary>
-        /// <param name="id">The cosmos database id</param>
+        /// <param name="id">The Cosmos database id</param>
         /// <remarks>
         /// <see cref="Database"/> proxy reference doesn't guarantee existence.
         /// Please ensure database exists through <see cref="CosmosClient.CreateDatabaseAsync(DatabaseProperties, int?, RequestOptions, CancellationToken)"/> 
@@ -344,8 +336,8 @@ namespace Microsoft.Azure.Cosmos
         /// or <see cref="Database.CreateContainerIfNotExistsAsync(ContainerProperties, int?, RequestOptions, CancellationToken)"/>, before
         /// operating on it.
         /// </remarks>
-        /// <param name="databaseId">cosmos database name</param>
-        /// <param name="containerId">cosmos container name</param>
+        /// <param name="databaseId">Cosmos database name</param>
+        /// <param name="containerId">Cosmos container name</param>
         /// <returns>Cosmos container proxy</returns>
         public virtual Container GetContainer(string databaseId, string containerId)
         {
@@ -363,7 +355,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Send a request for creating a database.
+        /// Sends a request for creating a database.
         ///
         /// A database manages users, permissions and a set of containers.
         /// Each Azure Cosmos DB Database Account is able to support multiple independent named databases,
@@ -378,9 +370,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="requestOptions">(Optional) A set of options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public virtual Task<DatabaseResponse> CreateDatabaseAsync(
                 string id,
                 int? throughput = null,
@@ -417,8 +407,8 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a database in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) A set of additional options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
-        /// <list>
+        /// <returns>A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.
+        /// <list type="table">
         ///     <listheader>
         ///         <term>StatusCode</term><description>Common success StatusCodes for the CreateDatabaseIfNotExistsAsync operation</description>
         ///     </listheader>
@@ -429,9 +419,8 @@ namespace Microsoft.Azure.Cosmos
         ///         <term>200</term><description>Accepted - This means the database already exists.</description>
         ///     </item>
         /// </list>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// </returns>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public virtual async Task<DatabaseResponse> CreateDatabaseIfNotExistsAsync(
             string id,
             int? throughput = null,
@@ -469,7 +458,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the databases.</returns>
         /// <remarks>
         /// Refer to https://docs.microsoft.com/azure/cosmos-db/sql-query-getting-started for syntax and examples.
@@ -498,7 +487,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the query request.</param>
         /// <returns>An iterator to go through the databases</returns>
         /// <remarks>
         /// Refer to https://docs.microsoft.com/azure/cosmos-db/sql-query-getting-started for syntax and examples.
@@ -526,7 +515,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the databases.</returns>
         /// <remarks>
         /// Refer to https://docs.microsoft.com/azure/cosmos-db/sql-query-getting-started for syntax and examples.
@@ -557,7 +546,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the query request.</param>
         /// <returns>An iterator to go through the databases</returns>
         /// <remarks>
         /// Refer to https://docs.microsoft.com/azure/cosmos-db/sql-query-getting-started for syntax and examples.
@@ -598,9 +587,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="requestOptions">(Optional) A set of options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public virtual Task<ResponseMessage> CreateDatabaseStreamAsync(
                 DatabaseProperties databaseProperties,
                 int? throughput = null,

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -19,7 +19,9 @@ namespace Microsoft.Azure.Cosmos
     /// Defines all the configurable options that the CosmosClient requires.
     /// </summary>
     /// <example>
-    /// An example on how to configure the serialization option to ignore null values
+    /// An example on how to configure the serialization option to ignore null values.
+    /// <code language="c#">
+    /// <![CDATA[
     /// CosmosClientOptions clientOptions = new CosmosClientOptions()
     /// {
     ///     SerializerOptions = new CosmosSerializationOptions(){
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Cosmos
     /// };
     /// 
     /// CosmosClient client = new CosmosClient("endpoint", "key", clientOptions);
+    /// ]]>
+    /// </code>
     /// </example>
     public class CosmosClientOptions
     {
@@ -98,10 +102,9 @@ namespace Microsoft.Azure.Cosmos
         /// When this property is specified, the SDK prefers the region to perform operations. Also SDK auto-selects 
         /// fallback geo-replicated regions for high availability. 
         /// When this property is not specified, the SDK uses the write region as the preferred region for all operations.
-        /// 
-        /// <seealso cref="CosmosClientBuilder.WithApplicationRegion(string)"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/how-to-multi-master"/>
         /// </remarks>
+        /// <seealso cref="CosmosClientBuilder.WithApplicationRegion(string)"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/how-to-multi-master">Configure multi-master</seealso>
         public string ApplicationRegion { get; set; }
 
         /// <summary>
@@ -384,7 +387,7 @@ namespace Microsoft.Azure.Cosmos
         /// When set to true, availability is limited to the endpoint specified on the CosmosClient constructor.
         /// Defining the <see cref="ApplicationRegion"/> is not allowed when setting the value to true.
         /// </remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/high-availability"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/high-availability">High availability</seealso>
         public bool LimitToEndpoint { get; set; } = false;
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// </code>
         /// </example>
         /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/high-availability"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/high-availability">High availability</seealso>
         /// <seealso cref="CosmosClientOptions.LimitToEndpoint"/>
         public CosmosClientBuilder WithLimitToEndpoint(bool limitToEndpoint)
         {

--- a/Microsoft.Azure.Cosmos/src/Fluent/Settings/ContainerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/Settings/ContainerBuilder.cs
@@ -64,9 +64,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// </summary>
         /// <param name="throughput">Desired throughput for the container expressed in Request Units per second.</param>
         /// <returns>An asynchronous Task representing the creation of a <see cref="Container"/> based on the Fluent definition.</returns>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public async Task<ContainerResponse> CreateAsync(int? throughput = null)
         {
             ContainerProperties containerProperties = this.Build();
@@ -79,9 +77,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// </summary>
         /// <param name="throughput">Desired throughput for the container expressed in Request Units per second.</param>
         /// <returns>An asynchronous Task representing the creation of a <see cref="Container"/> based on the Fluent definition.</returns>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public async Task<ContainerResponse> CreateIfNotExistsAsync(int? throughput = null)
         {
             ContainerProperties containerProperties = this.Build();

--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/Conflicts.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Azure.Cosmos
     /// There are two different types of operations.
     /// 1. The object operations where it serializes and deserializes the item on request/response
     /// 2. The stream response which takes a Stream containing a JSON serialized object and returns a response containing a Stream
-    /// <see cref="Cosmos.Database"/> for creating new containers, and reading/querying all containers;
+    /// See <see cref="Cosmos.Database"/> for creating new containers, and reading/querying all containers.
     /// </summary>
     /// <remarks>
     ///  Note: all these operations make calls against a fixed budget.
     ///  You should design your system such that these calls scale sub linearly with your application.
-    ///  For instance, do not call `container.readAsync()` before every single `item.read()` call, to ensure the cosmosContainer exists;
+    ///  For instance, do not call `container.readAsync()` before every single `container.readItemAsync()` call to ensure the container exists;
     ///  do this once on application start up.
     /// </remarks>
     public abstract class Container
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the replace resource record.
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <example>
         /// <code language="c#">
@@ -224,15 +224,15 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
         public abstract Task<int?> ReadThroughputAsync(
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Gets container throughput in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
-        /// <param name="requestOptions">The options for the throughput request.<see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">The options for the throughput request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The throughput response</returns>
         /// <value>
@@ -272,8 +272,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Sets throughput provisioned for a container in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
-        /// <param name="throughput">The cosmos container throughput, expressed in Request Units per second.</param>
-        /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
+        /// <param name="throughput">The Cosmos container throughput, expressed in Request Units per second.</param>
+        /// <param name="requestOptions">(Optional) The options for the throughput request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The throughput response.</returns>
         /// <value>
@@ -287,9 +287,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             int throughput,
             RequestOptions requestOptions = null,
@@ -299,13 +297,13 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a Item as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the payload.</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The <see cref="ResponseMessage"/> that was created contained within a <see cref="System.Threading.Tasks.Task"/> object representing the service response for the asynchronous operation.</returns>
-        /// <exception>
+        /// <remarks>
         /// The Stream operation only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
+        /// </remarks>
         /// <example>
         /// This example creates an item in a Cosmos container.
         /// <code language="c#">
@@ -341,8 +339,8 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a item as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
         /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer</param>
-        /// <param name="partitionKey">Partition key for the item. If not specified will be populated by extracting from {T}</param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="partitionKey"><see cref="PartitionKey"/> for the item. If not specified will be populated by extracting from {T}</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The <see cref="ItemResponse{T}"/> that was created contained within a <see cref="System.Threading.Tasks.Task"/> object representing the service response for the asynchronous operation.</returns>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s)</exception>
@@ -395,16 +393,16 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a item from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="id">The cosmos item id</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the read resource record.
         /// </returns>
-        /// <exception>
+        /// <remarks>
         /// The Stream operation only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
+        /// </remarks>
         /// <example>
         /// Read a response as a stream.
         /// <code language="c#">
@@ -439,9 +437,9 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a item from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="id">The cosmos item id</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ItemResponse{T}"/> which wraps the read resource record.
@@ -485,17 +483,17 @@ namespace Microsoft.Azure.Cosmos
         /// Upserts an item stream as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the payload.</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the read resource record.
         /// </returns>
-        /// <exception>
+        /// <remarks>
         /// The Stream operation only throws on client side exceptions. 
         /// This is to increase performance and prevent the overhead of throwing exceptions. 
         /// Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
+        /// </remarks>
         /// <example>
         /// Upsert a Stream containing the item to Cosmos
         /// <code language="c#">
@@ -530,8 +528,8 @@ namespace Microsoft.Azure.Cosmos
         /// Upserts an item as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
         /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer</param>
-        /// <param name="partitionKey">Partition key for the item. If not specified will be populated by extracting from {T}</param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="partitionKey"><see cref="PartitionKey"/> for the item. If not specified will be populated by extracting from {T}</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The <see cref="ItemResponse{T}"/> that was upserted contained within a <see cref="System.Threading.Tasks.Task"/> object representing the service response for the asynchronous operation.</returns>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s)</exception>
@@ -586,18 +584,18 @@ namespace Microsoft.Azure.Cosmos
         /// To change an item's partition key value you must delete the original item and insert a new item.
         /// </remarks>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the payload.</param>
-        /// <param name="id">The cosmos item id</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the replace resource record.
         /// </returns>
-        /// <exception>
+        /// <remarks>
         /// The Stream operation only throws on client side exceptions. 
         /// This is to increase performance and prevent the overhead of throwing exceptions. 
         /// Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
+        /// </remarks>
         /// <example>
         /// Replace an item in Cosmos
         /// <code language="c#">
@@ -637,9 +635,9 @@ namespace Microsoft.Azure.Cosmos
         /// To change an item's partition key value you must delete the original item and insert a new item.
         /// </remarks>
         /// <param name="item">A JSON serializable object that must contain an id property. <see cref="CosmosSerializer"/> to implement a custom serializer.</param>
-        /// <param name="id">The cosmos item id, which is expected to match the value within T.</param>
-        /// <param name="partitionKey">Partition key for the item. If not specified will be populated by extracting from {T}</param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id, which is expected to match the value within T.</param>
+        /// <param name="partitionKey"><see cref="PartitionKey"/> for the item. If not specified will be populated by extracting from {T}</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ItemResponse{T}"/> which wraps the updated resource record.
@@ -693,16 +691,16 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a item from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="id">The cosmos item id</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the delete resource record.
         /// </returns>
-        /// <exception>
+        /// <remarks>
         /// The Stream operation only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
+        /// </remarks>
         /// <example>
         /// Delete an item from Cosmos
         /// <code language="c#">
@@ -727,9 +725,9 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a item from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="id">The cosmos item id</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="PartitionKey"/></param>
-        /// <param name="requestOptions">(Optional) The options for the item request <see cref="ItemRequestOptions"/></param>
+        /// <param name="id">The Cosmos item id</param>
+        /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ItemResponse{T}"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">
@@ -765,9 +763,9 @@ namespace Microsoft.Azure.Cosmos
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
-        /// <param name="queryDefinition">The cosmos SQL query definition.</param>
+        /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
@@ -812,9 +810,9 @@ namespace Microsoft.Azure.Cosmos
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
-        /// <param name="queryDefinition">The cosmos SQL query definition.</param>
+        /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the items.</returns>
         /// <example>
         /// Create a query to get all the ToDoActivity that have a cost greater than 9000
@@ -852,9 +850,9 @@ namespace Microsoft.Azure.Cosmos
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
-        /// <param name="queryText">The cosmos SQL query text.</param>
+        /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
@@ -926,9 +924,9 @@ namespace Microsoft.Azure.Cosmos
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
-        /// <param name="queryText">The cosmos SQL query text.</param>
+        /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the items.</returns>
         /// <example>
         /// 1. Create a query to get all the ToDoActivity that have a cost greater than 9000
@@ -996,7 +994,7 @@ namespace Microsoft.Azure.Cosmos
         /// <typeparam name="T">The type of object to query.</typeparam>
         /// <param name="allowSynchronousQueryExecution">(Optional)the option which allows the query to be executed synchronously via IOrderedQueryable.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional)The options for the item query request.<see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>(Optional) An IOrderedQueryable{T} that can evaluate the query.</returns>
         /// <example>
         /// 1. This example below shows LINQ query generation and blocked execution.
@@ -1114,96 +1112,12 @@ namespace Microsoft.Azure.Cosmos
             TimeSpan? estimationPeriod = null);
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TransactionalBatch"/> class
+        /// Initializes a new instance of <see cref="TransactionalBatch"/>
         /// that can be used to perform operations across multiple items
         /// in the container with the provided partition key in a transactional manner.
         /// </summary>
-        /// <param name="partitionKey">The partition key for all items in the batch. <see cref="PartitionKey"/>.</param>
+        /// <param name="partitionKey">The partition key for all items in the batch.</param>
         /// <returns>A new instance of <see cref="TransactionalBatch"/>.</returns>
-        /// <exception>
-        /// This API only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
-        /// </exception>
-        /// <example>
-        /// This example atomically modifies a set of documents as a batch.
-        /// <code language="c#">
-        /// <![CDATA[
-        /// public class ToDoActivity
-        /// {
-        ///     public string type { get; set; }
-        ///     public string id { get; set; }
-        ///     public string status { get; set; }
-        /// }
-        ///
-        /// string activityType = "personal";
-        /// ToDoActivity test1 = new ToDoActivity()
-        /// {
-        ///     type = activityType,
-        ///     id = "learning",
-        ///     status = "ToBeDone"
-        /// };
-        ///
-        /// ToDoActivity test2 = new ToDoActivity()
-        /// {
-        ///     type = activityType,
-        ///     id = "shopping",
-        ///     status = "Done"
-        /// };
-        ///
-        /// ToDoActivity test3 = new ToDoActivity()
-        /// {
-        ///     type = activityType,
-        ///     id = "swimming",
-        ///     status = "ToBeDone"
-        /// };
-        ///
-        /// using (TransactionalBatchResponse batchResponse = await container.CreateTransactionalBatch(new Cosmos.PartitionKey(activityType))
-        ///     .CreateItem<ToDoActivity>(test1)
-        ///     .ReplaceItem<ToDoActivity>(test2.id, test2)
-        ///     .UpsertItem<ToDoActivity>(test3)
-        ///     .DeleteItem("reading")
-        ///     .CreateItemStream(streamPayload1)
-        ///     .ReplaceItemStream("eating", streamPayload2)
-        ///     .UpsertItemStream(streamPayload3)
-        ///     .ExecuteAsync())
-        /// {
-        ///    if (!batchResponse.IsSuccessStatusCode)
-        ///    {
-        ///        // Handle and log exception
-        ///        return;
-        ///    }
-        ///
-        ///    // Look up interested results - eg. via typed access on operation results
-        ///    TransactionalBatchOperationResult<ToDoActivity> replaceResult = batchResponse.GetOperationResultAtIndex<ToDoActivity>(0);
-        ///    ToDoActivity readActivity = replaceResult.Resource;
-        /// }
-        /// ]]>
-        /// </code>
-        /// </example>
-        /// <example>
-        /// This example atomically reads a set of documents as a batch.
-        /// <code language="c#">
-        /// <![CDATA[
-        /// string activityType = "personal";
-        /// using (TransactionalBatchResponse batchResponse = await container.CreateTransactionalBatch(new Cosmos.PartitionKey(activityType))
-        ///    .ReadItem("playing")
-        ///    .ReadItem("walking")
-        ///    .ReadItem("jogging")
-        ///    .ReadItem("running")
-        ///    .ExecuteAsync())
-        /// {
-        ///     // Look up interested results - eg. via direct access to operation result stream
-        ///     List<string> resultItems = new List<string>();
-        ///     foreach (TransactionalBatchOperationResult operationResult in batchResponse)
-        ///     {
-        ///         using (StreamReader streamReader = new StreamReader(operationResult.ResourceStream))
-        ///         {
-        ///             resultItems.Add(await streamReader.ReadToEndAsync());
-        ///         }
-        ///     }
-        /// }
-        /// ]]>
-        /// </code>
-        /// </example>
         public abstract TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the replace resource record.
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the replace resource record.
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The <see cref="RequestOptions"/> for the container request.</param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <example>
         /// <code language="c#">

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -12,12 +12,12 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Operations for reading or deleting an existing database.
     ///
-    /// <see cref="CosmosClient"/> for or creating new databases, and reading/querying all databases; use `client.Databases`.
+    /// See <see cref="CosmosClient"/> for creating new databases, and reading/querying all databases; use `client.Databases`.
     /// </summary>
     /// <remarks>
     /// Note: all these operations make calls against a fixed budget.
     /// You should design your system such that these calls scale sub-linearly with your application.
-    /// For instance, do not call `database.ReadAsync()` before every single `item.ReadAsync()` call, to ensure the database exists;
+    /// For instance, do not call `database.ReadAsync()` before every single `container.ReadItemAsync()` call to ensure the database exists;
     /// do this once on application start up.
     /// </remarks>
     public abstract class Database
@@ -30,13 +30,13 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="DatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the read resource record.
         /// </returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
-        /// <list>
+        /// <list type="table">
         ///     <listheader>
         ///         <term>StatusCode</term><description>Reason for exception</description>
         ///     </listheader>
@@ -51,8 +51,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// //Reads a Database resource where
-        /// // - database_id is the ID property of the Database resource you wish to read.
+        /// // Reads a Database resource where database_id is the ID property of the Database resource you wish to read.
         /// Database database = this.cosmosClient.GetDatabase(database_id);
         /// DatabaseResponse response = await database.ReadAsync();
         /// ]]>
@@ -68,13 +67,13 @@ namespace Microsoft.Azure.Cosmos
                     CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete a <see cref="DatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// Delete a Database from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
-        /// <list>
+        /// <list type="table">
         ///     <listheader>
         ///         <term>StatusCode</term><description>Reason for exception</description>
         ///     </listheader>
@@ -86,7 +85,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// //Delete a cosmos database
+        /// // Delete a Cosmos database
         /// Database database = cosmosClient.GetDatabase("myDbId");
         /// DatabaseResponse response = await database.DeleteAsync();
         /// ]]>
@@ -104,13 +103,10 @@ namespace Microsoft.Azure.Cosmos
         /// The provisioned throughput for this database.
         /// </value>
         /// <remarks>
-        /// <para>
         /// Null value indicates a database with no throughput provisioned.
-        /// 
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database"/>
-        /// </para>
         /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
         /// <example>
         /// The following example shows how to get database throughput.
         /// <code language="c#">
@@ -125,20 +121,17 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets database throughput in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
-        /// <param name="requestOptions">The options for the throughput request.<see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">The options for the throughput request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The throughput response.</returns>
         /// <value>
         /// The provisioned throughput for this database.
         /// </value>
         /// <remarks>
-        /// <para>
         /// Null value indicates a database with no throughput provisioned.
-        /// 
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database"/>
-        /// </para>
         /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
         /// <example>
         /// The following example shows how to get the throughput
         /// <code language="c#">
@@ -168,8 +161,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Sets throughput provisioned for a database in measurement of request units per second in the Azure Cosmos service.
         /// </summary>
-        /// <param name="throughput">The cosmos database throughput expressed in Request Units per second.</param>
-        /// <param name="requestOptions">(Optional) The options for the throughput request.<see cref="RequestOptions"/></param>
+        /// <param name="throughput">The Cosmos database throughput expressed in Request Units per second.</param>
+        /// <param name="requestOptions">(Optional) The options for the throughput request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The throughput response.</returns>
         /// <value>
@@ -184,7 +177,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         /// </remarks>
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             int throughput,
@@ -194,7 +187,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="DatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the read resource record.
@@ -202,8 +195,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// //Reads a Database resource where
-        /// // - database_id is the ID property of the Database resource you wish to read.
+        /// // Reads a Database resource where database_id is the ID property of the Database resource you wish to read.
         /// Database database = this.cosmosClient.GetDatabase(database_id);
         /// ResponseMessage response = await database.ReadContainerStreamAsync();
         /// ]]>
@@ -216,14 +208,13 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="DatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain information about the request issued.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
-        /// //Delete a Database resource where
-        /// // - database_id is the ID property of the Database resource you wish to delete.
+        /// // Delete a Database resource where database_id is the ID property of the Database resource you wish to delete.
         /// Database database = this.cosmosClient.GetDatabase(database_id);
         /// await database.DeleteStreamAsync();
         /// ]]>
@@ -236,17 +227,17 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns a reference to a container object. 
         /// </summary>
-        /// <param name="id">The cosmos container id.</param>
+        /// <param name="id">The Cosmos container id.</param>
         /// <returns>Cosmos container reference</returns>
         /// <remarks>
-        /// Returns a Container reference. Reference doesn't guarantees existence.
+        /// Returns a Container reference. Reference doesn't guarantee existence.
         /// Please ensure container already exists or is created through a create operation.
         /// </remarks>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
         /// Database db = this.cosmosClient.GetDatabase("myDatabaseId");
-        /// DatabaseResponse response = await db.GetContainer("testcontainer");
+        /// Container container = db.GetContainer("testcontainer");
         /// ]]>
         /// </code>
         /// </example>
@@ -257,10 +248,10 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
-        /// <exception cref="ArgumentNullException">If either <paramref name="containerProperties"/> is not set.</exception>
+        /// <exception cref="ArgumentNullException">If <paramref name="containerProperties"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
         /// <list type="table">
@@ -298,9 +289,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <seealso cref="DefineContainer(string, string)"/>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ContainerResponse> CreateContainerAsync(
                     ContainerProperties containerProperties,
                     int? throughput = null,
@@ -310,10 +299,10 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Creates a container as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
-        /// <param name="id">The cosmos container id</param>
+        /// <param name="id">The Cosmos container id</param>
         /// <param name="partitionKeyPath">The path to the partition key. Example: /location</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
@@ -343,9 +332,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <seealso cref="DefineContainer(string, string)"/>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ContainerResponse> CreateContainerAsync(
             string id,
             string partitionKeyPath,
@@ -359,9 +346,21 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.
+        /// <list type="table">
+        ///     <listheader>
+        ///         <term>StatusCode</term><description>Common success StatusCodes for the CreateDatabaseIfNotExistsAsync operation</description>
+        ///     </listheader>
+        ///     <item>
+        ///         <term>201</term><description>Created - New database is created.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>200</term><description>Accepted - This means the database already exists.</description>
+        ///     </item>
+        /// </list>
+        /// </returns>
         /// <exception cref="ArgumentNullException">If either <paramref name="containerProperties"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
@@ -380,17 +379,6 @@ namespace Microsoft.Azure.Cosmos
         ///     </item>
         /// </list>
         /// </exception>
-        /// <list>
-        ///     <listheader>
-        ///         <term>StatusCode</term><description>Common success StatusCodes for the CreateDatabaseIfNotExistsAsync operation</description>
-        ///     </listheader>
-        ///     <item>
-        ///         <term>201</term><description>Created - New database is created.</description>
-        ///     </item>
-        ///     <item>
-        ///         <term>200</term><description>Accepted - This means the database already exists.</description>
-        ///     </item>
-        /// </list>
         /// <example>
         ///
         /// <code language="c#">
@@ -410,9 +398,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ContainerResponse> CreateContainerIfNotExistsAsync(
             ContainerProperties containerProperties,
             int? throughput = null,
@@ -423,10 +409,10 @@ namespace Microsoft.Azure.Cosmos
         /// Check if a container exists, and if it doesn't, create it.
         /// This will make a read operation, and if the container is not found it will do a create operation.
         /// </summary>
-        /// <param name="id">The cosmos container id</param>
+        /// <param name="id">The Cosmos container id</param>
         /// <param name="partitionKeyPath">The path to the partition key. Example: /location</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ContainerResponse"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
@@ -455,9 +441,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ContainerResponse> CreateContainerIfNotExistsAsync(
             string id,
             string partitionKeyPath,
@@ -470,7 +454,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> containing the created resource record.</returns>
         /// <example>
@@ -490,9 +474,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <seealso cref="DefineContainer(string, string)"/>
-        /// <remarks>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
-        /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         public abstract Task<ResponseMessage> CreateContainerStreamAsync(
             ContainerProperties containerProperties,
             int? throughput = null,
@@ -502,10 +484,10 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns a reference to a user object.
         /// </summary>
-        /// <param name="id">The cosmos user id.</param>
+        /// <param name="id">The Cosmos user id.</param>
         /// <returns>Cosmos user reference</returns>
         /// <remarks>
-        /// Returns a User reference. Reference doesn't guarantees existence.
+        /// Returns a User reference. Reference doesn't guarantee existence.
         /// Please ensure user already exists or is created through a create operation.
         /// </remarks>
         /// <example>
@@ -522,8 +504,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Creates a user as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
-        /// <param name="id">The cosmos user id</param>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="id">The Cosmos user id</param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="UserResponse"/> which wraps a <see cref="UserProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
@@ -556,8 +538,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Upserts a user as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
-        /// <param name="id">The cosmos user id.</param>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="id">The Cosmos user id.</param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="UserResponse"/> which wraps a <see cref="UserProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
@@ -587,9 +569,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryDefinition">The cosmos SQL query definition.</param>
+        /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// This create the type feed iterator for containers with queryDefinition as input.
@@ -624,9 +606,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryDefinition">The cosmos SQL query definition.</param>
+        /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// This create the stream feed iterator for containers with queryDefinition as input.
@@ -664,9 +646,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryText">The cosmos SQL query text.</param>
+        /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// 1. This create the type feed iterator for containers with queryText as input,
@@ -710,9 +692,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryText">The cosmos SQL query text.</param>
+        /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the container request.</param>
         /// <returns>An iterator to go through the containers</returns>
         /// <example>
         /// 1. This create the stream feed iterator for containers with queryText as input.
@@ -756,9 +738,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryText">The cosmos SQL query text.</param>
+        /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user query request.</param>
         /// <returns>An iterator to go through the users</returns>
         /// <example>
         /// 1. This create the type feed iterator for users with queryText as input,
@@ -795,9 +777,9 @@ namespace Microsoft.Azure.Cosmos
         /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
-        /// <param name="queryDefinition">The cosmos SQL query definition.</param>
+        /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user query request.</param>
         /// <returns>An iterator to go through the users</returns>
         /// <example>
         /// This create the type feed iterator for users with queryDefinition as input.

--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/Permission.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/Permission.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos
         /// Reads a <see cref="PermissionProperties"/> from the Azure Cosmos service as an asynchronous operation. Each read will return a new ResourceToken with its respective expiration. 
         /// </summary>
         /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 seconds, to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
-        /// <param name="requestOptions">(Optional) The options for the permission request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the permission request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="PermissionResponse"/> which wraps a <see cref="PermissionProperties"/> containing the read resource record.
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="permissionProperties">The <see cref="PermissionProperties"/> object.</param>
         /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 seconds, to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="PermissionResponse"/> which wraps a <see cref="PermissionProperties"/> containing the replace resource record.
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="PermissionProperties"/> from the Azure Cosmos DB service as an asynchronous operation. This will not revoke existing ResourceTokens.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="PermissionResponse"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a permission are:

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// <summary>
         /// Creates a stored procedure as an asynchronous operation in the Azure Cosmos DB service.
         /// </summary>
-        /// <param name="storedProcedureProperties">The Stored Procedure to create</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="RequestOptions"/></param>
+        /// <param name="storedProcedureProperties">The Stored Procedure to create.</param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The <see cref="StoredProcedureProperties"/> that was created contained within a <see cref="Task"/> object representing the service response for the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="storedProcedureProperties"/> is not set.</exception>
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for sproc with queryDefinition as input.
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for sproc with queryDefinition as input.
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for sproc with queryText as input.
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for sproc with queryText as input.
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Reads a <see cref="StoredProcedureProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The identifier of the Stored Procedure to read.</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="StoredProcedureProperties"/>.
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Replaces a <see cref="StoredProcedureProperties"/> in the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="storedProcedureProperties">The Stored Procedure to replace</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="StoredProcedureProperties"/>.
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Delete a <see cref="StoredProcedureProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The identifier of the Stored Procedure to delete.</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which will contain the response to the request issued.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> are not set.</exception>
@@ -301,9 +301,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <typeparam name="TOutput">The return type that is JSON serializable.</typeparam>
         /// <param name="storedProcedureId">The identifier of the Stored Procedure to execute.</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="Cosmos.PartitionKey"/></param>
+        /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="parameters">(Optional) An array of dynamic objects representing the parameters for the stored procedure.</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="storedProcedureId"/> or <paramref name="partitionKey"/>  are not set.</exception>
@@ -358,9 +358,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Executes a stored procedure against a container as an asynchronous operation in the Azure Cosmos service and obtains a Stream as response.
         /// </summary>
         /// <param name="storedProcedureId">The identifier of the Stored Procedure to execute.</param>
-        /// <param name="partitionKey">The partition key for the item. <see cref="Cosmos.PartitionKey"/></param>
+        /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="parameters">(Optional) An array of dynamic objects representing the parameters for the stored procedure.</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="StoredProcedureRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>The task object representing the service response for the asynchronous operation which would contain any response set in the stored procedure.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="storedProcedureId"/> or <paramref name="partitionKey"/>  are not set.</exception>
@@ -420,7 +420,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Creates a trigger as an asynchronous operation in the Azure Cosmos DB service.
         /// </summary>
         /// <param name="triggerProperties">The <see cref="TriggerProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the stored procedure request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the stored procedure request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A task object representing the service response for the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="triggerProperties"/> is not set.</exception>
@@ -488,7 +488,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for Trigger with queryDefinition as input.
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for Trigger with queryDefinition as input.
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for Trigger with queryText as input.
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for Trigger with queryText as input.
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Reads a <see cref="TriggerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The id of the trigger to read.</param>
-        /// <param name="requestOptions">(Optional) The options for the trigger request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the trigger request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="TriggerResponse"/> which wraps a <see cref="TriggerProperties"/> containing the read resource record.
@@ -616,7 +616,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Replaces a <see cref="TriggerProperties"/> in the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="triggerProperties">The <see cref="TriggerProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the trigger request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the trigger request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="TriggerResponse"/> which wraps a <see cref="TriggerProperties"/> containing the updated resource record.
@@ -656,7 +656,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Delete a <see cref="TriggerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The id of the trigger to delete.</param>
-        /// <param name="requestOptions">(Optional) The options for the trigger request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the trigger request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="TriggerResponse"/> which wraps a <see cref="TriggerProperties"/> which will contain information about the request issued.</returns>
         /// /// <example>
@@ -677,7 +677,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Creates a user defined function as an asynchronous operation in the Azure Cosmos DB service.
         /// </summary>
         /// <param name="userDefinedFunctionProperties">The <see cref="UserDefinedFunctionProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the user defined function request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user defined function request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A task object representing the service response for the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="userDefinedFunctionProperties"/> is not set.</exception>
@@ -743,7 +743,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for UDF with queryDefinition as input.
@@ -768,7 +768,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for UDF with queryDefinition as input.
@@ -793,7 +793,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the type feed iterator for UDF with queryText as input.
@@ -816,7 +816,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
-        /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the item query request.</param>
         /// <returns>An iterator to read through the existing stored procedures.</returns>
         /// <example>
         /// This create the stream feed iterator for UDF with queryText as input.
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Reads a <see cref="UserDefinedFunctionProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The id of the user defined function to read</param>
-        /// <param name="requestOptions">(Optional) The options for the user defined function request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user defined function request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="UserDefinedFunctionResponse"/> which wraps a <see cref="UserDefinedFunctionProperties"/> containing the read resource record.
@@ -874,7 +874,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Replaces a <see cref="UserDefinedFunctionProperties"/> in the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="userDefinedFunctionProperties">The <see cref="UserDefinedFunctionProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the user defined function request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user defined function request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="UserDefinedFunctionResponse"/> which wraps a <see cref="UserDefinedFunctionProperties"/> containing the updated resource record.
@@ -904,7 +904,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
         /// Delete a <see cref="UserDefinedFunctionProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="id">The id of the user defined function to delete.</param>
-        /// <param name="requestOptions">(Optional) The options for the user defined function request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user defined function request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="UserDefinedFunctionResponse"/> which wraps a <see cref="UserDefinedFunctionProperties"/> which will contain information about the request issued.</returns>
         /// <example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -387,7 +387,7 @@ namespace Microsoft.Azure.Cosmos
         /// Initializes a new instance of the <see cref="ContainerProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
-        /// <param name="partitionKeyDefinition">The partition key <see cref="PartitionKeyDefinition"/></param>
+        /// <param name="partitionKeyDefinition">The partition key definition.</param>
         internal ContainerProperties(string id, PartitionKeyDefinition partitionKeyDefinition)
         {
             this.Id = id;

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/PermissionProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/PermissionProperties.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="id">The permission id.</param>
         /// <param name="permissionMode">The <see cref="PermissionMode"/>.</param>
         /// <param name="container">The <see cref="Container"/> object.</param>
-        /// <param name="resourcePartitionKey">(Optional) The partition key value for the permission in the Azure Cosmos DB service. see <see cref="PartitionKey"/></param>
+        /// <param name="resourcePartitionKey">(Optional) The partition key value for the permission in the Azure Cosmos DB service.</param>
         public PermissionProperties(string id,
             PermissionMode permissionMode,
             Container container,
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos
         {
             this.Id = id;
             this.PermissionMode = permissionMode;
-            ResourceUri = ((ContainerCore)container).ClientContext.CreateLink(
+            this.ResourceUri = ((ContainerCore)container).ClientContext.CreateLink(
                     parentLink: ((ContainerCore)container).LinkUri.OriginalString,
                     uriPathSegment: Paths.DocumentsPathSegment,
                     id: id).OriginalString;

--- a/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="UserProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="UserResponse"/> which wraps a <see cref="UserProperties"/> containing the read resource record.
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
         /// Replace a <see cref="UserProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="userProperties">The <see cref="UserProperties"/> object.</param>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="UserResponse"/> which wraps a <see cref="UserProperties"/> containing the replace resource record.
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Delete a <see cref="UserProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
-        /// <param name="requestOptions">(Optional) The options for the user request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the user request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="UserResponse"/> which will contain information about the request issued.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a user are:
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="id">The cosmos permission id.</param>
         /// <returns>Cosmos permission reference</returns>
         /// <remarks>
-        /// Returns a Permission reference. Reference doesn't guarantees existence.
+        /// Returns a Permission reference. Reference doesn't guarantee existence.
         /// Please ensure permssion already exists or is created through a create operation.
         /// </remarks>
         /// <example>
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="permissionProperties">The <see cref="PermissionProperties"/> object.</param>
         /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 seconds, to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
-        /// <param name="requestOptions">(Optional) The options for the permission request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the permission request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="PermissionResponse"/> which wraps a <see cref="PermissionProperties"/> containing the read resource record.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a permission are:
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="permissionProperties">The <see cref="PermissionProperties"/> object.</param>
         /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 seconds, to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
-        /// <param name="requestOptions">(Optional) The options for the permission request <see cref="RequestOptions"/></param>
+        /// <param name="requestOptions">(Optional) The options for the permission request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="PermissionResponse"/> which wraps a <see cref="PermissionProperties"/> containing the read resource record.</returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a permission are:

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Convert the object to a Stream. 
         /// The caller will take ownership of the stream and ensure it is correctly disposed of.
-        /// <see href="https://docs.microsoft.com/dotnet/api/system.io.stream.canread?view=netcore-2.0">Stream.CanRead</see> must be true.
+        /// <see href="https://docs.microsoft.com/dotnet/api/system.io.stream.canread">Stream.CanRead</see> must be true.
         /// </summary>
         /// <param name="input">Any type passed to <see cref="Container"/>.</param>
         /// <returns>A readable Stream containing JSON of the serialized object.</returns>

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs
@@ -16,18 +16,18 @@ namespace Microsoft.Azure.Cosmos
         /// The implementation is responsible for Disposing of the stream,
         /// including when an exception is thrown, to avoid memory leaks.
         /// </summary>
-        /// <typeparam name="T">Any typed passed to <see cref="Container"/></typeparam>
-        /// <param name="stream">The Stream response containing JSON from Cosmos</param>
+        /// <typeparam name="T">Any type passed to <see cref="Container"/>.</typeparam>
+        /// <param name="stream">The Stream response containing JSON from Cosmos DB.</param>
         /// <returns>The object deserialized from the stream.</returns>
         public abstract T FromStream<T>(Stream stream);
 
         /// <summary>
         /// Convert the object to a Stream. 
         /// The caller will take ownership of the stream and ensure it is correctly disposed of.
-        /// Stream.CanRead must be true https://docs.microsoft.com/dotnet/api/system.io.stream.canread?view=netcore-2.0
+        /// <see href="https://docs.microsoft.com/dotnet/api/system.io.stream.canread?view=netcore-2.0">Stream.CanRead</see> must be true.
         /// </summary>
-        /// <param name="input">Any typed passed to <see cref="Container"/></param>
-        /// <returns>A readable Stream containing JSON of the serialized object</returns>
+        /// <param name="input">Any type passed to <see cref="Container"/>.</param>
+        /// <returns>A readable Stream containing JSON of the serialized object.</returns>
         public abstract Stream ToStream<T>(T input);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task NegativeCreateDropItemTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.Serializer.ToStream(testItem), new Cosmos.PartitionKey("BadKey"));
+            ResponseMessage response = await this.Container.CreateItemStreamAsync(TestCommon.Serializer.ToStream(testItem), new Cosmos.PartitionKey("BadKey"));
             Assert.IsNotNull(response);
             Assert.IsNull(response.Content);
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);


### PR DESCRIPTION
## Description
Rename Batch in Samples to TransactionalBatch.

General doc fixes across SDK to fix non-displayed / stray links in generated documentation:
> see and seealso with href need text for display. 
> seealso should be top level (not within remarks etc.) and isn't inlined into the documentation but shows up as a separate section. 
> exception needs cref. 
> list needs a type attribute.

## Type of change

Sample and documentation update.