### PR TITLE
Updated exception messages

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Diagnostics;
     using System.IO;
     using System.Net;
+    using System.Text;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Documents;
 
@@ -99,7 +100,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the reason for a failure in the current response.
         /// </summary>
-        public virtual string ErrorMessage => this.CosmosException?.ToString(includeDiagnostics: false);
+        public virtual string ErrorMessage => this.CosmosException?.ToStringNoDiagnostics();
 
         /// <summary>
         /// Gets the current <see cref="ResponseMessage"/> HTTP headers.

--- a/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the reason for a failure in the current response.
         /// </summary>
-        public virtual string ErrorMessage => this.CosmosException?.ToStringNoDiagnostics();
+        public virtual string ErrorMessage => this.CosmosException?.ToString();
 
         /// <summary>
         /// Gets the current <see cref="ResponseMessage"/> HTTP headers.

--- a/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ResponseMessage.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the reason for a failure in the current response.
         /// </summary>
-        public virtual string ErrorMessage => this.CosmosException?.ToString();
+        public virtual string ErrorMessage => this.CosmosException?.Message;
 
         /// <summary>
         /// Gets the current <see cref="ResponseMessage"/> HTTP headers.

--- a/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos
                 subStatusCode: (int)SubStatusCodes.Unknown,
                 responseTimeUtc: DateTime.UtcNow,
                 requestCharge: cosmosException.Headers.RequestCharge,
-                errorMessage: cosmosException.Message,
+                errorMessage: documentClientException.ToString(),
                 method: requestMessage?.Method,
                 requestUri: requestMessage?.RequestUri,
                 requestSessionToken: requestMessage?.Headers?.Session,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1257,8 +1257,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, e.StatusCode, e.Message);
                 Assert.AreNotEqual(e.ActivityId, Guid.Empty);
                 Assert.IsTrue(e.RequestCharge > 0);
-                Assert.AreEqual("{\r\n  \"Errors\": [\r\n    \"One of the specified pre-condition is not met\"\r\n  ]\r\n}", e.ResponseBody);
-                Assert.AreEqual($"Response status code does not indicate success: PreconditionFailed; Substatus: 0; Reason: ({{\r\n  \"Errors\": [\r\n    \"One of the specified pre-condition is not met\"\r\n  ]\r\n}}); ActivityId = {e.ActivityId}; RequestCharge = {e.RequestCharge};", e.Message);
+                Assert.AreEqual($"{{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}}", e.ResponseBody);
+                string expectedMessage = $"Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; Reason: ({{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}});{Environment.NewLine}{e.StackTrace}{Environment.NewLine}{e.Diagnostics.ToString()}";
+                Assert.AreEqual(expectedMessage, e.Message);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1258,7 +1258,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreNotEqual(e.ActivityId, Guid.Empty);
                 Assert.IsTrue(e.RequestCharge > 0);
                 Assert.AreEqual($"{{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}}", e.ResponseBody);
-                string expectedMessage = $"Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; Reason: ({{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}});{Environment.NewLine}{e.StackTrace}{Environment.NewLine}{e.Diagnostics.ToString()}";
+                string expectedMessage = $"Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; ActivityId: {e.ActivityId}; Reason: ({{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}});";
                 Assert.AreEqual(expectedMessage, e.Message);
             }
             finally

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1232,8 +1232,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ItemResponse<ToDoActivity> response = await this.Container.ReplaceItemAsync<ToDoActivity>(
-                    id: testItem.id,
+                ItemResponse<ToDoActivity> response = await this.Container.UpsertItemAsync<ToDoActivity>(
                     item: testItem,
                     requestOptions: itemRequestOptions);
                 Assert.Fail("Access condition should have failed");
@@ -1241,6 +1240,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException e)
             {
                 Assert.IsNotNull(e);
+                Assert.AreEqual(e.Message, $"Response status code does not indicate success: PreconditionFailed; Substatus: 0; Reason: ({{\r\n  \"Errors\": [\r\n    \"One of the specified pre-condition is not met\"\r\n  ]\r\n}}); ActivityId = {e.ActivityId}; RequestCharge = {e.RequestCharge};");
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, e.StatusCode, e.Message);
                 Assert.IsNotNull(e.ActivityId);
                 Assert.IsTrue(e.RequestCharge > 0);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
             string message = responseMessage.ErrorMessage;
