### PR TITLE
vNext - Removal of JsonConverter decorators

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/FeedManagement/RemainingWorkEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/FeedManagement/RemainingWorkEstimatorCore.cs
@@ -24,7 +24,7 @@ namespace Azure.Cosmos.ChangeFeed
         private const char PKRangeIdSeparator = ':';
         private const char SegmentSeparator = '#';
         private static readonly JsonEncodedText LSNPropertyName = JsonEncodedText.Encode("_lsn");
-        private static readonly CosmosSerializer DefaultSerializer = new CosmosTextJsonSerializer();
+        private static readonly CosmosSerializer DefaultSerializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
         private readonly Func<string, string, bool, FeedIterator> feedCreator;
         private readonly DocumentServiceLeaseContainer leaseContainer;
         private readonly int degreeOfParallelism;

--- a/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -13,7 +13,7 @@ namespace Azure.Cosmos.ChangeFeed
 
     internal static class CosmosContainerExtensions
     {
-        public static readonly CosmosSerializer DefaultJsonSerializer = new CosmosTextJsonSerializer();
+        public static readonly CosmosSerializer DefaultJsonSerializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
 
         public static async Task<T> TryGetItemAsync<T>(
             this CosmosContainer container,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountConsistency.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountConsistency.cs
@@ -3,12 +3,9 @@
 //------------------------------------------------------------
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// Represents the consistency policy of a database account of the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonAccountConsistencyConverter))]
     public class AccountConsistency
     {
         private const ConsistencyLevel defaultDefaultConsistencyLevel = ConsistencyLevel.Session;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountProperties.cs
@@ -7,14 +7,11 @@ namespace Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary> 
     /// Represents a <see cref="AccountProperties"/>. A AccountProperties is the container for databases in the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonAccountPropertiesConverter))]
     public class AccountProperties
     {
         private Collection<AccountRegion> readRegions;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountRegion.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/AccountRegion.cs
@@ -3,12 +3,9 @@
 //------------------------------------------------------------
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// The AccountLocation class represents an Azure Cosmos DB database account in a specific region.
     /// </summary>
-    [JsonConverter(typeof(TextJsonAccountRegionConverter))]
     public class AccountRegion
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CompositePath.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CompositePath.cs
@@ -3,15 +3,12 @@
 //------------------------------------------------------------
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// DOM for a composite path.
     /// A composite path is used in a composite index.
     /// For example if you want to run a query like "SELECT * FROM c ORDER BY c.age, c.height",
     /// then you need to add "/age" and "/height" as composite paths to your composite index.
     /// </summary>
-    [JsonConverter(typeof(TextJsonCompositePathConverter))]
     public sealed class CompositePath
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ConflictProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ConflictProperties.cs
@@ -5,7 +5,6 @@
 namespace Azure.Cosmos
 {
     using System;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a conflict in the Azure Cosmos DB service.
@@ -16,7 +15,6 @@ namespace Azure.Cosmos
     /// Inspecting Conflict resources will allow you to determine which operations and resources resulted in conflicts.
     /// This is not related to operations returning a Conflict status code.
     /// </remarks>
-    [JsonConverter(typeof(TextJsonConflictPropertiesConverter))]
     public class ConflictProperties
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ConflictResolutionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ConflictResolutionPolicy.cs
@@ -4,13 +4,10 @@
 
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// Represents the conflict resolution policy configuration for specifying how to resolve conflicts 
     /// in case writes from different regions result in conflicts on items in the container in the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonConflictResolutionPolicyConverter))]
     public class ConflictResolutionPolicy
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ContainerProperties.cs
@@ -6,7 +6,6 @@ namespace Azure.Cosmos
 {
     using System;
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
 
@@ -24,7 +23,7 @@ namespace Azure.Cosmos
     /// The partition key is the first level 'country' property in all the documents within this container.
     /// <code language="c#">
     /// <![CDATA[
-    ///     Container container = await client.GetDatabase("dbName"].Containers.CreateAsync("MyCollection", "/country", 50000} );
+    ///     CosmosContainer container = await client.GetDatabase("dbName"].Containers.CreateAsync("MyCollection", "/country", 50000} );
     ///     ContainerProperties containerProperties = container.Resource;
     /// ]]>
     /// </code>
@@ -53,7 +52,6 @@ namespace Azure.Cosmos
     /// </example>
     /// <seealso cref="IndexingPolicy"/>
     /// <seealso cref="UniqueKeyPolicy"/>
-    [JsonConverter(typeof(TextJsonContainerPropertiesConverter))]
     public class ContainerProperties
     {
         private static readonly char[] partitionKeyTokenDelimeter = new char[] { '/' };

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosResource.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosResource.cs
@@ -15,7 +15,7 @@ namespace Azure.Cosmos
     /// </summary>
     internal static class CosmosResource
     {
-        private static CosmosTextJsonSerializer cosmosDefaultJsonSerializer = new CosmosTextJsonSerializer();
+        private static CosmosTextJsonSerializer cosmosDefaultJsonSerializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
 
         internal static T FromStream<T>(DocumentServiceResponse response)
         {

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/DatabaseProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/DatabaseProperties.cs
@@ -5,7 +5,6 @@
 namespace Azure.Cosmos
 {
     using System;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a database in the Azure Cosmos DB account.
@@ -55,7 +54,6 @@ namespace Azure.Cosmos
     /// </code>
     /// </example>
     /// <seealso cref="ContainerProperties"/>
-    [JsonConverter(typeof(TextJsonDatabasePropertiesConverter))]
     public class DatabaseProperties
     {
         private string id;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ExcludedPath.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ExcludedPath.cs
@@ -4,12 +4,9 @@
 
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary> 
     /// Specifies a path within a JSON document to be excluded while indexing data for the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonExcludedPathConverter))]
     public sealed class ExcludedPath
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IncludedPath.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IncludedPath.cs
@@ -5,12 +5,10 @@
 namespace Azure.Cosmos
 {
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
 
     /// <summary> 
     /// Specifies a path within a JSON document to be included in the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonIncludedPathConverter))]
     public sealed class IncludedPath
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Index.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Index.cs
@@ -4,12 +4,9 @@
 
 namespace Azure.Cosmos
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
     /// Base class for IndexingPolicy Indexes in the Azure Cosmos DB service, you should use a concrete Index like HashIndex or RangeIndex.
     /// </summary> 
-    [JsonConverter(typeof(TextJsonIndexConverter))]
     internal abstract class Index
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
@@ -7,7 +7,6 @@ namespace Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
     using Azure.Cosmos.Spatial;
 
     /// <summary>
@@ -22,7 +21,6 @@ namespace Azure.Cosmos
     /// </para>
     /// </remarks>
     /// <seealso cref="ContainerProperties"/>
-    [JsonConverter(typeof(TextJsonIndexingPolicyConverter))]
     public sealed class IndexingPolicy
     {
         internal const string DefaultPath = "/*";

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/PermissionProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/PermissionProperties.cs
@@ -5,13 +5,11 @@
 namespace Azure.Cosmos
 {
     using System;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary> 
     /// Represents a permission in the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonPermissionPropertiesConverter))]
     public class PermissionProperties
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialPath.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialPath.cs
@@ -5,12 +5,10 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Spatial index specification
     /// </summary>
-    [JsonConverter(typeof(TextJsonSpatialPathConverter))]
     public sealed class SpatialPath
     {
         private Collection<SpatialType> spatialTypesInternal;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/StoredProcedureProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/StoredProcedureProperties.cs
@@ -5,7 +5,6 @@
 namespace Azure.Cosmos.Scripts
 {
     using System;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a stored procedure in the Azure Cosmos DB service.
@@ -14,7 +13,6 @@ namespace Azure.Cosmos.Scripts
     /// Azure Cosmos DB allows application logic written entirely in JavaScript to be executed directly inside the database engine under the database transaction.
     /// For additional details, refer to the server-side JavaScript API documentation.
     /// </remarks>
-    [JsonConverter(typeof(TextJsonStoredProcedurePropertiesConverter))]
     public class StoredProcedureProperties
     {
         private string id;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ThroughputProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ThroughputProperties.cs
@@ -5,7 +5,6 @@
 namespace Azure.Cosmos
 {
     using System;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -24,7 +23,6 @@ namespace Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    [JsonConverter(typeof(TextJsonThroughputPropertiesConverter))]
     public class ThroughputProperties
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/TriggerProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/TriggerProperties.cs
@@ -4,7 +4,6 @@
 
 namespace Azure.Cosmos.Scripts
 {
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -14,7 +13,6 @@ namespace Azure.Cosmos.Scripts
     /// Azure Cosmos DB supports pre and post triggers written in JavaScript to be executed on creates, updates and deletes. 
     /// For additional details, refer to the server-side JavaScript API documentation.
     /// </remarks>
-    [JsonConverter(typeof(TextJsonTriggerPropertiesConverter))]
     public class TriggerProperties
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKey.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKey.cs
@@ -4,7 +4,6 @@
 namespace Azure.Cosmos
 {
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a unique key on that enforces uniqueness constraint on documents in the collection in the Azure Cosmos DB service.
@@ -15,7 +14,6 @@ namespace Azure.Cosmos
     /// For instance, if unique key policy defines a unique key with single property path, there could be only one document that has missing value for this property.
     /// </remarks>
     /// <seealso cref="UniqueKeyPolicy"/>
-    [JsonConverter(typeof(TextJsonUniqueKeyConverter))]
     public sealed class UniqueKey
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
@@ -4,7 +4,6 @@
 namespace Azure.Cosmos
 {
     using System.Collections.ObjectModel;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents the unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
@@ -57,7 +56,6 @@ namespace Azure.Cosmos
     /// }
     /// ]]>
     /// </example>
-    [JsonConverter(typeof(TextJsonUniqueKeyPolicyConverter))]
     public sealed class UniqueKeyPolicy
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserDefinedFunctionProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserDefinedFunctionProperties.cs
@@ -4,7 +4,6 @@
 
 namespace Azure.Cosmos.Scripts
 {
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -40,7 +39,6 @@ namespace Azure.Cosmos.Scripts
     /// ]]>
     /// </code>
     /// </example>
-    [JsonConverter(typeof(TextJsonUserDefinedFunctionPropertiesConverter))]
     public class UserDefinedFunctionProperties
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserProperties.cs
@@ -5,12 +5,10 @@
 namespace Azure.Cosmos
 {
     using System;
-    using System.Text.Json.Serialization;
 
     /// <summary> 
     /// Represents a user in the Azure Cosmos DB service.
     /// </summary>
-    [JsonConverter(typeof(TextJsonUserPropertiesConverter))]
     public class UserProperties
     {
         private string id;

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/BoundingBox.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/BoundingBox.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a coordinate range for geometries in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonBoundingBoxConverter))]
     public sealed class BoundingBox : IEquatable<BoundingBox>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/Crs.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/Crs.cs
@@ -5,13 +5,11 @@
 namespace Azure.Cosmos.Spatial
 {
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents Coordinate Reference System in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonCrsConverterFactory))]
     public abstract class Crs
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/Geometry.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/Geometry.cs
@@ -8,14 +8,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
     /// <summary>
     /// Base class for spatial geometry objects in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     public abstract class Geometry
     {
         /// <summary>
@@ -87,7 +85,6 @@ namespace Azure.Cosmos.Spatial
         /// <value>
         /// Additional geometry properties.
         /// </value>
-        [JsonExtensionData]
         [DataMember(Name = "properties")]
         public IDictionary<string, object> AdditionalProperties { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryCollection.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryCollection.cs
@@ -9,13 +9,11 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Represents a geometry consisting of other geometries.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     internal sealed class GeometryCollection : Geometry, IEquatable<GeometryCollection>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryParams.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryParams.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System.Collections.Generic;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Not frequently used geometry parameters in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryParamsJsonConverter))]
     public class GeometryParams
     {
         /// <summary>
@@ -21,7 +19,6 @@ namespace Azure.Cosmos.Spatial
         /// <value>
         /// Additional geometry properties.
         /// </value>
-        [JsonExtensionData]
         [DataMember(Name = "properties")]
         public IDictionary<string, object> AdditionalProperties { get; set; }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryValidationResult.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/GeometryValidationResult.cs
@@ -5,8 +5,7 @@
 namespace Azure.Cosmos.Spatial
 {
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// <para>
     /// Return value of <see cref="Geometry.IsValidDetailed"/> in the Azure Cosmos DB service.
@@ -16,7 +15,6 @@ namespace Azure.Cosmos.Spatial
     /// </para>
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryValidationResultConverter))]
     public class GeometryValidationResult
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/LineString.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/LineString.cs
@@ -9,13 +9,11 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Represents a geometry consisting of connected line segments.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     public sealed class LineString : Geometry, IEquatable<LineString>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/LineStringCoordinates.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/LineStringCoordinates.cs
@@ -9,14 +9,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Line string coordinates.
     /// </summary>
     /// <seealso cref="MultiLineString"/>
     [DataContract]
-    [JsonConverter(typeof(TextJsonLineStringCoordinatesConverter))]
     internal sealed class LineStringCoordinates : IEquatable<LineStringCoordinates>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/LinearRing.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/LinearRing.cs
@@ -9,8 +9,7 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// A <see cref="LinearRing" /> is closed LineString with 4 or more positions. The first and last positions are
     /// equivalent (they represent equivalent points).
@@ -18,7 +17,6 @@ namespace Azure.Cosmos.Spatial
     /// the <see cref="Polygon"/> geometry type definition in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonLinearRingConverter))]
     public sealed class LinearRing : IEquatable<LinearRing>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/LinkedCrs.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/LinkedCrs.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Coordinate Reference System which is identified by link in the Azure Cosmos DB service. 
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonCrsConverterFactory))]
     public sealed class LinkedCrs : Crs, IEquatable<LinkedCrs>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiLineString.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiLineString.cs
@@ -9,14 +9,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Represents a geometry consisting of multiple <see cref="LineString"/>.
     /// </summary>
     /// <seealso cref="LineString"/>.
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     internal sealed class MultiLineString : Geometry, IEquatable<MultiLineString>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiPoint.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiPoint.cs
@@ -9,14 +9,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Geometry consisting of several points.
     /// </summary>
     /// <seealso cref="Point"/>.
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     internal sealed class MultiPoint : Geometry, IEquatable<MultiPoint>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiPolygon.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/MultiPolygon.cs
@@ -9,14 +9,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Geometry which is comprised of multiple polygons.
     /// </summary>
     /// <seealso cref="Polygon"/>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     internal sealed class MultiPolygon : Geometry, IEquatable<MultiPolygon>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/NamedCrs.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/NamedCrs.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Coordinate Reference System which is identified by name in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonCrsConverterFactory))]
     public sealed class NamedCrs : Crs, IEquatable<NamedCrs>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/Point.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/Point.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Point geometry class in the Azure Cosmos DB service.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     public sealed class Point : Geometry, IEquatable<Point>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/Polygon.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/Polygon.cs
@@ -9,7 +9,6 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
 
     /// <summary>
     /// <para>
@@ -58,7 +57,6 @@ namespace Azure.Cosmos.Spatial
     /// </code>
     /// </example>
     [DataContract]
-    [JsonConverter(typeof(TextJsonGeometryConverterFactory))]
     public sealed class Polygon : Geometry, IEquatable<Polygon>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/PolygonCoordinates.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/PolygonCoordinates.cs
@@ -9,14 +9,12 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Polygon coordinates.
     /// </summary>
     /// <seealso cref="MultiPolygon"/>
     [DataContract]
-    [JsonConverter(typeof(TextJsonPolygonCoordinatesConverter))]
     internal sealed class PolygonCoordinates : IEquatable<PolygonCoordinates>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/Position.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/Position.cs
@@ -9,8 +9,7 @@ namespace Azure.Cosmos.Spatial
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// <para>
     /// A position is represented by an array of numbers in the Azure Cosmos DB service. There must be at least two elements, and may be more.
@@ -21,7 +20,6 @@ namespace Azure.Cosmos.Spatial
     /// </para>
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonPositionConverter))]
     public sealed class Position : IEquatable<Position>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Spatial/UnspecifiedCrs.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Spatial/UnspecifiedCrs.cs
@@ -6,13 +6,11 @@ namespace Azure.Cosmos.Spatial
 {
     using System;
     using System.Runtime.Serialization;
-    using System.Text.Json.Serialization;
-
+    
     /// <summary>
     /// Unspecified CRS. If a geometry has this CRS, no CRS can be assumed for it according to GeoJSON spec.
     /// </summary>
     [DataContract]
-    [JsonConverter(typeof(TextJsonCrsConverterFactory))]
     internal class UnspecifiedCrs : Crs, IEquatable<UnspecifiedCrs>
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -540,7 +540,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 StreamReader sr = new StreamReader(response.ContentStream);
                 string result = await sr.ReadToEndAsync();
-                ICollection<T> responseResults = JsonSerializer.Deserialize<CosmosFeedResponseUtil<T>>(result).Data;
+                ICollection<T> responseResults = JsonSerializer.Deserialize<CosmosFeedResponseUtil<T>>(result, this.jsonSerializerOptions.Value).Data;
                 Assert.IsTrue(responseResults.Count <= 1);
 
                 streamResults.AddRange(responseResults);
@@ -571,8 +571,8 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(pagedStreamResults.Count, streamResults.Count);
 
             // Both lists should be the same if not PermssionsProperties. PermissionProperties will have a different ResouceToken in the payload when read.
-            string streamResultString = JsonSerializer.Serialize(streamResults);
-            string streamPagedResultString = JsonSerializer.Serialize(pagedStreamResults);
+            string streamResultString = JsonSerializer.Serialize(streamResults, this.jsonSerializerOptions.Value);
+            string streamPagedResultString = JsonSerializer.Serialize(pagedStreamResults, this.jsonSerializerOptions.Value);
 
             if (typeof(T) != typeof(PermissionProperties))
             {
@@ -607,8 +607,8 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(pagedResults.Count, results.Count);
 
             // Both lists should be the same
-            string resultString = JsonSerializer.Serialize(results);
-            string pagedResultString = JsonSerializer.Serialize(pagedResults);
+            string resultString = JsonSerializer.Serialize(results, this.jsonSerializerOptions.Value);
+            string pagedResultString = JsonSerializer.Serialize(pagedResults, this.jsonSerializerOptions.Value);
 
             if (typeof(T) != typeof(PermissionProperties))
             {
@@ -624,6 +624,13 @@ namespace Azure.Cosmos.EmulatorTests
         public const string DefaultKey = "objectKey";
         public const string TestCollection = "testcollection";
         private static readonly Random Random = new Random();
+
+        private Lazy<JsonSerializerOptions> jsonSerializerOptions = new Lazy<JsonSerializerOptions>(() =>
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(options);
+            return options;
+        });
 
         //[TestMethod]
         //public async Task InvalidRangesOnQuery()

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -455,7 +455,7 @@ namespace Azure.Cosmos.EmulatorTests
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }))
              {
                 Assert.AreEqual((int)HttpStatusCode.OK, message.Status);
-                CosmosTextJsonSerializer defaultJsonSerializer = new CosmosTextJsonSerializer();
+                CosmosTextJsonSerializer defaultJsonSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
                 Dictionary<string, JsonElement> containers = defaultJsonSerializer.FromStream<Dictionary<string, JsonElement>>(message.ContentStream);
                 foreach (JsonElement container in containers["DocumentCollections"].EnumerateArray())
                 {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -90,7 +90,7 @@ namespace Azure.Cosmos.EmulatorTests
             // Create a client that ignore null
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
-                Serializer = new CosmosTextJsonSerializer(
+                Serializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer(
                     new CosmosSerializationOptions()
                     {
                         IgnoreNullValues = true

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -88,9 +88,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
             };
 
-            string test = JsonSerializer.Serialize(containerProperties);
-
-            CosmosTextJsonSerializer serializer = new CosmosTextJsonSerializer();
+            CosmosTextJsonSerializer serializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
             Stream stream = serializer.ToStream(containerProperties);
             ContainerProperties deserialziedTest = serializer.FromStream<ContainerProperties>(stream);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -54,6 +54,8 @@ namespace Azure.Cosmos.EmulatorTests
             jsonSerializerOptions.Converters.Add(new TextJsonCosmosElementListConverter());
             jsonSerializerOptions.Converters.Add(new TextJsonJObjectConverter());
             jsonSerializerOptions.Converters.Add(new TextJsonJTokenListConverter());
+            CosmosTextJsonSerializer.InitializeRESTConverters(jsonSerializerOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(jsonSerializerOptions);
             return new CosmosTextJsonSerializer(jsonSerializerOptions);
         });
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -227,7 +227,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
-            mockContext.Setup(x => x.CosmosSerializer).Returns(new CosmosTextJsonSerializer());
+            mockContext.Setup(x => x.CosmosSerializer).Returns(CosmosTextJsonSerializer.CreateUserDefaultSerializer());
             mockContext.Setup(x => x.Client).Returns(mockClient.Object);
             return mockContext.Object;
         }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -78,7 +78,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
 
             ResponseMessage mockFeedResponse = new ResponseMessage()
             {
-                Content = new CosmosTextJsonSerializer().ToStream(cosmosFeedResponse)
+                Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(cosmosFeedResponse)
             };
 
             Mock<IAsyncEnumerable<Response>> mockEnumerable = new Mock<IAsyncEnumerable<Response>>();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
             Cosmos.PartitionKey partitionKey = new Cosmos.PartitionKey("1");
             DocumentServiceLeaseCore leaseToUpdate = new DocumentServiceLeaseCore();
 
-            Stream leaseStream = new CosmosTextJsonSerializer().ToStream(leaseToUpdate);
+            Stream leaseStream = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate);
 
             Mock<ContainerCore> mockedItems = new Mock<ContainerCore>();
             mockedItems.Setup(i => i.ReplaceItemStreamAsync(
@@ -83,7 +83,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     };
                 });
 
@@ -101,7 +101,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return Task.FromResult((Response)new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     });
                 });
 
@@ -145,7 +145,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     };
                 });
 
@@ -186,7 +186,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     };
                 });
 
@@ -204,7 +204,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return Task.FromResult((Response)new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     });
                 });
 
