### PR TITLE
Adding query plan and pipeline generation diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/BackendMetricsExtractor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/BackendMetricsExtractor.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 
         public override (ParseFailureReason, BackendMetrics) Visit(QueryPipelineDiagnostics queryPipelineDiagnostics)
         {
-            throw new System.NotImplementedException();
+            return (ParseFailureReason.MetricsNotFound, default);
         }
 
         public enum ParseFailureReason

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/BackendMetricsExtractor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/BackendMetricsExtractor.cs
@@ -74,6 +74,11 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             return (ParseFailureReason.None, backendMetrics);
         }
 
+        public override (ParseFailureReason, BackendMetrics) Visit(QueryPipelineDiagnostics queryPipelineDiagnostics)
+        {
+            throw new System.NotImplementedException();
+        }
+
         public enum ParseFailureReason
         {
             None,

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContext.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.Cosmos
 
         internal abstract void AddDiagnosticsInternal(PointOperationStatistics pointOperationStatistics);
 
+        internal abstract void AddDiagnosticsInternal(QueryPipelineDiagnostics queryPipelineDiagnostics);
+
         internal abstract void AddDiagnosticsInternal(QueryPageDiagnostics queryPageDiagnostics);
 
         internal abstract void AddDiagnosticsInternal(CosmosDiagnosticsContext newContext);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -108,6 +108,16 @@ namespace Microsoft.Azure.Cosmos
             this.ContextList.Add(queryPageDiagnostics);
         }
 
+        internal override void AddDiagnosticsInternal(QueryPipelineDiagnostics queryPipelineDiagnostics)
+        {
+            if (queryPipelineDiagnostics == null)
+            {
+                throw new ArgumentNullException(nameof(queryPipelineDiagnostics));
+            }
+
+            this.ContextList.Add(queryPipelineDiagnostics);
+        }
+
         internal override void AddDiagnosticsInternal(CosmosDiagnosticsContext newContext)
         {
             this.AddSummaryInfo(newContext);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -115,6 +115,11 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(queryPipelineDiagnostics));
             }
 
+            if (queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
+            {
+                this.AddSummaryInfo(queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics);
+            }
+
             this.ContextList.Add(queryPipelineDiagnostics);
         }
 

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsInternalVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsInternalVisitor.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         public abstract void Visit(CosmosDiagnosticsContext cosmosDiagnosticsContext);
         public abstract void Visit(CosmosDiagnosticScope cosmosDiagnosticScope);
         public abstract void Visit(QueryPageDiagnostics queryPageDiagnostics);
+        public abstract void Visit(QueryPipelineDiagnostics queryPipelineDiagnostics);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsInternalVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsInternalVisitor{TResult}.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         public abstract TResult Visit(CosmosDiagnosticsContext cosmosDiagnosticsContext);
         public abstract TResult Visit(CosmosDiagnosticScope cosmosDiagnosticScope);
         public abstract TResult Visit(QueryPageDiagnostics queryPageDiagnostics);
+        public abstract TResult Visit(QueryPipelineDiagnostics queryPipelineDiagnostics);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -164,6 +164,11 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.jsonWriter.WritePropertyName("Context");
             this.jsonWriter.WriteStartArray();
 
