### PR TITLE
TCP endpoint rediscovery

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -180,6 +180,18 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Gets or sets the flag to enable address cache refresh on connection reset notification.
+        /// </summary>
+        /// <value>
+        /// The default value is false
+        /// </value>
+        public bool EnableTcpConnectionEndpointRediscovery
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets the default connection policy used to connect to the Azure Cosmos DB service.
         /// </summary>
         /// <value>

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -405,6 +405,17 @@ namespace Microsoft.Azure.Cosmos
         public bool AllowBulkExecution { get; set; }
 
         /// <summary>
+        /// Gets or sets the flag to enable address cache refresh on TCP connection reset notification.
+        /// </summary>
+        /// <remarks>
+        /// Does not apply if <see cref="ConnectionMode.Gateway"/> is used.
+        /// </remarks>
+        /// <value>
+        /// The default value is false
+        /// </value>
+        public bool EnableTcpConnectionEndpointRediscovery { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the connection protocol when connecting to the Azure Cosmos service.
         /// </summary>
         /// <value>
@@ -533,7 +544,8 @@ namespace Microsoft.Azure.Cosmos
                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
                 MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
                 EnableEndpointDiscovery = !this.LimitToEndpoint,
-                PortReuseMode = this.portReuseMode
+                PortReuseMode = this.portReuseMode,
+                EnableTcpConnectionEndpointRediscovery = this.EnableTcpConnectionEndpointRediscovery
             };
 
             if (this.ApplicationRegion != null)

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6801,6 +6801,18 @@ namespace Microsoft.Azure.Cosmos
 
         private void InitializeDirectConnectivity(IStoreClientFactory storeClientFactory)
         {
+            this.AddressResolver = new GlobalAddressResolver(
+                this.GlobalEndpointManager,
+                this.ConnectionPolicy.ConnectionProtocol,
+                this,
+                this.collectionCache,
+                this.partitionKeyRangeCache,
+                this.ConnectionPolicy.UserAgentContainer,
+                this.accountServiceConfiguration,
+                this.httpMessageHandler,
+                this.ConnectionPolicy,
+                this.ApiType);
+
             // Check if we have a store client factory in input and if we do, do not initialize another store client
             // The purpose is to reuse store client factory across all document clients inside compute gateway
             if (storeClientFactory != null)
@@ -6829,7 +6841,9 @@ namespace Microsoft.Azure.Cosmos
                     receiveHangDetectionTimeSeconds: this.rntbdReceiveHangDetectionTimeSeconds,
                     sendHangDetectionTimeSeconds: this.rntbdSendHangDetectionTimeSeconds,
                     enableCpuMonitor: this.enableCpuMonitor,
-                    retryWithConfiguration: this.ConnectionPolicy.RetryOptions?.GetRetryWithConfiguration());
+                    retryWithConfiguration: this.ConnectionPolicy.RetryOptions?.GetRetryWithConfiguration(),
+                    enableTcpConnectionEndpointRediscovery: this.ConnectionPolicy.EnableTcpConnectionEndpointRediscovery,
+                    addressResolver: this.AddressResolver);
 
                 if (this.transportClientHandlerFactory != null)
                 {
@@ -6839,18 +6853,6 @@ namespace Microsoft.Azure.Cosmos
                 this.storeClientFactory = newClientFactory;
                 this.isStoreClientFactoryCreatedInternally = true;
             }
-
-            this.AddressResolver = new GlobalAddressResolver(
-                this.GlobalEndpointManager,
-                this.ConnectionPolicy.ConnectionProtocol,
-                this,
-                this.collectionCache,
-                this.partitionKeyRangeCache,
-                this.ConnectionPolicy.UserAgentContainer,
-                this.accountServiceConfiguration,
-                this.httpMessageHandler,
-                this.ConnectionPolicy,
-                this.ApiType);
 
             this.CreateStoreModel(subscribeRntbdStatus: true);
         }

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -234,6 +234,10 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// (Direct/TCP) Controls the client port reuse policy used by the transport stack.
         /// The default value is PortReuseMode.ReuseUnicastPort.
         /// </param>
+        /// /// <param name="enableTcpConnectionEndpointRediscovery">
+        /// (Direct/TCP) Controls the address cache refresh on TCP connection reset notification.
+        /// The default value is false.
+        /// </param>
         /// <remarks>
         /// For more information, see <see href="https://docs.microsoft.com/azure/documentdb/documentdb-performance-tips#direct-connection">Connection policy: Use direct connection mode</see>.
         /// </remarks>
@@ -243,13 +247,18 @@ namespace Microsoft.Azure.Cosmos.Fluent
             TimeSpan? openTcpConnectionTimeout = null,
             int? maxRequestsPerTcpConnection = null,
             int? maxTcpConnectionsPerEndpoint = null,
