### PR TITLE
Default Query Request Options Picker

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryMetadata.cs
@@ -1,0 +1,113 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
+{
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+    public
+#else
+    internal
+#endif
+    readonly struct QueryMetadata
+    {
+        public enum TShirtSize
+        {
+            XSmall,
+            Small,
+            Medium,
+            Large,
+            XLarge
+        }
+
+        public QueryMetadata(
+            bool hasAggregate,
+            bool hasDistinct,
+            bool hasGroupBy,
+            bool hasOrderBy,
+            int? offsetCount,
+            int? limitCount,
+            int? topCount)
+        {
+            this.HasAggregate = hasAggregate;
+            this.HasDistinct = hasDistinct;
+            this.HasGroupBy = hasGroupBy;
+            this.HasOrderBy = hasOrderBy;
+            this.OffsetCount = offsetCount;
+            this.LimitCount = limitCount;
+            this.TopCount = topCount;
+        }
+
+        public bool HasAggregate { get; }
+        public bool HasDistinct { get; }
+        public bool HasGroupBy { get; }
+        public bool HasOrderBy { get; }
+        public int? OffsetCount { get; }
+        public int? LimitCount { get; }
+        public int? TopCount { get; }
+
+        public bool HasOffset => this.OffsetCount.HasValue;
+        public bool HasLimit => this.LimitCount.HasValue;
+        public bool HasTop => this.TopCount.HasValue;
+        public bool HasOffsetLimitOrTop => this.HasOffset || this.HasLimit || this.HasTop;
+        public int? OffsetLimitTopCount => this.HasOffsetLimitOrTop ? (int?)(this.OffsetCount.GetValueOrDefault(0) + this.LimitCount.GetValueOrDefault(0) + this.TopCount.GetValueOrDefault(0)) : null;
+
+        public TShirtSize? OffsetTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetCount);
+        public TShirtSize? LimitTShirtSize => QueryMetadata.GetTShirtSize(this.LimitCount);
+        public TShirtSize? TopTShirtSize => QueryMetadata.GetTShirtSize(this.TopCount);
+        public TShirtSize? OffsetLimitTopTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetLimitTopCount);
+
+        private static TShirtSize? GetTShirtSize(int? size)
+        {
+            if (!size.HasValue)
+            {
+                return default;
+            }
+
+            int value = size.Value;
+            TShirtSize tShirtSize;
+            if (value <= 1)
+            {
+                tShirtSize = TShirtSize.XSmall;
+            }
+            else if (value <= 10)
+            {
+                tShirtSize = TShirtSize.Small;
+            }
+            else if (value <= 128)
+            {
+                tShirtSize = TShirtSize.Medium;
+            }
+            else if (value <= 1024)
+            {
+                tShirtSize = TShirtSize.Large;
+            }
+            else
+            {
+                tShirtSize = TShirtSize.XLarge;
+            }
+
+            return tShirtSize;
+        }
+
+        /// <summary>
+        /// Determines if a query has partial results, meaning the SDK has to drain the query fully before returning a single result.
+        /// </summary>
+        public bool HasPartialResults => this.HasAggregate || this.HasDistinct || this.HasGroupBy;
+
+        internal static QueryMetadata Create(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        {
+            return new QueryMetadata(
+                hasAggregate: partitionedQueryExecutionInfo.QueryInfo.HasAggregates,
+                hasDistinct: partitionedQueryExecutionInfo.QueryInfo.HasDistinct,
+                hasGroupBy: partitionedQueryExecutionInfo.QueryInfo.HasGroupBy,
+                hasOrderBy: partitionedQueryExecutionInfo.QueryInfo.HasOrderBy,
+                offsetCount: partitionedQueryExecutionInfo.QueryInfo.Offset,
+                limitCount: partitionedQueryExecutionInfo.QueryInfo.Limit,
+                topCount: partitionedQueryExecutionInfo.QueryInfo.Top);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
@@ -1,24 +1,38 @@
-﻿namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
 {
     using System;
-    using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
 
     internal static class QueryRequestOptionsTuner
     {
-        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxPageSizeLookup;
-        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxBufferedItemCountSizeLookup;
-        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxConcurrencyLookup;
+        private static readonly TShirtSizes ConcurrencyTShirtSizes = new TShirtSizes(
+            xsmall: 0,
+            small: 1,
+            medium: 4,
+            large: 16,
+            xlarge: int.MaxValue);
+
+        private static readonly TShirtSizes BufferedItemCountTShirtSizes = new TShirtSizes(
+            xsmall: 0,
+            small: 1024,
+            medium: 4 * 1024,
+            large: 16 * 1024,
+            xlarge: int.MaxValue);
+
+        private static readonly TShirtSizes PageSizeTShirtSizes = new TShirtSizes(
+            xsmall: 100,
+            small: 512,
+            medium: 1024,
+            large: 4 * 1024,
+            xlarge: int.MaxValue);
 
         public static int GetOptimalMaxPageSize(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
         {
-            if (partitionedQueryExecutionInfo == null)
-            {
-                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
-            }
-
-            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
-            return QueryRequestOptionsTuner.OptimalMaxPageSizeLookup[queryMetadata];
+            return PageSizeTShirtSizes.XLarge;
         }
 
         public static int GetOptimalMaxBufferedItemCount(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
@@ -29,7 +43,51 @@
             }
 
             QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
-            return QueryRequestOptionsTuner.OptimalMaxBufferedItemCountSizeLookup[queryMetadata];
+            if (queryMetadata.HasPartialResults)
+            {
+                // If we are going to wait for the query to fully drain we might as well do it as fast as possible.
+                return BufferedItemCountTShirtSizes.XLarge;
+            }
+
+            if (queryMetadata.HasOrderBy)
+            {
+                // Since we need to block the query until we see all the results we might as well get them as fast as possible.
+                return BufferedItemCountTShirtSizes.Medium;
+            }
+
+            if (!queryMetadata.OffsetLimitTopTShirtSize.HasValue)
+            {
+                return BufferedItemCountTShirtSizes.XSmall;
+            }
+
+            int bufferedItemCount;
+            switch (queryMetadata.OffsetLimitTopTShirtSize.Value)
+            {
+                case QueryMetadata.TShirtSize.XSmall:
+                    bufferedItemCount = BufferedItemCountTShirtSizes.XSmall;
+                    break;
+
+                case QueryMetadata.TShirtSize.Small:
+                    bufferedItemCount = BufferedItemCountTShirtSizes.Small;
+                    break;
+
+                case QueryMetadata.TShirtSize.Medium:
+                    bufferedItemCount = BufferedItemCountTShirtSizes.Medium;
+                    break;
+
+                case QueryMetadata.TShirtSize.Large:
+                    bufferedItemCount = BufferedItemCountTShirtSizes.Large;
+                    break;
+
+                case QueryMetadata.TShirtSize.XLarge:
+                    bufferedItemCount = BufferedItemCountTShirtSizes.XLarge;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException($"Unknown {nameof(QueryMetadata.TShirtSize)}: {queryMetadata.OffsetLimitTopTShirtSize.Value}.");
+            }
+
+            return bufferedItemCount;
         }
 
         public static int GetOptimalMaxConcurrency(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
@@ -40,53 +98,156 @@
             }
 
             QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
-            return QueryRequestOptionsTuner.OptimalMaxConcurrencyLookup[queryMetadata];
+            if (queryMetadata.HasPartialResults)
+            {
+                // If we are going to wait for the query to fully drain we might as well do it as fast as possible.
+                return ConcurrencyTShirtSizes.XLarge;
+            }
+
+            if (queryMetadata.HasOrderBy)
+            {
+                // Since we need to block the query until we see all the results we might as well get them as fast as possible.
+                return ConcurrencyTShirtSizes.XLarge;
+            }
+
+            if (!queryMetadata.OffsetLimitTopTShirtSize.HasValue)
+            {
+                return ConcurrencyTShirtSizes.XSmall;
+            }
+
+            int concurrency;
+            switch (queryMetadata.OffsetLimitTopTShirtSize.Value)
+            {
+                case QueryMetadata.TShirtSize.XSmall:
+                    concurrency = ConcurrencyTShirtSizes.XSmall;
+                    break;
+
+                case QueryMetadata.TShirtSize.Small:
+                    concurrency = ConcurrencyTShirtSizes.Small;
+                    break;
+
+                case QueryMetadata.TShirtSize.Medium:
+                    concurrency = ConcurrencyTShirtSizes.Medium;
+                    break;
+
+                case QueryMetadata.TShirtSize.Large:
+                    concurrency = ConcurrencyTShirtSizes.Large;
+                    break;
+
+                case QueryMetadata.TShirtSize.XLarge:
+                    concurrency = ConcurrencyTShirtSizes.XLarge;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException($"Unknown {nameof(QueryMetadata.TShirtSize)}: {queryMetadata.OffsetLimitTopTShirtSize.Value}.");
+            }
+
+            return concurrency;
         }
 
-        private readonly struct QueryMetadata
+        private readonly struct TShirtSizes
         {
-            public QueryMetadata(bool hasAggregate, bool hasDistinct, bool hasGroupBy, bool hasOrderBy, bool hasOffsetLimit)
+            public TShirtSizes(int xsmall, int small, int medium, int large, int xlarge)
+            {
+                this.XSmall = xsmall >= 0 ? xsmall : throw new ArgumentOutOfRangeException(nameof(xsmall));
+                this.Small = small >= 0 ? small : throw new ArgumentOutOfRangeException(nameof(small));
+                this.Medium = medium >= 0 ? medium : throw new ArgumentOutOfRangeException(nameof(medium));
+                this.Large = large >= 0 ? large : throw new ArgumentOutOfRangeException(nameof(large));
+                this.XLarge = xlarge >= 0 ? xlarge : throw new ArgumentOutOfRangeException(nameof(xlarge));
+            }
+
+            public int XSmall { get; }
+            public int Small { get; }
+            public int Medium { get; }
+            public int Large { get; }
+            public int XLarge { get; }
+        }
+
+        private readonly ref struct QueryMetadata
+        {
+            public enum TShirtSize
+            {
+                XSmall,
+                Small,
+                Medium,
+                Large,
+                XLarge
+            }
+
+            public QueryMetadata(
+                bool hasAggregate,
+                bool hasDistinct,
+                bool hasGroupBy,
+                bool hasOrderBy,
+                int? offsetCount,
+                int? limitCount,
+                int? topCount)
             {
                 this.HasAggregate = hasAggregate;
                 this.HasDistinct = hasDistinct;
                 this.HasGroupBy = hasGroupBy;
                 this.HasOrderBy = hasOrderBy;
-                this.HasOffsetLimit = hasOffsetLimit;
+                this.OffsetCount = offsetCount;
+                this.LimitCount = limitCount;
+                this.TopCount = topCount;
             }
 
             public bool HasAggregate { get; }
             public bool HasDistinct { get; }
             public bool HasGroupBy { get; }
             public bool HasOrderBy { get; }
-            public bool HasOffsetLimit { get; }
+            public int? OffsetCount { get; }
+            public int? LimitCount { get; }
+            public int? TopCount { get; }
 
-            public override bool Equals(object obj)
+            public bool HasOffset => this.OffsetCount.HasValue;
+            public bool HasLimit => this.LimitCount.HasValue;
+            public bool HasTop => this.TopCount.HasValue;
+            public bool HasOffsetLimitOrTop => this.HasOffset || this.HasLimit || this.HasTop;
+            public int? OffsetLimitTopCount => this.HasOffsetLimitOrTop ? (int?)(this.OffsetCount.GetValueOrDefault(0) + this.LimitCount.GetValueOrDefault(0) + this.TopCount.GetValueOrDefault(0)) : null;
+
+            public TShirtSize? OffsetTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetCount);
+            public TShirtSize? LimitTShirtSize => QueryMetadata.GetTShirtSize(this.LimitCount);
+            public TShirtSize? TopTShirtSize => QueryMetadata.GetTShirtSize(this.TopCount);
+            public TShirtSize? OffsetLimitTopTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetLimitTopCount);
+
+            private static TShirtSize? GetTShirtSize(int? size)
             {
-                if (!(obj is QueryMetadata queryMetadata))
+                if (!size.HasValue)
                 {
-                    return false;
+                    return default;
                 }
 
-                return this.Equals(queryMetadata);
+                int value = size.Value;
+                TShirtSize tShirtSize;
+                if (value <= 1)
+                {
+                    tShirtSize = TShirtSize.XSmall;
+                }
+                else if (value <= 10)
+                {
+                    tShirtSize = TShirtSize.Small;
+                }
+                else if (value <= 128)
+                {
+                    tShirtSize = TShirtSize.Medium;
+                }
+                else if (value <= 1024)
+                {
+                    tShirtSize = TShirtSize.Large;
+                }
+                else
+                {
+                    tShirtSize = TShirtSize.XLarge;
+                }
+
+                return tShirtSize;
             }
 
-            public bool Equals(QueryMetadata other)
-            {
-                return this.HasAggregate == other.HasAggregate &&
-                    this.HasDistinct == other.HasDistinct &&
-                    this.HasGroupBy == other.HasGroupBy &&
-                    this.HasOffsetLimit == other.HasOffsetLimit &&
-                    this.HasOrderBy == other.HasOrderBy;
-            }
-
-            public override int GetHashCode()
-            {
-                return ((this.HasAggregate ? 1 : 0) << 5) +
-                    ((this.HasDistinct ? 1 : 0) << 4) +
-                    ((this.HasGroupBy ? 1 : 0) << 3) +
-                    ((this.HasOffsetLimit ? 1 : 0) << 2) +
-                    ((this.HasOrderBy ? 1 : 0) << 1);
-            }
+            /// <summary>
+            /// Determines if a query has partial results, meaning the SDK has to drain the query fully before returning a single result.
+            /// </summary>
+            public bool HasPartialResults => this.HasAggregate || this.HasDistinct || this.HasGroupBy;
 
             public static QueryMetadata Create(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
             {
@@ -95,7 +256,9 @@
                     hasDistinct: partitionedQueryExecutionInfo.QueryInfo.HasDistinct,
                     hasGroupBy: partitionedQueryExecutionInfo.QueryInfo.HasGroupBy,
                     hasOrderBy: partitionedQueryExecutionInfo.QueryInfo.HasOrderBy,
-                    hasOffsetLimit: partitionedQueryExecutionInfo.QueryInfo.HasOffset || partitionedQueryExecutionInfo.QueryInfo.HasLimit);
+                    offsetCount: partitionedQueryExecutionInfo.QueryInfo.Offset,
+                    limitCount: partitionedQueryExecutionInfo.QueryInfo.Limit,
+                    topCount: partitionedQueryExecutionInfo.QueryInfo.Top);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
@@ -1,0 +1,102 @@
+﻿namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+
+    internal static class QueryRequestOptionsTuner
+    {
+        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxPageSizeLookup;
+        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxBufferedItemCountSizeLookup;
+        private static readonly IReadOnlyDictionary<QueryMetadata, int> OptimalMaxConcurrencyLookup;
+
+        public static int GetOptimalMaxPageSize(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        {
+            if (partitionedQueryExecutionInfo == null)
+            {
+                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
+            }
+
+            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
+            return QueryRequestOptionsTuner.OptimalMaxPageSizeLookup[queryMetadata];
+        }
+
+        public static int GetOptimalMaxBufferedItemCount(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        {
+            if (partitionedQueryExecutionInfo == null)
+            {
+                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
+            }
+
+            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
+            return QueryRequestOptionsTuner.OptimalMaxBufferedItemCountSizeLookup[queryMetadata];
+        }
+
+        public static int GetOptimalMaxConcurrency(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        {
+            if (partitionedQueryExecutionInfo == null)
+            {
+                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
+            }
+
+            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
+            return QueryRequestOptionsTuner.OptimalMaxConcurrencyLookup[queryMetadata];
+        }
+
+        private readonly struct QueryMetadata
+        {
+            public QueryMetadata(bool hasAggregate, bool hasDistinct, bool hasGroupBy, bool hasOrderBy, bool hasOffsetLimit)
+            {
+                this.HasAggregate = hasAggregate;
+                this.HasDistinct = hasDistinct;
+                this.HasGroupBy = hasGroupBy;
+                this.HasOrderBy = hasOrderBy;
+                this.HasOffsetLimit = hasOffsetLimit;
+            }
+
+            public bool HasAggregate { get; }
+            public bool HasDistinct { get; }
+            public bool HasGroupBy { get; }
+            public bool HasOrderBy { get; }
+            public bool HasOffsetLimit { get; }
+
+            public override bool Equals(object obj)
+            {
+                if (!(obj is QueryMetadata queryMetadata))
+                {
+                    return false;
+                }
+
+                return this.Equals(queryMetadata);
+            }
+
+            public bool Equals(QueryMetadata other)
+            {
+                return this.HasAggregate == other.HasAggregate &&
+                    this.HasDistinct == other.HasDistinct &&
+                    this.HasGroupBy == other.HasGroupBy &&
+                    this.HasOffsetLimit == other.HasOffsetLimit &&
+                    this.HasOrderBy == other.HasOrderBy;
+            }
+
+            public override int GetHashCode()
+            {
+                return ((this.HasAggregate ? 1 : 0) << 5) +
+                    ((this.HasDistinct ? 1 : 0) << 4) +
+                    ((this.HasGroupBy ? 1 : 0) << 3) +
+                    ((this.HasOffsetLimit ? 1 : 0) << 2) +
+                    ((this.HasOrderBy ? 1 : 0) << 1);
+            }
+
+            public static QueryMetadata Create(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+            {
+                return new QueryMetadata(
+                    hasAggregate: partitionedQueryExecutionInfo.QueryInfo.HasAggregates,
+                    hasDistinct: partitionedQueryExecutionInfo.QueryInfo.HasDistinct,
+                    hasGroupBy: partitionedQueryExecutionInfo.QueryInfo.HasGroupBy,
+                    hasOrderBy: partitionedQueryExecutionInfo.QueryInfo.HasOrderBy,
+                    hasOffsetLimit: partitionedQueryExecutionInfo.QueryInfo.HasOffset || partitionedQueryExecutionInfo.QueryInfo.HasLimit);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/QueryRequestOptionsTuner.cs
@@ -30,19 +30,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             large: 4 * 1024,
             xlarge: int.MaxValue);
 
-        public static int GetOptimalMaxPageSize(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        public static int GetOptimalMaxPageSize(QueryMetadata queryMetadata)
         {
             return PageSizeTShirtSizes.XLarge;
         }
 
-        public static int GetOptimalMaxBufferedItemCount(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        public static int GetOptimalMaxBufferedItemCount(QueryMetadata queryMetadata)
         {
-            if (partitionedQueryExecutionInfo == null)
-            {
-                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
-            }
-
-            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
             if (queryMetadata.HasPartialResults)
             {
                 // If we are going to wait for the query to fully drain we might as well do it as fast as possible.
@@ -90,14 +84,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             return bufferedItemCount;
         }
 
-        public static int GetOptimalMaxConcurrency(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
+        public static int GetOptimalMaxConcurrency(QueryMetadata queryMetadata)
         {
-            if (partitionedQueryExecutionInfo == null)
-            {
-                throw new ArgumentNullException(nameof(partitionedQueryExecutionInfo));
-            }
-
-            QueryMetadata queryMetadata = QueryMetadata.Create(partitionedQueryExecutionInfo);
             if (queryMetadata.HasPartialResults)
             {
                 // If we are going to wait for the query to fully drain we might as well do it as fast as possible.
@@ -161,105 +149,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             public int Medium { get; }
             public int Large { get; }
             public int XLarge { get; }
-        }
-
-        private readonly ref struct QueryMetadata
-        {
-            public enum TShirtSize
-            {
-                XSmall,
-                Small,
-                Medium,
-                Large,
-                XLarge
-            }
-
-            public QueryMetadata(
-                bool hasAggregate,
-                bool hasDistinct,
-                bool hasGroupBy,
-                bool hasOrderBy,
-                int? offsetCount,
-                int? limitCount,
-                int? topCount)
-            {
-                this.HasAggregate = hasAggregate;
-                this.HasDistinct = hasDistinct;
-                this.HasGroupBy = hasGroupBy;
-                this.HasOrderBy = hasOrderBy;
-                this.OffsetCount = offsetCount;
-                this.LimitCount = limitCount;
-                this.TopCount = topCount;
-            }
-
-            public bool HasAggregate { get; }
-            public bool HasDistinct { get; }
-            public bool HasGroupBy { get; }
-            public bool HasOrderBy { get; }
-            public int? OffsetCount { get; }
-            public int? LimitCount { get; }
-            public int? TopCount { get; }
-
-            public bool HasOffset => this.OffsetCount.HasValue;
-            public bool HasLimit => this.LimitCount.HasValue;
-            public bool HasTop => this.TopCount.HasValue;
-            public bool HasOffsetLimitOrTop => this.HasOffset || this.HasLimit || this.HasTop;
-            public int? OffsetLimitTopCount => this.HasOffsetLimitOrTop ? (int?)(this.OffsetCount.GetValueOrDefault(0) + this.LimitCount.GetValueOrDefault(0) + this.TopCount.GetValueOrDefault(0)) : null;
-
-            public TShirtSize? OffsetTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetCount);
-            public TShirtSize? LimitTShirtSize => QueryMetadata.GetTShirtSize(this.LimitCount);
-            public TShirtSize? TopTShirtSize => QueryMetadata.GetTShirtSize(this.TopCount);
-            public TShirtSize? OffsetLimitTopTShirtSize => QueryMetadata.GetTShirtSize(this.OffsetLimitTopCount);
-
-            private static TShirtSize? GetTShirtSize(int? size)
-            {
-                if (!size.HasValue)
-                {
-                    return default;
-                }
-
-                int value = size.Value;
-                TShirtSize tShirtSize;
-                if (value <= 1)
-                {
-                    tShirtSize = TShirtSize.XSmall;
-                }
-                else if (value <= 10)
-                {
-                    tShirtSize = TShirtSize.Small;
-                }
-                else if (value <= 128)
-                {
-                    tShirtSize = TShirtSize.Medium;
-                }
-                else if (value <= 1024)
-                {
-                    tShirtSize = TShirtSize.Large;
-                }
-                else
-                {
-                    tShirtSize = TShirtSize.XLarge;
-                }
-
-                return tShirtSize;
-            }
-
-            /// <summary>
-            /// Determines if a query has partial results, meaning the SDK has to drain the query fully before returning a single result.
-            /// </summary>
-            public bool HasPartialResults => this.HasAggregate || this.HasDistinct || this.HasGroupBy;
-
-            public static QueryMetadata Create(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
-            {
-                return new QueryMetadata(
-                    hasAggregate: partitionedQueryExecutionInfo.QueryInfo.HasAggregates,
-                    hasDistinct: partitionedQueryExecutionInfo.QueryInfo.HasDistinct,
-                    hasGroupBy: partitionedQueryExecutionInfo.QueryInfo.HasGroupBy,
-                    hasOrderBy: partitionedQueryExecutionInfo.QueryInfo.HasOrderBy,
-                    offsetCount: partitionedQueryExecutionInfo.QueryInfo.Offset,
-                    limitCount: partitionedQueryExecutionInfo.QueryInfo.Limit,
-                    topCount: partitionedQueryExecutionInfo.QueryInfo.Top);
-            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -67,7 +67,8 @@ namespace Microsoft.Azure.Cosmos.Query
                 partitionedQueryExecutionInfo: partitionedQueryExecutionInfo,
                 executionEnvironment: queryRequestOptions.ExecutionEnvironment,
                 returnResultsInDeterministicOrder: queryRequestOptions.ReturnResultsInDeterministicOrder,
-                testInjections: queryRequestOptions.TestSettings);
+                testInjections: queryRequestOptions.TestSettings,
+                queryOptionsDefaultOptimizer: queryRequestOptions.Optimizer);
 
             return new QueryIterator(
                 cosmosQueryContext,

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -149,6 +149,15 @@ namespace Microsoft.Azure.Cosmos
 
         internal TestInjections TestSettings { get; set; }
 
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+    public
+#else
+        internal
+#endif
+        QueryOptionsDefaultOptimizer Optimizer { get; set; }
+
         /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties
         /// </summary>
@@ -245,6 +254,30 @@ namespace Microsoft.Azure.Cosmos
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.PageSize, maxItemCount.Value.ToString(CultureInfo.InvariantCulture));
             }
+        }
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+    public
+#else
+        internal
+#endif
+        sealed class QueryOptionsDefaultOptimizer
+        {
+            public QueryOptionsDefaultOptimizer(
+                Func<QueryMetadata, int> defaultForPageSizeCallback,
+                Func<QueryMetadata, int> defaultForMaxBufferedItemCountCallback,
+                Func<QueryMetadata, int> defaultForMaxConcurrencyCallback)
+            {
+                this.DefaultForPageSizeCallback = defaultForPageSizeCallback ?? throw new ArgumentNullException(nameof(defaultForPageSizeCallback));
+                this.DefaultForMaxBufferedItemCountCallback = defaultForMaxBufferedItemCountCallback ?? throw new ArgumentNullException(nameof(defaultForMaxBufferedItemCountCallback));
+                this.DefaultForMaxConcurrencyCallback = defaultForMaxConcurrencyCallback ?? throw new ArgumentNullException(nameof(defaultForMaxConcurrencyCallback));
+            }
+
+            public Func<QueryMetadata, int> DefaultForPageSizeCallback { get; }
+            public Func<QueryMetadata, int> DefaultForMaxBufferedItemCountCallback { get; }
+            public Func<QueryMetadata, int> DefaultForMaxConcurrencyCallback { get; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -264,7 +264,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 partitionedQueryExecutionInfo: null,
                 executionEnvironment: queryRequestOptions?.ExecutionEnvironment,
                 returnResultsInDeterministicOrder: true,
-                testInjections: queryRequestOptions?.TestSettings);
+                testInjections: queryRequestOptions?.TestSettings,
+                queryOptionsDefaultOptimizer: queryRequestOptions.Optimizer);
 
             CosmosQueryContext cosmosQueryContext = new CosmosQueryContextCore(
                 client: client.Object,


### PR DESCRIPTION
# Default Query Request Options Picker

## Description

This PR sets defaults for:

* PageSize
* MaxBufferedItemCount
* MaxConcurrency

Based on the query shape.

If the user knows more about the query, then they can over the picker in the Request Options. 

This PR is so Mongo can set better Request Options that compromise between latency and RUs consumed. I worked with Ashwini to come up with the first iteration of defaults.

