### PR TITLE
StandByFeedIterator breath first

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedResultSetIteratorCore.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Azure.Cosmos
             do
             {
                 (currentKeyRangeId, response) = await this.ReadNextInternalAsync(cancellationToken);
+                // Read only one range at a time - Breath first
+                this.compositeContinuationToken.MoveToNextToken();
+                (_, nextKeyRangeId) = await this.compositeContinuationToken.GetCurrentTokenAsync();
                 if (response.StatusCode != HttpStatusCode.NotModified)
                 {
                     break;
@@ -73,10 +76,6 @@ namespace Microsoft.Azure.Cosmos
                     // First NotModified Response
                     firstNotModifiedKeyRangeId = currentKeyRangeId;
                 }
-
-                // Current Range is done, push it to the end
-                this.compositeContinuationToken.MoveToNextToken();
-                (_, nextKeyRangeId) = await this.compositeContinuationToken.GetCurrentTokenAsync();
             }
             // We need to keep checking across all ranges until one of them returns OK or we circle back to the start
             while (!firstNotModifiedKeyRangeId.Equals(nextKeyRangeId, StringComparison.InvariantCultureIgnoreCase));

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1097](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1097) Add GeospatialConfig to ContainerProperties, BoundingBoxProperties to SpatialPath
 - [#1061](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1061) Add Stream payload to ExecuteStoredProcedureStreamAsync
 - [#1107](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1107) Add Source Link support
+- [#1121](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1121) StandByFeedIterator breath-first read strategy
 
 ### Fixed
 


### PR DESCRIPTION
# Pull Request Template

## Description

Currently the StandByFeedIterator will only move to the next partition if the current one has no more changes.

In scenarios where all partitions are receiving constant changes, changes from other partitions might get delayed.

With this change, the StandByFeedIterator will move to the next range upon receiving a Change Feed response, so the next `ReadNextAsync` will read from the next range.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Closing issues

This PR closes #1117