### PR TITLE
Add build for internal flag to catch build breaks

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -23,7 +23,7 @@
     <PackageReleaseNotes>The change log for this SDK is made available at https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md at the time of release.</PackageReleaseNotes>
     <PackageLicenseUrl>https://aka.ms/netcoregaeula</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-cosmos-dotnet-v3</PackageProjectUrl>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PublishRepositoryUrl Condition=" '$(ProjectRef)' != 'True' ">true</PublishRepositoryUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetrics.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Metrics received for queries from the backend.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetricsParser.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetricsParser.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Parser for <see cref="BackendMetrics"/>.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetricsTokenizer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/BackendMetricsTokenizer.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Tokenizer for <see cref="BackendMetrics"/>
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
+#pragma warning disable SA1602 // Enumeration items should be documented
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ClientSideMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ClientSideMetrics.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Stores client side QueryMetrics.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/FetchExecutionRange.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/FetchExecutionRange.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Stores information about fetch execution (for cross partition queries).
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/FetchExecutionRangeAccumulator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/FetchExecutionRangeAccumulator.cs
@@ -8,9 +8,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     using System.Diagnostics;
 
     /// <summary>
-    /// Accumlator that acts as a builder of FetchExecutionRanges
+    /// Accumulator that acts as a builder of FetchExecutionRanges
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationData.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationData.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Query index utilization data (sub-structure of the Index Utilization metrics) in the Azure Cosmos database service.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationInfo.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Query index utilization metrics in the Azure Cosmos database service.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal
@@ -26,7 +28,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
         public IReadOnlyList<IndexUtilizationData> PotentialIndexes { get; }
 
         /// <summary>
-        /// Iniialized a new instance of the Index Utilization class.
+        /// Initialized a new instance of the Index Utilization class.
         /// </summary>
         /// <param name="utilizedIndexes">The utilized indexes list</param>
         /// <param name="potentialIndexes">The potential indexes list</param>
@@ -67,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
         /// <summary>
         /// Creates a new IndexUtilizationInfo from the backend delimited string.
         /// </summary>
-        /// <param name="delimitedString">The backend delimted string to desrialize from.</param>
+        /// <param name="delimitedString">The backend delimited string to deserialize from.</param>
         /// <param name="result">The parsed index utilization info</param>
         /// <returns>A new IndexUtilizationInfo from the backend delimited string.</returns>
         internal static bool TryCreateFromDelimitedString(string delimitedString, out IndexUtilizationInfo result)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/PartitionedQueryMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/PartitionedQueryMetrics.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Class for composing multiple query metrics in a dictionary interface.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetrics.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// This metric represents a moving average for a set of queries whose metrics have been aggregated together.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsDelimitedStringWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsDelimitedStringWriter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// <see cref="QueryMetricsWriter"/> for delimited text.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsTextWriter.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Fancy <see cref="QueryMetricsWriter"/>.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryMetricsWriter.cs
@@ -7,9 +7,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     using System.Linq;
 
     /// <summary>
-    /// Base class for visting and serializing a <see cref="QueryMetrics"/>.
+    /// Base class for visiting and serializing a <see cref="QueryMetrics"/>.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryPreparationTimes.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/QueryPreparationTimes.cs
@@ -9,6 +9,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Query preparation metrics in the Azure DocumentDB database service.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/RuntimeExecutionTimes.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/RuntimeExecutionTimes.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Query runtime execution times in the Azure Cosmos DB service.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/TextTable.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/TextTable.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     /// Query runtime execution times in the Azure Cosmos DB service.
     /// </summary>
 #if INTERNAL
+#pragma warning disable SA1600
+#pragma warning disable CS1591
     public
 #else
     internal

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Scripts;
@@ -58,7 +57,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal virtual CosmosClientContext ClientContext { get; }
 
-        internal virtual BatchAsyncContainerExecutor BatchExecutor { get; } 
+        internal virtual BatchAsyncContainerExecutor BatchExecutor { get; }
 
         public override Conflicts Conflicts { get; }
 
@@ -105,14 +104,14 @@ namespace Microsoft.Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response);
         }
 
-        public async override Task<int?> ReadThroughputAsync(
+        public override async Task<int?> ReadThroughputAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
             ThroughputResponse response = await this.ReadThroughputIfExistsAsync(null, cancellationToken);
             return response.Resource?.Throughput;
         }
 
