### PR TITLE
Fix SplitException

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1140,17 +1140,6 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        public Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(
-            string collectionResourceId,
-            Range<string> range,
-            bool forceRefresh = false)
-        {
-            return this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
-                collectionResourceId,
-                range,
-                forceRefresh);
-        }
-
         /// <summary>
         /// Gets or sets the session object used for session consistency version tracking in the Azure Cosmos DB service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1140,6 +1140,19 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
+        public async Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRanges(
+            string collectionResourceId,
+            Range<string> range,
+            bool forceRefresh = false)
+        {
+            IReadOnlyList<PartitionKeyRange> ranges = await this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
+                collectionResourceId,
+                range,
+                forceRefresh);
+
+            return ranges;
+        }
+
         /// <summary>
         /// Gets or sets the session object used for session consistency version tracking in the Azure Cosmos DB service.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1140,17 +1140,15 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        public async Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRanges(
+        public Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(
             string collectionResourceId,
             Range<string> range,
             bool forceRefresh = false)
         {
-            IReadOnlyList<PartitionKeyRange> ranges = await this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
+            return this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
                 collectionResourceId,
                 range,
                 forceRefresh);
-
-            return ranges;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -355,12 +355,13 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal override Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(
+        internal override async Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(
             string collectionResourceId,
             Range<string> range,
             bool forceRefresh = false)
         {
-            return this.documentClient.TryGetOverlappingRangesAsync(collectionResourceId, range, forceRefresh);
+            PartitionKeyRangeCache partitionKeyRangeCache = await this.GetRoutingMapProviderAsync();
+            return await partitionKeyRangeCache.TryGetOverlappingRangesAsync(collectionResourceId, range, forceRefresh);
         }
 
         private Task<PartitionKeyRangeCache> GetRoutingMapProviderAsync()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos
             Range<string> range,
             bool forceRefresh = false)
         {
-            return this.documentClient.TryGetOverlappingRanges(collectionResourceId, range, forceRefresh);
+            return this.documentClient.TryGetOverlappingRangesAsync(collectionResourceId, range, forceRefresh);
         }
 
         private Task<PartitionKeyRangeCache> GetRoutingMapProviderAsync()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos
             Range<string> range,
             bool forceRefresh = false)
         {
-            throw new NotImplementedException();
+            return this.documentClient.TryGetOverlappingRanges(collectionResourceId, range, forceRefresh);
         }
 
         private Task<PartitionKeyRangeCache> GetRoutingMapProviderAsync()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosQueryClientCoreTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosQueryClientCoreTest.cs