-            Assert.AreEqual(responseMessage.ErrorMessage, responseMessage.CosmosException.ToString());
+            Assert.AreEqual(responseMessage.ErrorMessage, responseMessage.CosmosException.Message);
             Assert.IsTrue(message.Contains("TransportException: A client transport error occurred: The connection failed"), "StoreResult Exception is missing");
             string diagnostics = responseMessage.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
     using System.Diagnostics;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -64,13 +65,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 this.ValidateTransportException(ce);
             }
+
+            using (ResponseMessage responseMessage = await container.CreateItemStreamAsync(
+                TestCommon.SerializerCore.ToStream(new TestPayload { id = "bad" }),
+                new Cosmos.PartitionKey("bad")))
+            {
+                this.ValidateTransportException(responseMessage);
+            }
+
+            FeedIterator streamIterator = container.GetItemQueryStreamIterator("select * from T where T.Random = 19827 ");
+            using (ResponseMessage responseMessage = await streamIterator.ReadNextAsync())
+            {
+                this.ValidateTransportException(responseMessage);
+            }   
         }
 
         private void ValidateTransportException(CosmosException cosmosException)
         {
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, cosmosException.StatusCode);
             string message = cosmosException.ToString();
             Assert.IsTrue(message.Contains("TransportException: A client transport error occurred: The connection failed"), "StoreResult Exception is missing");
             string diagnostics = cosmosException.Diagnostics.ToString();
+            Assert.IsNotNull(diagnostics);
+            Assert.IsTrue(diagnostics.Contains("TransportException: A client transport error occurred: The connection failed"));
+        }
+
+        private void ValidateTransportException(ResponseMessage responseMessage)
+        {
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
+            string message = responseMessage.ErrorMessage;
+            Assert.AreEqual(responseMessage.ErrorMessage, responseMessage.CosmosException.ToString());
+            Assert.IsTrue(message.Contains("TransportException: A client transport error occurred: The connection failed"), "StoreResult Exception is missing");
+            string diagnostics = responseMessage.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);
             Assert.IsTrue(diagnostics.Contains("TransportException: A client transport error occurred: The connection failed"));
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -155,10 +155,10 @@ namespace Microsoft.Azure.Cosmos
             List<(HttpStatusCode statusCode, CosmosException exception)> exceptionsToStatusCodes = new List<(HttpStatusCode, CosmosException)>()
             {
                 (HttpStatusCode.NotFound, CosmosExceptionFactory.CreateNotFoundException(testMessage)),
-                (HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage)),
-                (HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage)),
-                (HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage)),
-                ((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage)),
+                //(HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage)),
+                //(HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage)),
+                //(HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage)),
+                //((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage)),
             };
 
             foreach((HttpStatusCode statusCode, CosmosException exception) item in exceptionsToStatusCodes)
@@ -239,8 +239,10 @@ namespace Microsoft.Azure.Cosmos
             HttpStatusCode httpStatusCode,
             string message)
         {
+            Assert.AreEqual(message, exception.ResponseBody);
             Assert.AreEqual(httpStatusCode, exception.StatusCode);
             Assert.IsTrue(exception.ToString().Contains(message));
+            Assert.AreEqual(exception.Message, $"Response status code does not indicate success: {httpStatusCode}; Substatus: 0; Reason: ({message}); ActivityId = {Guid.Empty.ToString()}; RequestCharge = 0;");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(HttpStatusCode.BadRequest, responseMessage.StatusCode);
             Assert.AreEqual(SubStatusCodes.WriteForbidden, responseMessage.Headers.SubStatusCode);
             Assert.IsTrue(responseMessage.ErrorMessage.Contains(errorMessage));
-            Assert.IsTrue(responseMessage.ErrorMessage.Contains("VerifyDocumentClientExceptionToResponseMessage"), $"Message should have method name for the stack trace {responseMessage.ErrorMessage}");
+            Assert.IsFalse(responseMessage.ErrorMessage.Contains("VerifyDocumentClientExceptionToResponseMessage"), $"Message should not have the stack trace {responseMessage.ErrorMessage}. StackTrace should be in Diagnostics.");
         }
 
         [TestMethod]
