### PR TITLE
Client encryption - Fix bug in read path without encrypted properties

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Encryption/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/EncryptionProcessor.cs
@@ -117,7 +117,14 @@ namespace Microsoft.Azure.Cosmos
                 return input;
             }
 
-            JObject itemJObj = EncryptionProcessor.baseSerializer.FromStream<JObject>(input);
+            JObject itemJObj;
+            using (StreamReader sr = new StreamReader(input, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))
+            {
+                using (JsonTextReader jsonTextReader = new JsonTextReader(sr))
+                {
+                    itemJObj = JsonSerializer.Create().Deserialize<JObject>(jsonTextReader);
+                }
+            }
 
             JProperty encryptionPropertiesJProp = itemJObj.Property(Constants.Properties.EncryptedInfo);
             JObject encryptionPropertiesJObj = null;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/EncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/EncryptionTests.cs
@@ -178,6 +178,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task EncryptionCreateItemWithoutEncryptionOptions()
+        {
+            TestDoc testDoc = TestDoc.Create();
+            ItemResponse<TestDoc> createResponse = await EncryptionTests.containerCore.CreateItemAsync(
+                testDoc,
+                new PartitionKey(testDoc.PK));
+            Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+            Assert.AreEqual(testDoc, createResponse.Resource);
+        }
+
+        [TestMethod]
         public async Task EncryptionCreateItem()
         {
             TestDoc testDoc = await EncryptionTests.CreateItemAsync(EncryptionTests.containerCore, EncryptionTests.dekId, TestDoc.PathsToEncrypt);

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) CosmosException now returns the original stack trace.
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) ResponseMessage.ErrorMessage is now always correctly populated. There was bug in some scenarios where the error message was left in the content stream.
+- [#1242](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1242) Client encryption - Fix bug in read path without encrypted properties
 
 ## <a name="3.7.0-preview"/> [3.7.0-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.7.0-preview) - 2020-02-25
 


### PR DESCRIPTION
Fix a bug in ClientEncryption decryption flow where the input stream would have been disposed by the base serializer and therefore couldn't be reused in case it can be returned as-is (i.e. when there is nothing to decrypt). This manifests when decryption has been invoked because the encryption key wrap provider is configured on the client, but a particular document being read wasn't encrypted.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)