@@ -234,7 +234,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     };
                 });
 
@@ -252,7 +252,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return Task.FromResult((Response)new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     });
                 });
 
@@ -297,7 +297,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                 {
                     return Task.FromResult((Response)new ResponseMessage(HttpStatusCode.OK)
                     {
-                        Content = new CosmosTextJsonSerializer().ToStream(leaseToUpdate)
+                        Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(leaseToUpdate)
                     });
                 });
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
@@ -93,7 +93,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
             mockIterator.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(GetResponse(statusCode, false, subStatusCode));
 
-            FeedProcessorCore<MyDocument> processor = new FeedProcessorCore<MyDocument>(mockObserver.Object, mockIterator.Object, FeedProcessorCoreTests.DefaultSettings, mockCheckpointer.Object, new CosmosTextJsonSerializer());
+            FeedProcessorCore<MyDocument> processor = new FeedProcessorCore<MyDocument>(mockObserver.Object, mockIterator.Object, FeedProcessorCoreTests.DefaultSettings, mockCheckpointer.Object, CosmosTextJsonSerializer.CreateUserDefaultSerializer());
 
             await Assert.ThrowsExceptionAsync<FeedSplitException>(() => processor.RunAsync(cancellationTokenSource.Token));
         }
@@ -117,7 +117,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                     document
                 };
 