@@ -143,21 +143,21 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsFalse(responseMessage.IsSuccessStatusCode);
             Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
             Assert.IsTrue(responseMessage.ErrorMessage.Contains(errorMessage));
-            Assert.IsTrue(responseMessage.ErrorMessage.Contains(transportException.ToString()));
+            Assert.IsFalse(responseMessage.ErrorMessage.Contains(transportException.ToString()), "InnerException tracked in Diagnostics");
         }
 
         [TestMethod]
         public void EnsureCorrectStatusCode()
         {
             string testMessage = "Test" + Guid.NewGuid().ToString();
-
+            
             List<(HttpStatusCode statusCode, CosmosException exception)> exceptionsToStatusCodes = new List<(HttpStatusCode, CosmosException)>()
             {
-                (HttpStatusCode.NotFound, CosmosExceptionFactory.CreateNotFoundException(testMessage)),
-                (HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage)),
-                (HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage)),
-                (HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage)),
-                ((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage)),
+                (HttpStatusCode.NotFound, CosmosExceptionFactory.CreateNotFoundException(testMessage, activityId: Guid.NewGuid().ToString())),
+                (HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage, activityId: Guid.NewGuid().ToString())),
+                (HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage, activityId: Guid.NewGuid().ToString())),
+                (HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage, activityId: Guid.NewGuid().ToString())),
+                ((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage, activityId: Guid.NewGuid().ToString())),
             };
 
             foreach((HttpStatusCode statusCode, CosmosException exception) item in exceptionsToStatusCodes)
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(message, exception.ResponseBody);
             Assert.AreEqual(httpStatusCode, exception.StatusCode);
             Assert.IsTrue(exception.ToString().Contains(message));
-            string expectedMessage = $"Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: {httpStatusCode} ({(int)httpStatusCode}); Substatus: 0; Reason: ({message});{Environment.NewLine}{exception.Diagnostics.ToString()}";
+            string expectedMessage = $"Response status code does not indicate success: {httpStatusCode} ({(int)httpStatusCode}); Substatus: 0; ActivityId: {exception.ActivityId}; Reason: ({message});";
 
             Assert.AreEqual(expectedMessage, exception.Message);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -155,10 +155,10 @@ namespace Microsoft.Azure.Cosmos
             List<(HttpStatusCode statusCode, CosmosException exception)> exceptionsToStatusCodes = new List<(HttpStatusCode, CosmosException)>()
             {
                 (HttpStatusCode.NotFound, CosmosExceptionFactory.CreateNotFoundException(testMessage)),
-                //(HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage)),
-                //(HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage)),
-                //(HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage)),
-                //((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage)),
+                (HttpStatusCode.InternalServerError, CosmosExceptionFactory.CreateInternalServerErrorException(testMessage)),
+                (HttpStatusCode.BadRequest, CosmosExceptionFactory.CreateBadRequestException(testMessage)),
+                (HttpStatusCode.RequestTimeout,CosmosExceptionFactory.CreateRequestTimeoutException(testMessage)),
+                ((HttpStatusCode)429, CosmosExceptionFactory.CreateThrottledException(testMessage)),
             };
 
             foreach((HttpStatusCode statusCode, CosmosException exception) item in exceptionsToStatusCodes)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -144,7 +144,6 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
             Assert.IsTrue(responseMessage.ErrorMessage.Contains(errorMessage));
             Assert.IsTrue(responseMessage.ErrorMessage.Contains(transportException.ToString()));
-            Assert.IsTrue(responseMessage.ErrorMessage.Contains("VerifyTransportExceptionToResponseMessage"), $"Message should have method name for the stack trace {responseMessage.ErrorMessage}");
         }
 
         [TestMethod]