@@ -1,0 +1,72 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CosmosQueryClientCoreTest : BaseCosmosClientHelper
+    {
+        private ContainerCore Container = null;
+        private CosmosQueryClientCore queryClientCore = null;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await base.TestInit();
+            // Throughput needs to be large enough for multiple partitions
+            ContainerResponse response = await this.database.CreateContainerAsync(
+                Guid.NewGuid().ToString(),
+                "/id",
+                15000,
+                cancellationToken: this.cancellationToken);
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Container);
+            Assert.IsNotNull(response.Resource);
+            this.Container = (ContainerCore)response;
+            this.queryClientCore = new CosmosQueryClientCore(this.Container.ClientContext, this.Container);
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            await base.TestCleanup();
+        }
+
+        [TestMethod]
+        public async Task TryGetOverlappingRangesAsyncTest()
+        {
+            ContainerQueryProperties containerProperties = await this.queryClientCore.GetCachedContainerQueryPropertiesAsync(
+                containerLink: this.Container.LinkUri,
+                partitionKey: new PartitionKey("Test"),
+                cancellationToken: default);
+
+            Assert.IsNotNull(containerProperties);
+            Assert.IsNotNull(containerProperties.ResourceId);
+            Assert.IsNotNull(containerProperties.EffectivePartitionKeyString);
+
+            IReadOnlyList<Documents.PartitionKeyRange> pkRange = await this.queryClientCore.TryGetOverlappingRangesAsync(
+                collectionResourceId: containerProperties.ResourceId,
+                range: new Documents.Routing.Range<string>("AA", "AB", true, false),
+                forceRefresh: false);
+
+            Assert.IsNotNull(pkRange);
+            Assert.AreEqual(1, pkRange.Count);
+
+            IReadOnlyList<Documents.PartitionKeyRange> pkRangeAll = await this.queryClientCore.TryGetOverlappingRangesAsync(
+                collectionResourceId: containerProperties.ResourceId,
+                range: new Documents.Routing.Range<string>("00", "FF", true, false),
+                forceRefresh: false);
+
+            Assert.IsNotNull(pkRangeAll);
+            Assert.IsTrue(pkRangeAll.Count > 1);
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
 - [#1060](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1060) Fixed unicode encoding bug in DISTINCT queries.
-- [#1091](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1091) Fixed NotImplementedException in for splits.
+- [#1091](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1091) Fixed a bug in query when a partition split occurs that causes a NotImplementedException to be thrown.
 
 ## <a name="3.5.0"/> [3.5.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.0) - 2019-12-03
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#1070](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1070) CreateItem will only retry for auto-extracted partition key in-case of collection re-creation
 - [#1060](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1060) Fixed unicode encoding bug in DISTINCT queries.
+- [#1091](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1091) Fixed NotImplementedException in for splits.
 
 ## <a name="3.5.0"/> [3.5.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.0) - 2019-12-03
 
@@ -20,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1000](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1000) Add PortReuseMode to CosmosClientOptions.
 - [#1017](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1017) Adding ClientSideRequestStatistics to gateway calls and making endtime nullable
 - [#1038](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1038) Add Selflink to resource properties
-  
+
 ### Fixed
 
 - [#921](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/921) Fixed error handling to preserve stack trace in certain scenarios
@@ -34,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1036](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1036) Fixed query responses to return null Content if it is a failure
 - [#1045](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1045) Added stack trace and innner exception to CosmosException
 - [#1050](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1050) Add mocking constructors to TransactionalBatchOperationResult
- 
+
 ## <a name="3.4.1"/> [3.4.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.4.1) - 2019-11-06
 
 ### Fixed
@@ -56,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#901](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/901) Fixed a bug causing query response to create a new stream for each content call
 - [#918](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/918) Fixed serializer being used for Scripts, Permissions, and Conflict related iterators
-- [#936](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/936) Fixed bulk requests with large resources to have natural exception 
+- [#936](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/936) Fixed bulk requests with large resources to have natural exception
 
 ## <a name="3.3.3"/> [3.3.3](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.3.3) - 2019-10-30
 
@@ -138,8 +139,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#612](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/612) Bug fix for ReadFeed with partition-key
 - [#614](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/614) Fixed SpatialPath serialization and compatibility with older index versions
-- [#619](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/619) Fixed PInvokeStackImbalance exception for .NET Framework 
-- [#626](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/626) FeedResponse<T> status code now return OK for success instead of the invalid status code 0 or Accepted 
+- [#619](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/619) Fixed PInvokeStackImbalance exception for .NET Framework
+- [#626](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/626) FeedResponse<T> status code now return OK for success instead of the invalid status code 0 or Accepted
 - [#629](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/629) Fixed CreateContainerIfNotExistsAsync validation to limited to partitionKeyPath only
 - [#630](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/630) Fixed User Agent to contain environment and package information
 
@@ -177,14 +178,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fluent builder APIs for CosmosClient, Container, and Change Feed processor
 - Idiomatic throughput management APIs
 - Granular RequestOptions and ResponseTypes for database, container, item, query and throughput requests
-- Ability to scale non-partitioned containers 
+- Ability to scale non-partitioned containers
 - Extensible and customizable serializer
 - Extensible request pipeline with support for custom handlers
 
 ## Release & Retirement dates
 Microsoft provides notification at least **12 months** in advance of retiring an SDK in order to smooth the transition to a newer/supported version.
 
-New features and functionality and optimizations are only added to the current SDK, as such it is recommended that you always upgrade to the latest SDK version as early as possible. 
+New features and functionality and optimizations are only added to the current SDK, as such it is recommended that you always upgrade to the latest SDK version as early as possible.
 
 Any requests to Azure Cosmos DB using a retired SDK are rejected by the service.
 


### PR DESCRIPTION
# Fix SplitException

## Description

CosmosQueryClientCore did not implement TryGetOverlappingRangesAsync, so when a query tries split proofing it runs into a NotImplementedException. We didn't have any integration tests (nor do we have any now), since the public emulator can't simulate a split.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