+            if (queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
+            {
+                queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics.Accept(this);
+            }
+
             foreach (CosmosDiagnosticScope scope in queryPipelineDiagnostics.QueryPipelineCreationScopes)
             {
                 scope.Accept(this);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -164,14 +164,14 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.jsonWriter.WritePropertyName("Context");
             this.jsonWriter.WriteStartArray();
 
-            if (queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
-            {
-                queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics.Accept(this);
-            }
-
             foreach (CosmosDiagnosticScope scope in queryPipelineDiagnostics.QueryPipelineCreationScopes)
             {
                 scope.Accept(this);
+            }
+
+            if (queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
+            {
+                queryPipelineDiagnostics.QueryPlanFromGatewayDiagnostics.Accept(this);
             }
 
             this.jsonWriter.WriteEndArray();

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -153,5 +153,24 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 
             this.jsonWriter.WriteEndObject();
         }
+
+        public override void Visit(QueryPipelineDiagnostics queryPipelineDiagnostics)
+        {
+            this.jsonWriter.WriteStartObject();
+
+            this.jsonWriter.WritePropertyName("Id");
+            this.jsonWriter.WriteValue("QueryPipelineDiagnostics");
+
+            this.jsonWriter.WritePropertyName("Context");
+            this.jsonWriter.WriteStartArray();
+
+            foreach (CosmosDiagnosticScope scope in queryPipelineDiagnostics.QueryPipelineCreationScopes)
+            {
+                scope.Accept(this);
+            }
+
+            this.jsonWriter.WriteEndArray();
+            this.jsonWriter.WriteEndObject();
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/EmptyCosmosDiagnosticsContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/EmptyCosmosDiagnosticsContext.cs
@@ -49,6 +49,10 @@ namespace Microsoft.Azure.Cosmos
         {
         }
 
+        internal override void AddDiagnosticsInternal(QueryPipelineDiagnostics queryPipelineDiagnostics)
+        {
+        }
+
         internal override void AddDiagnosticsInternal(CosmosDiagnosticsContext newContext)
         {
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/QueryPipelineDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/QueryPipelineDiagnostics.cs
@@ -1,0 +1,108 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+
+    internal sealed class QueryPipelineDiagnostics : CosmosDiagnosticsInternal
+    {
+        public QueryPipelineDiagnostics(
+            IReadOnlyCollection<CosmosDiagnosticScope> queryPipelineCreationScopes,
+            CosmosDiagnosticsContext queryPlanFromGatewayDiagnostics)
+        {
+            this.QueryPipelineCreationScopes = queryPipelineCreationScopes ?? throw new ArgumentNullException(nameof(queryPipelineCreationScopes));
+            this.QueryPlanFromGatewayDiagnostics = queryPlanFromGatewayDiagnostics;
+        }
+
+        internal IReadOnlyCollection<CosmosDiagnosticScope> QueryPipelineCreationScopes { get; }
+        internal CosmosDiagnosticsContext QueryPlanFromGatewayDiagnostics { get; }
+
+        internal static QueryPipelineDiagnostics Merge(
+            QueryPipelineDiagnostics source,
+            QueryPipelineDiagnostics target)
+        {
+            if (source == null)
+            {
+                return target;
+            }
+
+            if (target == null)
+            {
+                return source;
+            }
+
+            IReadOnlyCollection<CosmosDiagnosticScope> merged = source.QueryPipelineCreationScopes.Concat(target.QueryPipelineCreationScopes).ToList().AsReadOnly();
+
+            CosmosDiagnosticsContext diagnosticsContext = source.QueryPlanFromGatewayDiagnostics;
+            if (diagnosticsContext != null && target.QueryPlanFromGatewayDiagnostics != null)
+            {
+                diagnosticsContext.AddDiagnosticsInternal(target.QueryPlanFromGatewayDiagnostics);
+            }
+            else if (diagnosticsContext == null && target.QueryPlanFromGatewayDiagnostics != null)
+            {
+                diagnosticsContext = target.QueryPlanFromGatewayDiagnostics;
+            }
+
+            return new QueryPipelineDiagnostics(
+                merged,
+                diagnosticsContext);
+        }
+
+        public override void Accept(CosmosDiagnosticsInternalVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        public override TResult Accept<TResult>(CosmosDiagnosticsInternalVisitor<TResult> visitor)
+        {
+            return visitor.Visit(this);
+        }
+
+        internal struct QueryPipelineDiagnosticBuilder
+        {
+            private readonly IList<CosmosDiagnosticScope> pipelineDiagnostics;
+            private CosmosDiagnosticsContext gatewayDiagnosticContext;
+
+            internal QueryPipelineDiagnosticBuilder(int capacity)
+            {
+                this.pipelineDiagnostics = new List<CosmosDiagnosticScope>(capacity);
+                this.gatewayDiagnosticContext = null;
+            }
+
+            internal IDisposable CreateScope(string name)
+            {
+                if (this.pipelineDiagnostics == null)
+                {
+                    throw new ArgumentNullException(nameof(this.pipelineDiagnostics));
+                }
+
+                CosmosDiagnosticScope diagnosticScope = new CosmosDiagnosticScope(name);
+                this.pipelineDiagnostics.Add(diagnosticScope);
+                return diagnosticScope;
+            }
+
+            internal void AddGatewayDiagnostics(CosmosDiagnosticsContext gatewayDiagnosticContext)
+            {
+                if (this.gatewayDiagnosticContext == null)
+                {
+                    this.gatewayDiagnosticContext = gatewayDiagnosticContext;
+                }
+                else
+                {
+                    this.gatewayDiagnosticContext.AddDiagnosticsInternal(gatewayDiagnosticContext);
+                }
+            }
+
+            internal QueryPipelineDiagnostics Build()
+            {
+                return new QueryPipelineDiagnostics(
+                    new ReadOnlyCollection<CosmosDiagnosticScope>(this.pipelineDiagnostics),
+                    this.gatewayDiagnosticContext);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Client.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
                     disallowContinuationTokenMessage: null,
                     requestCharge: requestCharge,
                     diagnostics: diagnosticsPages,
+                    pipelineDiagnostics: null,
                     responseLengthBytes: responseLengthBytes);
             }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Compute.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
                 responseLengthBytes: 0,
                 disallowContinuationTokenMessage: null,
                 continuationToken: null,
-                diagnostics: QueryResponseCore.EmptyDiagnostics);
+                diagnostics: QueryResponseCore.EmptyDiagnostics,
+                pipelineDiagnostics: null);
 
             return response;
         }
@@ -160,7 +161,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
                 responseLengthBytes: sourceResponse.ResponseLengthBytes,
                 disallowContinuationTokenMessage: null,
                 continuationToken: updatedContinuationToken,
-                diagnostics: sourceResponse.Diagnostics);
+                diagnostics: sourceResponse.Diagnostics,
+                pipelineDiagnostics: sourceResponse.PipelineDiagnostics);
 
             return response;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Client.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
                         activityId: sourceResponse.ActivityId,
                         requestCharge: sourceResponse.RequestCharge,
                         diagnostics: sourceResponse.Diagnostics,
-                        responseLengthBytes: sourceResponse.ResponseLengthBytes);
+                        responseLengthBytes: sourceResponse.ResponseLengthBytes,
+                        pipelineDiagnostics: sourceResponse.PipelineDiagnostics);
                 }
                 else
                 {
@@ -124,7 +125,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
                         activityId: sourceResponse.ActivityId,
                         requestCharge: sourceResponse.RequestCharge,
                         diagnostics: sourceResponse.Diagnostics,
-                        responseLengthBytes: sourceResponse.ResponseLengthBytes);
+                        responseLengthBytes: sourceResponse.ResponseLengthBytes,
+                        pipelineDiagnostics: sourceResponse.PipelineDiagnostics);
                 }
 
                 return queryResponseCore;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Compute.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
                         activityId: sourceResponse.ActivityId,
                         requestCharge: sourceResponse.RequestCharge,
                         diagnostics: sourceResponse.Diagnostics,
