### PR TITLE
[vNext] Disable Core pipeline retries

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Handler/ClientPipelineTransport.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/ClientPipelineTransport.cs
@@ -40,7 +40,9 @@ namespace Azure.Cosmos
                 throw new NotImplementedException();
             }
 
-            message.Response = await this.requestInvokerHandler.SendAsync(requestMessage, message.CancellationToken);
+            // If the message previously has a response, it means the pipeline is retrying
+            bool isComingFromPipelineRetry = message.HasResponse;
+            message.Response = await this.requestInvokerHandler.SendAsync(requestMessage, isComingFromPipelineRetry, message.CancellationToken);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/azuredata/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/RequestInvokerHandler.cs
@@ -61,17 +61,18 @@ namespace Microsoft.Azure.Cosmos.Handlers
                     // Fill request options
                     promotedRequestOptions.PopulateRequestOptions(request);
                 }
+
+                await this.ValidateAndSetConsistencyLevelAsync(request);
+                (bool isError, ResponseMessage errorResponse) = await this.EnsureValidClientAsync(request);
+                if (isError)
+                {
+                    return errorResponse;
+                }
+
+                await request.AssertPartitioningDetailsAsync(this.clientPipelineBuilderContext.GetCollectionCacheAsync, cancellationToken);
+                this.FillMultiMasterContext(request);
             }
 
-            await this.ValidateAndSetConsistencyLevelAsync(request);
-            (bool isError, ResponseMessage errorResponse) = await this.EnsureValidClientAsync(request);
-            if (isError)
-            {
-                return errorResponse;
-            }
-
-            await request.AssertPartitioningDetailsAsync(this.clientPipelineBuilderContext.GetCollectionCacheAsync, cancellationToken);
-            this.FillMultiMasterContext(request);
             return await base.SendAsync(request, cancellationToken);
         }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/RequestInvokerHandler.cs
@@ -32,8 +32,19 @@ namespace Microsoft.Azure.Cosmos.Handlers
             this.RequestedClientConsistencyLevel = clientPipelineBuilderContext.ConsistencyLevel;
         }
 
-        public override async Task<ResponseMessage> SendAsync(
+        public override Task<ResponseMessage> SendAsync(
             RequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return this.SendAsync(
+                request: request,
+                isComingFromPipelineRetry: false,
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<ResponseMessage> SendAsync(
+            RequestMessage request,
+            bool isComingFromPipelineRetry,
             CancellationToken cancellationToken)
         {
             if (request == null)
@@ -41,11 +52,15 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 throw new ArgumentNullException(nameof(request));
             }
 
-            RequestOptions promotedRequestOptions = request.RequestOptions;
-            if (promotedRequestOptions != null)
+            // Headers are already populated
+            if (!isComingFromPipelineRetry)
             {
-                // Fill request options
-                promotedRequestOptions.PopulateRequestOptions(request);
+                RequestOptions promotedRequestOptions = request.RequestOptions;
+                if (promotedRequestOptions != null)
+                {
+                    // Fill request options
+                    promotedRequestOptions.PopulateRequestOptions(request);
+                }
             }
 
             await this.ValidateAndSetConsistencyLevelAsync(request);

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
@@ -43,7 +43,7 @@ namespace Azure.Cosmos
             this.DocumentClient = documentClient;
 
             this.ClientOptions.Transport = new ClientPipelineTransport(requestHandler);
-            // Disable Azure Core pipeline retry policies, the SDK has its own retries
+            // Disable the default Azure Core pipeline retry policies, the SDK has its own retries
             this.ClientOptions.Retry.MaxRetries = 0;
             this.pipeline = HttpPipelineBuilder.Build(this.ClientOptions);
             this.diagnostics = new ClientDiagnostics(this.ClientOptions);

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
@@ -43,6 +43,8 @@ namespace Azure.Cosmos
             this.DocumentClient = documentClient;
 
             this.ClientOptions.Transport = new ClientPipelineTransport(requestHandler);
+            // Disable Azure Core pipeline retry policies, the SDK has its own retries
+            this.ClientOptions.Retry.MaxRetries = 0;
             this.pipeline = HttpPipelineBuilder.Build(this.ClientOptions);
             this.diagnostics = new ClientDiagnostics(this.ClientOptions);
         }

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [#1118](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1118) Key already present exception when using custom retry policies on Core pipeline
+
 ## <a name="4.0.0-preview"/> [4.0.0-preview](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview) - 2019-10-31
 
 Initial preview release of the new 4.0.0 SDK that aligns with [Azure.Core for .NET](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/README.md).


### PR DESCRIPTION
Azure Core ClientOptions has a 3 max retry default that will make any failed request be retried after the SDK Retry policies already retried the expected amount of times.

The vNext flow leverages the Core Pipeline as follows:

1. The ClientContextCore creates the Request and sends it through the Core Pipeline
2. The Core Pipeline adds Pipeline policies (Logging, User Custom Retries, etc)
3. The Request gets sent through the SDK RequestInvoker
4. SDK internal retry policies are applied
5. Request is sent through Transport

If the request fails, retry policies are evaluated on 4 and if needed, the request is retried (like in a 429). If the request should not be retried or if retries were exhausted, the response goes up across the Core Pipeline (logging is leveraged) and eventually to the user.

If the Core Pipeline default retries are in place, the request would be retried 3 more times over the specified in the SDK retry configuration. It is expected that retry control options are honored and not overridden.

In case a user at some point adds a custom Retry policy on the Core Pipeline and decides to retry, this PR also covers the case to avoid adding headers twice. This happens because headers are added on the RequestInvoker and when the Core Pipeline retries, it does not re-create the request, so the headers from the RequestOptions are already set.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
