### PR TITLE
Client side encryption: Add AzureKeyVault implementation of KeyWrapProvider

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/Microsoft.Azure.Cosmos.Encryption.KeyVault.sln
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/Microsoft.Azure.Cosmos.Encryption.KeyVault.sln
@@ -1,0 +1,65 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.645
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Encryption.KeyVault", "src\Microsoft.Azure.Cosmos.Encryption.KeyVault.csproj", "{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos", "..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj", "{15DE1ACB-E52B-4F96-8406-E090F485C2FA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Direct", "..\..\C1\Product\SDK\.net\Microsoft.Azure.Cosmos.Direct\src\Microsoft.Azure.Cosmos.Direct.csproj", "{8758A6A7-0880-4705-B1D7-037C2B3A9E99}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|x64.Build.0 = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Debug|x86.Build.0 = Debug|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|x64.ActiveCfg = Release|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|x64.Build.0 = Release|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|x86.ActiveCfg = Release|Any CPU
+		{36FF76AC-231C-4D0B-9301-CAAFDA36BE6E}.Release|x86.Build.0 = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|x64.Build.0 = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Debug|x86.Build.0 = Debug|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|x64.ActiveCfg = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|x64.Build.0 = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|x86.ActiveCfg = Release|Any CPU
+		{15DE1ACB-E52B-4F96-8406-E090F485C2FA}.Release|x86.Build.0 = Release|Any CPU
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|x64.ActiveCfg = Debug|x64
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|x64.Build.0 = Debug|x64
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|x86.ActiveCfg = Debug|x86
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Debug|x86.Build.0 = Debug|x86
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|x64.ActiveCfg = Release|x64
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|x64.Build.0 = Release|x64
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|x86.ActiveCfg = Release|x86
+		{8758A6A7-0880-4705-B1D7-037C2B3A9E99}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C6A1D820-CB03-4DE6-87D1-46EF476F0040}
+	EndGlobalSection
+EndGlobal

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AADExceptionRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AADExceptionRetryPolicy.cs
@@ -1,0 +1,42 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Documents;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+    internal sealed class AADExceptionRetryPolicy : IRetryPolicy
+    {
+        private int maxRetries;
+        private int retriesAttempted = 0;
+        private TimeSpan retryBackoffTime;
+
+        public AADExceptionRetryPolicy(TimeSpan retryInterval, int retryCount)
+        {
+            this.maxRetries = retryCount;
+            this.retryBackoffTime = retryInterval;
+        }
+
+        public Task<ShouldRetryResult> ShouldRetryAsync(Exception exception, CancellationToken cancellationToken)
+        {
+            if ((exception is AdalException || WebExceptionUtility.IsWebExceptionRetriable(exception)) &&
+                this.retriesAttempted < this.maxRetries && !cancellationToken.IsCancellationRequested)
+            {
+                this.retriesAttempted++;
+                DefaultTrace.TraceInformation("AADExceptionRetryPolicy will retry. Retries Attempted = {0}. Backoff time = {1} ms.  Exception = {2}.", this.retriesAttempted, this.retryBackoffTime, exception.ToString());
+                return Task.FromResult(ShouldRetryResult.RetryAfter(this.retryBackoffTime));
+            }
+            else
+            {
+                DefaultTrace.TraceInformation("AADExceptionRetryPolicy will not retry. Retries Attempted = {0}. Exception = {1}.", this.retriesAttempted, exception.ToString());
+                return Task.FromResult(ShouldRetryResult.NoRetry());
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AADTokenProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AADTokenProvider.cs
@@ -1,0 +1,68 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+    /// <summary>
+    /// Default implementation of <see cref="IAADTokenProvider"/>.
+    /// </summary>
+    internal sealed class AADTokenProvider : IAADTokenProvider
+    {
+        private readonly string defaultAuthority; // AAD Login URI
+        private readonly string defaultResource;  // Key Vault Resource End Point
+
+        private readonly ClientAssertionCertificate clientAssertionCertificate;
+
+        private readonly TimeSpan retryInterval;
+        private readonly int retryCount;
+
+        private readonly TokenCache tokenCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AADTokenProvider"/> class.
+        /// </summary>
+        public AADTokenProvider(
+            string defaultAuthority,
+            string defaultResource,
+            ClientAssertionCertificate clientAssertionCertificate,
+            TimeSpan retryInterval,
+            int retryCount)
+        {
+            this.defaultAuthority = defaultAuthority;
+            this.defaultResource = defaultResource;
+            this.clientAssertionCertificate = clientAssertionCertificate;
+
+            this.retryInterval = retryInterval;
+            this.retryCount = retryCount;
+
+            // todo: should this be shared across AADTokenProvider instances?
+            this.tokenCache = new TokenCache();
+        }
+
+        public async Task<string> GetAccessTokenAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            AuthenticationContext context = new AuthenticationContext(
+                authority: this.defaultAuthority,
+                validateAuthority: true,
+                tokenCache: this.tokenCache);
+
+            AuthenticationResult result = await BackoffRetryUtility<AuthenticationResult>.ExecuteAsync(
+                                                () =>
+                                                {
+                                                    return context.AcquireTokenAsync(this.defaultResource, this.clientAssertionCertificate);
+                                                },
+                                                new AADExceptionRetryPolicy(this.retryInterval, this.retryCount),
+                                                cancellationToken);
+
+            return result.AccessToken;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AzureKeyVaultKeyWrapMetadata.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AzureKeyVaultKeyWrapMetadata.cs
@@ -1,0 +1,31 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    /// <summary>
+    /// Metadata used by Azure Key Vault to wrap (encrypt) and unwrap (decrypt) keys.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+        internal
+#endif
+        class AzureKeyVaultKeyWrapMetadata : KeyWrapMetadata
+    {
+        internal static string TypeConstant = "akv";
+
+        /// <summary>
+        /// Creates a new instance of metadata that the Azure Key Vault can use to wrap and unwrap keys.
+        /// </summary>
+        /// <param name="masterKeyUri">Key Vault URL of the master key to be used for wrapping and unwrapping keys.</param>
+        public AzureKeyVaultKeyWrapMetadata(Uri masterKeyUri)
+            : base(masterKeyUri.AbsoluteUri)
+        {
+            this.Type = TypeConstant;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AzureKeyVaultKeyWrapProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/AzureKeyVaultKeyWrapProvider.cs
@@ -1,0 +1,66 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+#if PREVIEW
+    public
+#else
+        internal
+#endif
+        class AzureKeyVaultKeyWrapProvider : KeyWrapProvider
+    {
+        private static KeyVaultAccessClientFactory keyVaultAccessClientFactory = new KeyVaultAccessClientFactory();
+        private IKeyVaultAccessClient keyVaultAccessClient;
+        private TimeSpan rawDekCacheTimeToLive;
+
+        /// <summary>
+        /// Creates a new instance of a provider to wrap (encrypt) and unwrap (decrypt) data encryption keys using master keys stored in Azure Key Vault.
+        /// See https://docs.microsoft.com/en-us/rest/api/azure/index#register-your-client-application-with-azure-ad for details on registering your application with Azure AD.
+        /// The registered application must have the keys/wrapKey and keys/unwrapKey permissions on the Azure Key Vaults that will be used for wrapping and unwrapping data encryption keys
+        /// - see https://docs.microsoft.com/en-us/azure/key-vault/about-keys-secrets-and-certificates#key-access-control for details on this.
+        /// See https://tbd for more information on client-side encryption support in Azure Cosmos DB.
+        /// </summary>
+        /// <param name="clientId">Application (client) ID.</param>
+        /// <param name="certificate">A certificate that can be used as secret to prove the application’s identity when requesting a token.</param>
+        /// <param name="rawDataEncryptionKeyCacheTimeToLive">
+        /// Amount of time the unencrypted form of the data encryption key can be cached on the client before <see cref="UnwrapKeyAsync"/> needs to be called again.
+        /// </param>
+        public AzureKeyVaultKeyWrapProvider(string clientId, X509Certificate2 certificate, TimeSpan rawDataEncryptionKeyCacheTimeToLive)
+        {
+            this.keyVaultAccessClient = AzureKeyVaultKeyWrapProvider.keyVaultAccessClientFactory.CreateKeyVaultAccessClient(clientId, certificate);
+            this.rawDekCacheTimeToLive = rawDataEncryptionKeyCacheTimeToLive;
+        }
+
+        /// <inheritdoc />
+        public override async Task<KeyUnwrapResponse> UnwrapKeyAsync(byte[] wrappedKey, KeyWrapMetadata metadata, CancellationToken cancellationToken)
+        {
+            if(metadata.Type != AzureKeyVaultKeyWrapMetadata.TypeConstant)
+            {
+                throw new ArgumentException("Invalid metadata", nameof(metadata));
+            }
+
+            string wrappedKeyString = Convert.ToBase64String(wrappedKey);
+            KeyVaultUnwrapResult result = await this.keyVaultAccessClient.UnwrapKeyAsync(wrappedKeyString, new Uri(metadata.Value), cancellationToken);
+            return new KeyUnwrapResponse(Convert.FromBase64String(result.UnwrappedKeyBytesInBase64), this.rawDekCacheTimeToLive);
+        }
+
+        /// <inheritdoc />
+        public override async Task<KeyWrapResponse> WrapKeyAsync(byte[] key, KeyWrapMetadata metadata, CancellationToken cancellationToken)
+        {
+            if (metadata.Type != AzureKeyVaultKeyWrapMetadata.TypeConstant)
+            {
+                throw new ArgumentException("Invalid metadata", nameof(metadata));
+            }
+
+            string keyString = Convert.ToBase64String(key);
+            KeyVaultWrapResult result = await this.keyVaultAccessClient.WrapKeyAsync(keyString, new Uri(metadata.Value), cancellationToken);
+            return new KeyWrapResponse(Convert.FromBase64String(result.WrappedKeyBytesInBase64), metadata);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/ErrorCodes.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/ErrorCodes.cs
@@ -1,0 +1,21 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using Microsoft.Azure.Documents;
+
+    public enum KeyVaultErrorCode
+    {
+        AadClientCredentialsGrantFailure = SubStatusCodes.AadClientCredentialsGrantFailure, // Indicated access to AAD failed to get a token
+        AadServiceUnavailable = SubStatusCodes.AadServiceUnavailable, // Aad Service is Unavailable
+        KeyVaultAuthenticationFailure = SubStatusCodes.KeyVaultAuthenticationFailure, // Indicate the KeyVault doesn't grant permission to the AAD, or the key is disabled.
+        KeyVaultKeyNotFound = SubStatusCodes.KeyVaultKeyNotFound, // Indicate the Key Vault Key is not found
+        KeyVaultServiceUnavailable = SubStatusCodes.KeyVaultServiceUnavailable, // Key Vault Service is Unavailable
+        KeyVaultWrapUnwrapFailure = SubStatusCodes.KeyVaultWrapUnwrapFailure, // Indicate that Key Vault is unable to Wrap or Unwrap, one possible scenario is KeyVault failed to decoded the encrypted blob using the latest key because customer has rotated the key.
+        InvalidKeyVaultKeyURI = SubStatusCodes.InvalidKeyVaultKeyURI, // Indicate the Key Vault Key URI is invalid.
+        InvalidInputBytes = SubStatusCodes.InvalidInputBytes, // The input bytes are not in the format of base64.
+        InternalServerError = SubStatusCodes.KeyVaultInternalServerError// Other unknown errors
+    }
+}
+

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IAADTokenProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IAADTokenProvider.cs
@@ -1,0 +1,16 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Interface for retrieving an access token for Active Directory authentication.
+    /// </summary>
+    internal interface IAADTokenProvider
+    {
+        Task<string> GetAccessTokenAsync(CancellationToken cancellationToken);
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IKeyVaultAccessClient.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IKeyVaultAccessClient.cs
@@ -1,0 +1,40 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// This interface represents the available functions that can be done using a KeyVault Access client.
+    /// </summary>
+    internal interface IKeyVaultAccessClient
+    {
+        /// <summary>
+        /// Unwrap the encrypted Key.
+        /// Only supports encrypted bytes in base64 format.
+        /// </summary>
+        /// <param name="bytesInBase64">encrypted bytes encoded to base64 string. </param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Result including KeyIdentifier and decrypted bytes in base64 string format, can be convert to bytes using Convert.FromBase64String().</returns>
+        Task<KeyVaultUnwrapResult> UnwrapKeyAsync(
+               string bytesInBase64,
+               Uri keyVaultKeyUri,
+               CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Wrap the Key. 
+        /// Only supports bytes in base64 format.
+        /// </summary>
+        /// <param name="bytesInBase64">bytes encoded to base64 string. E.g. Convert.ToBase64String(bytes) .</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Result including KeyIdentifier and encrypted bytes in base64 string format.</returns>
+        Task<KeyVaultWrapResult> WrapKeyAsync(
+               string bytesInBase64,
+               Uri keyVaultKeyUri,
+               CancellationToken cancellationToken = default(CancellationToken));
+    }
+}
+

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IKeyVaultAccessClientFactory.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/IKeyVaultAccessClientFactory.cs
@@ -1,0 +1,18 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+
+    internal interface IKeyVaultAccessClientFactory : IDisposable
+    {
+        IKeyVaultAccessClient CreateKeyVaultAccessClient(
+            string clientId,
+            X509Certificate2 certificate,
+            Uri keyVaultKeyUri,
+            int aadRetryIntervalInSeconds = KeyVaultConstants.DefaultAadRetryIntervalInSeconds,
+            int aadRetryCount = KeyVaultConstants.DefaultAadRetryCount);
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/InternalWrapUnwrapRequest.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/InternalWrapUnwrapRequest.cs
@@ -1,0 +1,12 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    internal sealed class InternalWrapUnwrapRequest
+    {
+        public string Alg { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/InternalWrapUnwrapResponse.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/InternalWrapUnwrapResponse.cs
@@ -1,0 +1,15 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+// Disable CA1812 to pass the compilation analysis check, as this is only used for deserialization.
+#pragma warning disable CA1812
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    internal sealed class InternalWrapUnwrapResponse
+    {
+        public string Kid { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessClient.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessClient.cs
@@ -1,0 +1,404 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Documents;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Implementation of <see cref="IKeyVaultAccessClient"/> that uses the
+    /// <see cref="KeyVaultAccessClient"/> client.
+    /// </summary>
+    internal sealed class KeyVaultAccessClient : IKeyVaultAccessClient
+    {
+        private readonly TimeSpan aadRetryInterval;
+        private readonly int aadRetryCount;
+
+        private readonly ClientAssertionCertificate clientAssertionCertificate;
+        private readonly AsyncCache<Uri, IAADTokenProvider> aadTokenProviderByKeyUri;
+
+        private readonly HttpClient httpClient;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyVaultAccessClient"/> class.
+        /// </summary>
+        /// <param name="clientId">AAD client id or service principle id.</param>
+        /// <param name="certificate">Authorization Certificate to authorize with AAD.</param>
+        internal KeyVaultAccessClient(
+            string clientId,
+            X509Certificate2 certificate,
+            HttpClient httpClient,
+            TimeSpan aadRetryInterval,
+            int aadRetryCount)
+        {
+            this.clientAssertionCertificate = new ClientAssertionCertificate(clientId, certificate);
+            this.aadTokenProviderByKeyUri = new AsyncCache<Uri, IAADTokenProvider>();
+            this.httpClient = httpClient;
+
+            this.aadRetryInterval = aadRetryInterval;
+            this.aadRetryCount = aadRetryCount;
+        }
+
+        /// <summary>
+        /// Unwrap the encrypted Key.
+        /// Only supports encrypted bytes in base64 format.
+        /// </summary>
+        /// <param name="keyVaultKeyUri">Sample Format: https://{keyvault-name}.vault.azure.net/keys/{key-name}/{key-version}, the /{key-version} is optional.</param>
+        /// <param name="bytesInBase64">encrypted bytes encoded to base64 string. </param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Result including KeyIdentifier and decrypted bytes in base64 string format, can be convert to bytes using Convert.FromBase64String().</returns>
+        public async Task<KeyVaultUnwrapResult> UnwrapKeyAsync(
+            string bytesInBase64,
+            Uri keyVaultKeyUri,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return (KeyVaultUnwrapResult)await this.WrapOrUnWrapKeyAsync(
+                keyVaultKeyUri: keyVaultKeyUri,
+                bytesInBase64: bytesInBase64,
+                shouldWrapKey: false,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Wrap the Key with latest Key version. 
+        /// Only supports bytes in base64 format.
+        /// </summary>
+        /// <param name="bytesInBase64">bytes encoded to base64 string. E.g. Convert.ToBase64String(bytes) .</param>
+        /// <param name="keyVaultKeyUri">Sample Format: https://{keyvault-name}.vault.azure.net/keys/{key-name}/{key-version}, the /{key-version} is optional.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Result including KeyIdentifier and encrypted bytes in base64 string format.</returns>
+        public async Task<KeyVaultWrapResult> WrapKeyAsync(
+            string bytesInBase64,
+            Uri keyVaultKeyUri,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return (KeyVaultWrapResult)await this.WrapOrUnWrapKeyAsync(
+                keyVaultKeyUri: keyVaultKeyUri,
+                bytesInBase64: bytesInBase64,
+                shouldWrapKey: true,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Wrap/Unwrap the plain/encrypted Key.
+        /// Currently supports encrypted bytes in base64 format.
+        /// </summary>
+        /// <param name="bytesInBase64">encrypted bytes encoded to base64 string. </param>
+        /// <param name="keyVaultKeyUri">Sample Format: https://{keyvault-name}.vault.azure.net/keys/{key-name}/{key-version}, the /{key-version} is optional.</param>
+        /// <param name="shouldWrapKey"> Choose Wrap or Unwrap.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Result including Wrapped or Unwrapped bytes in Base64 string format & KeyIdentifier.</returns>
+        private async Task<object> WrapOrUnWrapKeyAsync(
+            Uri keyVaultKeyUri,
+            string bytesInBase64,
+            bool shouldWrapKey,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!KeyVaultAccessClient.ValidateKeyVaultKeyUrl(keyVaultKeyUri))
+            {
+                throw new KeyVaultAccessException(HttpStatusCode.BadRequest, KeyVaultErrorCode.InvalidKeyVaultKeyURI, "Invalid KeyVaultKeyURI");
+            }
+
+            if (!KeyVaultAccessClient.ValidateBase64Encoding(bytesInBase64))
+            {
+                throw new KeyVaultAccessException(HttpStatusCode.BadRequest, KeyVaultErrorCode.InvalidInputBytes, "The Input is not a valid base 64 string");
+            }
+
+            string accessToken = await this.GetAadAccessTokenAsync(keyVaultKeyUri, cancellationToken);
+
+            using (HttpResponseMessage response = await this.InternalWrapUnwrapAsync(keyVaultKeyUri, bytesInBase64, accessToken, shouldWrapKey, cancellationToken))
+            {
+                string jsonResponse = await response.Content.ReadAsStringAsync();
+                jsonResponse = string.IsNullOrEmpty(jsonResponse) ? string.Empty : jsonResponse;
+
+                if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    DefaultTrace.TraceInformation("WrapOrUnWrapKeyAsync: Receive HttpStatusCode {0}, KeyVaultErrorCode {1}, Errors: {2}. ", response.StatusCode, KeyVaultErrorCode.KeyVaultAuthenticationFailure, jsonResponse);
+                    throw new KeyVaultAccessException(
+                        response.StatusCode,
+                        KeyVaultErrorCode.KeyVaultAuthenticationFailure,
+                        jsonResponse);
+                }
+
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    DefaultTrace.TraceInformation("WrapOrUnWrapKeyAsync: Receive HttpStatusCode {0}, KeyVaultErrorCode {1}, Errors: {2}. ", response.StatusCode, KeyVaultErrorCode.KeyVaultKeyNotFound, jsonResponse);
+                    throw new KeyVaultAccessException(
+                        response.StatusCode,
+                        KeyVaultErrorCode.KeyVaultKeyNotFound,
+                        jsonResponse);
+                }
+
+                if (response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    DefaultTrace.TraceInformation("WrapOrUnWrapKeyAsync: Receive HttpStatusCode {0}, KeyVaultErrorCode {1}, Errors: {2}. ", response.StatusCode, KeyVaultErrorCode.KeyVaultWrapUnwrapFailure, jsonResponse);
+                    throw new KeyVaultAccessException(
+                        response.StatusCode,
+                        KeyVaultErrorCode.KeyVaultWrapUnwrapFailure,
+                        jsonResponse);
+                }
+
+                if (response.StatusCode != HttpStatusCode.OK)
+                {
+                    DefaultTrace.TraceInformation("WrapOrUnWrapKeyAsync: Receive HttpStatusCode {0}, KeyVaultErrorCode {1}, Errors: {2}. ", response.StatusCode, KeyVaultErrorCode.InternalServerError, jsonResponse);
+                    throw new KeyVaultAccessException(
+                        response.StatusCode,
+                        KeyVaultErrorCode.InternalServerError,
+                        jsonResponse);
+                }
+
+                DefaultTrace.TraceInformation("WrapOrUnWrapKeyAsync succeed.");
+
+                InternalWrapUnwrapResponse internalWrapUnwrapResponse = JsonConvert.DeserializeObject<InternalWrapUnwrapResponse>(jsonResponse);
+
+                string responseBytesInBase64 = KeyVaultAccessClient.ConvertBase64UrlToBase64String(internalWrapUnwrapResponse.Value);
+                Uri responseKeyVaultKeyUri = new Uri(internalWrapUnwrapResponse.Kid);
+
+                if (shouldWrapKey)
+                {
+                    return new KeyVaultWrapResult(
+                        wrappedKeyBytesInBase64: responseBytesInBase64,
+                        keyVaultKeyUri: responseKeyVaultKeyUri);
+                }
+                else
+                {
+                    return new KeyVaultUnwrapResult(
+                        unwrappedKeyBytesInBase64: responseBytesInBase64,
+                        keyVaultKeyUri: responseKeyVaultKeyUri);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Helper Method for WrapOrUnWrapKeyAsync.
+        /// </summary>
+        private async Task<HttpResponseMessage> InternalWrapUnwrapAsync(
+            Uri keyVaultKeyUri,
+            string bytesInBase64,
+            string accessToken,
+            bool wrapKey,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string keyvaultUri = keyVaultKeyUri + (wrapKey ? KeyVaultConstants.WrapKeySegment : KeyVaultConstants.UnwrapKeySegment);
+
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, keyvaultUri + "?" + KeyVaultConstants.ApiVersionQueryParameters))
+            {
+                request.Headers.Add(HttpConstants.HttpHeaders.Accept, RuntimeConstants.MediaTypes.Json);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+                InternalWrapUnwrapRequest keyVaultRequest = new InternalWrapUnwrapRequest
+                {
+                    Alg = KeyVaultConstants.RsaOaep,
+                    Value = bytesInBase64.TrimEnd('=').Replace('+', '-').Replace('/', '_') // Format base 64 encoded string for http transfer
+                };
+
+                request.Content = new StringContent(
+                    JsonConvert.SerializeObject(keyVaultRequest),
+                    Encoding.UTF8,
+                    RuntimeConstants.MediaTypes.Json);
+
+                string correlationId = Guid.NewGuid().ToString();
+                DefaultTrace.TraceInformation("InternalWrapUnwrapAsync: request correlationId {0}.", correlationId);
+
+                // InternalWrapUnwrapAsync
+                request.Headers.Add(
+                    KeyVaultConstants.CorrelationId,
+                    correlationId);
+
+                try
+                {
+                    return await BackoffRetryUtility<HttpResponseMessage>.ExecuteAsync(
+                                            () =>
+                                            {
+                                                return this.httpClient.SendAsync(request, cancellationToken);
+                                            },
+                                            new WebExceptionRetryPolicy(),
+                                            cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    DefaultTrace.TraceInformation("InternalWrapUnwrapAsync: caught exception while trying to send http request: {0}.", ex.ToString());
+                    throw new KeyVaultAccessException(
+                        HttpStatusCode.ServiceUnavailable,
+                        KeyVaultErrorCode.KeyVaultServiceUnavailable,
+                        ex.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Obtain the AAD Token to be later used to access KeyVault.
+        /// </summary>
+        /// <returns>AAD Bearer Token. </returns>
+        private async Task<string> GetAadAccessTokenAsync(
+            Uri keyVaultKeyUri, 
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IAADTokenProvider aadTokenProvider = await this.aadTokenProviderByKeyUri.GetAsync(
+                key: keyVaultKeyUri,
+                obsoleteValue: null,
+                singleValueInitFunc: async () =>
+                {
+                    (string aadLoginUrl, string keyVaultResourceEndpoint) = await this.InitializeLoginUrlAndResourceEndpointAsync(keyVaultKeyUri, cancellationToken);
+
+                    return new AADTokenProvider(
+                        aadLoginUrl,
+                        keyVaultResourceEndpoint,
+                        this.clientAssertionCertificate,
+                        this.aadRetryInterval,
+                        this.aadRetryCount);
+                },
+                cancellationToken: cancellationToken);
+
+            try
+            {
+                return await aadTokenProvider.GetAccessTokenAsync(cancellationToken);
+            }
+            catch (AdalException ex)
+            {
+                DefaultTrace.TraceInformation("GetAadAccessTokenAsync: caught exception while trying to acquire token: {0}.", ex.ToString());
+                throw new KeyVaultAccessException(HttpStatusCode.ServiceUnavailable, KeyVaultErrorCode.AadServiceUnavailable, ex.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Initialize the LoginUrl and ResourceEndpoint.
+        /// The SDK will send GET request to the key vault url in order to retrieve the AAD authority and resource.
+        /// </summary>
+        private async Task<(string aadLoginUrl, string keyVaultResourceEndpoint)> InitializeLoginUrlAndResourceEndpointAsync(Uri keyVaultKeyUri, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, keyVaultKeyUri + "?" + KeyVaultConstants.ApiVersionQueryParameters))
+            {
+                string correlationId = Guid.NewGuid().ToString();
+                DefaultTrace.TraceInformation("InitializeLoginUrlAndResourceEndpointAsync: request correlationId {0}.", correlationId);
+
+                request.Headers.Add(
+                    KeyVaultConstants.CorrelationId,
+                    correlationId);
+
+                try
+                {
+                    using (HttpResponseMessage response = await BackoffRetryUtility<HttpResponseMessage>.ExecuteAsync(
+                                            () =>
+                                            {
+                                                return this.httpClient.SendAsync(request, cancellationToken);
+                                            },
+                                            new WebExceptionRetryPolicy(),
+                                            cancellationToken))
+                    {
+
+                        if (response.StatusCode != HttpStatusCode.Unauthorized)
+                        {
+                            DefaultTrace.TraceInformation("InitializeLoginUrlAndResourceEndpointAsync: Receive HttpStatusCode {0}, KeyVaultErrorCode {1}, The Status Code for the first try should be Unauthorized.", response.StatusCode, KeyVaultErrorCode.AadClientCredentialsGrantFailure);
+                            throw new KeyVaultAccessException(
+                                response.StatusCode,
+                                KeyVaultErrorCode.AadClientCredentialsGrantFailure,
+                                "The Status Code for the first try should be Unauthorized.");
+                        }
+
+                        // authenticationHeaderValue Sample:
+                        // Bearer authorization="https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47", resource="https://vault.azure.net"
+                        AuthenticationHeaderValue authenticationHeaderValue = response.Headers.WwwAuthenticate.Single();
+
+                        string[] source = authenticationHeaderValue.Parameter.Split('=', ',');
+
+                        // Sample aadLoginUrl: https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47
+                        string aadLoginUrl = source.ElementAt(1).Trim('"');
+
+                        // Sample keyVaultResourceEndpoint: https://vault.azure.net
+                        string keyVaultResourceEndpoint = source.ElementAt(3).Trim('"');
+
+                        return (aadLoginUrl, keyVaultResourceEndpoint);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    DefaultTrace.TraceInformation("InitializeLoginUrlAndResourceEndpointAsync: caught exception while trying to send http request: {0}.", ex.ToString());
+                    throw new KeyVaultAccessException(
+                        HttpStatusCode.ServiceUnavailable,
+                        KeyVaultErrorCode.KeyVaultServiceUnavailable,
+                        ex.ToString());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Convert base64 url to base64 string.
+        /// </summary>
+        private static string ConvertBase64UrlToBase64String(string str)
+        {
+            string base64EncodedValue = str.Replace('-', '+').Replace('_', '/');
+
+            int count = 3 - ((str.Length + 3) % 4);
+
+            for (int ich = 0; ich < count; ich++)
+            {
+                base64EncodedValue += "=";
+            }
+
+            return base64EncodedValue;
+        }
+
+        private static bool ValidateKeyVaultKeyUrl(Uri keyVaultKeyUri)
+        {
+            string[] segments = keyVaultKeyUri.Segments;
+            return (segments.Length == 3 || segments.Length == 4) &&
+                string.Equals(segments[1], KeyVaultConstants.KeysSegment, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        private static bool ValidateBase64Encoding(string bytesInBase64)
+        {
+            if (bytesInBase64 == null || bytesInBase64.Length % 4 != 0)
+            {
+                return false;
+            }
+
+            try
+            {
+                Convert.FromBase64String(bytesInBase64);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        internal static Uri GetKeyVaultKeyUrlWithNoKeyVersion(Uri keyVaultKeyUri)
+        {
+            string[] segments = keyVaultKeyUri.Segments;
+            if (segments.Length == 3)
+            {
+                return keyVaultKeyUri;
+            }
+
+            string[] newSegments = keyVaultKeyUri.Segments.Take(keyVaultKeyUri.Segments.Length - 1).ToArray();
+            newSegments[newSegments.Length - 1] = newSegments[newSegments.Length - 1].TrimEnd('/');
+
+            UriBuilder uriBuilder = new UriBuilder(keyVaultKeyUri);
+            uriBuilder.Path = string.Concat(newSegments);
+            return uriBuilder.Uri;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessClientFactory.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessClientFactory.cs
@@ -1,0 +1,54 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Net.Http;
+    using System.Security.Cryptography.X509Certificates;
+
+    internal sealed class KeyVaultAccessClientFactory : IKeyVaultAccessClientFactory
+    {
+        private readonly object singletonLock;
+        private HttpClient httpClient;
+
+        public KeyVaultAccessClientFactory()
+        {
+            this.singletonLock = new object();
+        }
+
+        public IKeyVaultAccessClient CreateKeyVaultAccessClient(
+            string clientId,
+            X509Certificate2 certificate,
+            Uri defaultKeyVaultKeyUri = null,
+            int aadRetryIntervalInSeconds = KeyVaultConstants.DefaultAadRetryIntervalInSeconds, 
+            int aadRetryCount = KeyVaultConstants.DefaultAadRetryCount)
+        {
+            if (this.httpClient == null)
+            {
+                lock (this.singletonLock)
+                {
+                    if (this.httpClient == null)
+                    {
+                        this.httpClient = new HttpClient
+                        {
+                            Timeout = TimeSpan.FromSeconds(KeyVaultConstants.DefaultHttpClientTimeoutInSeconds)
+                        };
+                    }   
+                }
+            }
+
+            return new KeyVaultAccessClient(
+                clientId: clientId,
+                certificate: certificate,
+                httpClient: this.httpClient,
+                aadRetryInterval: TimeSpan.FromSeconds(aadRetryIntervalInSeconds),
+                aadRetryCount: aadRetryCount);
+        }
+
+        public void Dispose()
+        {
+            this.httpClient?.Dispose();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessException.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultAccessException.cs
@@ -1,0 +1,39 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+    using System.Net;
+    using System.Runtime.Serialization;
+
+    [Serializable]
+    //[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Code guideline", Scope = "type")]
+    internal class KeyVaultAccessException : Exception
+    {
+        public KeyVaultAccessException(
+            HttpStatusCode statusCode,
+            KeyVaultErrorCode keyVaultErrorCode,
+            string errorMessage)
+        {
+            this.HttpStatusCode = statusCode;
+            this.KeyVaultErrorCode = keyVaultErrorCode;
+            this.ErrorMessage = errorMessage;
+        }
+
+        protected KeyVaultAccessException(SerializationInfo info, StreamingContext context)
+        {
+        }
+
+        public HttpStatusCode HttpStatusCode { get; }
+
+        public KeyVaultErrorCode KeyVaultErrorCode { get; }
+
+        public string ErrorMessage { get; }
+
+        public override string ToString()
+        {
+            return $"KeyVaultAccessClient failed with HttpStatusCode {this.HttpStatusCode} and KeyVaultError {this.KeyVaultErrorCode.ToString()}. {this.ErrorMessage}";
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultConstants.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultConstants.cs
@@ -1,0 +1,20 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    internal static class KeyVaultConstants
+    {
+        internal const string ApiVersionQueryParameters = "api-version=7.0";
+        internal const string CorrelationId = "client-request-id";
+        internal const string WrapKeySegment = "/wrapkey";
+        internal const string UnwrapKeySegment = "/unwrapkey";
+        internal const string KeysSegment = "keys/";
+
+        internal const string RsaOaep = "RSA-OAEP";
+
+        internal const int DefaultHttpClientTimeoutInSeconds = 30;
+        internal const int DefaultAadRetryCount = 3;
+        internal const int DefaultAadRetryIntervalInSeconds = 1;
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultUnwrapResult.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultUnwrapResult.cs
@@ -1,0 +1,20 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+
+    internal sealed class KeyVaultUnwrapResult
+    {
+        public KeyVaultUnwrapResult(string unwrappedKeyBytesInBase64, Uri keyVaultKeyUri)
+        {
+            this.UnwrappedKeyBytesInBase64 = unwrappedKeyBytesInBase64;
+            this.KeyVaultKeyUri = keyVaultKeyUri;
+        }
+
+        public string UnwrappedKeyBytesInBase64 { get; }
+
+        public Uri KeyVaultKeyUri { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultWrapResult.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/KeyVaultWrapResult.cs
@@ -1,0 +1,26 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.KeyVault
+{
+    using System;
+
+    internal sealed class KeyVaultWrapResult
+    {
+        public KeyVaultWrapResult(string wrappedKeyBytesInBase64, Uri keyVaultKeyUri)
+        {
+            this.WrappedKeyBytesInBase64 = wrappedKeyBytesInBase64;
+            this.KeyVaultKeyUri = keyVaultKeyUri;
+
+            string[] segments = keyVaultKeyUri.Segments;
+            this.KeyVersion = segments.Length < 4 ? string.Empty : segments[3];
+        }
+
+        public string WrappedKeyBytesInBase64 { get; }
+
+        public Uri KeyVaultKeyUri { get; }
+
+        public string KeyVersion { get; }
+    }
+}
+

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/Microsoft.Azure.Cosmos.Encryption.KeyVault.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/Microsoft.Azure.Cosmos.Encryption.KeyVault.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+	<SigningType>Product</SigningType>
+  </PropertyGroup>
+  <ItemGroup>      
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
+    <DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
+    <DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>  
+</Project>

--- a/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/stylecop.json
+++ b/Microsoft.Azure.Cosmos.Encryption.KeyVault/src/stylecop.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "documentationRules": {
+      "companyName": "Microsoft",
+      "documentInternalElements": false,
+      "documentInterfaces": false,
+      "xmlHeader": false,
+      "copyrightText": "{decoration}\r\nCopyright (c) Microsoft Corporation.  All rights reserved.\r\n{decoration}",
+      "variables": {
+        "decoration": "------------------------------------------------------------"
+      }
+    },
+    "readabilityRules": {
+      "allowBuiltInTypeAliases": false
+    },
+    "orderingRules": {
+      "systemUsingDirectivesFirst": true
+    }
+  }
+}

--- a/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
@@ -17,7 +17,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Table" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Table.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Table.Tests" + AssemblyKeys.TestPublicKey)]
-
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Encryption.KeyVault" + AssemblyKeys.ProductPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Encryption.KeyVault" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Performance.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Performance.Tests" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests" + AssemblyKeys.ProductPublicKey)]

--- a/Microsoft.Azure.Cosmos/src/Encryption/KeyUnwrapResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/KeyUnwrapResponse.cs
@@ -1,0 +1,44 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    /// <summary>
+    /// Response from a <see cref="KeyWrapProvider"/> on unwrapping a wrapped data encryption key.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+         class KeyUnwrapResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the response of unwrapping a wrapped data encryption key.
+        /// </summary>
+        /// <param name="dataEncryptionKey">Raw form of data encryption key.</param>
+        /// <param name="clientCacheTimeToLive">
+        /// Amount of time after which the raw data encryption key must not be used
+        /// without invoking the <see cref="KeyWrapProvider.UnwrapKeyAsync"/> again.
+        /// </param>
+        public KeyUnwrapResponse(byte[] dataEncryptionKey, TimeSpan clientCacheTimeToLive)
+        {
+            this.DataEncryptionKey = dataEncryptionKey;
+            this.ClientCacheTimeToLive = clientCacheTimeToLive;
+        }
+
+        /// <summary>
+        /// Raw form of the data encryption key.
+        /// </summary>
+        public byte[] DataEncryptionKey { get; }
+
+        /// <summary>
+        /// Amount of time after which the raw data encryption key must not be used
+        /// without invoking the <see cref="KeyWrapProvider.UnwrapKeyAsync"/> again.
+        /// </summary>
+        public TimeSpan ClientCacheTimeToLive { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapMetadata.cs
@@ -1,0 +1,79 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Metadata that a key wrapping provider can use to wrap/unwrap keys.
+    /// <seealso cref="KeyWrapProvider" />
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+         class KeyWrapMetadata : IEquatable<KeyWrapMetadata>
+    {
+        /// <summary>
+        /// Creates a new instance of key wrap metadata.
+        /// </summary>
+        /// <param name="value">Value of the metadata.</param>
+        public KeyWrapMetadata(string value)
+        {
+            this.Type = "custom";
+            this.Value = value;
+        }
+
+        internal KeyWrapMetadata(KeyWrapMetadata source)
+        {
+            this.Type = source.Type;
+            this.Value = source.Value;
+        }
+
+        [JsonProperty(PropertyName = "type", NullValueHandling = NullValueHandling.Ignore)]
+        internal string Type { get; set; }
+
+        /// <summary>
+        /// Serialized form of metadata.
+        /// Note: This value is saved in the Cosmos DB service.
+        /// Implementors of derived implementations should ensure that this does not have (private) key material or credential information.
+        /// </summary>
+        [JsonProperty(PropertyName = "value", NullValueHandling = NullValueHandling.Ignore)]
+        public string Value { get; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            KeyWrapMetadata metadata = obj as KeyWrapMetadata;
+            return this.Equals(metadata);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 1265339359;
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Type);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Value);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Returns whether the properties of the passed in key wrap metadata matches with those in the current instance.
+        /// </summary>
+        /// <param name="other">Key wrap metadata to be compared with current instance.</param>
+        /// <returns>
+        /// True if the properties of the key wrap metadata passed in matches with those in the current instance, else false.
+        /// </returns>
+        public bool Equals(KeyWrapMetadata other)
+        {
+            return other != null &&
+                   this.Type == other.Type &&
+                   this.Value == other.Value;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapProvider.cs
@@ -1,0 +1,39 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Interface for interacting with a provider that can be used to wrap (encrypt) and unwrap (decrypt) data encryption keys for envelope based encryption.
+    /// See https://tbd for more information on client-side encryption support in Azure Cosmos DB.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+        abstract class KeyWrapProvider
+    {
+        /// <summary>
+        /// Wraps (i.e. encrypts) the provided data encryption key.
+        /// </summary>
+        /// <param name="key">Data encryption key that needs to be wrapped.</param>
+        /// <param name="metadata">Metadata for the wrap provider that should be used to wrap / unwrap the key.</param>
+        /// <param name="cancellationToken">Cancellation token allowing for cancellation of this operation.</param>
+        /// <returns>Awaitable wrapped (i.e. encrypted) version of data encryption key passed in possibly with updated metadata.</returns>
+        public abstract Task<KeyWrapResponse> WrapKeyAsync(byte[] key, KeyWrapMetadata metadata, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Unwraps (i.e. decrypts) the provided wrapped data encryption key.
+        /// </summary>
+        /// <param name="wrappedKey">Wrapped form of data encryption key that needs to be unwrapped.</param>
+        /// <param name="metadata">Metadata for the wrap provider that should be used to wrap / unwrap the key.</param>
+        /// <param name="cancellationToken">Cancellation token allowing for cancellation of this operation.</param>
+        /// <returns>Awaitable unwrapped (i.e. unencrypted) version of data encryption key passed in and how long the raw data encryption key can be cached on the client.</returns>
+        public abstract Task<KeyUnwrapResponse> UnwrapKeyAsync(byte[] wrappedKey, KeyWrapMetadata metadata, CancellationToken cancellationToken);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/KeyWrapResponse.cs
@@ -1,0 +1,38 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    /// <summary>
+    /// Response from a <see cref="KeyWrapProvider"/> on wrapping a data encryption key.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+        class KeyWrapResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the response of wrapping a data encryption key.
+        /// </summary>
+        /// <param name="wrappedDataEncryptionKey">Wrapped form of data encryption key.</param>
+        /// <param name="keyWrapMetadata">Metadata that can be used by the wrap provider to unwrap the key.</param>
+        public KeyWrapResponse(byte[] wrappedDataEncryptionKey, KeyWrapMetadata keyWrapMetadata)
+        {
+            this.WrappedDataEncryptionKey = wrappedDataEncryptionKey;
+            this.KeyWrapMetadata = keyWrapMetadata;
+        }
+
+        /// <summary>
+        /// Wrapped form of the data encryption key.
+        /// </summary>
+        public byte[] WrappedDataEncryptionKey { get; }
+
+        /// <summary>
+        /// Metadata that can be used by the wrap provider to unwrap the key.
+        /// </summary>
+        public KeyWrapMetadata KeyWrapMetadata { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -69,7 +69,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
-    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
   </ItemGroup>
 
@@ -77,7 +76,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 
     <!--Direct Dependencies-->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
@@ -100,6 +99,10 @@
     <None Include="$(MSBuildThisFileDirectory)\Microsoft.Azure.Cosmos.targets" Pack="true" PackagePath="build\netstandard2.0">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\C1\Product\SDK\.net\Microsoft.Azure.Cosmos.Direct\src\Microsoft.Azure.Cosmos.Direct.csproj" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(ProjectRef)' != 'True' ">


### PR DESCRIPTION
# Pull Request Template

## Description

For use with client side encryption support with customer provided keys being added in https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1123.
Provides an implementation to wrap/unwrap (aka encrypt/decrypt) data encryption keys using  master keys stored in Azure Key Vault. When the methods to wrap or unwrap are invoked on this key wrap provider, it gets an access token for the app it is representing from AAD using ADAL and then talks to AKV for wrap/unwrap via REST. 
App has to be registered with AAD earlier and has an application id and a certificate using which it proves its identity. App needs to be provided wrap/unwrap access to the master keys via AKV access control policy.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