-                        responseLengthBytes: sourceResponse.ResponseLengthBytes);
+                        responseLengthBytes: sourceResponse.ResponseLengthBytes,
+                        pipelineDiagnostics: sourceResponse.PipelineDiagnostics);
             }
 
             public override bool TryGetContinuationToken(out string continuationToken)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Client.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
                 double requestCharge = 0.0;
                 long responseLengthBytes = 0;
                 List<QueryPageDiagnostics> queryPageDiagnostics = new List<QueryPageDiagnostics>();
+                QueryPipelineDiagnostics pipelineDiagnostics = null;
                 while (!this.Source.IsDone)
                 {
                     // Stage 1: 
@@ -83,6 +84,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
                         queryPageDiagnostics.AddRange(sourceResponse.Diagnostics);
                     }
 
+                    if (sourceResponse.PipelineDiagnostics != null)
+                    {
+                        pipelineDiagnostics = sourceResponse.PipelineDiagnostics;
+                    }
+
                     this.AggregateGroupings(sourceResponse.CosmosElements);
                 }
 
@@ -97,7 +103,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
                    activityId: null,
                    requestCharge: requestCharge,
                    diagnostics: queryPageDiagnostics,
-                   responseLengthBytes: responseLengthBytes);
+                   responseLengthBytes: responseLengthBytes,
+                   pipelineDiagnostics: pipelineDiagnostics);
 
                 return response;
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Compute.cs
@@ -116,7 +116,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
                         activityId: sourceResponse.ActivityId,
                         requestCharge: sourceResponse.RequestCharge,
                         diagnostics: sourceResponse.Diagnostics,
-                        responseLengthBytes: sourceResponse.ResponseLengthBytes);
+                        responseLengthBytes: sourceResponse.ResponseLengthBytes,
+                        pipelineDiagnostics: sourceResponse.PipelineDiagnostics);
                 }
                 else
                 {
@@ -131,7 +132,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
                        activityId: null,
                        requestCharge: 0,
                        diagnostics: QueryResponseCore.EmptyDiagnostics,
-                       responseLengthBytes: 0);
+                       responseLengthBytes: 0,
+                       pipelineDiagnostics: null);
                 }
 
                 return response;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
                     activityId: sourcePage.ActivityId,
                     requestCharge: sourcePage.RequestCharge,
                     diagnostics: sourcePage.Diagnostics,
-                    responseLengthBytes: sourcePage.ResponseLengthBytes);
+                    responseLengthBytes: sourcePage.ResponseLengthBytes,
+                    pipelineDiagnostics: sourcePage.PipelineDiagnostics);
         }
 
         public override bool TryGetContinuationToken(out string state)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.cs
@@ -153,7 +153,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
                     activityId: results.ActivityId,
                     requestCharge: results.RequestCharge,
                     diagnostics: results.Diagnostics,
-                    responseLengthBytes: results.ResponseLengthBytes);
+                    responseLengthBytes: results.ResponseLengthBytes,
+                    pipelineDiagnostics: null);
         }
 
         public override bool TryGetContinuationToken(out string state)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducer.cs
@@ -292,7 +292,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers
                             errorMessage: "Request Rate Too Large",
                             requestCharge: 0,
                             activityId: QueryResponseCore.EmptyGuidString,
-                            diagnostics: QueryResponseCore.EmptyDiagnostics);
+                            diagnostics: QueryResponseCore.EmptyDiagnostics,
+                            pipelineDiagnostics: feedResponse.PipelineDiagnostics);
                     }
                 }
 
@@ -309,7 +310,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers
                             responseLengthBytes: 0,
                             disallowContinuationTokenMessage: null,
                             continuationToken: this.BackendContinuationToken,
-                            diagnostics: QueryResponseCore.EmptyDiagnostics);
+                            diagnostics: QueryResponseCore.EmptyDiagnostics,
+                            pipelineDiagnostics: feedResponse.PipelineDiagnostics);
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.cs
@@ -304,7 +304,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
                 responseLengthBytes: this.GetAndResetResponseLengthBytes(),
                 disallowContinuationTokenMessage: null,
                 continuationToken: this.ContinuationToken,
