### PR TITLE
Fix broken link to GitHub samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ while (feedIterator.HasMoreResults)
 ## Useful links
 
 - [Get Started APP](https://docs.microsoft.com/azure/cosmos-db/sql-api-get-started)
-- [Github samples](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/CodeSamples)
+- [GitHub samples](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples)
 - [MultiMaster samples](https://github.com/markjbrown/azure-cosmosdb-dotnet/tree/master/samples/MultiMaster)
 - [Resource Model of Azure Cosmos DB Service](https://docs.microsoft.com/azure/cosmos-db/sql-api-resources)
 - [Cosmos DB Resource URI](https://docs.microsoft.com/rest/api/documentdb/documentdb-resource-uri-syntax-for-rest)


### PR DESCRIPTION
# Pull Request Template

## Description

The link to _GitHub samples_ in `README.md` resulted in a 404 Not Found response from GitHub. Moving one level up in the folder hierarchy of the source code links to what seems to be the intended folder on GitHub.

I also fixed the spelling of _GitHub_ in the link text.

## Type of change

Please delete options that are not relevant.

- [ x] Bug fix (non-breaking change which fixes an issue)