@@ -239,10 +238,13 @@ namespace Microsoft.Azure.Cosmos
             HttpStatusCode httpStatusCode,
             string message)
         {
+            exception.DiagnosticsContext.GetOverallScope().Dispose();
             Assert.AreEqual(message, exception.ResponseBody);
             Assert.AreEqual(httpStatusCode, exception.StatusCode);
             Assert.IsTrue(exception.ToString().Contains(message));
-            Assert.AreEqual(exception.Message, $"Response status code does not indicate success: {httpStatusCode}; Substatus: 0; Reason: ({message}); ActivityId = {Guid.Empty.ToString()}; RequestCharge = 0;");
+            string expectedMessage = $"Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: {httpStatusCode} ({(int)httpStatusCode}); Substatus: 0; Reason: ({message});{Environment.NewLine}{exception.Diagnostics.ToString()}";
+
+            Assert.AreEqual(expectedMessage, exception.Message);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         diagnostics: diagnostics);
 
             Assert.AreEqual(HttpStatusCode.NotFound, queryResponse.StatusCode);
-            Assert.AreEqual(cosmosException.ToString(includeDiagnostics: false), queryResponse.ErrorMessage);
+            Assert.AreEqual(cosmosException.Message, queryResponse.ErrorMessage);
             Assert.AreEqual(requestCharge, queryResponse.Headers.RequestCharge);
             Assert.AreEqual(activityId, queryResponse.Headers.ActivityId);
             Assert.AreEqual(diagnostics, queryResponse.DiagnosticsContext);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -40,8 +40,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             string errorMessage = "TestErrorMessage";
             string activityId = "TestActivityId";
             double requestCharge = 42.42;
-            CosmosException cosmosException = CosmosExceptionFactory.CreateBadRequestException(errorMessage);
             CosmosDiagnosticsContext diagnostics = new CosmosDiagnosticsContextCore();
+            CosmosException cosmosException = CosmosExceptionFactory.CreateBadRequestException(errorMessage, diagnosticsContext: diagnostics);
+            
+            diagnostics.GetOverallScope().Dispose();
             QueryResponse queryResponse = QueryResponse.CreateFailure(
                         statusCode: HttpStatusCode.NotFound,
                         cosmosException: cosmosException,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1812,6 +1812,11 @@
           ],
           "MethodInfo": "System.String get_ActivityId()"
         },
+        "System.String get_Message()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Message()"
+        },
         "System.String get_ResponseBody()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -1823,6 +1828,11 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.String get_StackTrace()"
+        },
+        "System.String Message": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
         },
         "System.String ResponseBody": {
           "Type": "Property",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1812,11 +1812,6 @@
           ],
           "MethodInfo": "System.String get_ActivityId()"
         },
-        "System.String get_Message()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_Message()"
-        },
         "System.String get_ResponseBody()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -1828,11 +1823,6 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.String get_StackTrace()"