-        public async override Task<ThroughputResponse> ReadThroughputAsync(
+        public override async Task<ThroughputResponse> ReadThroughputAsync(
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -130,7 +129,7 @@ namespace Microsoft.Azure.Cosmos
             return await cosmosOffers.ReadThroughputIfExistsAsync(rid, requestOptions, cancellationToken);
         }
 
-        public async override Task<ThroughputResponse> ReplaceThroughputAsync(
+        public override async Task<ThroughputResponse> ReplaceThroughputAsync(
             int throughput,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,4 +35,10 @@ jobs:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
     VmImage: $(VmImage)
+
+- template:  templates/build-internal.yml
+  parameters:
+    BuildConfiguration: Release
+    Arguments: $(ReleaseArguments)
+    VmImage: $(VmImage)
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,4 +40,4 @@ jobs:
   parameters:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
-    VmImage: vs2017-win2016 # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+    VmImage: $(VmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,4 +40,4 @@ jobs:
   parameters:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
-    VmImage: $(VmImage)
+    VmImage:  $(VmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,5 +40,4 @@ jobs:
   parameters:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
-    VmImage: $(VmImage)
-  
+    VmImage: vs2017-win2016 # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -24,6 +24,6 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: -p:Optimize=true -p:DefineConstants="INTERNAL"
+      arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20;INTERNAL"
       versioningScheme: OFF
       

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -23,7 +23,7 @@ jobs:
       command: build  
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
-      projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
+      projects: Microsoft.Azure.Cosmos.sln 
       arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT COSMOSCLIENT NETSTANDARD20 INTERNAL"
       versioningScheme: OFF
       

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -24,6 +24,6 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
+      arguments: -p:Optimize=true -p:DefineConstants="INTERNAL"
       versioningScheme: OFF
       

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -1,15 +1,23 @@
 # File: templates/build-internal.yml
 
 parameters:
-  BuildConfiguration: ''
-  Arguments: ''
-  VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
-  OS: 'Windows'
+- name: BuildConfiguration
+  type: string 
+  default: ''
+- name: Arguments
+  type: string 
+  default: ''
+- name: VmImage
+  type: string 
+  default: ''
+- name: OS
+  type: string 
+  default: 'Windows'
 
 jobs:
 
 - job:
-  displayName: Cosmos.InternalFlag ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: Cosmos.InternalFlag ${{ parameters.VmImage }} ${{ parameters.Arguments }}  ${{ parameters.BuildConfiguration }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -18,11 +18,12 @@ jobs:
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: DotNetCoreCLI@2
-      displayName: Build Microsoft.Azure.Cosmos
-      inputs: 
-        command: build  
-        configuration: $(parameters.BuildConfiguration)
-        nugetConfigPath: NuGet.config
-        projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-        arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
-        versioningScheme: OFF
+    displayName: Build Microsoft.Azure.Cosmos
+    inputs: 
+      command: build  
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
+      arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
+      versioningScheme: OFF
+      

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -24,6 +24,6 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT;NETSTANDARD20;INTERNAL"
+      arguments: -p:Optimize=true -p:DefineConstants='DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20;INTERNAL'
       versioningScheme: OFF
       

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -1,23 +1,15 @@
 # File: templates/build-internal.yml
 
 parameters:
-- name: BuildConfiguration
-  type: string 
-  default: ''
-- name: Arguments
-  type: string 
-  default: ''
-- name: VmImage
-  type: string 
-  default: ''
-- name: OS
-  type: string 
-  default: 'Windows'
+  BuildConfiguration: ''
+  Arguments: ''
+  VmImage: ''
+  OS: 'Windows'
 
 jobs:
 
 - job:
-  displayName: Cosmos.InternalFlag ${{ parameters.VmImage }} ${{ parameters.Arguments }}  ${{ parameters.BuildConfiguration }} 
+  displayName: InternalFlag ${{ parameters.BuildConfiguration }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -9,7 +9,7 @@ parameters:
 jobs:
 
 - job:
-  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.InternalFlag
+  displayName: Microsoft.Azure.Cosmos.InternalFlag ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -9,7 +9,7 @@ parameters:
 jobs:
 
 - job:
-  displayName: Microsoft.Azure.Cosmos.InternalFlag ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: Cosmos.InternalFlag ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -18,7 +18,7 @@ jobs:
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: DotNetCoreCLI@2
-    displayName: Build Microsoft.Azure.Cosmos
+    displayName: Build Microsoft.Azure.Cosmos Internal
     inputs: 
       command: build  
       configuration: $(parameters.BuildConfiguration)

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -24,6 +24,6 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: -p:Optimize=true -p:DefineConstants='DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20;INTERNAL'
+      arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT COSMOSCLIENT NETSTANDARD20 INTERNAL"
       versioningScheme: OFF
       

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -1,0 +1,28 @@
+# File: templates/build-internal.yml
+
+parameters:
+  BuildConfiguration: ''
+  Arguments: ''
+  VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+  OS: 'Windows'
+
+jobs:
+
+- job:
+  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.InternalFlag
+  pool:
+    vmImage: ${{ parameters.VmImage }}
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  - task: DotNetCoreCLI@2
+      displayName: Build Microsoft.Azure.Cosmos
+      inputs: 
+        command: build  
+        configuration: $(parameters.BuildConfiguration)
+        nugetConfigPath: NuGet.config
+        projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
+        arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
+        versioningScheme: OFF

--- a/templates/build-internal.yml
+++ b/templates/build-internal.yml
@@ -24,6 +24,6 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20;INTERNAL"
+      arguments: -p:Optimize=true -p:DefineConstants="DOCDBCLIENT;NETSTANDARD20;INTERNAL"
       versioningScheme: OFF
       

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job:
-  displayName: Cosmos.Tests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: Tests ${{ parameters.BuildConfiguration }}
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -28,7 +28,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.Tests
       
 - job:
-  displayName: Cosmos.PerformanceTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: PerformanceTests ${{ parameters.BuildConfiguration }}
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -48,7 +48,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.PerformanceTests
 
 - job:
-  displayName: Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }}
+  displayName: EmulatorTests ${{ parameters.BuildConfiguration }}
   timeoutInMinutes: 90
   condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
   pool:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -17,6 +17,16 @@ jobs:
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos
+    inputs: 
+      command: build  
+      configuration: $(BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
+      arguments: --configuration $(BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
+      versioningScheme: OFF
+
+  - task: DotNetCoreCLI@2
     displayName: Microsoft.Azure.Cosmos.Tests
     condition: succeeded()
     inputs:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job:
-  displayName: Microsoft.Azure.Cosmos.Tests ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} 
+  displayName: Microsoft.Azure.Cosmos.Tests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -28,7 +28,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.Tests
       
 - job:
-  displayName: ${{ parameters.BuildConfiguration }} - ${{ parameters.VmImage }} PerformanceTests
+  displayName: PerformanceTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -48,7 +48,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.PerformanceTests
 
 - job:
-  displayName: Microsoft.Azure.Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }}
+  displayName: Microsoft.Azure.Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }}
   timeoutInMinutes: 90
   condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
   pool:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job:
-  displayName: Microsoft.Azure.Cosmos.Tests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: Cosmos.Tests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -28,7 +28,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.Tests
       
 - job:
-  displayName: PerformanceTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
+  displayName: Cosmos.PerformanceTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -48,7 +48,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.PerformanceTests
 
 - job:
-  displayName: Microsoft.Azure.Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }}
+  displayName: Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }} ${{ parameters.VmImage }}
   timeoutInMinutes: 90
   condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
   pool:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job:
-  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.Tests
+  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.InternalFlag
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -17,14 +17,23 @@ jobs:
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: DotNetCoreCLI@2
-    displayName: Build Microsoft.Azure.Cosmos
-    inputs: 
-      command: build  
-      configuration: $(BuildConfiguration)
-      nugetConfigPath: NuGet.config
-      projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: --configuration $(BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
-      versioningScheme: OFF
+      displayName: Build Microsoft.Azure.Cosmos
+      inputs: 
+        command: build  
+        configuration: $(parameters.BuildConfiguration)
+        nugetConfigPath: NuGet.config
+        projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
+        arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
+        versioningScheme: OFF
+
+- job:
+  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.Tests
+  pool:
+    vmImage: ${{ parameters.VmImage }}
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
   - task: DotNetCoreCLI@2
     displayName: Microsoft.Azure.Cosmos.Tests

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,25 +8,6 @@ parameters:
 
 jobs:
 - job:
-  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.InternalFlag
-  pool:
-    vmImage: ${{ parameters.VmImage }}
-
-  steps:
-  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
-
-  - task: DotNetCoreCLI@2
-      displayName: Build Microsoft.Azure.Cosmos
-      inputs: 
-        command: build  
-        configuration: $(parameters.BuildConfiguration)
-        nugetConfigPath: NuGet.config
-        projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-        arguments: --configuration $(parameters.BuildConfiguration) -p:Optimize=true -p:DefineConstants="INTERNAL"
-        versioningScheme: OFF
-
-- job:
   displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.Tests
   pool:
     vmImage: ${{ parameters.VmImage }}

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -8,7 +8,7 @@ parameters:
 
 jobs:
 - job:
-  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.Tests
+  displayName: Microsoft.Azure.Cosmos.Tests ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} 
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -48,7 +48,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.PerformanceTests
 
 - job:
-  displayName: ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }} Microsoft.Azure.Cosmos.EmulatorTests
+  displayName: Microsoft.Azure.Cosmos.EmulatorTests ${{ parameters.BuildConfiguration }}-${{ parameters.VmImage }}
   timeoutInMinutes: 90
   condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
   pool:


### PR DESCRIPTION
# Pull Request Template

## Description

There is a lot of conditional logic based on the internal flag. This adds a yaml file to build the solution with the internal flag set to prevent build breaks from getting merged in.

Refactored the display name to make it easier to read and prevent the values from getting truncated. 