-                diagnostics: this.GetAndResetDiagnostics());
+                diagnostics: this.GetAndResetDiagnostics(),
+                pipelineDiagnostics: null);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/Parallel/CosmosParallelItemQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/Parallel/CosmosParallelItemQueryExecutionContext.cs
@@ -201,7 +201,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.Parallel
                     responseLengthBytes: this.GetAndResetResponseLengthBytes(),
                     disallowContinuationTokenMessage: null,
                     continuationToken: this.ContinuationToken,
-                    diagnostics: this.GetAndResetDiagnostics());
+                    diagnostics: this.GetAndResetDiagnostics(),
+                    pipelineDiagnostics: null);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
@@ -336,6 +336,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     activityId: queryResponse.ActivityId,
                     requestCharge: queryResponse.RequestCharge,
                     diagnostics: queryResponse.Diagnostics,
+                    pipelineDiagnostics: queryResponse.PipelineDiagnostics,
                     responseLengthBytes: queryResponse.ResponseLengthBytes);
             }
             catch (Exception)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             SchedulingStopwatch schedulingStopwatch,
             CancellationToken cancellationToken);
 
-        internal abstract Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(
+        internal abstract Task<(PartitionedQueryExecutionInfo, CosmosDiagnosticsContext)> ExecuteQueryPlanRequestAsync(
             Uri resourceUri,
             Documents.ResourceType resourceType,
             Documents.OperationType operationType,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
     using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Query.Core.Metrics;
     using SubStatusCodes = Documents.SubStatusCodes;
 
 #if INTERNAL
@@ -32,6 +31,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             double requestCharge,
             string activityId,
             IReadOnlyCollection<QueryPageDiagnostics> diagnostics,
+            QueryPipelineDiagnostics pipelineDiagnostics,
             long responseLengthBytes,
             string disallowContinuationTokenMessage,
             string continuationToken,
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             this.StatusCode = statusCode;
             this.ActivityId = activityId;
             this.Diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
+            this.PipelineDiagnostics = pipelineDiagnostics;
             this.ResponseLengthBytes = responseLengthBytes;
             this.RequestCharge = requestCharge;
             this.DisallowContinuationTokenMessage = disallowContinuationTokenMessage;
@@ -69,6 +70,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
 
         internal IReadOnlyCollection<QueryPageDiagnostics> Diagnostics { get; }
 
+        internal QueryPipelineDiagnostics PipelineDiagnostics { get; }
+
         internal long ResponseLengthBytes { get; }
 
         internal bool IsSuccess { get; }
@@ -80,7 +83,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             long responseLengthBytes,
             string disallowContinuationTokenMessage,
             string continuationToken,
-            IReadOnlyCollection<QueryPageDiagnostics> diagnostics)
+            IReadOnlyCollection<QueryPageDiagnostics> diagnostics,
+            QueryPipelineDiagnostics pipelineDiagnostics)
         {
             QueryResponseCore cosmosQueryResponse = new QueryResponseCore(
                result: result,
@@ -89,6 +93,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
                requestCharge: requestCharge,
                activityId: activityId,
                diagnostics: diagnostics,
+               pipelineDiagnostics: pipelineDiagnostics,
                responseLengthBytes: responseLengthBytes,
                disallowContinuationTokenMessage: disallowContinuationTokenMessage,
                continuationToken: continuationToken,
@@ -104,7 +109,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             string errorMessage,
             double requestCharge,
             string activityId,
-            IReadOnlyCollection<QueryPageDiagnostics> diagnostics)
+            IReadOnlyCollection<QueryPageDiagnostics> diagnostics,
+            QueryPipelineDiagnostics pipelineDiagnostics)
         {
             QueryResponseCore cosmosQueryResponse = new QueryResponseCore(
                 result: QueryResponseCore.EmptyList,
@@ -113,6 +119,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
                 requestCharge: requestCharge,
                 activityId: activityId,
                 diagnostics: diagnostics,
+                pipelineDiagnostics: pipelineDiagnostics,
                 responseLengthBytes: 0,
                 disallowContinuationTokenMessage: null,
                 continuationToken: null,
@@ -120,6 +127,26 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
                 subStatusCode: subStatusCodes);
 
             return cosmosQueryResponse;
+        }
+
+        internal static QueryResponseCore CreateWithDiagnostics(
+            QueryResponseCore queryResponse,
+            IReadOnlyCollection<QueryPageDiagnostics> queryPageDiagnostics,
+            QueryPipelineDiagnostics pipelineDiagnostics)
+        {
+            return new QueryResponseCore(
+                result: queryResponse.CosmosElements,
+                isSuccess: queryResponse.IsSuccess,
+                statusCode: queryResponse.StatusCode,
+                requestCharge: queryResponse.RequestCharge,
+                activityId: queryResponse.ActivityId,
+                diagnostics: queryPageDiagnostics,
+                pipelineDiagnostics: pipelineDiagnostics,
+                responseLengthBytes: queryResponse.ResponseLengthBytes,
+                disallowContinuationTokenMessage: queryResponse.DisallowContinuationTokenMessage,
+                continuationToken: queryResponse.ContinuationToken,
+                errorMessage: queryResponse.ErrorMessage,
+                subStatusCode: queryResponse.SubStatusCode);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             return tryGetQueryPlan.Result;
         }
 
