### PR TITLE
Fixed missing store result info from diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
@@ -81,8 +81,8 @@ namespace Microsoft.Azure.Cosmos
             stringBuilder.Append($",\"SubStatusCode\":\"{this.SubStatusCode.ToString()}\"");
             stringBuilder.Append($",\"RequestCharge\":\"{this.RequestCharge}\"");
             stringBuilder.Append($",\"ErrorMessage\":\"{errorMessage}\"");
-            stringBuilder.Append($",\"Method\":\"{this.Method.ToString()}\"");
-            stringBuilder.Append($",\"RequestUri\":\"{this.RequestUri.ToString()}\"");
+            stringBuilder.Append($",\"Method\":\"{this.Method?.ToString() ?? "null"}\"");
+            stringBuilder.Append($",\"RequestUri\":\"{this.RequestUri?.ToString() ?? "null"}\"");
             stringBuilder.Append($",\"RequestSessionToken\":\"{this.RequestSessionToken}\"");
             stringBuilder.Append($",\"ResponseSessionToken\":\"{this.ResponseSessionToken}\"");
             if (this.ClientSideRequestStatistics != null)

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using System.Net.Http;
     using System.Text;
+    using System.Web;
     using Newtonsoft.Json;
     using static Microsoft.Azure.Cosmos.CosmosClientSideRequestStatistics;
 
@@ -72,7 +73,7 @@ namespace Microsoft.Azure.Cosmos
             string errorMessage = string.Empty;
             if (this.ErrorMessage != null)
             {
-                errorMessage = JsonConvert.ToString(this.ErrorMessage, '\'', stringEscapeHandling: StringEscapeHandling.EscapeHtml);
+                errorMessage = HttpUtility.JavaScriptStringEncode(this.ErrorMessage);
             }
 
             stringBuilder.Append($"{{\"ActivityId\":\"{this.ActivityId}\"");

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/PointOperationStatistics.cs
@@ -29,24 +29,7 @@ namespace Microsoft.Azure.Cosmos
         public Uri RequestUri { get; }
         public string RequestSessionToken { get; }
         public string ResponseSessionToken { get; }
