### PR TITLE
Fix NullReferenceExceptions during serialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal CosmosSerializer GetCosmosSerializerWithWrapperOrDefault()
         {
-            if (this.SerializerOptions != null)
+            if (this.SerializerOptions != null && !this.SerializerOptions.IsDefaultSettings())
             {
                 CosmosJsonDotNetSerializer cosmosJsonDotNetSerializer = new CosmosJsonDotNetSerializer(this.SerializerOptions);
                 return new CosmosJsonSerializerWrapper(cosmosJsonDotNetSerializer);

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
@@ -12,15 +12,19 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public sealed class CosmosSerializationOptions
     {
+        private const bool DefaultIgnoreNullValues = false;
+        private const bool DefaultIndented = false;
+        private const CosmosPropertyNamingPolicy DefaultCosmosPropertyNamingPolicy = CosmosPropertyNamingPolicy.Default;
+
         /// <summary>
         /// Create an instance of CosmosSerializationOptions
         /// with the default values for the Cosmos SDK
         /// </summary>
         public CosmosSerializationOptions()
         {
-            this.IgnoreNullValues = false;
-            this.Indented = false;
-            this.PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default;
+            this.IgnoreNullValues = DefaultIgnoreNullValues;
+            this.Indented = DefaultIndented;
+            this.PropertyNamingPolicy = DefaultCosmosPropertyNamingPolicy;
         }
 
         /// <summary>
@@ -47,5 +51,15 @@ namespace Microsoft.Azure.Cosmos
         /// The default value is CosmosPropertyNamingPolicy.Default
         /// </remarks>
         public CosmosPropertyNamingPolicy PropertyNamingPolicy { get; set; }
+
+        /// <summary>
+        /// Helper method to check if all the setting values are the default.
+        /// </summary>
+        internal bool IsDefaultSettings()
+        {
+            return this.IgnoreNullValues == DefaultIgnoreNullValues &&
+                this.Indented == DefaultIndented &&
+                this.PropertyNamingPolicy == DefaultCosmosPropertyNamingPolicy;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/NewtonsoftBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/NewtonsoftBenchmark.cs
@@ -1,0 +1,55 @@
+﻿// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.Azure.Cosmos;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Benchmark for Item related operations.
+    /// </summary>
+    public class NewtonsoftBenchmark
+    {
+        private readonly CosmosClient clientForTests;
+        private readonly SqlQuerySpec sqlQuerySpec;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemBenchmark"/> class.
+        /// </summary>
+        public NewtonsoftBenchmark()
+        {
+            this.sqlQuerySpec = new SqlQuerySpec(
+                @"SELECT * FROM document d 
+                    WHERE(d.id = @documentId)
+                    AND(d.deviceId = @deviceId)",
+                new SqlParameterCollection()
+                {
+                    new SqlParameter("@documentId", "deviceEXISTS"),
+                    new SqlParameter("@deviceId", "devicetoken|5fe8caf682ba0e7d/deviceCREATE")
+                });
+
+            this.clientForTests = MockDocumentClient.CreateMockCosmosClient((builder) => builder.WithSerializerOptions(new CosmosSerializationOptions() { IgnoreNullValues = false, Indented = false, PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase }));
+        }
+
+        /// <summary>
+        /// Benchmark for CreateItemAsync.
+        /// </summary>
+        [Benchmark]
+        public void CreateSqlQuerySpec()
+        {
+            using (Stream stream = this.clientForTests.ClientContext.SqlQuerySpecSerializer.ToStream<SqlQuerySpec>(this.sqlQuerySpec))
+            {
+                if (stream == null)
+                {
+                    throw new Exception();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes observed null reference exceptions during serialization which seems to be caused by some race condition with the custom settings. To avoid this a new JsonSerializer is created for each call when there is custom settings. We found no issue when it was the default serializer so it does not create a new instance for each call to avoid the garbage collection overhead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #1079