-        },
-        "System.String Message": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
         },
         "System.String ResponseBody": {
           "Type": "Property",

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) CosmosException now returns the original stack trace.
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) ResponseMessage.ErrorMessage is now always correctly populated. There was bug in some scenarios where the error message was left in the content stream.
-- [#1298](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1298) CosmosException.Message contains activity id and request charge.
+- [#1298](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1298) CosmosException.Message contains the same information as CosmosException.ToString() to ensure all the information is being tracked
 - [#1242](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1242) Client encryption - Fix bug in read path without encrypted properties
 - [#1189](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1189) Query diagnostics shows correct overall time.
 - [#1189](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1189) Fixed a bug that caused duplicate information in diagnostic context.

--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) CosmosException now returns the original stack trace.
 - [#1213](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1213) ResponseMessage.ErrorMessage is now always correctly populated. There was bug in some scenarios where the error message was left in the content stream.
+- [#1298](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1298) CosmosException.Message contains activity id and request charge.
 - [#1242](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1242) Client encryption - Fix bug in read path without encrypted properties
 - [#1189](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1189) Query diagnostics shows correct overall time.
 - [#1189](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1189) Fixed a bug that caused duplicate information in diagnostic context.


### PR DESCRIPTION
# Pull Request Template

## Description

Updating the exception messages to provide a consistent story with all the information. This ensures that if a user only collects a Message or other property there will always be the information required to troubleshoot it.
### ResponseMessage
1. ResponseMessage.Content will always be null for exception scenarios
2. ResponseMessage.ErrorMessage will contain the same thing as CosmosException.Message (no stack trace, no diagnostics)

### CosmosException:

1. CosmosException.Message, ResponseMessage.ErrorMessage contain the same value.
2. CosmosException.ToString() includes stacktrace, diagnostics, error message, and all relevant information.
3. CosmosException.ResponseBody is the raw response from the service or DCE.Message
```
{
  "Errors": [
    "One of the specified pre-condition is not met"
  ]
}
```

### Example output CosmosException.Message and ResponseMessage.ErrorMessage 
```
Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; ActivityId: 9257c3ae-15fc-4c9f-a6c8-d995107c16df; Reason: ({
  "Errors": [
    "One of the specified pre-condition is not met"
  ]
});
```


### Example output CosmosException.ToString() 
```
Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; ActivityId: 9257c3ae-15fc-4c9f-a6c8-d995107c16df; Reason: ({
  "Errors": [
    "One of the specified pre-condition is not met"
  ]
});
   at Microsoft.Azure.Cosmos.ResponseMessage.EnsureSuccessStatusCode() in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Handler\ResponseMessage.cs:line 153
   at Microsoft.Azure.Cosmos.CosmosResponseFactory.ProcessMessageAsync[T](Task`1 cosmosResponseTask, Func`2 createResponse) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\CosmosResponseFactory.cs:line 256
   at Microsoft.Azure.Cosmos.ContainerCore.UpsertItemAsync[T](T item, Nullable`1 partitionKey, ItemRequestOptions requestOptions, CancellationToken cancellationToken) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\Container\ContainerCore.Items.cs:line 173
   at Microsoft.Azure.Cosmos.SDK.EmulatorTests.CosmosItemTests.ItemRequestOptionAccessConditionTest() in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\CosmosItemTests.cs:line 1249
{"Summary":{"StartUtc":"2020-03-25T19:59:26.9650800Z","TotalElapsedTime":"00:00:00.1440249","UserAgent":"cosmos-netstandard-sdk/3.7.0|3.7.1|96609|X64|Microsoft Windows 10.0.18363 |.NET Core 4.6.28325.01|","TotalRequestCount":1,"FailedRequestCount":1},"Context":[{"Id":"ItemSerialize","ElapsedTime":"00:00:00.0000571"},{"Id":"ExtractPkValue","ElapsedTime":"00:00:00.0001130"},{"Id":"AggregatedClientSideRequestStatistics","ContactedReplicas":[{"Count":12,"Uri":"rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer4/partitions/a4cb4950-38c8-11e6-8106-8cdcd42c33be/replicas/1p/"}],"RegionsContacted":["https://127.0.0.1:8081/"],"FailedReplicas":[]},{"Id":"Microsoft.Azure.Cosmos.Handlers.RetryHandler","ElapsedTime":"00:00:00.0067842"},{"Id":"Microsoft.Azure.Cosmos.Handlers.RouterHandler","ElapsedTime":"00:00:00.0034801"},{"Id":"TransportHandler","ElapsedTime":"00:00:00.0034742"},{"Id":"StoreResponseStatistics","ResponseTimeUtc":"2020-03-25T19:59:26.9678463Z","ResourceType":"Document","OperationType":"Upsert","LocationEndpoint":"https://127.0.0.1:8081/","StoreResult":"StorePhysicalAddress: rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer4/partitions/a4cb4950-38c8-11e6-8106-8cdcd42c33be/replicas/1p/, LSN: 130, GlobalCommittedLsn: -1, PartitionKeyRangeId: 0, IsValid: True, StatusCode: 412, SubStatusCode: 0, RequestCharge: 1.24, ItemLSN: -1, SessionToken: -1#130, UsingLocalLSN: False, TransportException: null"}]}
```