-
-        public DateTime requestStartTimeUtc { get; private set; }
-
-        public DateTime? requestEndTimeUtc { get; private set; }
-
-        public List<StoreResponseStatistics> responseStatisticsList { get; private set; }
-
-        public List<StoreResponseStatistics> supplementalResponseStatisticsList { get; private set; }
-
-        public Dictionary<string, AddressResolutionStatistics> addressResolutionStatistics { get; private set; }
-
-        public List<Uri> contactedReplicas { get; set; }
-
-        public HashSet<Uri> failedReplicas { get; private set; }
-
-        public HashSet<Uri> regionsContacted { get; private set; }
-
-        public TimeSpan requestLatency { get; private set; }
+        public CosmosClientSideRequestStatistics ClientSideRequestStatistics { get; }
 
         internal PointOperationStatistics(
             string activityId,
@@ -69,32 +52,45 @@ namespace Microsoft.Azure.Cosmos
             this.RequestUri = requestUri;
             this.RequestSessionToken = requestSessionToken;
             this.ResponseSessionToken = responseSessionToken;
-            if (clientSideRequestStatistics != null)
-            {
-                this.requestStartTimeUtc = clientSideRequestStatistics.requestStartTime;
-                this.requestEndTimeUtc = clientSideRequestStatistics.requestEndTime;
-                this.responseStatisticsList = clientSideRequestStatistics.responseStatisticsList;
-                this.supplementalResponseStatisticsList = clientSideRequestStatistics.supplementalResponseStatisticsList;
-                this.addressResolutionStatistics = clientSideRequestStatistics.addressResolutionStatistics;
-                this.contactedReplicas = clientSideRequestStatistics.ContactedReplicas;
-                this.failedReplicas = clientSideRequestStatistics.FailedReplicas;
-                this.regionsContacted = clientSideRequestStatistics.RegionsContacted;
-                this.requestLatency = clientSideRequestStatistics.RequestLatency;
-            }
+            this.ClientSideRequestStatistics = clientSideRequestStatistics;
         }
 
         public override string ToString()
         {
-            if (this.supplementalResponseStatisticsList != null)
+            StringBuilder stringBuilder = new StringBuilder();
+            this.AppendJsonToBuilder(stringBuilder);
+            return stringBuilder.ToString();
+        }
+
+        public void AppendJsonToBuilder(StringBuilder stringBuilder)
+        {
+            if (stringBuilder == null)
             {
-                int supplementalResponseStatisticsListCount = this.supplementalResponseStatisticsList.Count;
-                int countToRemove = Math.Max(supplementalResponseStatisticsListCount - CosmosClientSideRequestStatistics.MaxSupplementalRequestsForToString, 0);
-                if (countToRemove > 0)
-                {
-                    this.supplementalResponseStatisticsList.RemoveRange(0, countToRemove);
-                }
+                throw new ArgumentNullException(nameof(stringBuilder));
             }
-            return JsonConvert.SerializeObject(this, PointOperationStatistics.SerializerSettings);
+
+            string errorMessage = string.Empty;
+            if (this.ErrorMessage != null)
+            {
+                errorMessage = JsonConvert.ToString(this.ErrorMessage, '\'', stringEscapeHandling: StringEscapeHandling.EscapeHtml);
+            }
+
+            stringBuilder.Append($"{{\"ActivityId\":\"{this.ActivityId}\"");
+            stringBuilder.Append($",\"StatusCode\":\"{(int)this.StatusCode}\"");
+            stringBuilder.Append($",\"SubStatusCode\":\"{this.SubStatusCode.ToString()}\"");
+            stringBuilder.Append($",\"RequestCharge\":\"{this.RequestCharge}\"");
+            stringBuilder.Append($",\"ErrorMessage\":\"{errorMessage}\"");
+            stringBuilder.Append($",\"Method\":\"{this.Method.ToString()}\"");
+            stringBuilder.Append($",\"RequestUri\":\"{this.RequestUri.ToString()}\"");
+            stringBuilder.Append($",\"RequestSessionToken\":\"{this.RequestSessionToken}\"");
+            stringBuilder.Append($",\"ResponseSessionToken\":\"{this.ResponseSessionToken}\"");
+            if (this.ClientSideRequestStatistics != null)
+            {
+                stringBuilder.Append(",");
+                this.ClientSideRequestStatistics.AppendJsonToBuilder(stringBuilder);
+            }
+
+            stringBuilder.Append("}");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosClientSideRequestStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosClientSideRequestStatistics.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Globalization;
     using System.Text;
     using Microsoft.Azure.Documents;
-    using Newtonsoft.Json;
 
     internal sealed class CosmosClientSideRequestStatistics : IClientSideRequestStatistics
     {
@@ -204,14 +203,14 @@ namespace Microsoft.Azure.Cosmos
                         stringBuilder.Append(",");
                     }
 
-                    item.AppendJsonToBuilder(stringBuilder);            
+                    item.AppendJsonToBuilder(stringBuilder);
                 }
 
                 stringBuilder.Append("]");
 
                 //only take last 10 responses from this list - this has potential of having large number of entries. 
                 //since this is for establishing consistency, we can make do with the last responses to paint a meaningful picture.
-                int supplementalResponseStatisticsListCount = this.supplementalResponseStatisticsList.Count;
+                int supplementalResponseStatisticsListCount = this.supplementalResponseStatisticsList?.Count ?? 0;
                 int initialIndex = Math.Max(supplementalResponseStatisticsListCount - CosmosClientSideRequestStatistics.MaxSupplementalRequestsForToString, 0);
 
                 if (initialIndex != 0)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(createResponse.Diagnostics);
             string diagnostics = createResponse.Diagnostics.ToString();
             Assert.IsFalse(string.IsNullOrEmpty(diagnostics));
-            Assert.IsTrue(diagnostics.Contains("requestStartTime"));
+            Assert.IsTrue(diagnostics.Contains("RequestStartTimeUtc"));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -162,25 +162,26 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string info = diagnostics.ToString();
             Assert.IsNotNull(info);
             JObject jObject = JObject.Parse(info);
