### PR TITLE
Updating UpsertItemAsync

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/ItemManagement/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ItemManagement/Program.cs
@@ -368,24 +368,29 @@
             Console.WriteLine("\n1.6 - Upserting a item");
 
             SalesOrder upsertOrder = GetSalesOrderSample("SalesOrder3");
+            
+            //creates the initial SalesOrder document. 
+            //notice the response.StatusCode returned indicates a Create operation was performed
             ItemResponse<SalesOrder> response = await container.UpsertItemAsync(
                 partitionKey: new PartitionKey(upsertOrder.AccountNumber),
                 item: upsertOrder);
-
+            
             SalesOrder upserted = response.Resource;
             Console.WriteLine($"Request charge of upsert operation: {response.RequestCharge}");
             Console.WriteLine($"StatusCode of this operation: { response.StatusCode}");
             Console.WriteLine($"Id of upserted item: {upserted.Id}");
-            Console.WriteLine($"AccountNumber of upserted item: {upserted.AccountNumber}");
-
-            upserted.AccountNumber = "updated account number";
+            Console.WriteLine($"Shipped Date of upserted item: {upserted.ShippedDate}");
+            
+            //update any field (other than the id, and the partitionKey, as these cannot be changed
+            //notice the response.StatusCode from the Upsert operation now indicates that an Update was performed
+            upserted.ShippedDate = DateTime.UtcNow;
             response = await container.UpsertItemAsync(partitionKey: new PartitionKey(upserted.AccountNumber), item: upserted);
             upserted = response.Resource;
 
             Console.WriteLine($"Request charge of upsert operation: {response.RequestCharge}");
             Console.WriteLine($"StatusCode of this operation: { response.StatusCode}");
             Console.WriteLine($"Id of upserted item: {upserted.Id}");
-            Console.WriteLine($"AccountNumber of upserted item: {upserted.AccountNumber}");
+            Console.WriteLine($"ShippedDate of upserted item: {upserted.ShippedDate}");
 
             // For better performance upsert a SalesOrder object from a stream. 
             SalesOrder salesOrderV4 = GetSalesOrderSample("SalesOrder4");


### PR DESCRIPTION
# Pull Request Template

## Description

the original sample showed updating the value of AccountNumber (which is the partitionkey for this collection) on the retrieved item, and then doing an upsert

when i run this sample, it doesn't update the original item, it merely creates a new item, with a new partition key set but the old original item with the original partition key remains in the database. we effectively now have a duplicate document.
the observed behavior is as expected considering cosmosdb treats id + pk as unique for a document
therefore changing the pk value means cosmos db would never find the original item to update it, so it creates a new one.

if you run this sample, you end up with TWO SalesOrder3 items, 1 in the original partition, and another exactly the same but in a different partition

i believe the sample as it was is very misleading and confusing to users. you cannot change an item's partition this way, and if you do, you should go remove the old item that will still be there

this change modifies ShippedDate on the order, which results in the original item being updated, and not creating a duplicate which i believe is the intention of this sample.

## Type of change

Please delete options that are not relevant.

- [✔ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

