### PR TITLE
Partitionkey add methods for comparison

### DIFF
--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Represents a partition key value in the Azure Cosmos DB service.
     /// </summary>
-    public readonly struct PartitionKey
+    public readonly struct PartitionKey : IComparable<PartitionKey>, IEquatable<PartitionKey>
     {
         private static readonly PartitionKeyInternal NullPartitionKeyInternal = new Documents.PartitionKey(null).InternalKey;
         private static readonly PartitionKeyInternal TruePartitionKeyInternal = new Documents.PartitionKey(true).InternalKey;
@@ -107,6 +107,48 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null || this.GetType() != obj.GetType())
+                return false;
+
+            return this.Equals((PartitionKey)obj);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this partition key.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return this.InternalKey.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified partition key.
+        /// </summary>
+        /// <param name="other">A partition key value to compare to this instance.</param>
+        /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
+        public bool Equals(PartitionKey other)
+        {
+            return this.InternalKey.Equals(other.InternalKey);
+        }
+
+        /// <summary>
+        /// Compares this instance to a specified partition key and returns an indication of their relative values.
+        /// </summary>
+        /// <param name="other">A partition key to compare.</param>
+        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the <paramref name="other"/> parameter.</returns>
+        public int CompareTo(PartitionKey other)
+        {
+            return this.InternalKey.CompareTo(other.InternalKey);
+        }
+
+        /// <summary>
         /// Gets the string representation of the partition key value.
         /// </summary>
         /// <returns>The string representation of the partition key value</returns>
@@ -146,6 +188,28 @@ namespace Microsoft.Azure.Cosmos
                 partitionKey = default;
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of the PartitionKey are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> represent the same partition key; otherwise, false.</returns>
+        public static bool operator ==(PartitionKey left, PartitionKey right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of the PartitionKey are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> do not represent the same partition key; otherwise, false.</returns>
+        public static bool operator !=(PartitionKey left, PartitionKey right)
+        {
+            return !left.Equals(right);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Represents a partition key value in the Azure Cosmos DB service.
     /// </summary>
-    public readonly struct PartitionKey : IComparable<PartitionKey>, IEquatable<PartitionKey>
+    public readonly struct PartitionKey : IEquatable<PartitionKey>
     {
         private static readonly PartitionKeyInternal NullPartitionKeyInternal = new Documents.PartitionKey(null).InternalKey;
         private static readonly PartitionKeyInternal TruePartitionKeyInternal = new Documents.PartitionKey(true).InternalKey;
@@ -138,16 +138,6 @@ namespace Microsoft.Azure.Cosmos
         public bool Equals(PartitionKey other)
         {
             return this.InternalKey.Equals(other.InternalKey);
-        }
-
-        /// <summary>
-        /// Compares this instance to a specified partition key and returns an indication of their relative values.
-        /// </summary>
-        /// <param name="other">A partition key to compare.</param>
-        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the <paramref name="other"/> parameter.</returns>
-        public int CompareTo(PartitionKey other)
-        {
-            return this.InternalKey.CompareTo(other.InternalKey);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -109,14 +109,16 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
-        /// <param name="obj"></param>
+        /// <param name="obj">An object to compare.</param>
         /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
         public override bool Equals(object obj)
         {
-            if (obj is null || this.GetType() != obj.GetType())
-                return false;
+            if (obj is PartitionKey partitionkey)
+            {
+                return this.Equals(partitionkey);
+            }
 
-            return this.Equals((PartitionKey)obj);
+            return false;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -260,63 +260,6 @@
       },
       "NestedTypes": {}
     },
-    "ChangeFeedProcessor": {
-      "Subclasses": {},
-      "Members": {
-        "System.Threading.Tasks.Task StartAsync()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task StartAsync()"
-        },
-        "System.Threading.Tasks.Task StopAsync()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task StopAsync()"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "ChangeFeedProcessorBuilder": {
-      "Subclasses": {},
-      "Members": {
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)"
-        }
-      },
-      "NestedTypes": {}
-    },
     "CompositePath": {
       "Subclasses": {},
       "Members": {
@@ -647,16 +590,6 @@
     "Container": {
       "Subclasses": {},
       "Members": {
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)"
-        },
         "Microsoft.Azure.Cosmos.Conflicts Conflicts": {
           "Type": "Property",
           "Attributes": [],
@@ -696,6 +629,16 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)"
         },
         "Microsoft.Azure.Cosmos.Scripts.Scripts get_Scripts()": {
           "Type": "Method",
@@ -2979,6 +2922,63 @@
       },
       "NestedTypes": {}
     },
+    "ChangeFeedProcessor": {
+      "Subclasses": {},
+      "Members": {
+        "System.Threading.Tasks.Task StartAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StartAsync()"
+        },
+        "System.Threading.Tasks.Task StopAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StopAsync()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ChangeFeedProcessorBuilder": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)"
+        }
+      },
+      "NestedTypes": {}
+    },
     "IncludedPath": {
       "Subclasses": {},
       "Members": {
@@ -3635,6 +3635,36 @@
     "PartitionKey": {
       "Subclasses": {},
       "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Int32 CompareTo(Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 CompareTo(Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
         "Microsoft.Azure.Cosmos.PartitionKey None": {
           "Type": "Field",
           "Attributes": [],
@@ -4265,26 +4295,6 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.String ChinaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
         "System.String EastAsia": {
           "Type": "Field",
           "Attributes": [],
@@ -4331,6 +4341,26 @@
           "MethodInfo": null
         },
         "System.String GermanyWestCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth2": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -260,6 +260,63 @@
       },
       "NestedTypes": {}
     },
+    "ChangeFeedProcessor": {
+      "Subclasses": {},
+      "Members": {
+        "System.Threading.Tasks.Task StartAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StartAsync()"
+        },
+        "System.Threading.Tasks.Task StopAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StopAsync()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ChangeFeedProcessorBuilder": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)"
+        }
+      },
+      "NestedTypes": {}
+    },
     "CompositePath": {
       "Subclasses": {},
       "Members": {
@@ -590,6 +647,16 @@
     "Container": {
       "Subclasses": {},
       "Members": {
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)"
+        },
         "Microsoft.Azure.Cosmos.Conflicts Conflicts": {
           "Type": "Property",
           "Attributes": [],
@@ -629,16 +696,6 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)"
         },
         "Microsoft.Azure.Cosmos.Scripts.Scripts get_Scripts()": {
           "Type": "Method",
@@ -2922,63 +2979,6 @@
       },
       "NestedTypes": {}
     },