-        public static Task<PartitionedQueryExecutionInfo> GetQueryPlanThroughGatewayAsync(
+        public static Task<(PartitionedQueryExecutionInfo, CosmosDiagnosticsContext)> GetQueryPlanThroughGatewayAsync(
             CosmosQueryClient client,
             SqlQuerySpec sqlQuerySpec,
             Uri resourceLink,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
                     errorMessage: exceptionWithStackTrace.ToString(),
                     requestCharge: innerExceptionResponse.RequestCharge,
                     activityId: innerExceptionResponse.ActivityId,
-                    diagnostics: innerExceptionResponse.Diagnostics);
+                    diagnostics: innerExceptionResponse.Diagnostics,
+                    pipelineDiagnostics: null);
             }
             else
             {
@@ -57,7 +58,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
                         errorMessage: exception?.ToString(),
                         requestCharge: 0,
                         activityId: QueryResponseCore.EmptyGuidString,
-                        diagnostics: QueryResponseCore.EmptyDiagnostics);
+                        diagnostics: QueryResponseCore.EmptyDiagnostics,
+                        pipelineDiagnostics: null);
                 }
             }
 
@@ -72,7 +74,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
                 errorMessage: cosmosException.ToString(),
                 requestCharge: 0,
                 activityId: cosmosException.ActivityId,
-                diagnostics: QueryResponseCore.EmptyDiagnostics);
+                diagnostics: QueryResponseCore.EmptyDiagnostics,
+                pipelineDiagnostics: null);
 
             return queryResponseCore;
         }
@@ -85,7 +88,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
                 errorMessage: documentClientException.ToString(),
                 requestCharge: 0,
                 activityId: documentClientException.ActivityId,