-                message.Content = new CosmosTextJsonSerializer().ToStream(cosmosFeedResponse);
+                message.Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(cosmosFeedResponse);
             }
 
             return message;
@@ -130,7 +130,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
 
         private class CustomSerializer : CosmosSerializer
         {
-            private CosmosSerializer cosmosSerializer = new CosmosTextJsonSerializer();
+            private CosmosSerializer cosmosSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
             public int FromStreamCalled = 0;
             public int ToStreamCalled = 0;
 
@@ -149,7 +149,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
 
         private class CustomSerializerFails: CosmosSerializer
         {
-            private CosmosSerializer cosmosSerializer = new CosmosTextJsonSerializer();
+            private CosmosSerializer cosmosSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
             public override T FromStream<T>(Stream stream)
             {
                 throw new CustomException();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/RemainingWorkEstimatorTests.cs
@@ -216,7 +216,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
                     firstDocument
                 };
 
-                message.Content = new CosmosTextJsonSerializer().ToStream(cosmosFeedResponse);
+                message.Content = CosmosTextJsonSerializer.CreateUserDefaultSerializer().ToStream(cosmosFeedResponse);
             }
 
             return message;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -194,7 +194,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void GetCosmosSerializerWithWrapperOrDefaultTest()
         {
-            CosmosTextJsonSerializer serializer = new CosmosTextJsonSerializer();
+            CosmosTextJsonSerializer serializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
             CosmosClientOptions options = new CosmosClientOptions()
             {
                 Serializer = serializer
@@ -253,7 +253,7 @@ namespace Azure.Cosmos.Tests
         {
             CosmosClientOptions options = new CosmosClientOptions()
             {
-                Serializer = new CosmosTextJsonSerializer()
+                Serializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer()
             };
 
             options.SerializerOptions = new CosmosSerializationOptions();
@@ -268,7 +268,7 @@ namespace Azure.Cosmos.Tests
                 SerializerOptions = new CosmosSerializationOptions()
             };
 
-            options.Serializer = new CosmosTextJsonSerializer();
+            options.Serializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -128,12 +128,13 @@ namespace Azure.Cosmos.Tests
         {
             // HAKC: Work-around till BE fixes defautls 
             settings.ValidateRequiredProperties();
-
-            string containerSerialized = JsonSerializer.Serialize(settings);
+            JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(jsonSerializerOptions);
+            string containerSerialized = JsonSerializer.Serialize(settings, jsonSerializerOptions);
             string collectionSerialized = CosmosContainerSettingsTests.SerializeDocumentCollection(documentCollection);
 
-            Dictionary<string, object> containerJObject = JsonSerializer.Deserialize<Dictionary<string, object>>(containerSerialized);
-            Dictionary<string, object> collectionJObject = JsonSerializer.Deserialize<Dictionary<string, object>>(collectionSerialized);
+            Dictionary<string, object> containerJObject = JsonSerializer.Deserialize<Dictionary<string, object>>(containerSerialized, jsonSerializerOptions);
+            Dictionary<string, object> collectionJObject = JsonSerializer.Deserialize<Dictionary<string, object>>(collectionSerialized, jsonSerializerOptions);
 
             CollectionAssert.AreEqual(containerJObject.Keys.OrderBy( k => k).ToList(), collectionJObject.Keys.OrderBy(k => k).ToList());
         }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
@@ -36,7 +36,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void ValidateSerializer()
         {
-            CosmosTextJsonSerializer cosmosDefaultJsonSerializer = new CosmosTextJsonSerializer();
+            CosmosTextJsonSerializer cosmosDefaultJsonSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer(new CosmosSerializationOptions());
             using (Stream stream = cosmosDefaultJsonSerializer.ToStream<ToDoActivity>(this.toDoActivity))
             {
                 Assert.IsNotNull(stream);
@@ -53,7 +53,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void ValidateJson()
         {
-            CosmosTextJsonSerializer cosmosDefaultJsonSerializer = new CosmosTextJsonSerializer();
+            CosmosTextJsonSerializer cosmosDefaultJsonSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer(new CosmosSerializationOptions());
             using (Stream stream = cosmosDefaultJsonSerializer.ToStream<ToDoActivity>(this.toDoActivity))
             {
                 Assert.IsNotNull(stream);
@@ -206,8 +206,8 @@ namespace Azure.Cosmos.Tests
                 Parameters = sqlParameters
             });
 
-            CosmosTextJsonSerializer userSerializer = new CosmosTextJsonSerializer();
-            CosmosTextJsonSerializer propertiesSerializer = new CosmosTextJsonSerializer();
+            CosmosTextJsonSerializer userSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer(new CosmosSerializationOptions());
+            CosmosTextJsonSerializer propertiesSerializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
 
             CosmosSerializer sqlQuerySpecSerializer = TextJsonCosmosSqlQuerySpecConverter.CreateSqlQuerySpecSerializer(
                 userSerializer,

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -4344,11 +4344,10 @@
           "Attributes": [],
           "MethodInfo": "Int32 GetHashCode()"
         },
-        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[System.Text.Json.Serialization.JsonExtensionDataAttribute()]-[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
           "Type": "Property",
           "Attributes": [
-            "DataMemberAttribute",
-            "JsonExtensionDataAttribute"
+            "DataMemberAttribute"
           ],
           "MethodInfo": null
         },
@@ -4393,11 +4392,10 @@
           ],
           "MethodInfo": "Azure.Cosmos.Spatial.Crs get_Crs()"
         },
-        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[System.Text.Json.Serialization.JsonExtensionDataAttribute()]-[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
           "Type": "Property",
           "Attributes": [
-            "DataMemberAttribute",
-            "JsonExtensionDataAttribute"
+            "DataMemberAttribute"
           ],
           "MethodInfo": null
         },

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/MockCosmosUtil.cs
@@ -21,7 +21,7 @@ namespace Azure.Cosmos.Tests
 
     internal class MockCosmosUtil
     {
-        public static readonly CosmosSerializer Serializer = new CosmosTextJsonSerializer();
+        public static readonly CosmosSerializer Serializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
 
         public static CosmosClient CreateMockCosmosClient(
             Action<CosmosClientBuilder> customizeClientBuilder = null,

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Query/QueryResponseMessageFactory.cs
@@ -24,7 +24,7 @@ namespace Azure.Cosmos.Tests
 
     internal static class QueryResponseMessageFactory
     {
-        private static readonly CosmosSerializer cosmosSerializer = new CosmosTextJsonSerializer();
+        private static readonly CosmosSerializer cosmosSerializer = CosmosTextJsonSerializer.CreateUserDefaultSerializer();
         public const int SPLIT = -1;
 
         public static (QueryResponseCore queryResponse, IList<ToDoItem> items) Create(

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
@@ -18,7 +18,7 @@ namespace Azure.Cosmos.Test.Spatial
         public CommonSerializationTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
@@ -14,6 +14,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class CommonSerializationTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public CommonSerializationTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests that incorrect JSON throws exception.
         /// </summary>
@@ -22,7 +29,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestInvalidJson()
         {
             string json = @"{""type"":""Poi}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -33,7 +40,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestNullCoordinates()
         {
             string json = @"{""type"":""Point"",""coordinates"":null}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -44,7 +51,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestNullType()
         {
             string json = @"{""type"":null, ""coordinates"":[20, 30]}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -55,7 +62,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestNullTypeGeometry()
         {
             string json = @"{""type"":null, ""coordinates"":[20, 30]}";
-            var point = JsonSerializer.Deserialize<Geometry>(json);
+            var point = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -66,7 +73,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestBoundingBoxWithNonEvenNumberOfCoordinates()
         {
             string json = @"{""type"":""Point"", ""coordinates"":[20, 30], ""bbox"":[0, 0, 0, 5, 5]}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -77,7 +84,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestBoundingBoxWithNotEnoughCoordinates()
         {
             string json = @"{""type"":""Point"", ""coordinates"":[20, 30], ""bbox"":[0, 0]}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
 
         /// <summary>
@@ -87,7 +94,7 @@ namespace Azure.Cosmos.Test.Spatial
         public void TestNullBoundingBox()
         {
             string json = @"{""type"":""Point"", ""coordinates"":[20, 30], ""bbox"":null}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
             Assert.IsNull(point.BoundingBox);
         }
 
@@ -102,7 +109,7 @@ namespace Azure.Cosmos.Test.Spatial
                     ""type"":""Point"",
                     ""coordinates"":[],
                     }";
-            JsonSerializer.Deserialize<Point>(json);
+            JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CrsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CrsTest.cs
@@ -19,7 +19,7 @@ namespace Azure.Cosmos.Test.Spatial
         public CrsTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CrsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/CrsTest.cs
@@ -15,6 +15,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class CrsTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public CrsTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization of ""unspecified"" CRS.
         /// </summary>
@@ -23,12 +30,12 @@ namespace Azure.Cosmos.Test.Spatial
         [TestCategory("Quarantine")] // TODO: System.Text.Json does not apply converters when the value is null
         public void UnspecifiedCrsSerialization()
         {
-            Crs crs = JsonSerializer.Deserialize<Crs>(@"null");
+            Crs crs = JsonSerializer.Deserialize<Crs>(@"null", this.restContractOptions);
             Assert.AreEqual(CrsType.Unspecified, crs.Type);
             Assert.AreEqual(Crs.Unspecified, crs);
 
-            string json = JsonSerializer.Serialize(crs);
-            Crs crs1 = JsonSerializer.Deserialize<Crs>(json);
+            string json = JsonSerializer.Serialize(crs, this.restContractOptions);
+            Crs crs1 = JsonSerializer.Deserialize<Crs>(json, this.restContractOptions);
             Assert.AreEqual(crs1, crs);
         }
 
@@ -55,12 +62,12 @@ namespace Azure.Cosmos.Test.Spatial
         [Owner("laviswa")]
         public void LinkedCrsSerialization()
         {
-            LinkedCrs linkedCrs = (LinkedCrs)JsonSerializer.Deserialize<Crs>(@"{""type"":""link"", ""properties"":{""href"":""http://foo"", ""type"":""link""}}");
+            LinkedCrs linkedCrs = (LinkedCrs)JsonSerializer.Deserialize<Crs>(@"{""type"":""link"", ""properties"":{""href"":""http://foo"", ""type"":""link""}}", this.restContractOptions);
             Assert.AreEqual("http://foo", linkedCrs.Href);
             Assert.AreEqual(CrsType.Linked, linkedCrs.Type);
 
-            string json = JsonSerializer.Serialize(linkedCrs);
-            LinkedCrs linkedCrs1 = (LinkedCrs)JsonSerializer.Deserialize<Crs>(json);
+            string json = JsonSerializer.Serialize(linkedCrs, this.restContractOptions);
+            LinkedCrs linkedCrs1 = (LinkedCrs)JsonSerializer.Deserialize<Crs>(json, this.restContractOptions);
             Assert.AreEqual(linkedCrs1, linkedCrs);
         }
 
@@ -72,7 +79,7 @@ namespace Azure.Cosmos.Test.Spatial
         [ExpectedException(typeof(JsonException))]
         public void LinkedCrsSerializationNoHref()
         {
-            JsonSerializer.Deserialize<Crs>(@"{""type"":""linked"", ""properties"":{""href"":null}}");
+            JsonSerializer.Deserialize<Crs>(@"{""type"":""linked"", ""properties"":{""href"":null}}", this.restContractOptions);
         }
 
         /// <summary>
@@ -130,11 +137,11 @@ namespace Azure.Cosmos.Test.Spatial
         [Owner("laviswa")]
         public void NamedCrsSerialization()
         {
-            NamedCrs namedCrs = (NamedCrs)JsonSerializer.Deserialize<Crs>(@"{""type"":""name"", ""properties"":{""name"":""AName""}}");
+            NamedCrs namedCrs = (NamedCrs)JsonSerializer.Deserialize<Crs>(@"{""type"":""name"", ""properties"":{""name"":""AName""}}", this.restContractOptions);
             Assert.AreEqual("AName", namedCrs.Name);
 
-            string json = JsonSerializer.Serialize(namedCrs);
-            NamedCrs namedCrs1 = (NamedCrs)JsonSerializer.Deserialize<Crs>(json);
+            string json = JsonSerializer.Serialize(namedCrs, this.restContractOptions);
+            NamedCrs namedCrs1 = (NamedCrs)JsonSerializer.Deserialize<Crs>(json, this.restContractOptions);
             Assert.AreEqual(namedCrs1, namedCrs);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/GeometryCollectionTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/GeometryCollectionTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class GeometryCollectionTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public GeometryCollectionTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -31,7 +38,7 @@ namespace Azure.Cosmos.Test.Spatial
                    ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}
                   }";
 
-            var geometryCollection = JsonSerializer.Deserialize<GeometryCollection>(json);
+            var geometryCollection = JsonSerializer.Deserialize<GeometryCollection>(json, this.restContractOptions);
 
             Assert.AreEqual(1, geometryCollection.Geometries.Count);
             Assert.IsInstanceOfType(geometryCollection.Geometries[0], typeof(Point));
@@ -41,13 +48,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, geometryCollection.AdditionalProperties.Count);
             Assert.AreEqual(1L, geometryCollection.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.GeometryCollection, geom.Type);
 
             Assert.AreEqual(geom, geometryCollection);
 
-            string json1 = JsonSerializer.Serialize(geometryCollection);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(geometryCollection, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/GeometryCollectionTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/GeometryCollectionTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public GeometryCollectionTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/LineStringTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/LineStringTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class LineStringTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public LineStringTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -30,7 +37,7 @@ namespace Azure.Cosmos.Test.Spatial
                    ""extra"":1,
                    ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}
                   }";
-            var lineString = JsonSerializer.Deserialize<LineString>(json);
+            var lineString = JsonSerializer.Deserialize<LineString>(json, this.restContractOptions);
 
             Assert.AreEqual(2, lineString.Positions.Count);
             Assert.AreEqual(new Position(20, 30), lineString.Positions[0]);
@@ -42,13 +49,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, lineString.AdditionalProperties.Count);
             Assert.AreEqual(1L, lineString.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.LineString, geom.Type);
 
             Assert.AreEqual(geom, lineString);
 
-            string json1 = JsonSerializer.Serialize(lineString);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(lineString, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/LineStringTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/LineStringTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public LineStringTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiLineStringTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiLineStringTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class MultiLineStringTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public MultiLineStringTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -30,7 +37,7 @@ namespace Azure.Cosmos.Test.Spatial
                    ""extra"":1,
                    ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}
                   }";
-            var multiLineString = JsonSerializer.Deserialize<MultiLineString>(json);
+            var multiLineString = JsonSerializer.Deserialize<MultiLineString>(json, this.restContractOptions);
 
             Assert.AreEqual(2, multiLineString.LineStrings.Count);
             Assert.AreEqual(new Position(20, 30), multiLineString.LineStrings[0].Positions[0]);
@@ -42,13 +49,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, multiLineString.AdditionalProperties.Count);
             Assert.AreEqual(1L, multiLineString.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.MultiLineString, geom.Type);
 
             Assert.AreEqual(geom, multiLineString);
 
-            string json1 = JsonSerializer.Serialize(multiLineString);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(multiLineString, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiLineStringTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiLineStringTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public MultiLineStringTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPointTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPointTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public MultiPointTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPointTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPointTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class MultiPointTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public MultiPointTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization
         /// </summary>
@@ -29,7 +36,7 @@ namespace Azure.Cosmos.Test.Spatial
                     ""bbox"":[20, 20, 30, 30],
                     ""extra"":1,
                     ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}}";
-            var multiPoint = JsonSerializer.Deserialize<MultiPoint>(json);
+            var multiPoint = JsonSerializer.Deserialize<MultiPoint>(json, this.restContractOptions);
 
             Assert.AreEqual(new Position(20, 30), multiPoint.Points[0]);
             Assert.AreEqual(new Position(30, 40), multiPoint.Points[1]);
@@ -40,13 +47,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, multiPoint.AdditionalProperties.Count);
             Assert.AreEqual(1L, multiPoint.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.MultiPoint, geom.Type);
 
             Assert.AreEqual(geom, multiPoint);
 
-            string json1 = JsonSerializer.Serialize(multiPoint);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(multiPoint, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPolygonTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPolygonTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class MultiPolygonTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public MultiPolygonTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -32,7 +39,7 @@ namespace Azure.Cosmos.Test.Spatial
                     ""extra"":1,
                     ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}}";
 
-            var multiPolygon = JsonSerializer.Deserialize<MultiPolygon>(json);
+            var multiPolygon = JsonSerializer.Deserialize<MultiPolygon>(json, this.restContractOptions);
 
             Assert.AreEqual(2, multiPolygon.Polygons.Count);
             Assert.AreEqual(2, multiPolygon.Polygons[0].Rings.Count);
@@ -45,13 +52,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, multiPolygon.AdditionalProperties.Count);
             Assert.AreEqual(1L, multiPolygon.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.MultiPolygon, geom.Type);
 
             Assert.AreEqual(geom, multiPolygon);
 
-            string json1 = JsonSerializer.Serialize(multiPolygon);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(multiPolygon, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPolygonTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/MultiPolygonTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public MultiPolygonTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PointTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PointTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public PointTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PointTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PointTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class PointTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public PointTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -29,7 +36,7 @@ namespace Azure.Cosmos.Test.Spatial
                     ""bbox"":[20, 20, 30, 30],
                     ""extra"":1, 
                     ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}}";
-            var point = JsonSerializer.Deserialize<Point>(json);
+            var point = JsonSerializer.Deserialize<Point>(json, this.restContractOptions);
 
             Assert.AreEqual(2, point.Position.Coordinates.Count);
             Assert.AreEqual(20.232323232323232, point.Position.Longitude);
@@ -40,13 +47,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, point.AdditionalProperties.Count);
             Assert.AreEqual(1L, point.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.Point, geom.Type);
 
             Assert.AreEqual(geom, point);
 
