### PR TITLE
Dictionary Encoding RoundTrip

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/IJsonReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/IJsonReader.cs
@@ -57,10 +57,10 @@ namespace Microsoft.Azure.Cosmos.Json
         bool TryGetBufferedUtf8StringValue(out ReadOnlyMemory<byte> bufferedUtf8StringValue);
 
         /// <summary>
-        /// Gets current JSON token from the JsonReader as a raw series of bytes that is buffered.
+        /// Tries to get the current JSON token from the JsonReader as a raw series of bytes that is buffered.
         /// </summary>
-        /// <returns>The current JSON token from the JsonReader as a raw series of bytes that is buffered.</returns>
-        ReadOnlyMemory<byte> GetBufferedRawJsonToken();
+        /// <returns>true if the current JSON token was retrieved; false otherwise.</returns>
+        bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken);
 
         /// <summary>
         /// Gets the next JSON token from the JsonReader as a 1 byte signed integer.

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
@@ -140,7 +140,12 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
         public override byte[] ReadAsBytes()
         {
             this.Read();
-            byte[] value = this.jsonReader.GetBufferedRawJsonToken().ToArray();
+            if (!this.jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+            {
+                throw new Exception("Failed to get the bytes.");
+            }
+
+            byte[] value = bufferedRawJsonToken.ToArray();
             this.SetToken(JsonToken.Bytes, value);
             return value;
         }

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
@@ -165,12 +165,14 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
 
         public override bool TryGetBufferedUtf8StringValue(out ReadOnlyMemory<byte> bufferedUtf8StringValue)
         {
-            throw new NotImplementedException();
+            bufferedUtf8StringValue = default;
+            return false;
         }
 
         public override bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken)
         {
-            throw new NotImplementedException();
+            bufferedRawJsonToken = default;
+            return false;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
@@ -28,11 +28,6 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
             throw new NotImplementedException();
         }
 
-        public override ReadOnlyMemory<byte> GetBufferedRawJsonToken()
-        {
-            throw new NotImplementedException();
-        }
-
         public override float GetFloat32Value()
         {
             return (float)this.reader.Value;
@@ -169,6 +164,11 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
         }
 
         public override bool TryGetBufferedUtf8StringValue(out ReadOnlyMemory<byte> bufferedUtf8StringValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken)
         {
             throw new NotImplementedException();
         }

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBWriter.cs
@@ -139,7 +139,19 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
             JsonTokenType jsonTokenType,
             ReadOnlySpan<byte> rawJsonToken)
         {
-            throw new NotImplementedException();
+            string rawJson = Encoding.UTF8.GetString(rawJsonToken);
+            Newtonsoft.Json.JsonTextReader jsonTextReader = new Newtonsoft.Json.JsonTextReader(new StringReader(rawJson));
+            while (jsonTextReader.Read())
+            {
+                if (jsonTokenType == JsonTokenType.FieldName)
+                {
+                    this.writer.WritePropertyName(jsonTextReader.Value as string);
+                }
+                else
+                {
+                    this.writer.WriteValue(jsonTextReader.Value);
+                }
+            }
         }
 
         public static NewtonsoftToCosmosDBWriter CreateTextWriter()

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Cosmos.Json
                     throw new ArgumentException($"{nameof(jsonNode)} must be a {nameof(BinaryNavigatorNode)}");
                 }
 
-                if (this.jsonStringDictionary != null)
+                if ((this.jsonStringDictionary != null) && JsonBinaryNavigator.IsStringOrNested(binaryNavigatorNode))
                 {
                     // Force a rewrite for dictionary encoding.
                     bufferedRawJson = default;
@@ -494,6 +494,20 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 bufferedRawJson = buffer;
                 return true;
+            }
+
+            private static bool IsStringOrNested(BinaryNavigatorNode binaryNavigatorNode)
+            {
+                switch (binaryNavigatorNode.JsonNodeType)
+                {
+                    case JsonNodeType.String:
+                    case JsonNodeType.FieldName:
+                    case JsonNodeType.Array:
+                    case JsonNodeType.Object:
+                        return true; 
+                    default:
+                        return false;
+                }
             }
 
             private static int GetValueCount(ReadOnlySpan<byte> node)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonBinaryNavigator.cs
@@ -478,6 +478,13 @@ namespace Microsoft.Azure.Cosmos.Json
                     throw new ArgumentException($"{nameof(jsonNode)} must be a {nameof(BinaryNavigatorNode)}");
                 }
 
