### PR TITLE
[vNext] Double dynamic casting

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/CosmosTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/CosmosTextJsonSerializer.cs
@@ -113,7 +113,7 @@ namespace Azure.Cosmos
             JsonSerializerOptions jsonSerializerOptions)
         {
             MemoryStream memoryStream = stream as MemoryStream;
-            if (stream is MemoryStream
+            if (memoryStream != null
                 && memoryStream.TryGetBuffer(out ArraySegment<byte> buffer))
             {
                 if (buffer.Count >= CosmosTextJsonSerializer.Utf8Bom.Length


### PR DESCRIPTION
## Description

The System.Text.Json serializer was doing double dynamic casting, that is really not needed.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)