### PR TITLE
ORDER BY Resume Optimization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
 
     internal sealed partial class CosmosOrderByItemQueryExecutionContext : CosmosCrossPartitionQueryExecutionContext
     {
+        private const string TrueFilter = "true";
+
         private static class Expressions
         {
             public const string LessThan = "<";
@@ -599,7 +601,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
                 }
             }
 
-            return (left.ToString(), target.ToString(), right.ToString());
+            // For the target filter we can make an optimization to just return "true",
+            // since we already have the backend continuation token to resume with.
+            return (left.ToString(), TrueFilter, right.ToString());
         }
 
         private readonly struct OrderByInitInfo


### PR DESCRIPTION
# ORDER BY Resume Optimization

## Description

For cross partition ORDER BY queries we rewrite the query to inject a filter. For example if we left off on partition N with the value `("A", 1)`, then the filters are:

`(> "A") OR (= "A" AND > 1), (> "A") OR (= "A" AND >= 1), (> "A") OR (= "A" AND >= 1)`

The problem is that this filter is not efficient for the backend, since it can not leverage a composite index if any of the prefix filters have an inequality.

The solution is to just filter on `WHERE true` for the partition that we left off on, since we already have a continuation token. Note that for a single partition query we always resume on the partition we left off on meaning this optimization will pay extra dividends there.

In parallel backend will work on pushing the generated filter to the index, since we still need it for the other N - 1 partitions.