-                diagnostics: QueryResponseCore.EmptyDiagnostics);
+                diagnostics: QueryResponseCore.EmptyDiagnostics,
+                pipelineDiagnostics: null);
 
             return queryResponseCore;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Query
         public override async Task<ResponseMessage> ReadNextAsync(CancellationToken cancellationToken = default)
         {
             CosmosDiagnosticsContext diagnostics = CosmosDiagnosticsContext.Create(this.requestOptions);
-            using (diagnostics.CreateScope("QueryReadNextAsync"))
+            using (diagnostics.CreateOverallScope("QueryReadNextAsync"))
             {
                 // This catches exception thrown by the pipeline and converts it to QueryResponse
                 QueryResponseCore responseCore = await this.cosmosQueryExecutionContext.ExecuteNextAsync(cancellationToken);
@@ -92,11 +92,6 @@ namespace Microsoft.Azure.Cosmos.Query
 
                 if (responseCore.PipelineDiagnostics != null)
                 {
-                    if (responseCore.PipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
-                    {
-                        diagnostics.AddDiagnosticsInternal(responseCore.PipelineDiagnostics.QueryPlanFromGatewayDiagnostics);
-                    }
-                    
                     diagnostics.AddDiagnosticsInternal(responseCore.PipelineDiagnostics);
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -90,6 +90,16 @@ namespace Microsoft.Azure.Cosmos.Query
                 QueryResponseCore responseCore = await this.cosmosQueryExecutionContext.ExecuteNextAsync(cancellationToken);
                 CosmosQueryContext cosmosQueryContext = this.cosmosQueryContext;
 
+                if (responseCore.PipelineDiagnostics != null)
+                {
+                    if (responseCore.PipelineDiagnostics.QueryPlanFromGatewayDiagnostics != null)
+                    {
+                        diagnostics.AddDiagnosticsInternal(responseCore.PipelineDiagnostics.QueryPlanFromGatewayDiagnostics);
+                    }
+                    
+                    diagnostics.AddDiagnosticsInternal(responseCore.PipelineDiagnostics);
+                }
+
                 foreach (QueryPageDiagnostics queryPage in responseCore.Diagnostics)
                 {
                     diagnostics.AddDiagnosticsInternal(queryPage);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -201,10 +201,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DataRow(true, true)]
+        //[DataRow(true, true)]
         [DataRow(false, true)]
-        [DataRow(true, false)]
-        [DataRow(false, false)]
+        //[DataRow(true, false)]
+        //[DataRow(false, false)]
         public async Task QueryOperationDiagnostic(
             bool disableDiagnostics,
             bool forceGatewayQueryPlan)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -750,7 +750,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             Assert.AreEqual<T>(expectedValue, response.Resource);
             Assert.IsTrue(response.RequestCharge > 0);
-            CosmosDiagnosticsTests.VerifyQueryDiagnostics(response.Diagnostics, false, disableDiagnostics);
+            CosmosDiagnosticsTests.VerifyQueryDiagnostics(
+                diagnostics: response.Diagnostics,
+                isFirstPage: false,
+                disableDiagnostics: disableDiagnostics,
+                forceGatewayQueryPlan: false);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -752,7 +752,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(response.RequestCharge > 0);
             CosmosDiagnosticsTests.VerifyQueryDiagnostics(
                 diagnostics: response.Diagnostics,
-                isFirstPage: false,
+                isFirstPage: true,
                 disableDiagnostics: disableDiagnostics,
                 forceGatewayQueryPlan: false);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -258,16 +258,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 // Test query with no service interop via gateway query plan to replicate x32 app
                 ContainerCore containerCore = (ContainerInlineCore)tokenContainer;
-                CrossPartitionQueryTests.MockCosmosQueryClient mock = new CrossPartitionQueryTests.MockCosmosQueryClient(
-                    clientContext: containerCore.ClientContext,
-                    cosmosContainerCore: containerCore,
-                    forceQueryPlanGatewayElseServiceInterop: true);
-
-                Container tokenGatewayQueryPlan = new ContainerCore(
-                    containerCore.ClientContext,
-                    (DatabaseCore)containerCore.Database,
-                    containerCore.Id,
-                    mock);
+                Container tokenGatewayQueryPlan = QueryHelper.GetContainerWithForcedGatewayQueryPlan(containerCore);
 
                 FeedIterator<ToDoActivity> feedIteratorGateway = tokenGatewayQueryPlan.GetItemQueryIterator<ToDoActivity>(
                     queryText: "select * from T",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -729,6 +729,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             "Max Item Count is not being honored");
                     }
 
+                    string diagnostics = page.Diagnostics.ToString();
+
                     try
                     {
                         continuationTokenForRetries = page.ContinuationToken;
@@ -5113,7 +5115,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 return this.forceQueryPlanGatewayElseServiceInterop;
             }
 
-            internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(
+            internal override Task<(PartitionedQueryExecutionInfo, CosmosDiagnosticsContext)> ExecuteQueryPlanRequestAsync(
                 Uri resourceUri,
                 ResourceType resourceType,
                 OperationType operationType,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/QueryHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/QueryHelper.cs
@@ -1,0 +1,110 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.Metrics;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    internal static class QueryHelper
+    {
+        internal static ContainerCore GetContainerWithForcedGatewayQueryPlan(
+            ContainerCore containerCore)
+        {
+            MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
+                   containerCore.ClientContext,
+                   containerCore,
+                   true);
+
+            return new ContainerCore(
+                containerCore.ClientContext,
+                (DatabaseCore)containerCore.Database,
+                containerCore.Id,
+                cosmosQueryClientCore);
+        }
+
+        /// <summary>
+        /// A helper that forces the SDK to use the gateway or the service interop for the query plan
+        /// </summary>
+        private class MockCosmosQueryClient : CosmosQueryClientCore
+        {
+            /// <summary>
+            /// True it will use the gateway query plan.
+            /// False it will use the service interop
+            /// </summary>
+            private readonly bool forceQueryPlanGatewayElseServiceInterop;
+
+            public MockCosmosQueryClient(
+                CosmosClientContext clientContext,
+                ContainerCore cosmosContainerCore,
+                bool forceQueryPlanGatewayElseServiceInterop) : base(
+                    clientContext,
+                    cosmosContainerCore)
+            {
+                this.forceQueryPlanGatewayElseServiceInterop = forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            public int QueryPlanCalls { get; private set; }
+
+            internal override bool ByPassQueryParsing()
+            {
+                return this.forceQueryPlanGatewayElseServiceInterop;
+            }
+
+            internal override Task<(PartitionedQueryExecutionInfo, CosmosDiagnosticsContext)> ExecuteQueryPlanRequestAsync(
+                Uri resourceUri,
+                ResourceType resourceType,
+                OperationType operationType,
+                SqlQuerySpec sqlQuerySpec,
+                Cosmos.PartitionKey? partitionKey,
+                string supportedQueryFeatures,
+                CancellationToken cancellationToken)
+            {
+                this.QueryPlanCalls++;
+                return base.ExecuteQueryPlanRequestAsync(
+                    resourceUri,
+                    resourceType,
+                    operationType,
+                    sqlQuerySpec,
+                    partitionKey,
+                    supportedQueryFeatures,
+                    cancellationToken);
+            }
+
+            internal override Task<QueryResponseCore> ExecuteItemQueryAsync<RequestOptionType>(
+                Uri resourceUri,
+                ResourceType resourceType,
+                OperationType operationType,
+                RequestOptionType requestOptions,
+                SqlQuerySpec sqlQuerySpec,
+                string continuationToken,
+                PartitionKeyRangeIdentity partitionKeyRange,
+                bool isContinuationExpected,
+                int pageSize,
+                SchedulingStopwatch schedulingStopwatch,
+                CancellationToken cancellationToken)
+            {
+                Assert.IsFalse(this.forceQueryPlanGatewayElseServiceInterop && this.QueryPlanCalls == 0, "Query Plan is force gateway mode, but no ExecuteQueryPlanRequestAsync have been called");
+                return base.ExecuteItemQueryAsync(
+                    resourceUri: resourceUri,
+                    resourceType: resourceType,
+                    operationType: operationType,
+                    requestOptions: requestOptions,
+                    sqlQuerySpec: sqlQuerySpec,
+                    continuationToken: continuationToken,
+                    partitionKeyRange: partitionKeyRange,
+                    isContinuationExpected: isContinuationExpected,
+                    pageSize: pageSize,
+                    schedulingStopwatch: schedulingStopwatch,
+                    cancellationToken: cancellationToken);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -361,12 +361,13 @@ namespace Microsoft.Azure.Cosmos.Tests
             };
 
             QueryResponseCore failure = QueryResponseCore.CreateFailure(
-                System.Net.HttpStatusCode.Unauthorized,
-                SubStatusCodes.PartitionKeyMismatch,
-                "Random error message",
-                42.89,
-                "TestActivityId",
-                diagnostics);
+                statusCode: System.Net.HttpStatusCode.Unauthorized,
+                subStatusCodes: SubStatusCodes.PartitionKeyMismatch,
+                errorMessage: "Random error message",
+                requestCharge: 42.89,
+                activityId: "TestActivityId",
+                diagnostics: diagnostics,
+                pipelineDiagnostics: null);
 
             Mock<IDocumentQueryExecutionComponent> baseContext = new Mock<IDocumentQueryExecutionComponent>();
             baseContext.Setup(x => x.DrainAsync(It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult<QueryResponseCore>(failure));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ItemProducerTreeUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ItemProducerTreeUnitTests.cs
@@ -215,6 +215,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     requestCharge: 42,
                     activityId: "AA470D71-6DEF-4D61-9A08-272D8C9ABCFE",
                     diagnostics: pageDiagnostics,
+                    pipelineDiagnostics: null,
                     responseLengthBytes: 500,
                     disallowContinuationTokenMessage: null,
                     continuationToken: "TestToken")));
@@ -272,7 +273,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                     errorMessage: "Error message",
                     requestCharge: 10.2,
                     activityId: Guid.NewGuid().ToString(),
-                    diagnostics: pageDiagnostics)));
+                    diagnostics: pageDiagnostics,
+                    pipelineDiagnostics: null)));
 
             await itemProducerTree.BufferMoreDocumentsAsync(cancellationTokenSource.Token);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     activityId: activityId,
                     requestCharge: requestCharge,
                     diagnostics: diagnostics,