+                if (this.jsonStringDictionary != null)
+                {
+                    // Force a rewrite for dictionary encoding.
+                    bufferedRawJson = default;
+                    return false;
+                }
+
                 ReadOnlyMemory<byte> buffer = binaryNavigatorNode.Buffer;
 
                 if (buffer.Length == 0)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonTextNavigator.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonNavigator.JsonTextNavigator.cs
@@ -498,7 +498,12 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// <returns>JSON string AST node</returns>
                 private static StringNode ParseStringNode(IJsonReader jsonTextReader)
                 {
-                    StringNode stringNode = StringNode.Create(jsonTextReader.GetBufferedRawJsonToken());
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
+
+                    StringNode stringNode = StringNode.Create(bufferedRawJsonToken);
 
                     // consume the string from the reader
                     jsonTextReader.Read();
@@ -513,7 +518,12 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// <returns>JSON number AST node</returns>
                 private static NumberNode ParseNumberNode(IJsonReader jsonTextReader)
                 {
-                    NumberNode numberNode = NumberNode.Create(jsonTextReader.GetBufferedRawJsonToken());
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
+
+                    NumberNode numberNode = NumberNode.Create(bufferedRawJsonToken);
 
                     // consume the number from the reader
                     jsonTextReader.Read();
@@ -523,30 +533,32 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 private static IntegerNode ParseIntegerNode(IJsonReader jsonTextReader, JsonTokenType jsonTokenType)
                 {
-                    ReadOnlyMemory<byte> bytes = jsonTextReader.GetBufferedRawJsonToken();
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
 
                     IntegerNode integerNode;
-
                     switch (jsonTokenType)
                     {
                         case JsonTokenType.Int8:
-                            integerNode = Int8Node.Create(bytes);
+                            integerNode = Int8Node.Create(bufferedRawJsonToken);
                             break;
 
                         case JsonTokenType.Int16:
-                            integerNode = Int16Node.Create(bytes);
+                            integerNode = Int16Node.Create(bufferedRawJsonToken);
                             break;
 
                         case JsonTokenType.Int32:
-                            integerNode = Int32Node.Create(bytes);
+                            integerNode = Int32Node.Create(bufferedRawJsonToken);
                             break;
 
                         case JsonTokenType.Int64:
-                            integerNode = Int64Node.Create(bytes);
+                            integerNode = Int64Node.Create(bufferedRawJsonToken);
                             break;
 
                         case JsonTokenType.UInt32:
-                            integerNode = UInt32Node.Create(bytes);
+                            integerNode = UInt32Node.Create(bufferedRawJsonToken);
                             break;
 
                         default:
@@ -561,17 +573,20 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 private static FloatNode ParseFloatNode(IJsonReader jsonTextReader, JsonTokenType jsonTokenType)
                 {
-                    ReadOnlyMemory<byte> bytes = jsonTextReader.GetBufferedRawJsonToken();
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
 
                     FloatNode floatNode;
                     switch (jsonTokenType)
                     {
                         case JsonTokenType.Float32:
-                            floatNode = Float32Node.Create(bytes);
+                            floatNode = Float32Node.Create(bufferedRawJsonToken);
                             break;
 
                         case JsonTokenType.Float64:
-                            floatNode = Float64Node.Create(bytes);
+                            floatNode = Float64Node.Create(bufferedRawJsonToken);
                             break;
                         default:
                             throw new ArgumentException($"Unknown {nameof(JsonTokenType)}: {jsonTokenType}");
@@ -629,7 +644,12 @@ namespace Microsoft.Azure.Cosmos.Json
                 /// <returns>JSON property AST node</returns>
                 private static ObjectProperty ParsePropertyNode(IJsonReader jsonTextReader)
                 {
-                    FieldNameNode fieldName = FieldNameNode.Create(jsonTextReader.GetBufferedRawJsonToken());
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
+
+                    FieldNameNode fieldName = FieldNameNode.Create(bufferedRawJsonToken);
 
                     // Consume the fieldname from the jsonreader
                     jsonTextReader.Read();
@@ -640,7 +660,12 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 private static GuidNode ParseGuidNode(IJsonReader jsonTextReader)
                 {
-                    GuidNode node = GuidNode.Create(jsonTextReader.GetBufferedRawJsonToken());
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
+
+                    GuidNode node = GuidNode.Create(bufferedRawJsonToken);
 
                     // advance the reader forward.
                     jsonTextReader.Read();
@@ -649,7 +674,12 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 private static BinaryNode ParseBinaryNode(IJsonReader jsonTextReader)
                 {
-                    BinaryNode node = BinaryNode.Create(jsonTextReader.GetBufferedRawJsonToken());
+                    if (!jsonTextReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                    {
+                        throw new InvalidOperationException("Failed to get the buffered raw json token.");
+                    }
+
+                    BinaryNode node = BinaryNode.Create(bufferedRawJsonToken);
 
                     // advance the reader forward.
                     jsonTextReader.Read();

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -235,9 +235,7 @@ namespace Microsoft.Azure.Cosmos.Json
                     this.currentTokenPosition,
                     this.currentTokenPosition + length);
 
-                JsonTokenType type = GetJsonTokenType(candidate.Span[0]);
-
-                if ((this.jsonStringDictionary != null) && JsonBinaryReader.IsStringOrNested(type))
+                if ((this.jsonStringDictionary != null) && JsonBinaryReader.IsStringOrNested(this.CurrentTokenType))
                 {
                     // If there is dictionary encoding, then we need to force a rewrite.
                     bufferedRawJsonToken = default;
@@ -253,9 +251,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 switch (type)
                 {
                     case JsonTokenType.BeginArray:
-                    case JsonTokenType.EndArray:
                     case JsonTokenType.BeginObject:
-                    case JsonTokenType.EndObject:
                     case JsonTokenType.String:
                     case JsonTokenType.FieldName:
                         return true;

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Cosmos.Json
             }
 
             /// <inheritdoc />
-            public override ReadOnlyMemory<byte> GetBufferedRawJsonToken()
+            public override bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken)
             {
                 if (!JsonBinaryEncoding.TryGetValueLength(
                     this.jsonBinaryBuffer.GetBufferedRawJsonToken(this.currentTokenPosition).Span,
@@ -231,7 +231,15 @@ namespace Microsoft.Azure.Cosmos.Json
                     throw new InvalidOperationException();
                 }
 
-                return this.jsonBinaryBuffer.GetBufferedRawJsonToken(this.currentTokenPosition, this.currentTokenPosition + length);
+                if (this.jsonStringDictionary != null)
+                {
+                    // If there is dictionary encoding, then we need to force a rewrite.
+                    bufferedRawJsonToken = default;
+                    return false;
+                }
+
+                bufferedRawJsonToken = this.jsonBinaryBuffer.GetBufferedRawJsonToken(this.currentTokenPosition, this.currentTokenPosition + length);
+                return true;
             }
 
             /// <inheritdoc />

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
@@ -399,11 +399,12 @@ namespace Microsoft.Azure.Cosmos.Json
             }
 
             /// <inheritdoc />
-            public override ReadOnlyMemory<byte> GetBufferedRawJsonToken()
+            public override bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken)
             {
-                return this.jsonTextBuffer.GetBufferedRawJsonToken(
+                bufferedRawJsonToken = this.jsonTextBuffer.GetBufferedRawJsonToken(
                     this.token.Start,
                     this.token.End);
+                return true;
             }
 
             private static JsonTokenType JsonTextToJsonTokenType(JsonTextTokenType jsonTextTokenType)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.Json
         public abstract bool TryGetBufferedUtf8StringValue(out ReadOnlyMemory<byte> bufferedUtf8StringValue);
 
         /// <inheritdoc />
-        public abstract ReadOnlyMemory<byte> GetBufferedRawJsonToken();
+        public abstract bool TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken);
 
         /// <inheritdoc />
         public abstract sbyte GetInt8Value();

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
@@ -330,9 +330,48 @@ namespace Microsoft.Azure.Cosmos.Json
                 JsonTokenType jsonTokenType,
                 ReadOnlySpan<byte> rawJsonToken)
             {
+                switch (jsonTokenType)
+                {
+                    case JsonTokenType.String:
+                    case JsonTokenType.Number:
+                    case JsonTokenType.True:
+                    case JsonTokenType.False:
+                    case JsonTokenType.Null:
+                    case JsonTokenType.FieldName:
+                    case JsonTokenType.Int8:
+                    case JsonTokenType.Int16:
+                    case JsonTokenType.Int32:
+                    case JsonTokenType.Int64:
+                    case JsonTokenType.UInt32:
+                    case JsonTokenType.Float32:
+                    case JsonTokenType.Float64:
+                    case JsonTokenType.Guid:
+                    case JsonTokenType.Binary:
+                        // Supported Tokens
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException($"Unknown token type: {jsonTokenType}.");
+                }
+
+                if (rawJsonToken.IsEmpty)
+                {
+                    throw new ArgumentException($"Expected non empty {nameof(rawJsonToken)}.");
+                }
+
                 this.JsonObjectState.RegisterToken(jsonTokenType);
                 this.PrefixMemberSeparator();
-                this.jsonTextMemoryWriter.Write(rawJsonToken);
+
+                // No separator after property name
+                if (jsonTokenType == JsonTokenType.FieldName)
+                {
+                    this.firstValue = true;
+                    this.jsonTextMemoryWriter.Write(rawJsonToken);
+                    this.jsonTextMemoryWriter.Write(ValueSeperatorToken);
+                }
+                else
+                {
+                    this.jsonTextMemoryWriter.Write(rawJsonToken);
+                }
             }
 
             private void WriteIntegerInternal(long value)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -186,10 +186,9 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 default:
                     {
-                        if (sameFormat)
+                        if (sameFormat && jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
                         {
-                            ReadOnlySpan<byte> bufferedRawJson = jsonReader.GetBufferedRawJsonToken().Span;
-                            this.WriteRawJsonToken(jsonTokenType, bufferedRawJson);
+                            this.WriteRawJsonToken(jsonTokenType, bufferedRawJsonToken.Span);
                         }
                         else
                         {

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -146,9 +146,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 throw new ArgumentNullException("jsonReader can not be null");
             }
 
-            // For now we don't optimize for text, since the reader could be UTF-8 and the writer could be UTF-16.
-            // We need to add more enums for the different serialization formats.
-            bool sameFormat = jsonReader.SerializationFormat == this.SerializationFormat && (this.SerializationFormat == JsonSerializationFormat.Binary || this.SerializationFormat == JsonSerializationFormat.HybridRow);
+            bool sameFormat = jsonReader.SerializationFormat == this.SerializationFormat;
 
             JsonTokenType jsonTokenType = jsonReader.CurrentTokenType;
             switch (jsonTokenType)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -331,8 +331,6 @@ namespace Microsoft.Azure.Cosmos.Json
                 throw new ArgumentNullException($"{nameof(jsonNavigatorNode)} can not be null");
             }
 
-            bool sameFormat = jsonNavigator.SerializationFormat == this.SerializationFormat;
-
             JsonNodeType jsonNodeType = jsonNavigator.GetNodeType(jsonNavigatorNode);
 
             // See if we can write the node without looking at it's value
@@ -348,6 +346,8 @@ namespace Microsoft.Azure.Cosmos.Json
                     this.WriteBoolValue(true);
                     return;
             }
+
+            bool sameFormat = jsonNavigator.SerializationFormat == this.SerializationFormat;
 
             // If the navigator has the same format as this writer then we try to retrieve the node raw JSON
             if (sameFormat && jsonNavigator.TryGetBufferedRawJson(jsonNavigatorNode, out ReadOnlyMemory<byte> bufferedRawJson))

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -198,11 +198,6 @@ namespace Microsoft.Azure.Cosmos
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, this.CosmosSerializationFormatOptions.ContentSerializationFormat);
             }
-            else
-            {
-                // Default to binary
-                request.Headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.CosmosBinary.ToString());
-            }
 
             request.Headers.Add(HttpConstants.HttpHeaders.PopulateQueryMetrics, bool.TrueString);
 

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -198,6 +198,11 @@ namespace Microsoft.Azure.Cosmos
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, this.CosmosSerializationFormatOptions.ContentSerializationFormat);
             }
+            else
+            {
+                // Default to binary
+                request.Headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.CosmosBinary.ToString());
+            }
 
             request.Headers.Add(HttpConstants.HttpHeaders.PopulateQueryMetrics, bool.TrueString);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -540,7 +540,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 StreamReader sr = new StreamReader(response.Content);
                 string result = await sr.ReadToEndAsync();
-                ICollection<T> responseResults = JsonConvert.DeserializeObject<CosmosFeedResponseUtil<T>>(result).Data;
+                ICollection<T> responseResults;
+                try
+                {
+                    responseResults = JsonConvert.DeserializeObject<CosmosFeedResponseUtil<T>>(result).Data;
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
+
                 Assert.IsTrue(responseResults.Count <= 1);
 
                 streamResults.AddRange(responseResults);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -541,14 +541,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 StreamReader sr = new StreamReader(response.Content);
                 string result = await sr.ReadToEndAsync();
                 ICollection<T> responseResults;
-                try
-                {
-                    responseResults = JsonConvert.DeserializeObject<CosmosFeedResponseUtil<T>>(result).Data;
-                }
-                catch (Exception ex)
-                {
-                    throw ex;
-                }
+                responseResults = JsonConvert.DeserializeObject<CosmosFeedResponseUtil<T>>(result).Data;
 
                 Assert.IsTrue(responseResults.Count <= 1);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonReaderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonReaderTests.cs
@@ -2466,7 +2466,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
 
                 double valueFromString = double.Parse(stringRawJsonToken, CultureInfo.InvariantCulture);
@@ -2485,7 +2489,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"I{expected}", stringRawJsonToken);
             }