+            int statusCode = jObject["StatusCode"].ToObject<int>();
             Assert.IsNotNull(jObject["ActivityId"].ToString());
             Assert.IsNotNull(jObject["StatusCode"].ToString());
             Assert.IsNotNull(jObject["RequestCharge"].ToString());
             Assert.IsNotNull(jObject["RequestUri"].ToString());
-            Assert.IsNotNull(jObject["requestStartTimeUtc"].ToString()); 
-            Assert.IsNotNull(jObject["responseStatisticsList"].ToString());
-            Assert.IsNotNull(jObject["supplementalResponseStatisticsList"].ToString());
-            Assert.IsNotNull(jObject["addressResolutionStatistics"].ToString());
-            Assert.IsNotNull(jObject["contactedReplicas"].ToString());
-            Assert.IsNotNull(jObject["failedReplicas"].ToString());
-            Assert.IsNotNull(jObject["regionsContacted"].ToString());
-            Assert.IsNotNull(jObject["requestLatency"].ToString());
-
-            int statusCode = jObject["StatusCode"].ToObject<int>();
+            Assert.IsNotNull(jObject["ClientSideRequestStatistics"].ToString());
+            JObject clientJObject = jObject["ClientSideRequestStatistics"].ToObject<JObject>();
+            Assert.IsNotNull(clientJObject["RequestStartTimeUtc"].ToString()); 
+            Assert.IsNotNull(clientJObject["ResponseStatisticsList"].ToString());
+            Assert.IsNotNull(clientJObject["AddressResolutionStatistics"].ToString());
+            Assert.IsNotNull(clientJObject["SupplementalResponseStatistics"].ToString());
+            Assert.IsNotNull(clientJObject["ContactedReplicas"].ToString());
+            Assert.IsNotNull(clientJObject["FailedReplicas"].ToString());
+            Assert.IsNotNull(clientJObject["RegionsContacted"].ToString());
+            Assert.IsNotNull(clientJObject["RequestLatency"].ToString());
 
             // Session token only expected on success
             if (statusCode >= 200 && statusCode < 300)
             {
-                Assert.IsNotNull(jObject["requestEndTimeUtc"].ToString());
+                Assert.IsNotNull(clientJObject["RequestEndTimeUtc"].ToString());
                 Assert.IsNotNull(jObject["ResponseSessionToken"].ToString());
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PointOperationStatisticsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PointOperationStatisticsTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos
                 clientSideRequestStatistics: cosmosClientSideRequestStatistics);
 
             pointOperationStatistics.ToString();
-            Assert.IsNull(pointOperationStatistics.supplementalResponseStatisticsList);
+            Assert.IsNull(pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList);
 
             //Adding 5 objects supplementalResponseStatisticsList
             cosmosClientSideRequestStatistics.supplementalResponseStatisticsList = new List<StoreResponseStatistics>
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos
                 responseSessionToken: null,
                 clientSideRequestStatistics: cosmosClientSideRequestStatistics);
             pointOperationStatistics.ToString();
-            Assert.AreEqual(5, pointOperationStatistics.supplementalResponseStatisticsList.Count);
+            Assert.AreEqual(5, pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList.Count);
 
             //Adding 5 more objects supplementalResponseStatisticsList, making total 10
             cosmosClientSideRequestStatistics.supplementalResponseStatisticsList.AddRange(new List<StoreResponseStatistics>()
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
                 responseSessionToken: null,
                 clientSideRequestStatistics:  cosmosClientSideRequestStatistics);
             pointOperationStatistics.ToString();
-            Assert.AreEqual(10, pointOperationStatistics.supplementalResponseStatisticsList.Count);
+            Assert.AreEqual(10, pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList.Count);
 
             //Adding 2 more objects supplementalResponseStatisticsList, making total 12
             cosmosClientSideRequestStatistics.supplementalResponseStatisticsList.AddRange(new List<StoreResponseStatistics>()
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos
                 responseSessionToken: null,
                 clientSideRequestStatistics:  cosmosClientSideRequestStatistics);
             pointOperationStatistics.ToString();
-            Assert.AreEqual(10, pointOperationStatistics.supplementalResponseStatisticsList.Count);
+            Assert.AreEqual(10, pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList.Count);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PointOperationStatisticsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PointOperationStatisticsTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos
                 responseSessionToken: null,
                 clientSideRequestStatistics:  cosmosClientSideRequestStatistics);
             pointOperationStatistics.ToString();