+                    pipelineDiagnostics: null,
                     responseLengthBytes: responseLengthBytes);
 
             return (message, items);
@@ -128,6 +129,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     requestCharge: 4,
                     activityId: Guid.NewGuid().ToString(),
                     diagnostics: diagnostics,
+                    pipelineDiagnostics: null,
                     responseLengthBytes: responseLengthBytes,
                     disallowContinuationTokenMessage: null,
                     continuationToken: continuationToken);
@@ -171,6 +173,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                statusCode: httpStatusCode,
                subStatusCodes: subStatusCodes,
                errorMessage: errorMessage,
+               pipelineDiagnostics: null,
                requestCharge: 10.4,
                activityId: Guid.NewGuid().ToString(),
                diagnostics: diagnostics);

--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1223](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1223) Add diagnostics for get query plan and query pipeline creation.
+
 ### Fixed
+
+- [#1223](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1223) Fixed query overall timestamp in diagnostic summary.
 
 ## <a name="3.6.0"/> [3.6.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.6.0) - 2020-01-23
 


### PR DESCRIPTION
# Pull Request Template

## Description

Adding query plan and pipeline generation diagnostics. This makes it possible to trouble shoot latency issues with query. 

Fixed the QueryReadNextAsync overall time to show the correct value.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Example with query plan with gateway:

```
{
    "Summary": {
        "StartUtc": "2020-02-24T19:40:01.5494291Z",
        "ElapsedTime": "00:00:00.0539344",
        "UserAgent": "cosmos-netstandard-sdk/3.7.0|3.7.0|24004|X64|Microsoft Windows 10.0.18363 |.NET Core 4.6.28008.01|",
        "TotalRequestCount": 2,
        "FailedRequestCount": 0
    },
    "Context": [
        {
            "Id": "QueryReadNextAsync",
            "ElapsedTime": "00:00:00.0539344"
        },
        {
            "Id": "QueryPipelineDiagnostics",
            "Context": [
                {
                    "Id": "QueryPipelineCreation",
                    "ElapsedTime": "00:00:00.0476669"
                },
                {
                    "Id": "GetCachedContainerPropertiesAsync",
                    "ElapsedTime": "00:00:00.0000083"
                },
                {
                    "Id": "GetQueryPlanWithGateway",
                    "ElapsedTime": "00:00:00.0473506"
                },
                {
                    "Id": "GetTargetPartitionKeyRangesAsync",
                    "ElapsedTime": "00:00:00.0000442"
                },
                {
                    "Id": "CreateExecutionContext",
                    "ElapsedTime": "00:00:00.0002622"
                },
                {
                    "Summary": {
                        "StartUtc": "2020-02-24T19:40:01.5494520Z",
                        "ElapsedTime": "00:00:00.0472476",
                        "UserAgent": "cosmos-netstandard-sdk/3.7.0|3.7.0|24004|X64|Microsoft Windows 10.0.18363 |.NET Core 4.6.28008.01|",
                        "TotalRequestCount": 1,
                        "FailedRequestCount": 0
                    },
                    "Context": [
                        {
                            "Id": "RequestInvokerHandler",
                            "ElapsedTime": "00:00:00.0472476"
                        },
                        {
                            "Id": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                            "ElapsedTime": "00:00:00.0472211"
                        },
                        {
                            "Id": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                            "ElapsedTime": "00:00:00.0472078"
                        },
                        {
                            "Id": "TransportHandler",
                            "ElapsedTime": "00:00:00.0472040"
                        },
                        {
                            "Id": "PointOperationStatistics",
                            "ActivityId": null,
                            "StatusCode": 200,
                            "SubStatusCode": 0,
                            "RequestCharge": 0.0,
                            "RequestUri": "dbs/ec48c0bd-bbe2-4a35-b5f3-e2c9aac1e29f/colls/effa11bd-aff9-4dee-bb39-dfa93b644097",
                            "RequestSessionToken": null,
                            "ResponseSessionToken": null,
                            "ClientRequestStats": {
                                "RequestStartTimeUtc": "2020-02-24T19:40:01.5494750Z",
                                "RequestEndTimeUtc": "2020-02-24T19:40:01.5965945Z",
                                "RequestLatency": "00:00:00.0471195",
                                "IsCpuOverloaded": false,
                                "NumberRegionsAttempted": 1,
                                "ResponseStatisticsList": [],
                                "AddressResolutionStatistics": [
                                    {
                                        "StartTime": "2020-02-24T19:40:01.5495311Z",
                                        "EndTime": "2020-02-24T19:40:01.5965945Z",
                                        "TargetEndpoint": "https://127.0.0.1:8081/dbs/ec48c0bd-bbe2-4a35-b5f3-e2c9aac1e29f/colls/effa11bd-aff9-4dee-bb39-dfa93b644097/docs"
                                    }
                                ],
                                "SupplementalResponseStatistics": [],
                                "FailedReplicas": [],
                                "RegionsContacted": [],
                                "ContactedReplicas": []
                            }
                        }
                    ]
                }
            ]
        },
        {
            "PKRangeId": "0",
            "QueryMetric": "totalExecutionTimeInMs=0.24;queryCompileTimeInMs=0.05;queryLogicalPlanBuildTimeInMs=0.01;queryPhysicalPlanBuildTimeInMs=0.01;queryOptimizationTimeInMs=0.00;VMExecutionTimeInMs=0.03;indexLookupTimeInMs=0.00;documentLoadTimeInMs=0.03;systemFunctionExecuteTimeInMs=0.00;userFunctionExecuteTimeInMs=0.00;retrievedDocumentCount=1;retrievedDocumentSize=679;outputDocumentCount=1;outputDocumentSize=728;writeOutputTimeInMs=0.00;indexUtilizationRatio=1.00",
            "IndexUtilization": "",
            "SchedulingTimeSpan": {
                "TurnaroundTimeInMs": 3.7895000000000003,
                "ResponseTimeInMs": 0.0439,
                "RunTimeInMs": 3.7427,
                "WaitTime": 0.046900000000000004,
                "NumberOfPreemptions": 1
            },
            "Context": [
                {
                    "Id": "RequestInvokerHandler",
                    "ElapsedTime": "00:00:00.0037011"
                },
                {
                    "Id": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                    "ElapsedTime": "00:00:00.0036319"
                },
                {
                    "Id": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                    "ElapsedTime": "00:00:00.0035769"
                },
                {
                    "Id": "TransportHandler",
                    "ElapsedTime": "00:00:00.0035698"
                },
                {
                    "Id": "PointOperationStatistics",
                    "ActivityId": "66f04a98-4ce2-4c95-a7cb-1f8e10394869",
                    "StatusCode": 200,
                    "SubStatusCode": 0,
                    "RequestCharge": 2.29,
                    "RequestUri": "dbs/ec48c0bd-bbe2-4a35-b5f3-e2c9aac1e29f/colls/effa11bd-aff9-4dee-bb39-dfa93b644097",
                    "RequestSessionToken": null,
                    "ResponseSessionToken": "0:-1#1817",
                    "ClientRequestStats": {
                        "RequestStartTimeUtc": "2020-02-24T19:40:01.5972192Z",
                        "RequestEndTimeUtc": "2020-02-24T19:40:01.5998870Z",
                        "RequestLatency": "00:00:00.0026678",
                        "IsCpuOverloaded": false,
                        "NumberRegionsAttempted": 1,
                        "ResponseStatisticsList": [
                            {
                                "ResponseTime": "2020-02-24T19:40:01.599887Z",
                                "ResourceType": 2,
                                "OperationType": 15,
                                "StoreResult": "StorePhysicalAddress: rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer12/partitions/a4cb4958-38c8-11e6-8106-8cdcd42c33be/replicas/1p/, LSN: 1817, GlobalCommittedLsn: -1, PartitionKeyRangeId: 0, IsValid: True, StatusCode: 200, SubStatusCode: 0, RequestCharge: 2.29, ItemLSN: -1, SessionToken: -1#1817, UsingLocalLSN: True, TransportException: null"
                            }
                        ],
                        "AddressResolutionStatistics": [],
                        "SupplementalResponseStatistics": [],
                        "FailedReplicas": [],
                        "RegionsContacted": [
                            "https://127.0.0.1:8081/"
                        ],
                        "ContactedReplicas": [
                            "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer12/partitions/a4cb4958-38c8-11e6-8106-8cdcd42c33be/replicas/1p/"
                        ]
                    }
                }
            ]
        }
    ]
}
```