### PR TITLE
vNext - CosmosClient constructor

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -6,7 +6,6 @@ namespace Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.IO;
     using System.Net;
     using System.Net.Http;
@@ -17,7 +16,6 @@ namespace Azure.Cosmos
     using Azure.Cosmos.Serialization;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Handlers;
-    using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -129,16 +127,49 @@ namespace Azure.Cosmos
         /// performance guide at <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>.
         /// </summary>
         /// <param name="connectionString">The connection string to the cosmos account. ex: https://mycosmosaccount.documents.azure.com:443/;AccountKey=SuperSecretKey; </param>
-        /// <param name="clientOptions">(Optional) client options</param>
         /// <example>
         /// The CosmosClient is created with the connection string and configured to use "East US 2" region.
         /// <code language="c#">
         /// <![CDATA[
-        /// using Microsoft.Azure.Cosmos;
+        /// using Azure.Cosmos;
         /// 
         /// CosmosClient cosmosClient = new CosmosClient(
-        ///             "account-endpoint-from-portal", 
-        ///             "account-key-from-portal", 
+        ///             "connection-string-from-azure-portal");
+        /// 
+        /// // Dispose cosmosClient at application exit
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <remarks>
+        /// <seealso cref="CosmosClientOptions"/>
+        /// <seealso cref="Fluent.CosmosClientBuilder"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/troubleshoot-dot-net-sdk"/>
+        /// </remarks>
+        public CosmosClient(string connectionString)
+            : this(
+                  CosmosClientOptions.GetAccountEndpoint(connectionString),
+                  CosmosClientOptions.GetAccountKey(connectionString))
+        {
+        }
+
+        /// <summary>
+        /// Create a new CosmosClient with the connection string
+        /// 
+        /// CosmosClient is thread-safe. Its recommended to maintain a single instance of CosmosClient per lifetime 
+        /// of the application which enables efficient connection management and performance. Please refer to 
+        /// performance guide at <see href="https://docs.microsoft.com/azure/cosmos-db/performance-tips"/>.
+        /// </summary>
+        /// <param name="connectionString">The connection string to the cosmos account. ex: https://mycosmosaccount.documents.azure.com:443/;AccountKey=SuperSecretKey; </param>
+        /// <param name="clientOptions">Client options</param>
+        /// <example>
+        /// The CosmosClient is created with the connection string and configured to use "East US 2" region.
+        /// <code language="c#">
+        /// <![CDATA[
+        /// using Azure.Cosmos;
+        /// 
+        /// CosmosClient cosmosClient = new CosmosClient(
+        ///             "connection-string-from-azure-portal",
         ///             new CosmosClientOptions()
         ///             {
         ///                 ApplicationRegion = Regions.EastUS2,
@@ -156,7 +187,7 @@ namespace Azure.Cosmos
         /// </remarks>
         public CosmosClient(
             string connectionString,
-            CosmosClientOptions clientOptions = null)
+            CosmosClientOptions clientOptions)
             : this(
                   CosmosClientOptions.GetAccountEndpoint(connectionString),
                   CosmosClientOptions.GetAccountKey(connectionString),
@@ -178,7 +209,7 @@ namespace Azure.Cosmos
         /// The CosmosClient is created with the AccountEndpoint, AccountKey or ResourceToken and configured to use "East US 2" region.
         /// <code language="c#">
         /// <![CDATA[
-        /// using Microsoft.Azure.Cosmos;
+        /// using Azure.Cosmos;
         /// 
         /// CosmosClient cosmosClient = new CosmosClient(
         ///             "account-endpoint-from-portal", 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -653,7 +653,7 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.CosmosDatabase GetDatabase(System.String)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<GetDatabaseQueryStreamIterator>d__40))]": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<GetDatabaseQueryStreamIterator>d__41))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncIteratorStateMachineAttribute"
@@ -675,7 +675,7 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__37))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__38))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
@@ -698,6 +698,11 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "System.Uri get_Endpoint()"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
         },
         "Void .ctor(System.String, Azure.Cosmos.CosmosClientOptions)": {
           "Type": "Constructor",

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1257](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1257) Explicit CosmosClient constructors for most common scenarios
+
+
 ### Fixed
 
 ## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09


### PR DESCRIPTION
# Pull Request Template

## Description

Aligning with the Azure Core SDK guidelines for client constructors (https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-client-ctor), this PR explicitly adds a `CosmosClient` constructor that just takes `connectionString`, and one that takes `connectionString` and `options`.

```csharp
public CosmosClient(string connectionString);
public CosmosClient(
            string connectionString,
            CosmosClientOptions clientOptions);
```

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1245