-            Assert.AreEqual(10, pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList.Count);
+            Assert.AreEqual(12, pointOperationStatistics.ClientSideRequestStatistics.supplementalResponseStatisticsList.Count);
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -9,16 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 
- 
 ### Fixed
 
+- [#1060](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1060) Fixed unicode encoding bug in DISTINCT queries.
+- [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
 - [#1075](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1075) Including header size details for BadRequest with large headers
 - [#1086](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1086) Fix possible NullReferenceException on a TransactionalBatch code path
-
-
-### Fixed
-- [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
-- [#1060](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1060) Fixed unicode encoding bug in DISTINCT queries.
+- [#1087](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1087) Transport exception is now logged in diagnostics and exception messages.
 
 ## <a name="3.5.0"/> [3.5.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.0) - 2019-12-03
 


### PR DESCRIPTION
# Pull Request Template

## Description

Using JsonConverter from the object causes several classes to miss private properties that are only exposed via an AppendToBuilder method. This converted the diagnostics to use the AppendToBuilder to retrieve the additional information.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Example for success:
```
{
    "ActivityId": "51ec34e7-559b-422f-984e-56105ec57e81",
    "StatusCode": "201",
    "SubStatusCode": "Unknown",
    "RequestCharge": "11.62",
    "ErrorMessage": "",
    "Method": "POST",
    "RequestUri": "dbs/771e57a9-9280-49a1-8f85-4c6715a2700d/colls/8adc660b-16ea-419f-ba05-1ad3bdc9968a",
    "RequestSessionToken": "",
    "ResponseSessionToken": "0:-1#41",
    "ClientSideRequestStatistics": {
        "RequestStartTimeUtc": "2019-12-06T21:46:46.5829811Z",
        "RequestEndTimeUtc": "2019-12-06T21:46:46.9974853Z",
        "NumberRegionsAttempted": "1",
        "RequestLatency": "00:00:00.4145042",
        "ResponseStatisticsList": [
            {
                "ResponseTime": "2019-12-06T21:46:46.9974853Z",
                "ResourceType": "Document",
                "OperationType": "Create",
                "StoreResult": "StorePhysicalAddress: rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/, LSN: 41, GlobalCommittedLsn: -1, PartitionKeyRangeId: 0, IsValid: True, StatusCode: 201, SubStatusCode: 0, RequestCharge: 11.62, ItemLSN: -1, SessionToken: -1#41, UsingLocalLSN: False, TransportException: null"
            }
        ],
        "AddressResolutionStatistics": [
            {
                "AddressResolution": {
                    "StartTime": "2019-12-06T21:46:46.7288518Z",
                    "EndTime": "2019-12-06T21:46:46.7774389Z",
                    "TargetEndpoint": "https://127.0.0.1:8081//addresses/?$resolveFor=dbs%2fRQlmAA%3d%3d%2fcolls%2fRQlmAIFxC7o%3d%2fdocs&$filter=protocol eq rntbd&$partitionKeyRangeIds=0"
                }
            }
        ],
        "SupplementalResponseStatistics": [],
        "FailedReplicas": [],
        "RegionsContacted": [
            "https://127.0.0.1:8081/"
        ],
        "ContactedReplicas": [
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer1/partitions/a4cb494d-38c8-11e6-8106-8cdcd42c33be/replicas/1p/"
        ]
    }
}
```


Example with an error message:
```
{
    "ActivityId": "8bdb8c56-0563-48d7-8169-be1a64fae25d",
    "StatusCode": "413",
    "SubStatusCode": "Unknown",
    "RequestCharge": "0",
    "ErrorMessage": "'Microsoft.Azure.Documents.RequestEntityTooLargeException: Message: {"Errors":["Request size is too large"]}ActivityId: 8bdb8c56-0563-48d7-8169-be1a64fae25d, Request URI: /apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/, RequestStats: RequestStartTime: 2019-12-06T21:33:40.1210059Z, RequestEndTime: Not set,  Number of regions attempted:1, SDK: Windows/10.0.18363 cosmos-netstandard-sdk/3.4.2   at Microsoft.Azure.Documents.TransportClient.ThrowServerException(String resourceAddress, StoreResponse storeResponse, Uri physicalAddress, Guid activityId, DocumentServiceRequest request)   at Microsoft.Azure.Documents.Rntbd.TransportClient.InvokeStoreAsync(Uri physicalAddress, ResourceOperation resourceOperation, DocumentServiceRequest request)   at Microsoft.Azure.Documents.ConsistencyWriter.WritePrivateAsync(DocumentServiceRequest request, TimeoutHelper timeout, Boolean forceRefresh)   at Microsoft.Azure.Documents.StoreResult.VerifyCanContinueOnException(DocumentClientException ex)   at Microsoft.Azure.Documents.StoreResult.CreateStoreResult(StoreResponse storeResponse, Exception responseException, Boolean requiresValidLsn, Boolean useLocalLSNBasedHeaders, Uri storePhysicalAddress)   at Microsoft.Azure.Documents.ConsistencyWriter.WritePrivateAsync(DocumentServiceRequest request, TimeoutHelper timeout, Boolean forceRefresh)   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)   at Microsoft.Azure.Documents.BackoffRetryUtility`1.ExecuteRetryAsync(Func`1 callbackMethod, Func`3 callShouldRetry, Func`1 inBackoffAlternateCallbackMethod, TimeSpan minBackoffForInBackoffCallback, CancellationToken cancellationToken, Action`1 preRetryCallback)   at Microsoft.Azure.Documents.ConsistencyWriter.WriteAsync(DocumentServiceRequest entity, TimeoutHelper timeout, Boolean forceRefresh, CancellationToken cancellationToken)   at Microsoft.Azure.Documents.ReplicatedResourceClient.<>c__DisplayClass26_0.<<InvokeAsync>b__0>d.MoveNext()--- End of stack trace from previous location where exception was thrown ---   at Microsoft.Azure.Documents.RequestRetryUtility.ProcessRequestAsync[TRequest,IRetriableResponse](Func`1 executeAsync, Func`1 prepareRequest, IRequestRetryPolicy`2 policy, CancellationToken cancellationToken, Func`1 inBackoffAlternateCallbackMethod, Nullable`1 minBackoffForInBackoffCallback)   at Microsoft.Azure.Documents.ShouldRetryResult.ThrowIfDoneTrying(ExceptionDispatchInfo capturedException)   at Microsoft.Azure.Documents.RequestRetryUtility.ProcessRequestAsync[TRequest,IRetriableResponse](Func`1 executeAsync, Func`1 prepareRequest, IRequestRetryPolicy`2 policy, CancellationToken cancellationToken, Func`1 inBackoffAlternateCallbackMethod, Nullable`1 minBackoffForInBackoffCallback)   at Microsoft.Azure.Documents.StoreClient.ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken, IRetryPolicy retryPolicy, Func`2 prepareRequestAsyncDelegate)   at Microsoft.Azure.Documents.ServerStoreModel.ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken)   at Microsoft.Azure.Cosmos.Handlers.TransportHandler.SendAsync(RequestMessage request, CancellationToken cancellationToken) in C:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Handler\\TransportHandler.cs:line 36'",
    "Method": "POST",
    "RequestUri": "dbs/ad7ec210-9676-4243-8253-2c6613293994/colls/ad2b5c62-c4bd-4e42-a8ba-82d594bdcf90",
    "RequestSessionToken": "",
    "ResponseSessionToken": "",
    "ClientSideRequestStatistics": {
        "RequestStartTimeUtc": "2019-12-06T21:33:40.1210059Z",
        "RequestEndTimeUtc": "Not set",
        "NumberRegionsAttempted": "1",
        "RequestLatency": "10675199.02:48:05.4775807",
        "ResponseStatisticsList": [],
        "AddressResolutionStatistics": [],
        "SupplementalResponseStatistics": [],
        "FailedReplicas": [],
        "RegionsContacted": [],
        "ContactedReplicas": [
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer15/partitions/a4cb495b-38c8-11e6-8106-8cdcd42c33be/replicas/1p/"
        ]
    }
}
```