### PR TITLE
Compare case for default(PartitionKey)

### DIFF
--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -127,6 +127,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
+            if (this.InternalKey == null)
+            {
+                return PartitionKey.NullPartitionKeyInternal.GetHashCode();
+            }
+
             return this.InternalKey.GetHashCode();
         }
 
@@ -137,7 +142,19 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
         public bool Equals(PartitionKey other)
         {
-            return this.InternalKey.Equals(other.InternalKey);
+            PartitionKeyInternal partitionKeyInternal = this.InternalKey;
+            PartitionKeyInternal otherPartitionKeyInternal = other.InternalKey;
+            if (partitionKeyInternal == null)
+            {
+                partitionKeyInternal = PartitionKey.NullPartitionKeyInternal;
+            }
+
+            if (otherPartitionKeyInternal == null)
+            {
+                otherPartitionKeyInternal = PartitionKey.NullPartitionKeyInternal;
+            }
+
+            return partitionKeyInternal.Equals(otherPartitionKeyInternal);
         }
 
         /// <summary>
@@ -146,6 +163,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The string representation of the partition key value</returns>
         public override string ToString()
         {
+            if (this.InternalKey == null)
+            {
+                return PartitionKey.NullPartitionKeyInternal.ToJsonString();
+            }
+
             return this.InternalKey.ToJsonString();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -125,6 +125,13 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("other_pk")));
             Assert.IsFalse(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("other_pk"));
             Assert.IsFalse(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(Cosmos.PartitionKey.None.Equals(Cosmos.PartitionKey.None));
+            Assert.IsTrue(Cosmos.PartitionKey.Null.Equals(Cosmos.PartitionKey.Null));
+            Assert.IsTrue(default(Cosmos.PartitionKey).Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(Cosmos.PartitionKey.None.Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(Cosmos.PartitionKey.None));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(new Cosmos.PartitionKey("pk")));
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#1312](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1312) Fixed null reference when using default(PartitionKey)
+
 ## <a name="3.7.0"/> [3.7.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.7.0) - 2020-03-26
 
 ### Added


### PR DESCRIPTION
# Pull Request Template

## Description

`PartitionKey` is a struct. `default(struct)` initializes all referenced properties to their default values (ref https://docs.microsoft.com/dotnet/csharp/language-reference/language-specification/structs#class-and-struct-differences)

>The default value of a struct is the value produced by setting all value type fields to their default value and all reference type fields to null (Default values).

Due to this behavior, comparisons using `default(PartitionKey)` were causing NullRefs.

This PR handles the case of `default(PartitionKey)` by assigning it the `Null` value for comparison purposes.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1307