### PR TITLE
Fixed the serializer check. 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -134,14 +134,11 @@ namespace Microsoft.Azure.Cosmos
             }
 
 #if DEBUG
-            // Users can pass in Newtonsoft types so ignore it for the tests where all the types are internal
-            // If the type is from internal namespace and not from a test project then throw
-            if ((inputType.FullName.StartsWith("Microsoft.Azure.Documents") ||
-                inputType.FullName.StartsWith("Microsoft.Azure.Cosmos")) && 
-                !inputType.FullName.StartsWith("Newtonsoft.Json.") &&
-                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.SDK.EmulatorTests") &&
-                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.ChangeFeed.Tests") &&
-                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.Client.Tests")) 
+            string clientAssemblyName = typeof(DatabaseProperties).Assembly.GetName().Name;
+            string directAssemblyName = typeof(Documents.PartitionKeyRange).Assembly.GetName().Name;
+            string inputAssemblyName = inputType.Assembly.GetName().Name;
+            if (string.Equals(inputAssemblyName, clientAssemblyName) ||
+                string.Equals(inputAssemblyName, directAssemblyName)) 
             {
                 throw new ArgumentException($"User serializer is being used for internal type:{inputType.FullName}.");
             }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -135,9 +135,13 @@ namespace Microsoft.Azure.Cosmos
 
 #if DEBUG
             // Users can pass in Newtonsoft types so ignore it for the tests where all the types are internal
-            if (inputType != typeof(Document) &&
+            // If the type is from internal namespace and not from a test project then throw
+            if ((inputType.FullName.StartsWith("Microsoft.Azure.Documents") ||
+                inputType.FullName.StartsWith("Microsoft.Azure.Cosmos")) && 
                 !inputType.FullName.StartsWith("Newtonsoft.Json.") &&
-                (inputType.IsPublic || inputType.IsNested))
+                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.SDK.EmulatorTests") &&
+                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.ChangeFeed.Tests") &&
+                !inputType.FullName.StartsWith("Microsoft.Azure.Cosmos.Client.Tests")) 
             {
                 throw new ArgumentException($"User serializer is being used for internal type:{inputType.FullName}.");
             }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core;
@@ -134,7 +133,15 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentException("SqlQuerySpec to stream must use the SqlQuerySpec override");
             }
 
-            Debug.Assert(inputType.IsPublic || inputType.IsNested, $"User serializer is being used for internal type:{inputType.FullName}.");
+#if DEBUG
+            // Users can pass in Newtonsoft types so ignore it for the tests where all the types are internal
+            if (inputType != typeof(Document) &&
+                !inputType.FullName.StartsWith("Newtonsoft.Json.") &&
+                (inputType.IsPublic || inputType.IsNested))
+            {
+                throw new ArgumentException($"User serializer is being used for internal type:{inputType.FullName}.");
+            }
+#endif
 
             return this.customSerializer;
         }


### PR DESCRIPTION
# Pull Request Template

## Description

The previous check only shows up in debug test runs but causes  normal test run to fail without reason. The new check always throws an exception with a message so it is clear why the test failed. Added additional types to skip to avoid breaking tests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

