### PR TITLE
vNext - DefaultSerializationOptions

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -55,7 +55,6 @@ namespace Azure.Cosmos
         /// Default request timeout
         /// </summary>
         private static readonly CosmosSerializer propertiesSerializer = new CosmosJsonSerializerWrapper(new CosmosTextJsonSerializer());
-        private static readonly CosmosSerializationOptions defaultSerializerOptions = new CosmosSerializationOptions();
 
         private int gatewayModeMaxConnectionLimit;
         private CosmosSerializationOptions serializerOptions;
@@ -304,7 +303,7 @@ namespace Azure.Cosmos
         /// </example>
         public CosmosSerializationOptions DefaultSerializerOptions
         {
-            get => this.serializerOptions ?? CosmosClientOptions.defaultSerializerOptions;
+            get => this.serializerOptions ?? new CosmosSerializationOptions();
             set
             {
                 if (this.serializer != null)

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -55,6 +55,7 @@ namespace Azure.Cosmos
         /// Default request timeout
         /// </summary>
         private static readonly CosmosSerializer propertiesSerializer = new CosmosJsonSerializerWrapper(new CosmosTextJsonSerializer());
+        private static readonly CosmosSerializationOptions defaultSerializerOptions = new CosmosSerializationOptions();
 
         private int gatewayModeMaxConnectionLimit;
         private CosmosSerializationOptions serializerOptions;
@@ -80,7 +81,6 @@ namespace Azure.Cosmos
             this.ConnectionProtocol = CosmosClientOptions.DefaultProtocol;
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
-            this.serializerOptions = new CosmosSerializationOptions();
         }
 
         /// <summary>
@@ -304,10 +304,10 @@ namespace Azure.Cosmos
         /// </example>
         public CosmosSerializationOptions DefaultSerializerOptions
         {
-            get => this.serializerOptions;
+            get => this.serializerOptions ?? CosmosClientOptions.defaultSerializerOptions;
             set
             {
-                if (this.Serializer != null)
+                if (this.serializer != null)
                 {
                     throw new ArgumentException(
                         $"{nameof(this.DefaultSerializerOptions)} is not compatible with {nameof(this.Serializer)}. Only one can be set.  ");
@@ -337,7 +337,7 @@ namespace Azure.Cosmos
             get => this.serializer;
             set
             {
-                if (this.DefaultSerializerOptions != null)
+                if (this.serializerOptions != null)
                 {
                     throw new ArgumentException(
                         $"{nameof(this.Serializer)} is not compatible with {nameof(this.DefaultSerializerOptions)}. Only one can be set.  ");
@@ -491,9 +491,9 @@ namespace Azure.Cosmos
         /// </summary>
         internal CosmosSerializer GetCosmosSerializerWithWrapperOrDefault()
         {
-            if (this.DefaultSerializerOptions != null)
+            if (this.serializerOptions != null)
             {
-                CosmosTextJsonSerializer cosmosJsonDotNetSerializer = new CosmosTextJsonSerializer(this.DefaultSerializerOptions);
+                CosmosTextJsonSerializer cosmosJsonDotNetSerializer = new CosmosTextJsonSerializer(this.serializerOptions);
                 return new CosmosJsonSerializerWrapper(cosmosJsonDotNetSerializer);
             }
             else

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -25,7 +25,7 @@ namespace Azure.Cosmos
     /// An example on how to configure the serialization option to ignore null values
     /// CosmosClientOptions clientOptions = new CosmosClientOptions()
     /// {
-    ///     SerializerOptions = new CosmosSerializationOptions(){
+    ///     DefaultSerializerOptions = new CosmosSerializationOptions(){
     ///         IgnoreNullValues = true
     ///     },
     ///     ConnectionMode = ConnectionMode.Gateway,
@@ -80,6 +80,7 @@ namespace Azure.Cosmos
             this.ConnectionProtocol = CosmosClientOptions.DefaultProtocol;
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
+            this.serializerOptions = new CosmosSerializationOptions();
         }
 
         /// <summary>
@@ -294,14 +295,14 @@ namespace Azure.Cosmos
         /// An example on how to configure the serialization option to ignore null values
         /// CosmosClientOptions clientOptions = new CosmosClientOptions()
         /// {
-        ///     SerializerOptions = new CosmosSerializationOptions(){
+        ///     DefaultSerializerOptions = new CosmosSerializationOptions(){
         ///         IgnoreNullValues = true
         ///     }
         /// };
         /// 
         /// CosmosClient client = new CosmosClient("endpoint", "key", clientOptions);
         /// </example>
-        public CosmosSerializationOptions SerializerOptions
+        public CosmosSerializationOptions DefaultSerializerOptions
         {
             get => this.serializerOptions;
             set
@@ -309,7 +310,7 @@ namespace Azure.Cosmos
                 if (this.Serializer != null)
                 {
                     throw new ArgumentException(
-                        $"{nameof(this.SerializerOptions)} is not compatible with {nameof(this.Serializer)}. Only one can be set.  ");
+                        $"{nameof(this.DefaultSerializerOptions)} is not compatible with {nameof(this.Serializer)}. Only one can be set.  ");
                 }
 
                 this.serializerOptions = value;
@@ -336,10 +337,10 @@ namespace Azure.Cosmos
             get => this.serializer;
             set
             {
-                if (this.SerializerOptions != null)
+                if (this.DefaultSerializerOptions != null)
                 {
                     throw new ArgumentException(
-                        $"{nameof(this.Serializer)} is not compatible with {nameof(this.SerializerOptions)}. Only one can be set.  ");
+                        $"{nameof(this.Serializer)} is not compatible with {nameof(this.DefaultSerializerOptions)}. Only one can be set.  ");
                 }
 
                 this.serializer = value;
@@ -490,9 +491,9 @@ namespace Azure.Cosmos
         /// </summary>
         internal CosmosSerializer GetCosmosSerializerWithWrapperOrDefault()
         {
-            if (this.SerializerOptions != null)
+            if (this.DefaultSerializerOptions != null)
             {
-                CosmosTextJsonSerializer cosmosJsonDotNetSerializer = new CosmosTextJsonSerializer(this.SerializerOptions);
+                CosmosTextJsonSerializer cosmosJsonDotNetSerializer = new CosmosTextJsonSerializer(this.DefaultSerializerOptions);
                 return new CosmosJsonSerializerWrapper(cosmosJsonDotNetSerializer);
             }
             else

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
@@ -323,10 +323,10 @@ namespace Azure.Cosmos.Fluent
         /// <param name="cosmosSerializerOptions">The custom class that implements <see cref="CosmosSerializer"/> </param>
         /// <returns>The <see cref="CosmosClientBuilder"/> object</returns>
         /// <seealso cref="CosmosSerializer"/>
-        /// <seealso cref="CosmosClientOptions.SerializerOptions"/>
+        /// <seealso cref="CosmosClientOptions.DefaultSerializerOptions"/>
         public CosmosClientBuilder WithSerializerOptions(CosmosSerializationOptions cosmosSerializerOptions)
         {
-            this.clientOptions.SerializerOptions = cosmosSerializerOptions;
+            this.clientOptions.DefaultSerializerOptions = cosmosSerializerOptions;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Cosmos.Tests
             Assert.AreNotEqual(apiType, clientOptions.ApiType);
             Assert.IsFalse(clientOptions.AllowBulkExecution);
             Assert.AreEqual(0, clientOptions.CustomHandlers.Count);
-            Assert.IsNull(clientOptions.SerializerOptions);
+            Assert.IsNull(clientOptions.DefaultSerializerOptions);
             Assert.IsNull(clientOptions.Serializer);
             Assert.IsNull(clientOptions.WebProxy);
             Assert.IsFalse(clientOptions.LimitToEndpoint);
@@ -106,9 +106,9 @@ namespace Azure.Cosmos.Tests
             Assert.AreEqual(apiType, clientOptions.ApiType);
             Assert.AreEqual(maxRetryAttemptsOnThrottledRequests, clientOptions.MaxRetryAttemptsOnRateLimitedRequests);
             Assert.AreEqual(maxRetryWaitTime, clientOptions.MaxRetryWaitTimeOnRateLimitedRequests);
-            Assert.AreEqual(cosmosSerializerOptions.IgnoreNullValues, clientOptions.SerializerOptions.IgnoreNullValues);
-            Assert.AreEqual(cosmosSerializerOptions.PropertyNamingPolicy, clientOptions.SerializerOptions.PropertyNamingPolicy);
-            Assert.AreEqual(cosmosSerializerOptions.Indented, clientOptions.SerializerOptions.Indented);
+            Assert.AreEqual(cosmosSerializerOptions.IgnoreNullValues, clientOptions.DefaultSerializerOptions.IgnoreNullValues);
+            Assert.AreEqual(cosmosSerializerOptions.PropertyNamingPolicy, clientOptions.DefaultSerializerOptions.PropertyNamingPolicy);
+            Assert.AreEqual(cosmosSerializerOptions.Indented, clientOptions.DefaultSerializerOptions.Indented);
             Assert.IsTrue(object.ReferenceEquals(webProxy, clientOptions.WebProxy));
             Assert.IsTrue(clientOptions.AllowBulkExecution);
 
@@ -219,7 +219,7 @@ namespace Azure.Cosmos.Tests
 
             CosmosClientOptions options = new CosmosClientOptions()
             {
-                SerializerOptions = new CosmosSerializationOptions()
+                DefaultSerializerOptions = new CosmosSerializationOptions()
                 {
                     IgnoreNullValues = true,
                     Indented = true,
@@ -256,7 +256,7 @@ namespace Azure.Cosmos.Tests
                 Serializer = new CosmosTextJsonSerializer()
             };
 
-            options.SerializerOptions = new CosmosSerializationOptions();
+            options.DefaultSerializerOptions = new CosmosSerializationOptions();
         }
 
         [TestMethod]
@@ -265,7 +265,7 @@ namespace Azure.Cosmos.Tests
         {
             CosmosClientOptions options = new CosmosClientOptions()
             {
-                SerializerOptions = new CosmosSerializationOptions()
+                DefaultSerializerOptions = new CosmosSerializationOptions()
             };
 
             options.Serializer = new CosmosTextJsonSerializer();
@@ -404,6 +404,13 @@ namespace Azure.Cosmos.Tests
 
             connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
             Assert.IsFalse(connectionPolicy.EnableEndpointDiscovery);
+        }
+
+        [TestMethod]
+        public void HasDefaultSerializationOptions()
+        {
+            CosmosClientOptions options = new CosmosClientOptions();
+            Assert.IsNotNull(options.DefaultSerializerOptions);
         }
 
         private class TestWebProxy : IWebProxy

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -66,7 +66,7 @@ namespace Azure.Cosmos.Tests
             Assert.AreNotEqual(apiType, clientOptions.ApiType);
             Assert.IsFalse(clientOptions.AllowBulkExecution);
             Assert.AreEqual(0, clientOptions.CustomHandlers.Count);
-            Assert.IsNull(clientOptions.DefaultSerializerOptions);
+            Assert.IsNotNull(clientOptions.DefaultSerializerOptions);
             Assert.IsNull(clientOptions.Serializer);
             Assert.IsNull(clientOptions.WebProxy);
             Assert.IsFalse(clientOptions.LimitToEndpoint);
@@ -404,13 +404,6 @@ namespace Azure.Cosmos.Tests
 
             connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
             Assert.IsFalse(connectionPolicy.EnableEndpointDiscovery);
-        }
-
-        [TestMethod]
-        public void HasDefaultSerializationOptions()
-        {
-            CosmosClientOptions options = new CosmosClientOptions();
-            Assert.IsNotNull(options.DefaultSerializerOptions);
         }
 
         private class TestWebProxy : IWebProxy

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -730,15 +730,15 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.ConnectionMode get_ConnectionMode()"
         },
-        "Azure.Cosmos.Serialization.CosmosSerializationOptions get_SerializerOptions()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.Serialization.CosmosSerializationOptions get_SerializerOptions()"
-        },
-        "Azure.Cosmos.Serialization.CosmosSerializationOptions SerializerOptions": {
+        "Azure.Cosmos.Serialization.CosmosSerializationOptions DefaultSerializerOptions": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
+        },
+        "Azure.Cosmos.Serialization.CosmosSerializationOptions get_DefaultSerializerOptions()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.Serialization.CosmosSerializationOptions get_DefaultSerializerOptions()"
         },
         "Azure.Cosmos.Serialization.CosmosSerializer get_Serializer()": {
           "Type": "Method",
@@ -921,6 +921,11 @@
           ],
           "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Azure.Cosmos.ConsistencyLevel])"
         },
+        "Void set_DefaultSerializerOptions(Azure.Cosmos.Serialization.CosmosSerializationOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_DefaultSerializerOptions(Azure.Cosmos.Serialization.CosmosSerializationOptions)"
+        },
         "Void set_GatewayModeMaxConnectionLimit(Int32)": {
           "Type": "Method",
           "Attributes": [],
@@ -978,11 +983,6 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Void set_Serializer(Azure.Cosmos.Serialization.CosmosSerializer)"
-        },
-        "Void set_SerializerOptions(Azure.Cosmos.Serialization.CosmosSerializationOptions)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_SerializerOptions(Azure.Cosmos.Serialization.CosmosSerializationOptions)"
         },
         "Void set_WebProxy(System.Net.IWebProxy)": {
           "Type": "Method",

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1258](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1258) Renamed CosmosClientOptions.SerializerOptions to CosmosClientOptions.DefaultSerializerOptions
+
 ### Fixed
 
 ## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09


### PR DESCRIPTION
# Pull Request Template

## Description

Following API review, this PR does two thing:

1. Rename `CosmosClientOptions.SerializerOptions` to `CosmosClientOptions.DefaultSerializerOptions` to better reflect the intent (customizing the default serializer)
2. Getting the `CosmosClientOptions.DefaultSerializerOptions` no longer returns `null` but the default instance with the default values of the `SerializerOptions`.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #1246