### PR TITLE
vNext - Remove CosmosClient.CosmosClientOptions

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -277,7 +277,7 @@ namespace Azure.Cosmos
         /// <summary>
         /// The <see cref="Cosmos.CosmosClientOptions"/> used initialize CosmosClient
         /// </summary>
-        public virtual CosmosClientOptions ClientOptions { get; private set; }
+        internal CosmosClientOptions ClientOptions { get; private set; }
 
         /// <summary>
         /// Gets the endpoint Uri for the Azure Cosmos DB service.

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -631,18 +631,6 @@
           "Attributes": [],
           "MethodInfo": "Azure.AsyncPageable`1[T] GetDatabaseQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.Cosmos.CosmosClientOptions ClientOptions": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosClientOptions get_ClientOptions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.CosmosClientOptions get_ClientOptions()"
-        },
         "Azure.Cosmos.CosmosContainer GetContainer(System.String, System.String)": {
           "Type": "Method",
           "Attributes": [],

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1256](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1256) Removed public accessor to CosmosClient.CosmosClientOptions to avoid mutation after pipeline is created
+
 ### Fixed
 
 ## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09


### PR DESCRIPTION
## Description

Based on API Review, the pipeline should be immutable after being created and exposing publicly the CosmosClientOptions would allow for changes to be made after.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #1244