@@ -2502,7 +2510,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"H{expected}", stringRawJsonToken);
             }
@@ -2519,7 +2531,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"L{expected}", stringRawJsonToken);
             }
@@ -2536,7 +2552,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"LL{expected}", stringRawJsonToken);
             }
@@ -2553,7 +2573,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"UL{expected}", stringRawJsonToken);
             }
@@ -2570,7 +2594,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"S{expected.ToString("G9", CultureInfo.InvariantCulture)}", stringRawJsonToken);
             }
@@ -2587,7 +2615,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"D{expected.ToString("G17", CultureInfo.InvariantCulture)}", stringRawJsonToken);
             }
@@ -2604,7 +2636,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"G{expected.ToString()}", stringRawJsonToken);
             }
@@ -2621,7 +2657,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
             // Additionally check if the text is correct
             if (jsonReader.SerializationFormat == JsonSerializationFormat.Text)
             {
-                ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+                if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+                {
+                    Assert.Fail("Failed to get the buffered raw json token.");
+                }
+
                 string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
                 Assert.AreEqual($"B{Convert.ToBase64String(expected.ToArray())}", stringRawJsonToken);
             }
@@ -2656,7 +2696,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
 
         private void VerifyFragment(IJsonReader jsonReader, string fragment, Encoding encoding)
         {
-            ReadOnlyMemory<byte> bufferedRawJsonToken = jsonReader.GetBufferedRawJsonToken();
+            if (!jsonReader.TryGetBufferedRawJsonToken(out ReadOnlyMemory<byte> bufferedRawJsonToken))
+            {
+                Assert.Fail("Failed to get the buffered raw json token.");
+            }
+
             string stringRawJsonToken = encoding.GetString(bufferedRawJsonToken.ToArray());
             Assert.AreEqual(fragment, stringRawJsonToken);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTestUtils.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonTestUtils.cs
@@ -16,9 +16,9 @@
             return binaryWriter.GetResult().ToArray();
         }
 
-        public static string ConvertBinaryToText(byte[] binary)
+        public static string ConvertBinaryToText(byte[] binary, JsonStringDictionary jsonStringDictionary = null)
         {
-            IJsonReader binaryReader = JsonReader.Create(binary);
+            IJsonReader binaryReader = JsonReader.Create(binary, jsonStringDictionary);
             IJsonWriter textWriter = JsonWriter.Create(JsonSerializationFormat.Text);
             textWriter.WriteAll(binaryReader);
             return Encoding.UTF8.GetString(textWriter.GetResult().ToArray());


### PR DESCRIPTION
# Dictionary Encoding RoundTrip

## Description

This PR enables binary encoding with dictionary encoding to roundtrip. Currently if we try and read the payload of a dictionary encoded binary with a regular binary reader, which is the case for stream API where we can't pass around the dictionary, then the data is essentially corrupted.

The fix is to return false for `TryGetBufferedRawJson` on all the binary readers / navigators if they have a `JsonStringDictionary`. This forces the writer to get the actual string value. The saving grace is we now have TryGetBufferedUTF8StringValue. This should allow us to turn on dictionary encoding from the backend.

I updated the roundtrip tests with dictionary encoding to show that we are able to roundtrip dictionary encoding with regular binary writers and text writers.
