### PR TITLE
[vNext] Newtonsoft dependency

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -9,7 +9,7 @@
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
     <AzureSDKClientVersion>4.0.0</AzureSDKClientVersion>
     <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
-    <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview2</VersionSuffix>
+    <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview3</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(AzureSDKClientVersion)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(AzureSDKClientVersion)-$(VersionSuffix)</Version>
     <FileVersion>$(AzureSDKClientVersion)</FileVersion>

--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -232,6 +232,7 @@
   
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="All" />

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09
+
+### Fixed
+
+- [#1144](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1144) Newtonsoft.Json chain dependency fix
+
+
 ## <a name="4.0.0-preview2"/> [4.0.0-preview2](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview2) - 2020-01-07
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [#1144](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1144) Newtonsoft.Json chain dependency fix
+- [#1144](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1144) Newtonsoft.Json dependency needed for internal dependencies
 
 
 ## <a name="4.0.0-preview2"/> [4.0.0-preview2](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview2) - 2020-01-07


### PR DESCRIPTION
Even though we don't have any public usage, internal classes still require the Newtonsoft.Json package to be available at runtime.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)