### PR TITLE
Fixed authorization with query using resource token for a specific partition key

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                         cosmosQueryContext.QueryClient,
                         inputParameters.SqlQuerySpec,
                         cosmosQueryContext.ResourceLink,
+                        inputParameters.PartitionKey,
                         cancellationToken);
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             Documents.ResourceType resourceType,
             Documents.OperationType operationType,
             SqlQuerySpec sqlQuerySpec,
+            PartitionKey? partitionKey,
             string supportedQueryFeatures,
             CancellationToken cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -74,6 +74,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             CosmosQueryClient client,
             SqlQuerySpec sqlQuerySpec,
             Uri resourceLink,
+            PartitionKey? partitionKey,
             CancellationToken cancellationToken = default)
         {
             if (client == null)
@@ -98,6 +99,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 ResourceType.Document,
                 OperationType.QueryPlan,
                 sqlQuerySpec,
+                partitionKey,
                 QueryPlanRetriever.SupportedQueryFeaturesString,
                 cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Azure.Cosmos
             ResourceType resourceType,
             OperationType operationType,
             SqlQuerySpec sqlQuerySpec,
+            PartitionKey? partitionKey,
             string supportedQueryFeatures,
             CancellationToken cancellationToken)
         {
@@ -178,7 +179,7 @@ namespace Microsoft.Azure.Cosmos
                 resourceType: resourceType,
                 operationType: operationType,
                 requestOptions: null,
-                partitionKey: null,
+                partitionKey: partitionKey,
                 cosmosContainerCore: this.cosmosContainerCore,
                 streamPayload: this.clientContext.SerializerCore.ToStreamSqlQuerySpec(sqlQuerySpec, resourceType),
                 requestEnricher: (requestMessage) =>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/PermissionProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/PermissionProperties.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos
             this.ResourceUri = ((ContainerInlineCore)container).ClientContext.CreateLink(
                     parentLink: ((ContainerInlineCore)container).LinkUri.OriginalString,
                     uriPathSegment: Paths.DocumentsPathSegment,
-                    id: id).OriginalString;
+                    id: itemId).OriginalString;
             this.InternalResourcePartitionKey = resourcePartitionKey.InternalKey;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -316,12 +316,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //delete resource with PermissionMode.Read
             using (CosmosClient tokenCosmosClient = TestCommon.CreateCosmosClient(clientOptions: null, resourceToken: permission.Token))
             {
+                Container tokenContainer = tokenCosmosClient.GetContainer(this.cosmosDatabase.Id, containerId);
+                ItemResponse<dynamic> readPermissionItem = await tokenContainer.ReadItemAsync<dynamic>(itemId, partitionKey);
+                Assert.AreEqual(itemId, readPermissionItem.Resource.id.ToString());
+
                 try
                 {
-                    ItemResponse<dynamic> response = await tokenCosmosClient
-                    .GetDatabase(this.cosmosDatabase.Id)
-                    .GetContainer(containerId)
-                    .DeleteItemAsync<dynamic>(itemId, partitionKey);
+                    ItemResponse<dynamic> response = await tokenContainer.DeleteItemAsync<dynamic>(
+                        itemId,
+                        partitionKey);
+
                     Assert.Fail();
                 }
                 catch (CosmosException ex)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -167,12 +167,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         public async Task ContainerPartitionResourcePermissionTest()
-        {
-            CosmosClientBuilder clientBuilder = new CosmosClientBuilder(
-                "https://jawilleytemp.documents.azure.com:443/",
-                "V8uLVUaKNeKy4np8galPyL56ALfKEcfgs7zfSfDfUY3LiZjU7YGGbE0dVz8TZg0MVy2qimBql5Fq8n61iHBGMA==")
-                .WithConnectionModeGateway();
-            CosmosClient cosmosClient = clientBuilder.Build();
+        { 
+            CosmosClient cosmosClient = TestCommon.CreateCosmosClient(
+                builder => builder.WithConnectionModeGateway());
 
             Database database = await cosmosClient.CreateDatabaseIfNotExistsAsync("PermissionTest");
 
@@ -227,12 +224,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ConnectionProtocol = Documents.Client.Protocol.Https
             };
 
-            CosmosClientBuilder tokenClientBuilder = new CosmosClientBuilder(
-               "https://jawilleytemp.documents.azure.com:443/",
-               permission.Token)
-               .WithConnectionModeGateway();
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Gateway
+            };
 
-            using (CosmosClient tokenCosmosClient = tokenClientBuilder.Build())
+            using (CosmosClient tokenCosmosClient = TestCommon.CreateCosmosClient(clientOptions: cosmosClientOptions, resourceToken: permission.Token))
             {
                 Container tokenContainer = tokenCosmosClient.GetContainer(database.Id, containerId);
                 await tokenContainer.ReadItemAsync<ToDoActivity>(itemAccess.id, new PartitionKey(itemAccess.id));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -5047,10 +5047,24 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 return this.forceQueryPlanGatewayElseServiceInterop;
             }
 
-            internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(Uri resourceUri, ResourceType resourceType, OperationType operationType, SqlQuerySpec sqlQuerySpec, string supportedQueryFeatures, CancellationToken cancellationToken)
+            internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(
+                Uri resourceUri,
+                ResourceType resourceType,
+                OperationType operationType,
+                SqlQuerySpec sqlQuerySpec,
+                Cosmos.PartitionKey? partitionKey,
+                string supportedQueryFeatures,
+                CancellationToken cancellationToken)
             {
                 this.QueryPlanCalls++;
-                return base.ExecuteQueryPlanRequestAsync(resourceUri, resourceType, operationType, sqlQuerySpec, supportedQueryFeatures, cancellationToken);
+                return base.ExecuteQueryPlanRequestAsync(
+                    resourceUri,
+                    resourceType,
+                    operationType,
+                    sqlQuerySpec,
+                    partitionKey,
+                    supportedQueryFeatures,
+                    cancellationToken);
             }
 
             internal override Task<QueryResponseCore> ExecuteItemQueryAsync<RequestOptionType>(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -5022,7 +5022,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// <summary>
         /// A helper that forces the SDK to use the gateway or the service interop for the query plan
         /// </summary>
-        private class MockCosmosQueryClient : CosmosQueryClientCore
+        internal class MockCosmosQueryClient : CosmosQueryClientCore
         {
             /// <summary>
             /// True it will use the gateway query plan.

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1105](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1105) Custom serializer no longer calls SDK owned types that would cause serialization exceptions
 - [#1116](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1116) Fixed a deadlock on scenarios with SynchronizationContext while executing async query operations
+- [#1143](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1143) Fixed authorization issue when doing a query with resource token for a specific partition key
 
 ## <a name="3.5.1"/> [3.5.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.1) - 2019-12-11
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1105](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1105) Custom serializer no longer calls SDK owned types that would cause serialization exceptions
 - [#1116](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1116) Fixed a deadlock on scenarios with SynchronizationContext while executing async query operations
-- [#1143](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1143) Fixed authorization issue when doing a query with resource token for a specific partition key
+- [#1143](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1143) Fixed permission resource link and authorization issue when doing a query with resource token for a specific partition key
 
 ## <a name="3.5.1"/> [3.5.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.5.1) - 2019-12-11
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed authorization issue when doing a query with resource token for a specific partition key when using the gateway query plan retriever.

Fixed a bug for permissions on a specific item. The resource link generation was using the permission id instead of the item id. So the permission was for the incorrect resource link. 

closes #1073 