### PR TITLE
CreateItem will only retry for auto-extracted partition key in-case of container re-creation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Azure.Cosmos
                 streamPayload,
                 OperationType.Create,
                 requestOptions,
-                extractPartitionKeyIfNeeded: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -66,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
             Task<ResponseMessage> response = this.ExtractPartitionKeyAndProcessItemStreamAsync(
                 partitionKey: partitionKey,
                 itemId: null,
-                streamPayload: this.ClientContext.CosmosSerializer.ToStream<T>(item),
+                item: item,
                 operationType: OperationType.Create,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
@@ -86,7 +85,6 @@ namespace Microsoft.Azure.Cosmos
                 null,
                 OperationType.Read,
                 requestOptions,
-                extractPartitionKeyIfNeeded: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -117,7 +115,6 @@ namespace Microsoft.Azure.Cosmos
                 streamPayload,
                 OperationType.Upsert,
                 requestOptions,
-                extractPartitionKeyIfNeeded: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -135,7 +132,7 @@ namespace Microsoft.Azure.Cosmos
             Task<ResponseMessage> response = this.ExtractPartitionKeyAndProcessItemStreamAsync(
                 partitionKey: partitionKey,
                 itemId: null,
-                streamPayload: this.ClientContext.CosmosSerializer.ToStream<T>(item),
+                item: item,
                 operationType: OperationType.Upsert,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
@@ -156,7 +153,6 @@ namespace Microsoft.Azure.Cosmos
                 streamPayload,
                 OperationType.Replace,
                 requestOptions,
-                extractPartitionKeyIfNeeded: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -180,7 +176,7 @@ namespace Microsoft.Azure.Cosmos
             Task<ResponseMessage> response = this.ExtractPartitionKeyAndProcessItemStreamAsync(
                partitionKey: partitionKey,
                itemId: id,
-               streamPayload: this.ClientContext.CosmosSerializer.ToStream<T>(item),
+               item: item,
                operationType: OperationType.Replace,
                requestOptions: requestOptions,
                cancellationToken: cancellationToken);
@@ -200,7 +196,6 @@ namespace Microsoft.Azure.Cosmos
                 null,
                 OperationType.Delete,
                 requestOptions,
-                extractPartitionKeyIfNeeded: false,
                 cancellationToken: cancellationToken);
         }
 
@@ -511,24 +506,39 @@ namespace Microsoft.Azure.Cosmos
         // Extracted partition key might be invalid as CollectionCache might be stale.
         // Stale collection cache is refreshed through PartitionKeyMismatchRetryPolicy
         // and partition-key is extracted again. 
-        internal async Task<ResponseMessage> ExtractPartitionKeyAndProcessItemStreamAsync(
+        internal async Task<ResponseMessage> ExtractPartitionKeyAndProcessItemStreamAsync<T>(
             PartitionKey? partitionKey,
             string itemId,
-            Stream streamPayload,
+            T item,
             OperationType operationType,
             RequestOptions requestOptions,
             CancellationToken cancellationToken)
         {
+            Stream streamPayload = this.ClientContext.CosmosSerializer.ToStream<T>(item);
+
+            // User specified PK value, no need to extract it
+            if (partitionKey.HasValue)
+            {
+                return await this.ProcessItemStreamAsync(
+                        partitionKey,
+                        itemId,
+                        streamPayload,
+                        operationType,
+                        requestOptions,
+                        cancellationToken: cancellationToken);
+            }
+
             PartitionKeyMismatchRetryPolicy requestRetryPolicy = null;
             while (true)
             {
+                partitionKey = await this.GetPartitionKeyValueFromStreamAsync(streamPayload, cancellationToken);
+
                 ResponseMessage responseMessage = await this.ProcessItemStreamAsync(
                     partitionKey,
                     itemId,
                     streamPayload,
                     operationType,
                     requestOptions,
-                    extractPartitionKeyIfNeeded: true,
                     cancellationToken: cancellationToken);
 
                 if (responseMessage.IsSuccessStatusCode)
@@ -555,7 +565,6 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             OperationType operationType,
             RequestOptions requestOptions,
-            bool extractPartitionKeyIfNeeded,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             if (requestOptions != null && requestOptions.IsEffectivePartitionKeyRouting)
@@ -563,25 +572,20 @@ namespace Microsoft.Azure.Cosmos
                 partitionKey = null;
             }
 
-            if (extractPartitionKeyIfNeeded && partitionKey == null)
-            {
-                partitionKey = await this.GetPartitionKeyValueFromStreamAsync(streamPayload, cancellationToken);
-            }
-
             ContainerCore.ValidatePartitionKey(partitionKey, requestOptions);
             Uri resourceUri = this.GetResourceUri(requestOptions, operationType, itemId);
 
             return await this.ClientContext.ProcessResourceOperationStreamAsync(
-                resourceUri,
-                ResourceType.Document,
-                operationType,
-                requestOptions,
-                this,
-                partitionKey,
-                itemId,
-                streamPayload,
-                null,
-                cancellationToken);
+                resourceUri: resourceUri,
+                resourceType: ResourceType.Document,
+                operationType: operationType,
+                requestOptions: requestOptions,
+                cosmosContainerCore: this,
+                partitionKey: partitionKey,
+                itemId: itemId,
+                streamPayload: streamPayload,
+                requestEnricher: null,
+                cancellationToken: cancellationToken);
         }
 
         internal async Task<PartitionKey> GetPartitionKeyValueFromStreamAsync(

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.Contracts;
     using System.Globalization;
     using System.IO;
     using System.Linq;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
@@ -111,20 +111,5 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             public string description { get; set; }
             public string status { get; set; }
         }
