### PR TITLE
Client Encryption - Decrypt the encrypted properties before returning query result

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -158,7 +158,8 @@ namespace Microsoft.Azure.Cosmos
                 partitionKeyRange,
                 queryPageDiagnostics);
 
-            if (this.clientContext.ClientOptions.EncryptionKeyWrapProvider != null)
+            if (queryResponseCore.IsSuccess &&
+                this.clientContext.ClientOptions.EncryptionKeyWrapProvider != null)
             {
                 return await this.GetDecryptedElementResponseAsync(queryResponseCore, message, cancellationToken);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -173,10 +173,9 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken)
         {
             List<CosmosElement> documents = new List<CosmosElement>();
-
-            foreach (CosmosElement document in queryResponseCore.CosmosElements)
+            using (message.DiagnosticsContext.CreateScope("Decrypt"))
             {
-                using (message.DiagnosticsContext.CreateScope("Decrypt"))
+                foreach (CosmosElement document in queryResponseCore.CosmosElements)
                 {
                     if (!(document is CosmosObject documentObject))
                     {
@@ -185,7 +184,7 @@ namespace Microsoft.Azure.Cosmos
                     }
 
                     CosmosObject decryptedDocument = await this.clientContext.EncryptionProcessor.DecryptAsync(
-                        documentObject, 
+                        documentObject,
                         (DatabaseCore)this.cosmosContainerCore.Database,
                         this.clientContext.ClientOptions.EncryptionKeyWrapProvider,
                         message.DiagnosticsContext,

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -178,8 +178,14 @@ namespace Microsoft.Azure.Cosmos
             {
                 using (message.DiagnosticsContext.CreateScope("Decrypt"))
                 {
+                    if (!(document is CosmosObject documentObject))
+                    {
+                        documents.Add(document);
+                        continue;
+                    }
+
                     CosmosObject decryptedDocument = await this.clientContext.EncryptionProcessor.DecryptAsync(
-                        document as CosmosObject, 
+                        documentObject, 
                         (DatabaseCore)this.cosmosContainerCore.Database,
                         this.clientContext.ClientOptions.EncryptionKeyWrapProvider,
                         message.DiagnosticsContext,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/EncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/EncryptionTests.cs
@@ -335,6 +335,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task DecryptQueryValueResponse()
+        {
+            TestDoc testDoc = await EncryptionTests.CreateItemAsync(EncryptionTests.containerCore, EncryptionTests.dekId, TestDoc.PathsToEncrypt);
+            string query = "SELECT VALUE COUNT(1) FROM c";
+
+            FeedIterator feedIterator = EncryptionTests.containerCore.GetItemQueryStreamIterator(query);
+            while (feedIterator.HasMoreResults)
+            {
+                ResponseMessage response = await feedIterator.ReadNextAsync();
+                Assert.IsTrue(response.IsSuccessStatusCode);
+                Assert.IsNull(response.ErrorMessage);
+            }
+        }
+
+        [TestMethod]
         public async Task EncryptionRudItem()
         {
             TestDoc testDoc = await EncryptionTests.UpsertItemAsync(

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1274](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1274) ObjectDisposedException is thrown when calling all SDK objects like Database and Container that reference a disposed client 
 - [#1268](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1268) Fix bug where Request Options was getting lost for Database.ReadStreamAsync and Database.DeleteStreamAsync
 - [#1304](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1304) Fixed XML documentation so it now is visible in Visual Studio
+- [#1296](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1296) Decrypt the encrypted properties before returning query result
 
 ## <a name="3.7.0-preview2"/> [3.7.0-preview2](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.7.0-preview2) - 2020-03-09
 


### PR DESCRIPTION
# Pull Request Template

## Description
While we do not support filtering on encrypted properties etc., for queries where the full item would be returned, we want to decrypt the encrypted properties on the client before returning the query result.

## Type of change
- [ ] Bug fix.
