### PR TITLE
Fix Double.NaN roundtrip bug for CosmosElementContinuationToken

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
@@ -819,6 +819,16 @@ namespace Microsoft.Azure.Cosmos.Json
                     case JsonTokenType.True:
                     case JsonTokenType.False:
                     case JsonTokenType.Null:
+                    case JsonTokenType.Int8:
+                    case JsonTokenType.Int16:
+                    case JsonTokenType.Int32:
+                    case JsonTokenType.Int64:
+                    case JsonTokenType.UInt32:
+                    case JsonTokenType.Float32:
+                    case JsonTokenType.Float64:
+                    case JsonTokenType.Guid:
+                    case JsonTokenType.Binary:
+                        // Valid token, if in Array or Object.
                         this.hasSeperator = true;
                         break;
                     default:

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SumAggregator.cs
@@ -86,7 +86,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
                 }
                 else if (requestContinuationToken is CosmosString cosmosString)
                 {
-                    if (!double.TryParse(cosmosString.Value, out partialSum))
+                    if (!double.TryParse(
+                        cosmosString.Value,
+                        NumberStyles.Float | NumberStyles.AllowThousands,
+                        CultureInfo.InvariantCulture,
+                        out partialSum))
                     {
                         return TryCatch<IAggregator>.FromException(
                             new MalformedContinuationTokenException(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/DistinctQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/DistinctQueryTests.cs
@@ -180,7 +180,7 @@
         }
 
         [TestMethod]
-        public async Task TestDistinct_TryGetContinuationTokenSupportAsync()
+        public async Task TestDistinct_CosmosElementContinuationTokenAsync()
         {
             async Task ImplemenationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -597,7 +597,19 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     }
 
                     resultsFromCosmosElementContinuationToken.AddRange(cosmosQueryResponse);
-                    continuationToken = itemQuery.GetCosmosElementContinuationToken();
+
+                    // Force a rewrite of the continuation token, so that we test the case where we roundtrip it over the wire.
+                    // There was a bug where resuming from double.NaN lead to an exception,
+                    // since we parsed the type assuming it was always a double and not a string.
+                    CosmosElement originalContinuationToken = itemQuery.GetCosmosElementContinuationToken();
+                    if(originalContinuationToken != null)
+                    {
+                        continuationToken = CosmosElement.Parse(originalContinuationToken.ToString());
+                    }
+                    else
+                    {
+                        continuationToken = null;
+                    }
                 }
                 catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
                 {


### PR DESCRIPTION
# Fix Double.NaN roundtrip bug for CosmosElementContinuationToken

## Description

For CosmosElementContinuationToken double.NaN serializes to a string in JSON, meaning that the type changes when we try to roundtrip it. The fix was to try and parse the double if the user gives a string continuation token. Binary doesn't have this issue.


