### PR TITLE
Fix possible NullReferenceException on a TransactionalBatch code path

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
@@ -211,7 +211,8 @@ namespace Microsoft.Azure.Cosmos
         internal static async Task<TransactionalBatchResponse> FromResponseMessageAsync(
             ResponseMessage responseMessage,
             ServerBatchRequest serverRequest,
-            CosmosSerializer serializer)
+            CosmosSerializer serializer,
+            bool shouldPromoteOperationStatus = true)
         {
             using (responseMessage)
             {
@@ -230,7 +231,13 @@ namespace Microsoft.Azure.Cosmos
                     if (content.ReadByte() == (int)HybridRowVersion.V1)
                     {
                         content.Position = 0;
-                        response = await TransactionalBatchResponse.PopulateFromContentAsync(content, responseMessage, serverRequest, serializer);
+                        response = await TransactionalBatchResponse.PopulateFromContentAsync(
+                            content,
+                            responseMessage,
+                            serverRequest,
+                            serializer,
+                            shouldPromoteOperationStatus);
+
                         if (response == null)
                         {
                             // Convert any payload read failures as InternalServerError
@@ -247,7 +254,8 @@ namespace Microsoft.Azure.Cosmos
                         }
                     }
                 }
-                else
+
+                if (response == null)
                 {
                     response = new TransactionalBatchResponse(
                         responseMessage.StatusCode,
@@ -317,7 +325,8 @@ namespace Microsoft.Azure.Cosmos
             Stream content,
             ResponseMessage responseMessage,
             ServerBatchRequest serverRequest,
-            CosmosSerializer serializer)
+            CosmosSerializer serializer,
+            bool shouldPromoteOperationStatus)
         {
             List<TransactionalBatchOperationResult> results = new List<TransactionalBatchOperationResult>();
 
@@ -348,7 +357,8 @@ namespace Microsoft.Azure.Cosmos
 
             // Promote the operation error status as the Batch response error status if we have a MultiStatus response
             // to provide users with status codes they are used to.
-            if ((int)responseMessage.StatusCode == (int)StatusCodes.MultiStatus)
+            if ((int)responseMessage.StatusCode == (int)StatusCodes.MultiStatus
+                && shouldPromoteOperationStatus)
             {
                 foreach (TransactionalBatchOperationResult result in results)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Client.Core.Tests;
@@ -336,6 +337,33 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(SubStatusCodes.Unknown, batchResponse[1].SubStatusCode);
             Assert.IsNull(batchResponse[1].ETag);
             Assert.IsNull(batchResponse[1].ResourceStream);
+        }
+
+        [TestMethod]
+        [Owner("abpai")]
+        public async Task BatchJsonServerResponseAsync()
+        {
+            TestHandler testHandler = new TestHandler((request, cancellationToken) =>
+            {
+                HttpStatusCode serverStatusCode = HttpStatusCode.Gone;
+                Stream serverContent = new MemoryStream(Encoding.UTF8.GetBytes("{ \"random\": 1 }"));
+
+                ResponseMessage responseMessage = new ResponseMessage(serverStatusCode, requestMessage: null, errorMessage: null)
+                {
+                    Content = serverContent
+                };
+
+                return Task.FromResult(responseMessage);
+            });
+
+            Container container = BatchUnitTests.GetContainer(testHandler);
+
+            TransactionalBatchResponse batchResponse = await new BatchCore((ContainerCore)container, new Cosmos.PartitionKey(BatchUnitTests.PartitionKey1))
+                .ReadItem("id1")
+                .ReadItem("id2")
+                .ExecuteAsync();
+
+            Assert.AreEqual(HttpStatusCode.Gone, batchResponse.StatusCode);
         }
 
         /// <summary>

--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [#1075](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1075) Including header size details for BadRequest with large headers
-
+- [#1086](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1086) Fix possible NullReferenceException on a TransactionalBatch code path
 
 
 ### Fixed


### PR DESCRIPTION
## Description

Ensure the TransactionalBatchResponse is formed even when the server returns some response with a body that isn't in the expected format.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