-    "ChangeFeedProcessor": {
-      "Subclasses": {},
-      "Members": {
-        "System.Threading.Tasks.Task StartAsync()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task StartAsync()"
-        },
-        "System.Threading.Tasks.Task StopAsync()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task StopAsync()"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "ChangeFeedProcessorBuilder": {
-      "Subclasses": {},
-      "Members": {
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)"
-        },
-        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)"
-        }
-      },
-      "NestedTypes": {}
-    },
     "IncludedPath": {
       "Subclasses": {},
       "Members": {
@@ -4295,6 +4295,26 @@
           "Attributes": [],
           "MethodInfo": null
         },
+        "System.String ChinaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
         "System.String EastAsia": {
           "Type": "Field",
           "Attributes": [],
@@ -4341,26 +4361,6 @@
           "MethodInfo": null
         },
         "System.String GermanyWestCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth2": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -3655,11 +3655,6 @@
           "Attributes": [],
           "MethodInfo": "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
         },
-        "Int32 CompareTo(Microsoft.Azure.Cosmos.PartitionKey)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Int32 CompareTo(Microsoft.Azure.Cosmos.PartitionKey)"
-        },
         "Int32 GetHashCode()": {
           "Type": "Method",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -119,7 +119,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("pk")));
             Assert.IsTrue(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("pk"));
             Assert.IsTrue(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("other_pk"));
-            Assert.IsTrue(new Cosmos.PartitionKey("pk").CompareTo(new Cosmos.PartitionKey("pk")) == 0);
             Assert.IsTrue(new Cosmos.PartitionKey("pk").GetHashCode() == new Cosmos.PartitionKey("pk").GetHashCode());
 
             Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("other_pk")));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -4,8 +4,8 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class PartitionKeyTests
@@ -110,6 +110,34 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
 
             Assert.IsFalse(Cosmos.PartitionKey.TryParseJsonString("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
+        }
+
+        [TestMethod]
+        public void TestCosmosPartitionKeyComparison()
+        {
+            Cosmos.PartitionKey pk = new Cosmos.PartitionKey("partition_key");
+            Cosmos.PartitionKey equal_to_pk = new Cosmos.PartitionKey("partition_key");
+            Cosmos.PartitionKey differs_from_pk = new Cosmos.PartitionKey("different_partition_key");
+
+            (Func<bool> testFunction, bool expectedResult)[] testcases =
+            {
+                (() => pk.Equals((object)equal_to_pk), true),
+                (() => pk.Equals((object)differs_from_pk), false),
+                (() => pk.Equals(equal_to_pk), true),
+                (() => pk.Equals(differs_from_pk), false),
+                (() => pk == equal_to_pk, true),
+                (() => pk == differs_from_pk, false),
+                (() => pk != equal_to_pk, false),
+                (() => pk != differs_from_pk, true),
+                (() => pk.CompareTo(equal_to_pk) == 0, true),
+                (() => pk.GetHashCode() == equal_to_pk.GetHashCode(), true),
+            };
+
+            foreach ((Func<bool> testFunction, bool expectedResult) in testcases)
+            {
+                bool result = testFunction();
+                Assert.AreEqual(result, expectedResult);
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -115,29 +115,17 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void TestCosmosPartitionKeyComparison()
         {
-            Cosmos.PartitionKey pk = new Cosmos.PartitionKey("partition_key");
-            Cosmos.PartitionKey equal_to_pk = new Cosmos.PartitionKey("partition_key");
-            Cosmos.PartitionKey differs_from_pk = new Cosmos.PartitionKey("different_partition_key");
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("other_pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").CompareTo(new Cosmos.PartitionKey("pk")) == 0);
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").GetHashCode() == new Cosmos.PartitionKey("pk").GetHashCode());
 
-            (Func<bool> testFunction, bool expectedResult)[] testcases =
-            {
-                (() => pk.Equals((object)equal_to_pk), true),
-                (() => pk.Equals((object)differs_from_pk), false),
-                (() => pk.Equals(equal_to_pk), true),
-                (() => pk.Equals(differs_from_pk), false),
-                (() => pk == equal_to_pk, true),
-                (() => pk == differs_from_pk, false),
-                (() => pk != equal_to_pk, false),
-                (() => pk != differs_from_pk, true),
-                (() => pk.CompareTo(equal_to_pk) == 0, true),
-                (() => pk.GetHashCode() == equal_to_pk.GetHashCode(), true),
-            };
-
-            foreach ((Func<bool> testFunction, bool expectedResult) in testcases)
-            {
-                bool result = testFunction();
-                Assert.AreEqual(result, expectedResult);
-            }
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("other_pk"));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("pk"));
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [#1233](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1265) PartitionKey now supports operators ==, != for equality comparison.
+
 ### Fixed
 
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) CosmosException now returns the original stack trace.


### PR DESCRIPTION
## Description

This PR adds methods and operators for basic comparison to the `PartitionKey` struct.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

closes #1233