-            string json1 = JsonSerializer.Serialize(point);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(point, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PolygonTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PolygonTest.cs
@@ -16,6 +16,13 @@ namespace Azure.Cosmos.Test.Spatial
     [TestClass]
     public class PolygonTest
     {
+        private JsonSerializerOptions restContractOptions;
+        public PolygonTest()
+        {
+            this.restContractOptions = new JsonSerializerOptions();
+            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+        }
+
         /// <summary>
         /// Tests serialization/deserialization.
         /// </summary>
@@ -29,7 +36,7 @@ namespace Azure.Cosmos.Test.Spatial
                     ""extra"":1,
                     ""crs"":{""type"":""name"", ""properties"":{""name"":""hello""}}}";
 
-            var polygon = JsonSerializer.Deserialize<Polygon>(json);
+            var polygon = JsonSerializer.Deserialize<Polygon>(json, this.restContractOptions);
 
             Assert.AreEqual(2, polygon.Rings.Count);
             Assert.AreEqual(5, polygon.Rings[0].Positions.Count);
@@ -42,13 +49,13 @@ namespace Azure.Cosmos.Test.Spatial
             Assert.AreEqual(1, polygon.AdditionalProperties.Count);
             Assert.AreEqual(1L, polygon.AdditionalProperties["extra"]);
 
-            var geom = JsonSerializer.Deserialize<Geometry>(json);
+            var geom = JsonSerializer.Deserialize<Geometry>(json, this.restContractOptions);
             Assert.AreEqual(GeometryType.Polygon, geom.Type);
 
             Assert.AreEqual(geom, polygon);
 
-            string json1 = JsonSerializer.Serialize(polygon);
-            var geom1 = JsonSerializer.Deserialize<Geometry>(json1);
+            string json1 = JsonSerializer.Serialize(polygon, this.restContractOptions);
+            var geom1 = JsonSerializer.Deserialize<Geometry>(json1, this.restContractOptions);
             Assert.AreEqual(geom1, geom);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PolygonTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Spatial/PolygonTest.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos.Test.Spatial
         public PolygonTest()
         {
             this.restContractOptions = new JsonSerializerOptions();
-            CosmosTextJsonSerializer.InitializeRESTConverters(this.restContractOptions);
+            CosmosTextJsonSerializer.InitializeDataContractConverters(this.restContractOptions);
         }
 
         /// <summary>

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1256](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1256) Removed public accessor to CosmosClient.CosmosClientOptions to avoid mutation after pipeline is created
 - [#1258](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1258) Renamed CosmosClientOptions.SerializerOptions to CosmosClientOptions.DefaultSerializerOptions
 - [#1257](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1257) Explicit CosmosClient constructors for most common scenarios
+- [#1283](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1283) Removed JsonConverter from the public API surface
 
 ### Fixed
 


### PR DESCRIPTION
# Pull Request Template

## Description

Based on API Review feedback, this PR removes the `[JsonConverter]` from the REST contract classes and public surface.

This decouples System.Text.Json from the public surface contract.

In order to solve this, we are now injecting the Converters in the Serializer we create for contract classes.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Closing issues

Closes #1247 