-
-        public class CustomHandler : RequestHandler
-        {
-            public Action<RequestMessage> UpdateRequestMessage = null;
-
-            public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
-            {
-                if (this.UpdateRequestMessage != null)
-                {
-                    this.UpdateRequestMessage(request);
-                }
-
-                return base.SendAsync(request, cancellationToken);
-            }
-        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task TestCustomPropertyWithHandler()
         { 
-            CustomHandler testHandler = new CustomHandler();
+            RequestHandlerHelper testHandler = new RequestHandlerHelper();
 
             // Add the random guid to the property
             Guid randomGuid = Guid.NewGuid();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task TestInvalidPartitionKeyException()
         {
-            CustomHandler testHandler = new CustomHandler();
+            RequestHandlerHelper testHandler = new RequestHandlerHelper();
             int createItemCount = 0;
             string partitionKey = null;
             testHandler.UpdateRequestMessage = (requestMessage) =>
@@ -1375,7 +1375,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     createItemCount++;
                     string pk = requestMessage.Headers.PartitionKey;
-                    Assert.AreEqual(partitionKey, pk, $"Same PK value should not be sent again. PK value:{pk}");
+                    Assert.AreNotEqual(partitionKey, pk, $"Same PK value should not be sent again. PK value:{pk}");
                     partitionKey = pk;
                 }
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1363,6 +1363,52 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [TestMethod]
+        public async Task TestInvalidPartitionKeyException()
+        {
+            CustomHandler testHandler = new CustomHandler();
+            int createItemCount = 0;
+            string partitionKey = null;
+            testHandler.UpdateRequestMessage = (requestMessage) =>
+            {
+                if (requestMessage.ResourceType == ResourceType.Document)
+                {
+                    createItemCount++;
+                    string pk = requestMessage.Headers.PartitionKey;
+                    Assert.IsFalse(string.Equals(partitionKey, pk), $"Same PK value should not be sent again. PK value:{pk}");
+                    partitionKey = pk;
+                }
+            };
+
+            using (CosmosClient client = TestCommon.CreateCosmosClient((builder) => builder.AddCustomHandlers(testHandler)))
+            {
+                Cosmos.Database database = null;
+                try
+                {
+                    database = await client.CreateDatabaseAsync("TestInvalidPartitionKey" + Guid.NewGuid().ToString());
+                    Container container = await database.CreateContainerAsync(id: "coll1", partitionKeyPath: "/doesnotexist");
+                    ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
+
+                    ItemResponse<ToDoActivity> response = await container.CreateItemAsync(toDoActivity, partitionKey: new Cosmos.PartitionKey(toDoActivity.status));
+                    Assert.Fail("Create item should fail with wrong partition key value");
+                }
+                catch (CosmosException ce)
+                {
+                    Assert.AreEqual(HttpStatusCode.BadRequest, ce.StatusCode);
+                    Assert.AreEqual(SubStatusCodes.PartitionKeyMismatch, (SubStatusCodes)ce.SubStatusCode);
+                }
+                finally
+                {
+                    if (database != null)
+                    {
+                        await database.DeleteAsync();
+                    }
+                }
+
+                Assert.AreEqual(1, createItemCount, $"Request should use the custom handler, and it should only be used once. Count {createItemCount}");
+            }
+        }
+
         /// <summary>
         /// Tests that collection cache is refreshed when collection is recreated.
         /// The test just ensures that client retries and completes successfully for query - request which doesn't target single partition key.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1375,7 +1375,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     createItemCount++;
                     string pk = requestMessage.Headers.PartitionKey;
-                    Assert.IsFalse(string.Equals(partitionKey, pk), $"Same PK value should not be sent again. PK value:{pk}");
+                    Assert.AreEqual(partitionKey, pk, $"Same PK value should not be sent again. PK value:{pk}");
                     partitionKey = pk;
                 }
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/CustomHandler.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/CustomHandler.cs
@@ -1,0 +1,22 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class CustomHandler : RequestHandler
+    {
+        public Action<RequestMessage> UpdateRequestMessage = null;
+
+        public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
+        {
+            this.UpdateRequestMessage?.Invoke(request);
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RequestHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RequestHandlerHelper.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Threading;
     using System.Threading.Tasks;
 
-    public class CustomHandler : RequestHandler
+    public class RequestHandlerHelper : RequestHandler
     {
         public Action<RequestMessage> UpdateRequestMessage = null;
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1036](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1036) Fixed query responses to return null Content if it is a failure
 - [#1045](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1045) Added stack trace and innner exception to CosmosException
 - [#1050](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1050) Add mocking constructors to TransactionalBatchOperationResult
-- [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) Fixed bug where wrong partition key value might cause two requests
+- [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
 
 ## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1036](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1036) Fixed query responses to return null Content if it is a failure
 - [#1045](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1045) Added stack trace and innner exception to CosmosException
 - [#1050](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1050) Add mocking constructors to TransactionalBatchOperationResult
- 
+- [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) Fixed bug where wrong partition key value might cause two requests
+
 ## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
 
 ### Fixed


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed bug where if a user provided the wrong partition key value the request would be sent twice. The retry logic for the partition key extraction was always being used if it was a user provided partition key value or an extracted partition key value. The retry logic should only be used for SDK extracted partition key value in scenarios where the cache is stale.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