-            Cosmos.PortReuseMode? portReuseMode = null)
+            Cosmos.PortReuseMode? portReuseMode = null,
+            bool? enableTcpConnectionEndpointRediscovery = null)
         {
             this.clientOptions.IdleTcpConnectionTimeout = idleTcpConnectionTimeout;
             this.clientOptions.OpenTcpConnectionTimeout = openTcpConnectionTimeout;
             this.clientOptions.MaxRequestsPerTcpConnection = maxRequestsPerTcpConnection;
             this.clientOptions.MaxTcpConnectionsPerEndpoint = maxTcpConnectionsPerEndpoint;
             this.clientOptions.PortReuseMode = portReuseMode;
+            if (enableTcpConnectionEndpointRediscovery.HasValue)
+            {
+                this.clientOptions.EnableTcpConnectionEndpointRediscovery = enableTcpConnectionEndpointRediscovery.Value;
+            }
 
             this.clientOptions.ConnectionMode = ConnectionMode.Direct;
             this.clientOptions.ConnectionProtocol = Protocol.Tcp;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ApiType apiType = ApiType.Sql;
             int maxRetryAttemptsOnThrottledRequests = 9999;
             TimeSpan maxRetryWaitTime = TimeSpan.FromHours(6);
+            bool enableTcpConnectionEndpointRediscovery = true;
             CosmosSerializationOptions cosmosSerializerOptions = new CosmosSerializationOptions()
             {
                 IgnoreNullValues = true,
@@ -70,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsNull(clientOptions.Serializer);
             Assert.IsNull(clientOptions.WebProxy);
             Assert.IsFalse(clientOptions.LimitToEndpoint);
+            Assert.IsFalse(clientOptions.EnableTcpConnectionEndpointRediscovery);
 
             //Verify GetConnectionPolicy returns the correct values for default
             ConnectionPolicy policy = clientOptions.GetConnectionPolicy();
@@ -82,6 +84,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsNull(policy.MaxRequestsPerTcpConnection);
             Assert.IsNull(policy.MaxTcpConnectionsPerEndpoint);
             Assert.IsTrue(policy.EnableEndpointDiscovery);
+            Assert.IsFalse(policy.EnableTcpConnectionEndpointRediscovery);
 
             cosmosClientBuilder.WithApplicationRegion(region)
                 .WithConnectionModeGateway(maxConnections, webProxy)
@@ -133,7 +136,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 openTcpConnectionTimeout,
                 maxRequestsPerTcpConnection,
                 maxTcpConnectionsPerEndpoint,
-                portReuseMode
+                portReuseMode,
+                enableTcpConnectionEndpointRediscovery
             );
 
             cosmosClient = cosmosClientBuilder.Build(new MockDocumentClient());
@@ -145,6 +149,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(maxRequestsPerTcpConnection, clientOptions.MaxRequestsPerTcpConnection);
             Assert.AreEqual(maxTcpConnectionsPerEndpoint, clientOptions.MaxTcpConnectionsPerEndpoint);
             Assert.AreEqual(portReuseMode, clientOptions.PortReuseMode);
+            Assert.IsTrue(clientOptions.EnableTcpConnectionEndpointRediscovery);
 
             //Verify GetConnectionPolicy returns the correct values
             policy = clientOptions.GetConnectionPolicy();
@@ -153,6 +158,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(maxRequestsPerTcpConnection, policy.MaxRequestsPerTcpConnection);
             Assert.AreEqual(maxTcpConnectionsPerEndpoint, policy.MaxTcpConnectionsPerEndpoint);
             Assert.AreEqual(portReuseMode, policy.PortReuseMode);
+            Assert.IsTrue(policy.EnableTcpConnectionEndpointRediscovery);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1383,12 +1383,24 @@
           "Attributes": [],
           "MethodInfo": null
         },
+        "Boolean EnableTcpConnectionEndpointRediscovery": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
         "Boolean get_AllowBulkExecution()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Boolean get_AllowBulkExecution()"
+        },
+        "Boolean get_EnableTcpConnectionEndpointRediscovery()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_EnableTcpConnectionEndpointRediscovery()"
         },
         "Boolean get_LimitToEndpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -1629,6 +1641,13 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+        },
+        "Void set_EnableTcpConnectionEndpointRediscovery(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EnableTcpConnectionEndpointRediscovery(Boolean)"
         },
         "Void set_GatewayModeMaxConnectionLimit(Int32)": {
           "Type": "Method",

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [#1314](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1314) Added configuration for proactive TCP end-of-connection detection
+
 ## <a name="3.7.0"/> [3.7.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.7.0) - 2020-03-26
 
 ### Added


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a new Direct/TCP configuration to enable TCP end-of-connection detection for proactive address refresh.

## Type of change

- [X] New feature (non-breaking change which adds functionality)