### PR TITLE
Bulk API - Operations with no PK

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Cosmos
         private async Task FillOperationPropertiesAsync(ItemBatchOperation operation, CancellationToken cancellationToken)
         {
             // Same logic from RequestInvokerHandler to manage partition key migration
-            if (object.ReferenceEquals(operation.PartitionKey, PartitionKey.None))
+            if (operation.PartitionKey.Value.IsNone)
             {
                 Documents.Routing.PartitionKeyInternal partitionKeyInternal = await this.cosmosContainer.GetNonePartitionKeyValueAsync(cancellationToken).ConfigureAwait(false);
                 operation.PartitionKeyJson = partitionKeyInternal.ToJsonString();

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -205,9 +205,8 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task<Documents.Routing.PartitionKeyInternal> GetPartitionKeyInternalAsync(ItemBatchOperation operation, CancellationToken cancellationToken)
         {
-            // Same logic from RequestInvokerHandler to manage partition key migration
-            if (!operation.PartitionKey.HasValue
-                || operation.PartitionKey.Value.IsNone)
+            Debug.Assert(operation.PartitionKey.HasValue, "PartitionKey should be set on the operation");
+            if (operation.PartitionKey.Value.IsNone)
             {
                 return await this.cosmosContainer.GetNonePartitionKeyValueAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -197,22 +197,22 @@ namespace Microsoft.Azure.Cosmos
             CollectionRoutingMap collectionRoutingMap = await this.cosmosContainer.GetRoutingMapAsync(cancellationToken);
 
             Debug.Assert(operation.RequestOptions?.Properties?.TryGetValue(WFConstants.BackendHeaders.EffectivePartitionKeyString, out object epkObj) == null, "EPK is not supported");
-            await this.FillOperationPropertiesAsync(operation, cancellationToken);
-            return BatchExecUtils.GetPartitionKeyRangeId(operation.PartitionKey.Value, partitionKeyDefinition, collectionRoutingMap);
+            Documents.Routing.PartitionKeyInternal partitionKeyInternal = await this.GetPartitionKeyInternalAsync(operation, cancellationToken);
+            operation.PartitionKeyJson = partitionKeyInternal.ToJsonString();
+            string effectivePartitionKeyString = partitionKeyInternal.GetEffectivePartitionKeyString(partitionKeyDefinition);
+            return collectionRoutingMap.GetRangeByEffectivePartitionKey(effectivePartitionKeyString).Id;
         }
 
-        private async Task FillOperationPropertiesAsync(ItemBatchOperation operation, CancellationToken cancellationToken)
+        private async Task<Documents.Routing.PartitionKeyInternal> GetPartitionKeyInternalAsync(ItemBatchOperation operation, CancellationToken cancellationToken)
         {
             // Same logic from RequestInvokerHandler to manage partition key migration
-            if (operation.PartitionKey.Value.IsNone)
+            if (!operation.PartitionKey.HasValue
+                || operation.PartitionKey.Value.IsNone)
             {
-                Documents.Routing.PartitionKeyInternal partitionKeyInternal = await this.cosmosContainer.GetNonePartitionKeyValueAsync(cancellationToken).ConfigureAwait(false);
-                operation.PartitionKeyJson = partitionKeyInternal.ToJsonString();
+                return await this.cosmosContainer.GetNonePartitionKeyValueAsync(cancellationToken).ConfigureAwait(false);
             }
-            else
-            {
-                operation.PartitionKeyJson = operation.PartitionKey.Value.ToString();
-            }
+
+            return operation.PartitionKey.Value.InternalKey;
         }
 
         private async Task<PartitionKeyRangeBatchExecutionResult> ExecuteAsync(

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
@@ -137,24 +137,7 @@ namespace Microsoft.Azure.Cosmos
 
         public static string GetPartitionKeyRangeId(PartitionKey partitionKey, PartitionKeyDefinition partitionKeyDefinition, Routing.CollectionRoutingMap collectionRoutingMap)
         {
-            Documents.Routing.PartitionKeyInternal partitionKeyInternal = null;
-            if (partitionKey.IsNone)
-            {
-                if (partitionKeyDefinition.Paths.Count == 0 || (partitionKeyDefinition.IsSystemKey == true))
-                {
-                    partitionKeyInternal = Documents.Routing.PartitionKeyInternal.Empty;
-                }
-                else
-                {
-                    partitionKeyInternal = Documents.Routing.PartitionKeyInternal.Undefined;
-                }
-            }
-            else
-            {
-                partitionKeyInternal = partitionKey.InternalKey;
-            }
-
-            string effectivePartitionKey = partitionKeyInternal.GetEffectivePartitionKeyString(partitionKeyDefinition);
+            string effectivePartitionKey = partitionKey.InternalKey.GetEffectivePartitionKeyString(partitionKeyDefinition);
             return collectionRoutingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey).Id;
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchExecUtils.cs
@@ -137,7 +137,24 @@ namespace Microsoft.Azure.Cosmos
 
         public static string GetPartitionKeyRangeId(PartitionKey partitionKey, PartitionKeyDefinition partitionKeyDefinition, Routing.CollectionRoutingMap collectionRoutingMap)
         {
-            string effectivePartitionKey = partitionKey.InternalKey.GetEffectivePartitionKeyString(partitionKeyDefinition);
+            Documents.Routing.PartitionKeyInternal partitionKeyInternal = null;
+            if (partitionKey.IsNone)
+            {
+                if (partitionKeyDefinition.Paths.Count == 0 || (partitionKeyDefinition.IsSystemKey == true))
+                {
+                    partitionKeyInternal = Documents.Routing.PartitionKeyInternal.Empty;
+                }
+                else
+                {
+                    partitionKeyInternal = Documents.Routing.PartitionKeyInternal.Undefined;
+                }
+            }
+            else
+            {
+                partitionKeyInternal = partitionKey.InternalKey;
+            }
+
+            string effectivePartitionKey = partitionKeyInternal.GetEffectivePartitionKeyString(partitionKeyDefinition);
             return collectionRoutingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey).Id;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -393,8 +393,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static Task<ItemResponse<MyDocument>> ExecuteCreateAsync(Container container, MyDocument item)
         {
-            //return container.CreateItemAsync<MyDocument>(item, new PartitionKey(item.Status));
-            return container.CreateItemAsync<MyDocument>(item);
+            return container.CreateItemAsync<MyDocument>(item, new PartitionKey(item.Status));
         }
 
         private static Task<ItemResponse<JObject>> ExecuteCreateAsync(Container container, JObject item)

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
 - [#1060](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1060) Fixed unicode encoding bug in DISTINCT queries.
+- [#1089](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1089) Fixes a NullReferenceException when using Bulk with items with no PK
 
 ## <a name="3.5.0"/> [3.5.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.0) - 2019-12-03
 


### PR DESCRIPTION
# Pull Request Template

## Description

When an item was sent through Bulk using the Type API and the object did not contain the PartitionKey, the process was failing with a Null Reference due to the BulkExecutor failing to correctly resolve the Partition.

The PK is extracted as PartitionKey.None but the Executor is unable to correctly detect it.

This PR fixes the issue, plus adds coverage for the scenario.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

This PR closes #1088
