### PR TITLE
Adding Contract Changes verification for internal

### DIFF
--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Emul
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Performance.Tests", "Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Performance.Tests\Microsoft.Azure.Cosmos.Performance.Tests.csproj", "{0392A590-68EF-4283-94D8-33F350BEC9BF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Tests.Internal", "Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests.Internal\Microsoft.Azure.Cosmos.Tests.Internal.csproj", "{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Cover|Any CPU = Cover|Any CPU
@@ -69,6 +71,18 @@ Global
 		{0392A590-68EF-4283-94D8-33F350BEC9BF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0392A590-68EF-4283-94D8-33F350BEC9BF}.Release|x64.ActiveCfg = Release|Any CPU
 		{0392A590-68EF-4283-94D8-33F350BEC9BF}.Release|x64.Build.0 = Release|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Cover|x64.Build.0 = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC6710E2-EEC1-4A0F-9B59-BBAA998112ED}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -113,6 +113,7 @@
     <DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
     <DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
     <DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
+    <DefineConstants Condition=" '$(IncludeInternals)' == 'true' ">$(DefineConstants);INTERNAL</DefineConstants>
     <DefineConstants>$(DefineConstants);DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20</DefineConstants>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/ContractEnforcement.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/ContractEnforcement.cs
@@ -1,0 +1,154 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    [TestCategory("Windows")]
+    [TestClass]
+    public class ContractEnforcement
+    {
+        private const string BaselinePath = "DotNetSDKAPI.json";
+        private const string BreakingChangesPath = "DotNetSDKAPIChanges.json";
+
+        private static readonly InvariantComparer invariantComparer = new InvariantComparer();
+
+        [TestMethod]
+        public void InternalContractChanges()
+        {
+            System.Diagnostics.Process process = System.Diagnostics.Process.Start("CMD.exe", $"/c dotnet build ../../../../../src/Microsoft.Azure.Cosmos.csproj -o . /p:IncludeInternals=true");
+            process.WaitForExit();
+            Assert.IsFalse(
+                ContractEnforcement.DoesContractContainBreakingChanges("Microsoft.Azure.Cosmos.Client", BaselinePath, BreakingChangesPath),
+                $@"Internal API has changed. If this is expected, then refresh {BaselinePath} with {Environment.NewLine} Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/testbaseline.cmd /update after this test is run locally. To see the differences run testbaselines.cmd /diff"
+            );
+        }
+
+        private static Assembly GetAssemblyLocally(string name)
+        {
+            Assembly.Load(name);
+            Assembly[] loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+            return loadedAssemblies
+                .Where((candidate) => candidate.FullName.Contains(name + ","))
+                .FirstOrDefault();
+        }
+
+        private sealed class MemberMetadata
+        {
+            [JsonConverter(typeof(StringEnumConverter))]
+            public MemberTypes Type { get; }
+            public List<string> Attributes { get; }
+            public string MethodInfo { get; }
+            public MemberMetadata(MemberTypes type, List<string> attributes, string methodInfo)
+            {
+                this.Type = type;
+                this.Attributes = attributes;
+                this.MethodInfo = methodInfo;
+            }
+        }
+
+        private sealed class TypeTree
+        {
+            [JsonIgnore]
+            public Type Type { get; }
+            public Dictionary<string, TypeTree> Subclasses { get; } = new Dictionary<string, TypeTree>();
+            public Dictionary<string, MemberMetadata> Members { get; } = new Dictionary<string, MemberMetadata>();
+            public Dictionary<string, TypeTree> NestedTypes { get; } = new Dictionary<string, TypeTree>();
+
+            public TypeTree(Type type)
+            {
+                this.Type = type;
+            }
+        }
+
+        private static IEnumerable<CustomAttributeData> RemoveDebugSpecificAttributes(IEnumerable<CustomAttributeData> attributes)
+        {
+            return attributes.Where(x =>
+                !x.AttributeType.Name.Contains("SuppressMessageAttribute") &&
+                !x.AttributeType.Name.Contains("DynamicallyInvokableAttribute") &&
+                !x.AttributeType.Name.Contains("NonVersionableAttribute") &&
+                !x.AttributeType.Name.Contains("ReliabilityContractAttribute") &&
+                !x.AttributeType.Name.Contains("NonVersionableAttribute") &&
+                !x.AttributeType.Name.Contains("DebuggerStepThroughAttribute") &&
+                !x.AttributeType.Name.Contains("IsReadOnlyAttribute")
+            );
+        }
+
+        private static TypeTree BuildTypeTree(TypeTree root, Type[] types)
+        {
+            IEnumerable<Type> subclassTypes = types.Where((type) => type.IsSubclassOf(root.Type)).OrderBy(o => o.FullName, invariantComparer);
+            foreach (Type subclassType in subclassTypes)
+            {
+                root.Subclasses[subclassType.Name] = ContractEnforcement.BuildTypeTree(new TypeTree(subclassType), types);
+            }
+
+            IEnumerable<KeyValuePair<string, MemberInfo>> memberInfos =
+                root.Type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Select(memberInfo => new KeyValuePair<string, MemberInfo>($"{memberInfo.ToString()}{string.Join("-", ContractEnforcement.RemoveDebugSpecificAttributes(memberInfo.CustomAttributes))}", memberInfo))
+                    .OrderBy(o => o.Key, invariantComparer);
+            foreach (KeyValuePair<string, MemberInfo> memberInfo in memberInfos)
+            {
+                List<string> attributes = ContractEnforcement.RemoveDebugSpecificAttributes(memberInfo.Value.CustomAttributes)
+                        .Select((customAttribute) => customAttribute.AttributeType.Name)
+                        .ToList();
+                attributes.Sort(invariantComparer);
+
+                string methodSignature = null;
+
+                if (memberInfo.Value.MemberType == MemberTypes.Constructor | memberInfo.Value.MemberType == MemberTypes.Method | memberInfo.Value.MemberType == MemberTypes.Event)
+                {
+                    methodSignature = memberInfo.Value.ToString();
+                }
+
+                root.Members[
+                        memberInfo.Key
+                    ] = new MemberMetadata(
+                    memberInfo.Value.MemberType,
+                    attributes,
+                    methodSignature);
+            }
+
+            foreach (Type nestedType in root.Type.GetNestedTypes().OrderBy(o => o.FullName))
+            {
+                root.NestedTypes[nestedType.Name] = ContractEnforcement.BuildTypeTree(new TypeTree(nestedType), types);
+            }
+
+            return root;
+        }
+
+        private static bool DoesContractContainBreakingChanges(string dllName, string baselinePath, string breakingChangesPath)
+        {
+            TypeTree locally = new TypeTree(typeof(object));
+            ContractEnforcement.BuildTypeTree(locally, ContractEnforcement.GetAssemblyLocally(dllName).GetExportedTypes());
+
+            TypeTree baseline = JsonConvert.DeserializeObject<TypeTree>(File.ReadAllText(baselinePath));
+
+            string localJson = JsonConvert.SerializeObject(locally, Formatting.Indented);
+            File.WriteAllText($"{breakingChangesPath}", localJson);
+            string baselineJson = JsonConvert.SerializeObject(baseline, Formatting.Indented);
+
+            System.Diagnostics.Trace.TraceWarning($"String length Expected: {baselineJson.Length};Actual:{localJson.Length}");
+            if (string.Equals(localJson, baselineJson, StringComparison.InvariantCulture))
+            {
+                return false;
+            }
+            else
+            {
+                System.Diagnostics.Trace.TraceWarning($"Expected: {baselineJson}");
+                System.Diagnostics.Trace.TraceWarning($"Actual: {localJson}");
+                return true;
+            }
+        }
+
+        private class InvariantComparer : IComparer<string>
+        {
+            public int Compare(string a, string b) => Comparer.DefaultInvariant.Compare(a, b);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/DotNetSDKAPI.json
@@ -1,0 +1,14768 @@
+{
+  "Subclasses": {
+    "AccountConsistency": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 get_MaxStalenessIntervalInSeconds()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int32 get_MaxStalenessIntervalInSeconds()"
+        },
+        "Int32 get_MaxStalenessPrefix()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int32 get_MaxStalenessPrefix()"
+        },
+        "Int32 MaxStalenessIntervalInSeconds[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"maxIntervalInSeconds\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Int32 MaxStalenessPrefix[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"maxStalenessPrefix\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel DefaultConsistencyLevel[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"defaultConsistencyLevel\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel get_DefaultConsistencyLevel()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ConsistencyLevel get_DefaultConsistencyLevel()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "AccountProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.AccountConsistency Consistency[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"userConsistencyPolicy\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.AccountConsistency get_Consistency()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.AccountConsistency get_Consistency()"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] get_ReadableRegions()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] get_ReadableRegions()"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] get_WritableRegions()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] get_WritableRegions()"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] ReadableRegions[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.AccountRegion] WritableRegions[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "AccountRegion": {
+      "Subclasses": {},
+      "Members": {
+        "System.String Endpoint[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"databaseAccountEndpoint\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Endpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Endpoint()"
+        },
+        "System.String get_Name()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Name()"
+        },
+        "System.String Name[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"name\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "BoundingBoxProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_Xmax()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_Xmax()"
+        },
+        "Double get_Xmin()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_Xmin()"
+        },
+        "Double get_Ymax()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_Ymax()"
+        },
+        "Double get_Ymin()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_Ymin()"
+        },
+        "Double Xmax[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"xmax\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Double Xmin[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"xmin\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Double Ymax[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"ymax\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Double Ymin[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"ymin\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Xmax(Double)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Xmax(Double)"
+        },
+        "Void set_Xmin(Double)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Xmin(Double)"
+        },
+        "Void set_Ymax(Double)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Ymax(Double)"
+        },
+        "Void set_Ymin(Double)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Ymin(Double)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ChangeFeedProcessor": {
+      "Subclasses": {},
+      "Members": {
+        "System.Threading.Tasks.Task StartAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StartAsync()"
+        },
+        "System.Threading.Tasks.Task StopAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task StopAsync()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ChangeFeedProcessorBuilder": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessor Build()"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithInstanceName(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseConfiguration(System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan], System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithLeaseContainer(Microsoft.Azure.Cosmos.Container)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithMaxItems(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithPollInterval(System.TimeSpan)"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder WithStartTime(System.DateTime)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CompositePath": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CompositePathSortOrder get_Order()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CompositePathSortOrder get_Order()"
+        },
+        "Microsoft.Azure.Cosmos.CompositePathSortOrder Order[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"order\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Path()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Path()"
+        },
+        "System.String Path[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"path\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Order(Microsoft.Azure.Cosmos.CompositePathSortOrder)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Order(Microsoft.Azure.Cosmos.CompositePathSortOrder)"
+        },
+        "Void set_Path(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Path(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CompositePathSortOrder": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CompositePathSortOrder Ascending[System.Runtime.Serialization.EnumMemberAttribute(Value = \"ascending\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "EnumMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CompositePathSortOrder Descending[System.Runtime.Serialization.EnumMemberAttribute(Value = \"descending\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "EnumMemberAttribute"
+          ],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConflictProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.OperationKind get_OperationKind()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.OperationKind get_OperationKind()"
+        },
+        "Microsoft.Azure.Cosmos.OperationKind OperationKind[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"operationType\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Id()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConflictResolutionMode": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConflictResolutionMode Custom": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConflictResolutionMode LastWriterWins": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConflictResolutionPolicy": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ConflictResolutionMode get_Mode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ConflictResolutionMode get_Mode()"
+        },
+        "Microsoft.Azure.Cosmos.ConflictResolutionMode Mode[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"mode\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ResolutionPath()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ResolutionPath()"
+        },
+        "System.String get_ResolutionProcedure()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ResolutionProcedure()"
+        },
+        "System.String ResolutionPath[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"conflictResolutionPath\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ResolutionProcedure[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"conflictResolutionProcedure\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Mode(Microsoft.Azure.Cosmos.ConflictResolutionMode)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Mode(Microsoft.Azure.Cosmos.ConflictResolutionMode)"
+        },
+        "Void set_ResolutionPath(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ResolutionPath(System.String)"
+        },
+        "Void set_ResolutionProcedure(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ResolutionProcedure(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Conflicts": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.FeedIterator GetConflictQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetConflictQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetConflictQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetConflictQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetConflictQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetConflictQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetConflictQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetConflictQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReadCurrentAsync[T](Microsoft.Azure.Cosmos.ConflictProperties, Microsoft.Azure.Cosmos.PartitionKey, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReadCurrentAsync[T](Microsoft.Azure.Cosmos.ConflictProperties, Microsoft.Azure.Cosmos.PartitionKey, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteAsync(Microsoft.Azure.Cosmos.ConflictProperties, Microsoft.Azure.Cosmos.PartitionKey, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteAsync(Microsoft.Azure.Cosmos.ConflictProperties, Microsoft.Azure.Cosmos.PartitionKey, System.Threading.CancellationToken)"
+        },
+        "T ReadConflictContent[T](Microsoft.Azure.Cosmos.ConflictProperties)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T ReadConflictContent[T](Microsoft.Azure.Cosmos.ConflictProperties)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConnectionMode": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConnectionMode Direct": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConnectionMode Gateway": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConsistencyLevel": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel BoundedStaleness": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel ConsistentPrefix": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel Eventual": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel Session": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConsistencyLevel Strong": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Container": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedEstimatorBuilder(System.String, ChangesEstimationHandler, System.Nullable`1[System.TimeSpan])"
+        },
+        "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedProcessorBuilder GetChangeFeedProcessorBuilder[T](System.String, ChangesHandler`1)"
+        },
+        "Microsoft.Azure.Cosmos.Conflicts Conflicts": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Conflicts get_Conflicts()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Conflicts get_Conflicts()"
+        },
+        "Microsoft.Azure.Cosmos.Container+ChangesEstimationHandler": {
+          "Type": "NestedType",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Container+ChangesHandler`1[T]": {
+          "Type": "NestedType",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetItemQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetItemQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetItemQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetItemQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetItemQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.Scripts get_Scripts()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.Scripts get_Scripts()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.Scripts Scripts": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch CreateTransactionalBatch(Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch CreateTransactionalBatch(Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "System.Linq.IOrderedQueryable`1[T] GetItemLinqQueryable[T](Boolean, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Linq.IOrderedQueryable`1[T] GetItemLinqQueryable[T](Boolean, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] ReadContainerAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] ReadContainerAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Microsoft.Azure.Cosmos.ContainerProperties, Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Microsoft.Azure.Cosmos.ContainerProperties, Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] CreateItemAsync[T](T, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] CreateItemAsync[T](T, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] DeleteItemAsync[T](System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] DeleteItemAsync[T](System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReadItemAsync[T](System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReadItemAsync[T](System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReplaceItemAsync[T](T, System.String, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] ReplaceItemAsync[T](T, System.String, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] UpsertItemAsync[T](T, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[T]] UpsertItemAsync[T](T, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey], Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateItemStreamAsync(System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateItemStreamAsync(System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteItemStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteItemStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadItemStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadItemStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReplaceContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerProperties, Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReplaceContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerProperties, Microsoft.Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReplaceItemStreamAsync(System.IO.Stream, System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReplaceItemStreamAsync(System.IO.Stream, System.String, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] UpsertItemStreamAsync(System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] UpsertItemStreamAsync(System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReplaceThroughputAsync(Int32, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReplaceThroughputAsync(Int32, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {
+        "ChangesEstimationHandler": {
+          "Subclasses": {},
+          "Members": {
+            "System.IAsyncResult BeginInvoke(Int64, System.Threading.CancellationToken, System.AsyncCallback, System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.IAsyncResult BeginInvoke(Int64, System.Threading.CancellationToken, System.AsyncCallback, System.Object)"
+            },
+            "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)"
+            },
+            "System.Threading.Tasks.Task Invoke(Int64, System.Threading.CancellationToken)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Threading.Tasks.Task Invoke(Int64, System.Threading.CancellationToken)"
+            },
+            "Void .ctor(System.Object, IntPtr)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Object, IntPtr)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "ChangesHandler`1": {
+          "Subclasses": {},
+          "Members": {
+            "System.IAsyncResult BeginInvoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken, System.AsyncCallback, System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.IAsyncResult BeginInvoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken, System.AsyncCallback, System.Object)"
+            },
+            "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)"
+            },
+            "System.Threading.Tasks.Task Invoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Threading.Tasks.Task Invoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken)"
+            },
+            "Void .ctor(System.Object, IntPtr)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Object, IntPtr)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "ChangesEstimationHandler": {
+      "Subclasses": {},
+      "Members": {
+        "System.IAsyncResult BeginInvoke(Int64, System.Threading.CancellationToken, System.AsyncCallback, System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IAsyncResult BeginInvoke(Int64, System.Threading.CancellationToken, System.AsyncCallback, System.Object)"
+        },
+        "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)"
+        },
+        "System.Threading.Tasks.Task Invoke(Int64, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task Invoke(Int64, System.Threading.CancellationToken)"
+        },
+        "Void .ctor(System.Object, IntPtr)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Object, IntPtr)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ChangesHandler`1": {
+      "Subclasses": {},
+      "Members": {
+        "System.IAsyncResult BeginInvoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken, System.AsyncCallback, System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IAsyncResult BeginInvoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken, System.AsyncCallback, System.Object)"
+        },
+        "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task EndInvoke(System.IAsyncResult)"
+        },
+        "System.Threading.Tasks.Task Invoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task Invoke(System.Collections.Generic.IReadOnlyCollection`1[T], System.Threading.CancellationToken)"
+        },
+        "Void .ctor(System.Object, IntPtr)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Object, IntPtr)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ContainerProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ConflictResolutionPolicy ConflictResolutionPolicy[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()"
+        },
+        "Microsoft.Azure.Cosmos.GeospatialConfig GeospatialConfig[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.GeospatialConfig get_GeospatialConfig()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.GeospatialConfig get_GeospatialConfig()"
+        },
+        "Microsoft.Azure.Cosmos.IndexingPolicy get_IndexingPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.IndexingPolicy get_IndexingPolicy()"
+        },
+        "Microsoft.Azure.Cosmos.IndexingPolicy IndexingPolicy[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()"
+        },
+        "Microsoft.Azure.Cosmos.UniqueKeyPolicy UniqueKeyPolicy[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion] PartitionKeyDefinitionVersion[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] DefaultTimeToLive[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"defaultTtl\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_PartitionKeyPath()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_PartitionKeyPath()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String get_TimeToLivePropertyPath()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_TimeToLivePropertyPath()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String PartitionKeyPath[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String TimeToLivePropertyPath[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"ttlPropertyPath\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String)"
+        },
+        "Void set_ConflictResolutionPolicy(Microsoft.Azure.Cosmos.ConflictResolutionPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConflictResolutionPolicy(Microsoft.Azure.Cosmos.ConflictResolutionPolicy)"
+        },
+        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
+        },
+        "Void set_GeospatialConfig(Microsoft.Azure.Cosmos.GeospatialConfig)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_GeospatialConfig(Microsoft.Azure.Cosmos.GeospatialConfig)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        },
+        "Void set_IndexingPolicy(Microsoft.Azure.Cosmos.IndexingPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_IndexingPolicy(Microsoft.Azure.Cosmos.IndexingPolicy)"
+        },
+        "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion])"
+        },
+        "Void set_PartitionKeyPath(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyPath(System.String)"
+        },
+        "Void set_TimeToLivePropertyPath(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_TimeToLivePropertyPath(System.String)"
+        },
+        "Void set_UniqueKeyPolicy(Microsoft.Azure.Cosmos.UniqueKeyPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_UniqueKeyPolicy(Microsoft.Azure.Cosmos.UniqueKeyPolicy)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ContainerRequestOptions": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_PopulateQuotaInfo()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_PopulateQuotaInfo()"
+        },
+        "Boolean PopulateQuotaInfo": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_PopulateQuotaInfo(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PopulateQuotaInfo(Boolean)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ContainerResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Container Container": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Container get_Container()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Container get_Container()"
+        },
+        "Microsoft.Azure.Cosmos.Container op_Implicit(Microsoft.Azure.Cosmos.ContainerResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Container op_Implicit(Microsoft.Azure.Cosmos.ContainerResponse)"
+        },
+        "Microsoft.Azure.Cosmos.ContainerProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ContainerProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.ContainerProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosClient": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Container GetContainer(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Container GetContainer(System.String, System.String)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosClientOptions ClientOptions": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosClientOptions get_ClientOptions()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosClientOptions get_ClientOptions()"
+        },
+        "Microsoft.Azure.Cosmos.Database GetDatabase(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Database GetDatabase(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetDatabaseQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetDatabaseQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetDatabaseQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetDatabaseQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetDatabaseQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetDatabaseQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetDatabaseQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetDatabaseQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.AccountProperties] ReadAccountAsync()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.AccountProperties] ReadAccountAsync()"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateDatabaseStreamAsync(Microsoft.Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateDatabaseStreamAsync(Microsoft.Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Uri Endpoint": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Uri get_Endpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Uri get_Endpoint()"
+        },
+        "Void .ctor(System.String, Microsoft.Azure.Cosmos.CosmosClientOptions)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, Microsoft.Azure.Cosmos.CosmosClientOptions)"
+        },
+        "Void .ctor(System.String, System.String, Microsoft.Azure.Cosmos.CosmosClientOptions)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String, Microsoft.Azure.Cosmos.CosmosClientOptions)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosClientOptions": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean AllowBulkExecution": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean get_AllowBulkExecution()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_AllowBulkExecution()"
+        },
+        "Boolean get_LimitToEndpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_LimitToEndpoint()"
+        },
+        "Boolean LimitToEndpoint": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 GatewayModeMaxConnectionLimit": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_GatewayModeMaxConnectionLimit()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_GatewayModeMaxConnectionLimit()"
+        },
+        "Microsoft.Azure.Cosmos.ConnectionMode ConnectionMode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ConnectionMode get_ConnectionMode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ConnectionMode get_ConnectionMode()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosSerializationOptions get_SerializerOptions()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosSerializationOptions get_SerializerOptions()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosSerializationOptions SerializerOptions": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosSerializer get_Serializer()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosSerializer get_Serializer()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosSerializer Serializer[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Cosmos.CosmosClientOptions+ClientOptionJsonConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.RequestHandler] CustomHandlers[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Cosmos.CosmosClientOptions+ClientOptionJsonConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.RequestHandler] get_CustomHandlers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.RequestHandler] get_CustomHandlers()"
+        },
+        "System.Net.IWebProxy get_WebProxy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Net.IWebProxy get_WebProxy()"
+        },
+        "System.Net.IWebProxy WebProxy[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PortReuseMode] get_PortReuseMode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PortReuseMode] get_PortReuseMode()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PortReuseMode] PortReuseMode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_MaxRequestsPerTcpConnection()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxRequestsPerTcpConnection()"
+        },
+        "System.Nullable`1[System.Int32] get_MaxRetryAttemptsOnRateLimitedRequests()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxRetryAttemptsOnRateLimitedRequests()"
+        },
+        "System.Nullable`1[System.Int32] get_MaxTcpConnectionsPerEndpoint()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxTcpConnectionsPerEndpoint()"
+        },
+        "System.Nullable`1[System.Int32] MaxRequestsPerTcpConnection": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] MaxRetryAttemptsOnRateLimitedRequests": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] MaxTcpConnectionsPerEndpoint": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.TimeSpan] get_IdleTcpConnectionTimeout()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_IdleTcpConnectionTimeout()"
+        },
+        "System.Nullable`1[System.TimeSpan] get_MaxRetryWaitTimeOnRateLimitedRequests()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_MaxRetryWaitTimeOnRateLimitedRequests()"
+        },
+        "System.Nullable`1[System.TimeSpan] get_OpenTcpConnectionTimeout()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_OpenTcpConnectionTimeout()"
+        },
+        "System.Nullable`1[System.TimeSpan] IdleTcpConnectionTimeout": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.TimeSpan] MaxRetryWaitTimeOnRateLimitedRequests": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.TimeSpan] OpenTcpConnectionTimeout": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ApplicationName": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ApplicationRegion": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ApplicationName()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ApplicationName()"
+        },
+        "System.String get_ApplicationRegion()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ApplicationRegion()"
+        },
+        "System.TimeSpan get_RequestTimeout()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_RequestTimeout()"
+        },
+        "System.TimeSpan RequestTimeout": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_AllowBulkExecution(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_AllowBulkExecution(Boolean)"
+        },
+        "Void set_ApplicationName(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ApplicationName(System.String)"
+        },
+        "Void set_ApplicationRegion(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ApplicationRegion(System.String)"
+        },
+        "Void set_ConnectionMode(Microsoft.Azure.Cosmos.ConnectionMode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConnectionMode(Microsoft.Azure.Cosmos.ConnectionMode)"
+        },
+        "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+        },
+        "Void set_GatewayModeMaxConnectionLimit(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_GatewayModeMaxConnectionLimit(Int32)"
+        },
+        "Void set_IdleTcpConnectionTimeout(System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_IdleTcpConnectionTimeout(System.Nullable`1[System.TimeSpan])"
+        },
+        "Void set_LimitToEndpoint(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_LimitToEndpoint(Boolean)"
+        },
+        "Void set_MaxRequestsPerTcpConnection(System.Nullable`1[System.Int32])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_MaxRequestsPerTcpConnection(System.Nullable`1[System.Int32])"
+        },
+        "Void set_MaxRetryAttemptsOnRateLimitedRequests(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxRetryAttemptsOnRateLimitedRequests(System.Nullable`1[System.Int32])"
+        },
+        "Void set_MaxRetryWaitTimeOnRateLimitedRequests(System.Nullable`1[System.TimeSpan])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxRetryWaitTimeOnRateLimitedRequests(System.Nullable`1[System.TimeSpan])"
+        },
+        "Void set_MaxTcpConnectionsPerEndpoint(System.Nullable`1[System.Int32])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_MaxTcpConnectionsPerEndpoint(System.Nullable`1[System.Int32])"
+        },
+        "Void set_OpenTcpConnectionTimeout(System.Nullable`1[System.TimeSpan])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_OpenTcpConnectionTimeout(System.Nullable`1[System.TimeSpan])"
+        },
+        "Void set_PortReuseMode(System.Nullable`1[Microsoft.Azure.Cosmos.PortReuseMode])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PortReuseMode(System.Nullable`1[Microsoft.Azure.Cosmos.PortReuseMode])"
+        },
+        "Void set_RequestTimeout(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_RequestTimeout(System.TimeSpan)"
+        },
+        "Void set_Serializer(Microsoft.Azure.Cosmos.CosmosSerializer)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Serializer(Microsoft.Azure.Cosmos.CosmosSerializer)"
+        },
+        "Void set_SerializerOptions(Microsoft.Azure.Cosmos.CosmosSerializationOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_SerializerOptions(Microsoft.Azure.Cosmos.CosmosSerializationOptions)"
+        },
+        "Void set_WebProxy(System.Net.IWebProxy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_WebProxy(System.Net.IWebProxy)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDiagnostics": {
+      "Subclasses": {},
+      "Members": {
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "System.TimeSpan GetClientElapsedTime()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.TimeSpan GetClientElapsedTime()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosArray": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Item [Int32]": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] GetEnumerator()"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosBinary": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(System.ReadOnlyMemory`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(System.ReadOnlyMemory`1[System.Byte])"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] get_Value()"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosBoolean": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_Value()"
+        },
+        "Boolean Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean Create(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean Create(Boolean)"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosElement": {
+      "Subclasses": {
+        "CosmosArray": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 Count": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int32 get_Count()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 get_Count()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosArray Create(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(Int32)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(Int32)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Item [Int32]": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] GetEnumerator()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] GetEnumerator()"
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosBinary": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(System.ReadOnlyMemory`1[System.Byte])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary Create(System.ReadOnlyMemory`1[System.Byte])"
+            },
+            "System.ReadOnlyMemory`1[System.Byte] get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] get_Value()"
+            },
+            "System.ReadOnlyMemory`1[System.Byte] Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosBoolean": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Boolean get_Value()"
+            },
+            "Boolean Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean Create(Boolean)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean Create(Boolean)"
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosGuid": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(System.Guid)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(System.Guid)"
+            },
+            "System.Guid get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Guid get_Value()"
+            },
+            "System.Guid Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosNull": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosNull Create()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosNull Create()"
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosNumber": {
+          "Subclasses": {
+            "CosmosFloat32": {
+              "Subclasses": {},
+              "Members": {
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "Single GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Single GetValue()"
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosFloat64": {
+              "Subclasses": {},
+              "Members": {
+                "Double GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Double GetValue()"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosInt16": {
+              "Subclasses": {},
+              "Members": {
+                "Int16 GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Int16 GetValue()"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosInt32": {
+              "Subclasses": {},
+              "Members": {
+                "Int32 GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Int32 GetValue()"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosInt64": {
+              "Subclasses": {},
+              "Members": {
+                "Int64 GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Int64 GetValue()"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosInt8": {
+              "Subclasses": {},
+              "Members": {
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "SByte GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "SByte GetValue()"
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosNumber64": {
+              "Subclasses": {},
+              "Members": {
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetValue()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                }
+              },
+              "NestedTypes": {}
+            },
+            "CosmosUInt32": {
+              "Subclasses": {},
+              "Members": {
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+                },
+                "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)"
+                },
+                "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+                },
+                "Microsoft.Azure.Cosmos.Number64 Value": {
+                  "Type": "Property",
+                  "Attributes": [],
+                  "MethodInfo": null
+                },
+                "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+                },
+                "UInt32 GetValue()": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "UInt32 GetValue()"
+                },
+                "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+                },
+                "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+                  "Type": "Method",
+                  "Attributes": [],
+                  "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+                }
+              },
+              "NestedTypes": {}
+            }
+          },
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType get_NumberType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType get_NumberType()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType NumberType": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosObject": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean ContainsKey(System.String)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean ContainsKey(System.String)"
+            },
+            "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)"
+            },
+            "Boolean TryGetValue[TCosmosElement](System.String, TCosmosElement ByRef)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean TryGetValue[TCosmosElement](System.String, TCosmosElement ByRef)"
+            },
+            "Int32 Count": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int32 get_Count()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 get_Count()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(System.String)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(System.String)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Item [System.String]": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyList`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyList`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]])"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] get_Values()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] get_Values()"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] Values": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()"
+            },
+            "System.Collections.Generic.IEnumerable`1[System.String] Keys": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]] GetEnumerator()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]] GetEnumerator()"
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosString": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean TryGetBufferedUtf8Value(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean TryGetBufferedUtf8Value(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(System.String)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(System.String)"
+            },
+            "System.String get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.String get_Value()"
+            },
+            "System.String Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+            },
+            "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosFloat32": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Single GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Single GetValue()"
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosFloat64": {
+          "Subclasses": {},
+          "Members": {
+            "Double GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Double GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt16": {
+          "Subclasses": {},
+          "Members": {
+            "Int16 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int16 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt32": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt64": {
+          "Subclasses": {},
+          "Members": {
+            "Int64 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int64 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt8": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "SByte GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "SByte GetValue()"
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosNumber64": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosUInt32": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "UInt32 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "UInt32 GetValue()"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean TryCreateFromBuffer[TCosmosElement](System.ReadOnlyMemory`1[System.Byte], TCosmosElement ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryCreateFromBuffer[TCosmosElement](System.ReadOnlyMemory`1[System.Byte], TCosmosElement ByRef)"
+        },
+        "Boolean TryParse(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryParse(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)"
+        },
+        "Boolean TryParse[TCosmosElement](System.String, TCosmosElement ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryParse[TCosmosElement](System.String, TCosmosElement ByRef)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement CreateFromBuffer(System.ReadOnlyMemory`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement CreateFromBuffer(System.ReadOnlyMemory`1[System.Byte])"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Dispatch(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Dispatch(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Parse(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Parse(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType get_Type()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType get_Type()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Type": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "TCosmosElement Parse[TCosmosElement](System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TCosmosElement Parse[TCosmosElement](System.String)"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosElementEqualityComparer": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray, Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray, Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary, Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary, Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean, Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean, Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid, Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid, Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber, Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber, Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject, Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject, Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)"
+        },
+        "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosString, Microsoft.Azure.Cosmos.CosmosElements.CosmosString)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.CosmosElements.CosmosString, Microsoft.Azure.Cosmos.CosmosElements.CosmosString)"
+        },
+        "Int32 GetHashCode(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode(Microsoft.Azure.Cosmos.CosmosElements.CosmosElement)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementEqualityComparer Value": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosElementJsonConverter": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean CanConvert(System.Type)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean CanConvert(System.Type)"
+        },
+        "System.Object ReadJson(Newtonsoft.Json.JsonReader, System.Type, System.Object, Newtonsoft.Json.JsonSerializer)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Object ReadJson(Newtonsoft.Json.JsonReader, System.Type, System.Object, Newtonsoft.Json.JsonSerializer)"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void WriteJson(Newtonsoft.Json.JsonWriter, System.Object, Newtonsoft.Json.JsonSerializer)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteJson(Newtonsoft.Json.JsonWriter, System.Object, Newtonsoft.Json.JsonSerializer)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosElementSerializer": {
+      "Subclasses": {},
+      "Members": {},
+      "NestedTypes": {}
+    },
+    "CosmosElementType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Array": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Binary": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Boolean": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Guid": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Null": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType Object": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElementType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosGuid": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(System.Guid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid Create(System.Guid)"
+        },
+        "System.Guid get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Guid get_Value()"
+        },
+        "System.Guid Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosNull": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNull Create()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosNull Create()"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosNumber": {
+      "Subclasses": {
+        "CosmosFloat32": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Single GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Single GetValue()"
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosFloat64": {
+          "Subclasses": {},
+          "Members": {
+            "Double GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Double GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt16": {
+          "Subclasses": {},
+          "Members": {
+            "Int16 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int16 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt32": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt64": {
+          "Subclasses": {},
+          "Members": {
+            "Int64 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int64 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosInt8": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "SByte GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "SByte GetValue()"
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosNumber64": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetValue()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "CosmosUInt32": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+            },
+            "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)"
+            },
+            "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+            },
+            "Microsoft.Azure.Cosmos.Number64 Value": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+            },
+            "UInt32 GetValue()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "UInt32 GetValue()"
+            },
+            "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+            },
+            "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType get_NumberType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType get_NumberType()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType NumberType": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosNumberType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Float32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Float64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Int16": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Int32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Int64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Int8": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType Number64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosNumberType UInt32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosObject": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean ContainsKey(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean ContainsKey(System.String)"
+        },
+        "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.CosmosElements.CosmosElement ByRef)"
+        },
+        "Boolean TryGetValue[TCosmosElement](System.String, TCosmosElement ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetValue[TCosmosElement](System.String, TCosmosElement ByRef)"
+        },
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement get_Item(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement Item [System.String]": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement])"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyList`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosObject Create(System.Collections.Generic.IReadOnlyList`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]])"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] get_Values()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] get_Values()"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.CosmosElements.CosmosElement] Values": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()"
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] Keys": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.CosmosElements.CosmosElement]] GetEnumerator()"
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosString": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetBufferedUtf8Value(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedUtf8Value(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosString Create(System.String)"
+        },
+        "System.String get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Value()"
+        },
+        "System.String Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TArg,TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`2[TArg,TResult], TArg)"
+        },
+        "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Accept[TResult](Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor`1[TResult])"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.ICosmosElementVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ICosmosElementVisitor": {
+      "Subclasses": {},
+      "Members": {
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ICosmosElementVisitor`1": {
+      "Subclasses": {},
+      "Members": {
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ICosmosElementVisitor`2": {
+      "Subclasses": {},
+      "Members": {
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosArray, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBinary, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosBoolean, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosGuid, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNull, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosNumber, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosObject, TArg)"
+        },
+        "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TResult Visit(Microsoft.Azure.Cosmos.CosmosElements.CosmosString, TArg)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosFloat32": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32 Create(Single)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Single GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Single GetValue()"
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosFloat64": {
+      "Subclasses": {},
+      "Members": {
+        "Double GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double GetValue()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Double)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosInt16": {
+      "Subclasses": {},
+      "Members": {
+        "Int16 GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int16 GetValue()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Int16)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosInt32": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetValue()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosInt64": {
+      "Subclasses": {},
+      "Members": {
+        "Int64 GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 GetValue()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Int64)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosInt8": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8 Create(SByte)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "SByte GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "SByte GetValue()"
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosNumber64": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64 Create(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetValue()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosUInt32": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32 Create(UInt32)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 get_Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 get_Value()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Accept[TArg,TOutput](Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor`2[TArg,TOutput], TArg)"
+        },
+        "UInt32 GetValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "UInt32 GetValue()"
+        },
+        "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Accept(Microsoft.Azure.Cosmos.CosmosElements.Numbers.ICosmosNumberVisitor)"
+        },
+        "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteTo(Microsoft.Azure.Cosmos.Json.IJsonWriter)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ICosmosNumberVisitor": {
+      "Subclasses": {},
+      "Members": {
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64)"
+        },
+        "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ICosmosNumberVisitor`2": {
+      "Subclasses": {},
+      "Members": {
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat32, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosFloat64, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt16, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt32, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt64, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosInt8, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosNumber64, TArg)"
+        },
+        "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32, TArg)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "TOutput Visit(Microsoft.Azure.Cosmos.CosmosElements.Numbers.CosmosUInt32, TArg)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosException": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetHeader(System.String, System.String ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetHeader(System.String, System.String ByRef)"
+        },
+        "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_SubStatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int32 get_SubStatusCode()"
+        },
+        "Int32 SubStatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.TimeSpan] get_RetryAfter()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_RetryAfter()"
+        },
+        "System.Nullable`1[System.TimeSpan] RetryAfter": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ResponseBody()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ResponseBody()"
+        },
+        "System.String get_StackTrace()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_StackTrace()"
+        },
+        "System.String ResponseBody": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String StackTrace": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "Void .ctor(System.String, System.Net.HttpStatusCode, Int32, System.String, Double)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.Net.HttpStatusCode, Int32, System.String, Double)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosPropertyNamingPolicy": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy CamelCase": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy Default": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosSerializationOptions": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_IgnoreNullValues()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_IgnoreNullValues()"
+        },
+        "Boolean get_Indented()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_Indented()"
+        },
+        "Boolean IgnoreNullValues": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean Indented": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy get_PropertyNamingPolicy()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy get_PropertyNamingPolicy()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy PropertyNamingPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_IgnoreNullValues(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IgnoreNullValues(Boolean)"
+        },
+        "Void set_Indented(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Indented(Boolean)"
+        },
+        "Void set_PropertyNamingPolicy(Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PropertyNamingPolicy(Microsoft.Azure.Cosmos.CosmosPropertyNamingPolicy)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosSerializer": {
+      "Subclasses": {},
+      "Members": {
+        "System.IO.Stream ToStream[T](T)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream ToStream[T](T)"
+        },
+        "T FromStream[T](System.IO.Stream)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T FromStream[T](System.IO.Stream)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Database": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Container GetContainer(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Container GetContainer(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetContainerQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetContainerQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetContainerQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetContainerQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetContainerQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetContainerQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetContainerQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetContainerQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder DefineContainer(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder DefineContainer(System.String, System.String)"
+        },
+        "Microsoft.Azure.Cosmos.User GetUser(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.User GetUser(System.String)"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] ReadAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DatabaseResponse] ReadAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] CreateContainerStreamAsync(Microsoft.Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteStreamAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] DeleteStreamAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadStreamAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadStreamAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReplaceThroughputAsync(Int32, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ThroughputResponse] ReplaceThroughputAsync(Int32, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] CreateUserAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] CreateUserAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] UpsertUserAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] UpsertUserAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "DatabaseProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "DatabaseResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Database Database": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Database get_Database()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Database get_Database()"
+        },
+        "Microsoft.Azure.Cosmos.Database op_Implicit(Microsoft.Azure.Cosmos.DatabaseResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Database op_Implicit(Microsoft.Azure.Cosmos.DatabaseResponse)"
+        },
+        "Microsoft.Azure.Cosmos.DatabaseProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.DatabaseProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.DatabaseProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "DataType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.DataType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ExcludedPath": {
+      "Subclasses": {},
+      "Members": {
+        "System.String get_Path()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Path()"
+        },
+        "System.String Path[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"path\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Path(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Path(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FeedIterator": {
+      "Subclasses": {
+        "FeedIteratorInternal": {
+          "Subclasses": {},
+          "Members": {
+            "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmsoElementContinuationToken()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmsoElementContinuationToken()"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Boolean get_HasMoreResults()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_HasMoreResults()"
+        },
+        "Boolean HasMoreResults": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadNextAsync(System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadNextAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FeedIterator`1": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_HasMoreResults()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_HasMoreResults()"
+        },
+        "Boolean HasMoreResults": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.FeedResponse`1[T]] ReadNextAsync(System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.FeedResponse`1[T]] ReadNextAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FeedIteratorInternal": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmsoElementContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmsoElementContinuationToken()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FeedIteratorInternal`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmosElementContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosElements.CosmosElement GetCosmosElementContinuationToken()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FeedResponse`1": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "System.Collections.Generic.IEnumerator`1[T] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[T] GetEnumerator()"
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ContinuationToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ContinuationToken()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CompositeIndexDefinition`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[T] Path(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[T] Path(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[T] Path(System.String, Microsoft.Azure.Cosmos.CompositePathSortOrder)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[T] Path(System.String, Microsoft.Azure.Cosmos.CompositePathSortOrder)"
+        },
+        "T Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T Attach()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ConflictResolutionDefinition": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithCustomStoredProcedureResolution(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithCustomStoredProcedureResolution(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithLastWriterWinsResolution(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithLastWriterWinsResolution(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder Attach()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ContainerBuilder": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ContainerProperties Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ContainerProperties Build()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithConflictResolution()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ConflictResolutionDefinition WithConflictResolution()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.UniqueKeyDefinition WithUniqueKey()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.UniqueKeyDefinition WithUniqueKey()"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Fluent.ContainerBuilder+<CreateAsync>d__9))]": {
+          "Type": "Method",
+          "Attributes": [
+            "AsyncStateMachineAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Fluent.ContainerBuilder+<CreateIfNotExistsAsync>d__10))]": {
+          "Type": "Method",
+          "Attributes": [
+            "AsyncStateMachineAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ContainerDefinition`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ContainerProperties Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ContainerProperties Build()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingPolicy()"
+        },
+        "T WithDefaultTimeToLive(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T WithDefaultTimeToLive(Int32)"
+        },
+        "T WithDefaultTimeToLive(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T WithDefaultTimeToLive(System.TimeSpan)"
+        },
+        "T WithPartitionKeyDefinitionVersion(Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T WithPartitionKeyDefinitionVersion(Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion)"
+        },
+        "T WithTimeToLivePropertyPath(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T WithTimeToLivePropertyPath(System.String)"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosClientBuilder": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.CosmosClient Build()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosClient Build()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder AddCustomHandlers(Microsoft.Azure.Cosmos.RequestHandler[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder AddCustomHandlers(Microsoft.Azure.Cosmos.RequestHandler[])"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithApplicationName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithApplicationName(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithApplicationRegion(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithApplicationRegion(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithBulkExecution(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithBulkExecution(Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConnectionModeDirect()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConnectionModeDirect()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConnectionModeGateway(System.Nullable`1[System.Int32], System.Net.IWebProxy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConnectionModeGateway(System.Nullable`1[System.Int32], System.Net.IWebProxy)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConsistencyLevel(Microsoft.Azure.Cosmos.ConsistencyLevel)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithConsistencyLevel(Microsoft.Azure.Cosmos.ConsistencyLevel)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithCustomSerializer(Microsoft.Azure.Cosmos.CosmosSerializer)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithCustomSerializer(Microsoft.Azure.Cosmos.CosmosSerializer)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithLimitToEndpoint(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithLimitToEndpoint(Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithRequestTimeout(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithRequestTimeout(System.TimeSpan)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithSerializerOptions(Microsoft.Azure.Cosmos.CosmosSerializationOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithSerializerOptions(Microsoft.Azure.Cosmos.CosmosSerializationOptions)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThrottlingRetryOptions(System.TimeSpan, Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThrottlingRetryOptions(System.TimeSpan, Int32)"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        },
+        "Void .ctor(System.String, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexingPolicyDefinition`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithCompositeIndex()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CompositeIndexDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithCompositeIndex()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithAutomaticIndexing(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithAutomaticIndexing(Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingMode(Microsoft.Azure.Cosmos.IndexingMode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingMode(Microsoft.Azure.Cosmos.IndexingMode)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithExcludedPaths()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithExcludedPaths()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithIncludedPaths()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithIncludedPaths()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithSpatialIndex()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[Microsoft.Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T]] WithSpatialIndex()"
+        },
+        "T Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T Attach()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PathsDefinition`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[T] Path(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.PathsDefinition`1[T] Path(System.String)"
+        },
+        "T Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T Attach()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "SpatialIndexDefinition`1": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Microsoft.Azure.Cosmos.SpatialType[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Microsoft.Azure.Cosmos.SpatialType[])"
+        },
+        "T Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T Attach()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UniqueKeyDefinition": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder Attach()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.ContainerBuilder Attach()"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.UniqueKeyDefinition Path(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.UniqueKeyDefinition Path(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeospatialConfig": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.GeospatialType GeospatialType[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"type\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.GeospatialType get_GeospatialType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.GeospatialType get_GeospatialType()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.GeospatialType)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.GeospatialType)"
+        },
+        "Void set_GeospatialType(Microsoft.Azure.Cosmos.GeospatialType)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_GeospatialType(Microsoft.Azure.Cosmos.GeospatialType)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeospatialType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.GeospatialType Geography": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.GeospatialType Geometry": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Headers": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetValue(System.String, System.String ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetValue(System.String, System.String ByRef)"
+        },
+        "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerator`1[System.String] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[System.String] GetEnumerator()"
+        },
+        "System.String ActivityId[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"x-ms-activity-id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ContentLength[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"Content-Length\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ContentType[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"Content-Type\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ContinuationToken[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"x-ms-continuation\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String Get(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String Get(System.String)"
+        },
+        "System.String get_ActivityId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ContentLength()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ContentLength()"
+        },
+        "System.String get_ContentType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ContentType()"
+        },
+        "System.String get_ContinuationToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ContinuationToken()"
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Item(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Item(System.String)"
+        },
+        "System.String get_Location()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Location()"
+        },
+        "System.String get_Session()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Session()"
+        },
+        "System.String GetValueOrDefault(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetValueOrDefault(System.String)"
+        },
+        "System.String Item [System.String]": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String Location[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"Location\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String Session[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"x-ms-session-token\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "CosmosKnownHeaderAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String[] AllKeys()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String[] AllKeys()"
+        },
+        "T GetHeaderValue[T](System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T GetHeaderValue[T](System.String)"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void Add(System.String, System.Collections.Generic.IEnumerable`1[System.String])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Add(System.String, System.Collections.Generic.IEnumerable`1[System.String])"
+        },
+        "Void Add(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Add(System.String, System.String)"
+        },
+        "Void Remove(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Remove(System.String)"
+        },
+        "Void Set(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Set(System.String, System.String)"
+        },
+        "Void set_ContentLength(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ContentLength(System.String)"
+        },
+        "Void set_Item(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Item(System.String, System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IncludedPath": {
+      "Subclasses": {},
+      "Members": {
+        "System.String get_Path()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Path()"
+        },
+        "System.String Path[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"path\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Path(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Path(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexingDirective": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingDirective Default": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingDirective Exclude": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingDirective Include": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexingMode": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingMode Consistent": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingMode Lazy": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexingMode None": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexingPolicy": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Automatic[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"automatic\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Boolean get_Automatic()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_Automatic()"
+        },
+        "Microsoft.Azure.Cosmos.IndexingMode get_IndexingMode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.IndexingMode get_IndexingMode()"
+        },
+        "Microsoft.Azure.Cosmos.IndexingMode IndexingMode[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"indexingMode\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.ExcludedPath] ExcludedPaths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"excludedPaths\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.ExcludedPath] get_ExcludedPaths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.ExcludedPath] get_ExcludedPaths()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.IncludedPath] get_IncludedPaths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.IncludedPath] get_IncludedPaths()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.IncludedPath] IncludedPaths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"includedPaths\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialPath] get_SpatialIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialPath] get_SpatialIndexes()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialPath] SpatialIndexes[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"spatialIndexes\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.CompositePath]] CompositeIndexes[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"compositeIndexes\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.Collection`1[System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.CompositePath]] get_CompositeIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.CompositePath]] get_CompositeIndexes()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Automatic(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Automatic(Boolean)"
+        },
+        "Void set_IndexingMode(Microsoft.Azure.Cosmos.IndexingMode)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IndexingMode(Microsoft.Azure.Cosmos.IndexingMode)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexKind": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexKind Hash": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexKind Range": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.IndexKind Spatial": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ItemRequestOptions": {
+      "Subclasses": {},
+      "Members": {
+        "System.Collections.Generic.IEnumerable`1[System.String] get_PostTriggers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_PostTriggers()"
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] get_PreTriggers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_PreTriggers()"
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] PostTriggers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] PreTriggers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] IndexingDirective": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SessionToken()"
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+        },
+        "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])"
+        },
+        "Void set_PostTriggers(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PostTriggers(System.Collections.Generic.IEnumerable`1[System.String])"
+        },
+        "Void set_PreTriggers(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PreTriggers(System.Collections.Generic.IEnumerable`1[System.String])"
+        },
+        "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_SessionToken(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ItemResponse`1": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "T get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "T get_Resource()"
+        },
+        "T Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IJsonNavigator": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetBufferedBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedRawJson(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedRawJson(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedUtf8StringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedUtf8StringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetObjectProperty(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.String, Microsoft.Azure.Cosmos.Json.ObjectProperty ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetObjectProperty(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.String, Microsoft.Azure.Cosmos.Json.ObjectProperty ByRef)"
+        },
+        "Double GetFloat64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double GetFloat64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int16 GetInt16Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int16 GetInt16Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetArrayItemCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetArrayItemCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetObjectPropertyCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetObjectPropertyCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int64 GetInt64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 GetInt64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetArrayItemAt(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetArrayItemAt(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Int32)"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetRootNode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetRootNode()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType GetNodeType(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonNodeType GetNodeType(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Number64 GetNumberValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetNumberValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "SByte GetInt8Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "SByte GetInt8Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Single GetFloat32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Single GetFloat32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode] GetArrayItems(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode] GetArrayItems(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.ObjectProperty] GetObjectProperties(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.ObjectProperty] GetObjectProperties(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Guid GetGuidValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Guid GetGuidValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.String GetStringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetStringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "UInt32 GetUInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "UInt32 GetUInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IJsonNavigatorNode": {
+      "Subclasses": {},
+      "Members": {},
+      "NestedTypes": {}
+    },
+    "IJsonReader": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Read()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Read()"
+        },
+        "Boolean TryGetBufferedRawJsonToken(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedRawJsonToken(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedUtf8StringValue(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedUtf8StringValue(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Double GetFloat64Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double GetFloat64Value()"
+        },
+        "Int16 GetInt16Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int16 GetInt16Value()"
+        },
+        "Int32 CurrentDepth": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_CurrentDepth()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_CurrentDepth()"
+        },
+        "Int32 GetInt32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetInt32Value()"
+        },
+        "Int64 GetInt64Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 GetInt64Value()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType CurrentTokenType": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType get_CurrentTokenType()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonTokenType get_CurrentTokenType()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 GetNumberValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetNumberValue()"
+        },
+        "SByte GetInt8Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "SByte GetInt8Value()"
+        },
+        "Single GetFloat32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Single GetFloat32Value()"
+        },
+        "System.Guid GetGuidValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Guid GetGuidValue()"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue()"
+        },
+        "System.String GetStringValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetStringValue()"
+        },
+        "UInt32 GetUInt32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "UInt32 GetUInt32Value()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IJsonWriter": {
+      "Subclasses": {},
+      "Members": {
+        "Int64 CurrentLength": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 get_CurrentLength()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 get_CurrentLength()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetResult()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetResult()"
+        },
+        "Void WriteAll(Microsoft.Azure.Cosmos.Json.IJsonReader)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteAll(Microsoft.Azure.Cosmos.Json.IJsonReader)"
+        },
+        "Void WriteArrayEnd()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteArrayEnd()"
+        },
+        "Void WriteArrayStart()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteArrayStart()"
+        },
+        "Void WriteBinaryValue(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteBinaryValue(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteBoolValue(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteBoolValue(Boolean)"
+        },
+        "Void WriteCurrentToken(Microsoft.Azure.Cosmos.Json.IJsonReader)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteCurrentToken(Microsoft.Azure.Cosmos.Json.IJsonReader)"
+        },
+        "Void WriteFieldName(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFieldName(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteFieldName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFieldName(System.String)"
+        },
+        "Void WriteFloat32Value(Single)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFloat32Value(Single)"
+        },
+        "Void WriteFloat64Value(Double)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFloat64Value(Double)"
+        },
+        "Void WriteGuidValue(System.Guid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteGuidValue(System.Guid)"
+        },
+        "Void WriteInt16Value(Int16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt16Value(Int16)"
+        },
+        "Void WriteInt32Value(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt32Value(Int32)"
+        },
+        "Void WriteInt64Value(Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt64Value(Int64)"
+        },
+        "Void WriteInt8Value(SByte)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt8Value(SByte)"
+        },
+        "Void WriteJsonFragment(System.ReadOnlyMemory`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteJsonFragment(System.ReadOnlyMemory`1[System.Byte])"
+        },
+        "Void WriteJsonNode(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteJsonNode(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Void WriteNullValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteNullValue()"
+        },
+        "Void WriteNumberValue(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteNumberValue(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Void WriteObjectEnd()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteObjectEnd()"
+        },
+        "Void WriteObjectStart()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteObjectStart()"
+        },
+        "Void WriteStringValue(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStringValue(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteStringValue(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStringValue(System.String)"
+        },
+        "Void WriteUInt32Value(UInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteUInt32Value(UInt32)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDBToNewtonsoftReader": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Read()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Read()"
+        },
+        "Byte[] ReadAsBytes()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Byte[] ReadAsBytes()"
+        },
+        "System.Nullable`1[System.DateTime] ReadAsDateTime()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.DateTime] ReadAsDateTime()"
+        },
+        "System.Nullable`1[System.DateTimeOffset] ReadAsDateTimeOffset()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.DateTimeOffset] ReadAsDateTimeOffset()"
+        },
+        "System.Nullable`1[System.Decimal] ReadAsDecimal()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Decimal] ReadAsDecimal()"
+        },
+        "System.Nullable`1[System.Int32] ReadAsInt32()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] ReadAsInt32()"
+        },
+        "System.String ReadAsString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ReadAsString()"
+        },
+        "Void .ctor(System.ReadOnlyMemory`1[System.Byte])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.ReadOnlyMemory`1[System.Byte])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDBToNewtonsoftWriter": {
+      "Subclasses": {},
+      "Members": {
+        "System.ReadOnlyMemory`1[System.Byte] GetResult()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetResult()"
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Json.JsonSerializationFormat)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Json.JsonSerializationFormat)"
+        },
+        "Void Flush()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Flush()"
+        },
+        "Void WriteComment(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteComment(System.String)"
+        },
+        "Void WriteEndArray()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteEndArray()"
+        },
+        "Void WriteEndConstructor()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteEndConstructor()"
+        },
+        "Void WriteEndObject()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteEndObject()"
+        },
+        "Void WriteNull()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteNull()"
+        },
+        "Void WritePropertyName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WritePropertyName(System.String)"
+        },
+        "Void WritePropertyName(System.String, Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WritePropertyName(System.String, Boolean)"
+        },
+        "Void WriteRaw(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteRaw(System.String)"
+        },
+        "Void WriteRawValue(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteRawValue(System.String)"
+        },
+        "Void WriteStartArray()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStartArray()"
+        },
+        "Void WriteStartConstructor(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStartConstructor(System.String)"
+        },
+        "Void WriteStartObject()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStartObject()"
+        },
+        "Void WriteUndefined()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteUndefined()"
+        },
+        "Void WriteValue(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Boolean)"
+        },
+        "Void WriteValue(Byte)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Byte)"
+        },
+        "Void WriteValue(Byte[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Byte[])"
+        },
+        "Void WriteValue(Char)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Char)"
+        },
+        "Void WriteValue(Double)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Double)"
+        },
+        "Void WriteValue(Int16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Int16)"
+        },
+        "Void WriteValue(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Int32)"
+        },
+        "Void WriteValue(Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Int64)"
+        },
+        "Void WriteValue(SByte)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(SByte)"
+        },
+        "Void WriteValue(Single)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(Single)"
+        },
+        "Void WriteValue(System.DateTime)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.DateTime)"
+        },
+        "Void WriteValue(System.Decimal)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.Decimal)"
+        },
+        "Void WriteValue(System.Guid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.Guid)"
+        },
+        "Void WriteValue(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.Object)"
+        },
+        "Void WriteValue(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.String)"
+        },
+        "Void WriteValue(System.TimeSpan)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.TimeSpan)"
+        },
+        "Void WriteValue(System.Uri)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(System.Uri)"
+        },
+        "Void WriteValue(UInt16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(UInt16)"
+        },
+        "Void WriteValue(UInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(UInt32)"
+        },
+        "Void WriteValue(UInt64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteValue(UInt64)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IReadOnlyJsonStringDictionary": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetStringAtIndex(Int32, System.String ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetStringAtIndex(Int32, System.String ByRef)"
+        },
+        "Boolean TryGetUtf8StringAtIndex(Int32, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetUtf8StringAtIndex(Int32, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonNavigator": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryGetBufferedBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedRawJson(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedRawJson(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedUtf8StringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedUtf8StringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetObjectProperty(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.String, Microsoft.Azure.Cosmos.Json.ObjectProperty ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetObjectProperty(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, System.String, Microsoft.Azure.Cosmos.Json.ObjectProperty ByRef)"
+        },
+        "Double GetFloat64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double GetFloat64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int16 GetInt16Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int16 GetInt16Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetArrayItemCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetArrayItemCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int32 GetObjectPropertyCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetObjectPropertyCount(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Int64 GetInt64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 GetInt64Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigator Create(System.ReadOnlyMemory`1[System.Byte], Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigator Create(System.ReadOnlyMemory`1[System.Byte], Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetArrayItemAt(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetArrayItemAt(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Int32)"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetRootNode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode GetRootNode()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType GetNodeType(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonNodeType GetNodeType(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Number64 GetNumberValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetNumberValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "SByte GetInt8Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "SByte GetInt8Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Single GetFloat32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Single GetFloat32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode] GetArrayItems(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode] GetArrayItems(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.ObjectProperty] GetObjectProperties(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Json.ObjectProperty] GetObjectProperties(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.Guid GetGuidValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Guid GetGuidValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "System.String GetStringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetStringValue(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "UInt32 GetUInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "UInt32 GetUInt32Value(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonNodeType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Array": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Binary": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType False": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType FieldName": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Float32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Float64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Guid": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Int16": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Int32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Int64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Int8": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Null": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Object": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType True": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType UInt32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonNodeType Unknown": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonReader": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Read()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Read()"
+        },
+        "Boolean TryGetBufferedRawJsonToken(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedRawJsonToken(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Boolean TryGetBufferedUtf8StringValue(System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetBufferedUtf8StringValue(System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Double GetFloat64Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double GetFloat64Value()"
+        },
+        "Int16 GetInt16Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int16 GetInt16Value()"
+        },
+        "Int32 CurrentDepth": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_CurrentDepth()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_CurrentDepth()"
+        },
+        "Int32 GetInt32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetInt32Value()"
+        },
+        "Int64 GetInt64Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 GetInt64Value()"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonReader Create(System.ReadOnlyMemory`1[System.Byte], Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonReader Create(System.ReadOnlyMemory`1[System.Byte], Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType CurrentTokenType": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType get_CurrentTokenType()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonTokenType get_CurrentTokenType()"
+        },
+        "Microsoft.Azure.Cosmos.Number64 GetNumberValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 GetNumberValue()"
+        },
+        "SByte GetInt8Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "SByte GetInt8Value()"
+        },
+        "Single GetFloat32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Single GetFloat32Value()"
+        },
+        "System.Guid GetGuidValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Guid GetGuidValue()"
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetBinaryValue()"
+        },
+        "System.String GetStringValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetStringValue()"
+        },
+        "UInt32 GetUInt32Value()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "UInt32 GetUInt32Value()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonSerializationFormat": {
+      "Subclasses": {},
+      "Members": {
+        "Byte value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat Binary": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat HybridRow": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat Text": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonStringDictionary": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryAddString(System.ReadOnlySpan`1[System.Byte], Int32 ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryAddString(System.ReadOnlySpan`1[System.Byte], Int32 ByRef)"
+        },
+        "Boolean TryAddString(System.String, Int32 ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryAddString(System.String, Int32 ByRef)"
+        },
+        "Boolean TryGetStringAtIndex(Int32, System.String ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetStringAtIndex(Int32, System.String ByRef)"
+        },
+        "Boolean TryGetUtf8StringAtIndex(Int32, System.ReadOnlyMemory`1[System.Byte] ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetUtf8StringAtIndex(Int32, System.ReadOnlyMemory`1[System.Byte] ByRef)"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonStringDictionary CreateFromStringArray(System.Collections.Generic.IReadOnlyList`1[System.String])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonStringDictionary CreateFromStringArray(System.Collections.Generic.IReadOnlyList`1[System.String])"
+        },
+        "Void .ctor(Int32)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Int32)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonTokenType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType BeginArray": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType BeginObject": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Binary": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType EndArray": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType EndObject": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType False": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType FieldName": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Float32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Float64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Guid": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Int16": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Int32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Int64": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Int8": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType NotStarted": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Null": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType True": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonTokenType UInt32": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "JsonWriter": {
+      "Subclasses": {},
+      "Members": {
+        "Int64 CurrentLength": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 get_CurrentLength()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 get_CurrentLength()"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonWriter Create(Microsoft.Azure.Cosmos.Json.JsonSerializationFormat, Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonWriter Create(Microsoft.Azure.Cosmos.Json.JsonSerializationFormat, Microsoft.Azure.Cosmos.Json.JsonStringDictionary, Boolean)"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat get_SerializationFormat()"
+        },
+        "Microsoft.Azure.Cosmos.Json.JsonSerializationFormat SerializationFormat": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] GetResult()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ReadOnlyMemory`1[System.Byte] GetResult()"
+        },
+        "Void WriteAll(Microsoft.Azure.Cosmos.Json.IJsonReader)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteAll(Microsoft.Azure.Cosmos.Json.IJsonReader)"
+        },
+        "Void WriteArrayEnd()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteArrayEnd()"
+        },
+        "Void WriteArrayStart()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteArrayStart()"
+        },
+        "Void WriteBinaryValue(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteBinaryValue(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteBoolValue(Boolean)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteBoolValue(Boolean)"
+        },
+        "Void WriteCurrentToken(Microsoft.Azure.Cosmos.Json.IJsonReader)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteCurrentToken(Microsoft.Azure.Cosmos.Json.IJsonReader)"
+        },
+        "Void WriteFieldName(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFieldName(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteFieldName(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFieldName(System.String)"
+        },
+        "Void WriteFloat32Value(Single)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFloat32Value(Single)"
+        },
+        "Void WriteFloat64Value(Double)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteFloat64Value(Double)"
+        },
+        "Void WriteGuidValue(System.Guid)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteGuidValue(System.Guid)"
+        },
+        "Void WriteInt16Value(Int16)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt16Value(Int16)"
+        },
+        "Void WriteInt32Value(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt32Value(Int32)"
+        },
+        "Void WriteInt64Value(Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt64Value(Int64)"
+        },
+        "Void WriteInt8Value(SByte)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteInt8Value(SByte)"
+        },
+        "Void WriteJsonFragment(System.ReadOnlyMemory`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteJsonFragment(System.ReadOnlyMemory`1[System.Byte])"
+        },
+        "Void WriteJsonNode(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteJsonNode(Microsoft.Azure.Cosmos.Json.IJsonNavigator, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        },
+        "Void WriteNullValue()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteNullValue()"
+        },
+        "Void WriteNumberValue(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteNumberValue(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Void WriteObjectEnd()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteObjectEnd()"
+        },
+        "Void WriteObjectStart()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteObjectStart()"
+        },
+        "Void WriteStringValue(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStringValue(System.ReadOnlySpan`1[System.Byte])"
+        },
+        "Void WriteStringValue(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteStringValue(System.String)"
+        },
+        "Void WriteUInt32Value(UInt32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteUInt32Value(UInt32)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ObjectProperty": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode get_NameNode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode get_NameNode()"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode get_ValueNode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode get_ValueNode()"
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode NameNode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode ValueNode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode, Microsoft.Azure.Cosmos.Json.IJsonNavigatorNode)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosLinqExtensions": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean IsDefined(System.Object)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Boolean IsDefined(System.Object)"
+        },
+        "Boolean IsNull(System.Object)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Boolean IsNull(System.Object)"
+        },
+        "Boolean IsPrimitive(System.Object)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Boolean IsPrimitive(System.Object)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator ToStreamIterator[T](System.Linq.IQueryable`1[T])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator ToStreamIterator[T](System.Linq.IQueryable`1[T])"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] ToFeedIterator[T](System.Linq.IQueryable`1[T])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] ToFeedIterator[T](System.Linq.IQueryable`1[T])"
+        },
+        "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T])"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] SumAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] AverageAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Double]] SumAsync(System.Linq.IQueryable`1[System.Double], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] CountAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int32]] SumAsync(System.Linq.IQueryable`1[System.Int32], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Int64]] SumAsync(System.Linq.IQueryable`1[System.Int64], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Decimal]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Decimal]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Double]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Double]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int32]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int32]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int32]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int64]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Int64]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Int64]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] AverageAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Nullable`1[System.Single]]] SumAsync(System.Linq.IQueryable`1[System.Nullable`1[System.Single]], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] AverageAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Single]] SumAsync(System.Linq.IQueryable`1[System.Single], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MaxAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[TSource]] MinAsync[TSource](System.Linq.IQueryable`1[TSource], System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Number64": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean get_IsDouble()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsDouble()"
+        },
+        "Boolean get_IsInfinity()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsInfinity()"
+        },
+        "Boolean get_IsInteger()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsInteger()"
+        },
+        "Boolean get_IsNaN()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsNaN()"
+        },
+        "Boolean IsDouble": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean IsInfinity": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean IsInteger": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean IsNaN": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean op_Equality(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Equality(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean op_GreaterThan(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_GreaterThan(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean op_GreaterThanOrEqual(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_GreaterThanOrEqual(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean op_Inequality(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Inequality(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean op_LessThan(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_LessThan(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Boolean op_LessThanOrEqual(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_LessThanOrEqual(Microsoft.Azure.Cosmos.Number64, Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Double ToDouble(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double ToDouble(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Int32 CompareTo(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 CompareTo(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Int32 CompareTo(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 CompareTo(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Int32 SizeOf": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 ToLong(Microsoft.Azure.Cosmos.Number64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int64 ToLong(Microsoft.Azure.Cosmos.Number64)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 MaxValue": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Number64 MinValue": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Number64 op_Implicit(Double)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 op_Implicit(Double)"
+        },
+        "Microsoft.Azure.Cosmos.Number64 op_Implicit(Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Number64 op_Implicit(Int64)"
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "System.String ToString(System.IFormatProvider)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString(System.IFormatProvider)"
+        },
+        "System.String ToString(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString(System.String)"
+        },
+        "System.String ToString(System.String, System.IFormatProvider)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString(System.String, System.IFormatProvider)"
+        },
+        "Void CopyTo(System.Span`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void CopyTo(System.Span`1[System.Byte])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "OperationKind": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.OperationKind Create": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.OperationKind Delete": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.OperationKind Invalid": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.OperationKind Read[System.ObsoleteAttribute(\"This item is obsolete as it does not apply to Conflict.\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.OperationKind Replace": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PartitionKey": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Microsoft.Azure.Cosmos.PartitionKey None": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PartitionKey Null": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SystemKeyName": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SystemKeyPath": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "Void .ctor(Boolean)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Boolean)"
+        },
+        "Void .ctor(Double)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Double)"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PartitionKeyDefinitionVersion": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion V1": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PartitionKeyDefinitionVersion V2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Permission": {
+      "Subclasses": {},
+      "Members": {
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] ReadAsync(System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] ReadAsync(System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] ReplaceAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] ReplaceAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PermissionMode": {
+      "Subclasses": {},
+      "Members": {
+        "Byte value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PermissionMode All": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PermissionMode Read": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PermissionProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.PermissionMode get_PermissionMode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PermissionMode get_PermissionMode()"
+        },
+        "Microsoft.Azure.Cosmos.PermissionMode PermissionMode[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"permissionMode\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_ResourcePartitionKey()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_ResourcePartitionKey()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] ResourcePartitionKey[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_ResourceUri()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ResourceUri()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String get_Token()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Token()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ResourceUri[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"resource\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String Token[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_token\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String, Microsoft.Azure.Cosmos.PermissionMode, Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, Microsoft.Azure.Cosmos.PermissionMode, Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String)"
+        },
+        "Void .ctor(System.String, Microsoft.Azure.Cosmos.PermissionMode, Microsoft.Azure.Cosmos.Container, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, Microsoft.Azure.Cosmos.PermissionMode, Microsoft.Azure.Cosmos.Container, System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])"
+        },
+        "Void set_ResourcePartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ResourcePartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PermissionResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Permission get_Permission()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Permission get_Permission()"
+        },
+        "Microsoft.Azure.Cosmos.Permission op_Implicit(Microsoft.Azure.Cosmos.PermissionResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Permission op_Implicit(Microsoft.Azure.Cosmos.PermissionResponse)"
+        },
+        "Microsoft.Azure.Cosmos.Permission Permission": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PermissionProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PermissionProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.PermissionProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PortReuseMode": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PortReuseMode PrivatePortPool": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.PortReuseMode ReuseUnicastPort": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "BackendMetrics": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryParseFromDelimitedString(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryParseFromDelimitedString(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ByRef)"
+        },
+        "Double get_IndexHitRatio()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_IndexHitRatio()"
+        },
+        "Double IndexHitRatio": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 get_OutputDocumentCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_OutputDocumentCount()"
+        },
+        "Int64 get_OutputDocumentSize()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_OutputDocumentSize()"
+        },
+        "Int64 get_RetrievedDocumentCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_RetrievedDocumentCount()"
+        },
+        "Int64 get_RetrievedDocumentSize()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_RetrievedDocumentSize()"
+        },
+        "Int64 OutputDocumentCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 OutputDocumentSize": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 RetrievedDocumentCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 RetrievedDocumentSize": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics])"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics Empty": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ParseFromDelimitedString(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ParseFromDelimitedString(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes get_QueryPreparationTimes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes get_QueryPreparationTimes()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes QueryPreparationTimes": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes get_RuntimeExecutionTimes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes get_RuntimeExecutionTimes()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes RuntimeExecutionTimes": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "System.TimeSpan DocumentLoadTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan DocumentWriteTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan get_DocumentLoadTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_DocumentLoadTime()"
+        },
+        "System.TimeSpan get_DocumentWriteTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_DocumentWriteTime()"
+        },
+        "System.TimeSpan get_IndexLookupTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_IndexLookupTime()"
+        },
+        "System.TimeSpan get_TotalTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_TotalTime()"
+        },
+        "System.TimeSpan get_VMExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_VMExecutionTime()"
+        },
+        "System.TimeSpan IndexLookupTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan TotalTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan VMExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(Int64, Int64, Int64, Int64, Double, System.TimeSpan, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes, System.TimeSpan, System.TimeSpan, System.TimeSpan, Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes, System.TimeSpan)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Int64, Int64, Int64, Int64, Double, System.TimeSpan, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes, System.TimeSpan, System.TimeSpan, System.TimeSpan, Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes, System.TimeSpan)"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics)"
+            },
+            "Accumulator get_QueryPreparationTimesAccumulator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Accumulator get_QueryPreparationTimesAccumulator()"
+            },
+            "Accumulator get_RuntimeExecutionTimesAccumulator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Accumulator get_RuntimeExecutionTimesAccumulator()"
+            },
+            "Accumulator QueryPreparationTimesAccumulator": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Accumulator RuntimeExecutionTimesAccumulator": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Double get_IndexHitRatio()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Double get_IndexHitRatio()"
+            },
+            "Double IndexHitRatio": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int64 get_OutputDocumentCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int64 get_OutputDocumentCount()"
+            },
+            "Int64 get_OutputDocumentSize()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int64 get_OutputDocumentSize()"
+            },
+            "Int64 get_RetrievedDocumentCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int64 get_RetrievedDocumentCount()"
+            },
+            "Int64 get_RetrievedDocumentSize()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int64 get_RetrievedDocumentSize()"
+            },
+            "Int64 OutputDocumentCount": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int64 OutputDocumentSize": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int64 RetrievedDocumentCount": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int64 RetrievedDocumentSize": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ToBackendMetrics(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ToBackendMetrics(Accumulator)"
+            },
+            "System.TimeSpan DocumentLoadTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan DocumentWriteTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan get_DocumentLoadTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_DocumentLoadTime()"
+            },
+            "System.TimeSpan get_DocumentWriteTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_DocumentWriteTime()"
+            },
+            "System.TimeSpan get_IndexLookupTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_IndexLookupTime()"
+            },
+            "System.TimeSpan get_TotalTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_TotalTime()"
+            },
+            "System.TimeSpan get_VMExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_VMExecutionTime()"
+            },
+            "System.TimeSpan IndexLookupTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan TotalTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan VMExecutionTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.TimeSpan, Int64, Int64, Int64, Int64, Double, Accumulator, System.TimeSpan, System.TimeSpan, Accumulator, System.TimeSpan, System.TimeSpan)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.TimeSpan, Int64, Int64, Int64, Int64, Double, Accumulator, System.TimeSpan, System.TimeSpan, Accumulator, System.TimeSpan, System.TimeSpan)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "Accumulator": {
+      "Subclasses": {},
+      "Members": {
+        "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes ToRuntimeExecutionTimes(Accumulator)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes ToRuntimeExecutionTimes(Accumulator)"
+        },
+        "System.TimeSpan get_QueryEngineExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_QueryEngineExecutionTime()"
+        },
+        "System.TimeSpan get_SystemFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_SystemFunctionExecutionTime()"
+        },
+        "System.TimeSpan get_UserDefinedFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_UserDefinedFunctionExecutionTime()"
+        },
+        "System.TimeSpan QueryEngineExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan SystemFunctionExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan UserDefinedFunctionExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)"
+        },
+        "Void set_QueryEngineExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_QueryEngineExecutionTime(System.TimeSpan)"
+        },
+        "Void set_SystemFunctionExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_SystemFunctionExecutionTime(System.TimeSpan)"
+        },
+        "Void set_UserDefinedFunctionExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_UserDefinedFunctionExecutionTime(System.TimeSpan)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "BackendMetricsParser": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean TryParse(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryParse(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics ByRef)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "BackendMetricsTokenizer": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetricsTokenizer+TokenBuffers": {
+          "Type": "NestedType",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetricsTokenizer+TokenType": {
+          "Type": "NestedType",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ValueTuple`2[System.Nullable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetricsTokenizer+TokenType],System.ReadOnlyMemory`1[System.Byte]] Read(System.ReadOnlySpan`1[System.Byte])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.ValueTuple`2[System.Nullable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetricsTokenizer+TokenType],System.ReadOnlyMemory`1[System.Byte]] Read(System.ReadOnlySpan`1[System.Byte])"
+        }
+      },
+      "NestedTypes": {
+        "TokenBuffers": {
+          "Subclasses": {},
+          "Members": {
+            "System.ReadOnlyMemory`1[System.Byte] DocumentLoadTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] IndexLookupTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] IndexUtilizationRatio": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] OutputDocumentCount": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] OutputDocumentSize": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] QueryCompileTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] QueryLogicalPlanBuildTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] QueryOptimizationTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] QueryPhysicalPlanBuildTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] RetrievedDocumentCount": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] RetrievedDocumentSize": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] SystemFunctionExecuteTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] TotalExecutionTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] UserFunctionExecuteTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] VMExecutionTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.ReadOnlyMemory`1[System.Byte] WriteOutputTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            }
+          },
+          "NestedTypes": {}
+        },
+        "TokenType": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 value__": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType DocumentLoadTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType EqualsDelimiter": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType IndexLookupTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType IndexUtilizationRatio": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType NumberToken": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType OutputDocumentCount": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType OutputDocumentSize": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType QueryCompileTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType QueryLogicalPlanBuildTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType QueryOptimizationTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType QueryPhysicalPlanBuildTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType RetrievedDocumentCount": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType RetrievedDocumentSize": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType SemiColonDelimiter": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType SystemFunctionExecuteTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType TotalExecutionTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType UserFunctionExecuteTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType VMExecutionTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "TokenType WriteOutputTimeInMs": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "TokenBuffers": {
+      "Subclasses": {},
+      "Members": {
+        "System.ReadOnlyMemory`1[System.Byte] DocumentLoadTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] IndexLookupTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] IndexUtilizationRatio": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] OutputDocumentCount": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] OutputDocumentSize": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] QueryCompileTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] QueryLogicalPlanBuildTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] QueryOptimizationTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] QueryPhysicalPlanBuildTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] RetrievedDocumentCount": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] RetrievedDocumentSize": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] SystemFunctionExecuteTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] TotalExecutionTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] UserFunctionExecuteTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] VMExecutionTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.ReadOnlyMemory`1[System.Byte] WriteOutputTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TokenType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType DocumentLoadTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType EqualsDelimiter": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType IndexLookupTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType IndexUtilizationRatio": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType NumberToken": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType OutputDocumentCount": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType OutputDocumentSize": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType QueryCompileTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType QueryLogicalPlanBuildTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType QueryOptimizationTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType QueryPhysicalPlanBuildTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType RetrievedDocumentCount": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType RetrievedDocumentSize": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType SemiColonDelimiter": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType SystemFunctionExecuteTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType TotalExecutionTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType UserFunctionExecuteTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType VMExecutionTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "TokenType WriteOutputTimeInMs": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ClientSideMetrics": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 get_Retries()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_Retries()"
+        },
+        "Int64 Retries": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics Empty": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] FetchExecutionRanges": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] get_FetchExecutionRanges()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] get_FetchExecutionRanges()"
+        },
+        "Void .ctor(Int64, Double, System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Int64, Double, System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange])"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics)"
+            },
+            "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Double get_RequestCharge()"
+            },
+            "Double RequestCharge": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int64 get_Retries()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int64 get_Retries()"
+            },
+            "Int64 Retries": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics ToClientSideMetrics(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics ToClientSideMetrics(Accumulator)"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] FetchExecutionRanges": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] get_FetchExecutionRanges()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] get_FetchExecutionRanges()"
+            },
+            "Void .ctor(Int64, Double, System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(Int64, Double, System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange])"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "FetchExecutionRange": {
+      "Subclasses": {},
+      "Members": {
+        "Int64 get_NumberOfDocuments()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_NumberOfDocuments()"
+        },
+        "Int64 get_RetryCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int64 get_RetryCount()"
+        },
+        "Int64 NumberOfDocuments": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int64 RetryCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.DateTime EndTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.DateTime get_EndTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.DateTime get_EndTime()"
+        },
+        "System.DateTime get_StartTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.DateTime get_StartTime()"
+        },
+        "System.DateTime StartTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_PartitionId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_PartitionId()"
+        },
+        "System.String PartitionId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String, System.String, System.DateTime, System.DateTime, Int64, Int64)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String, System.DateTime, System.DateTime, Int64, Int64)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "FetchExecutionRangeAccumulator": {
+      "Subclasses": {},
+      "Members": {
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] GetExecutionRanges()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.FetchExecutionRange] GetExecutionRanges()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void BeginFetchRange()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void BeginFetchRange()"
+        },
+        "Void EndFetchRange(System.String, System.String, Int64, Int64)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void EndFetchRange(System.String, System.String, Int64, Int64)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexUtilizationData": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean FilterExpressionPrecision[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"FilterPreciseSet\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Boolean get_FilterExpressionPrecision()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_FilterExpressionPrecision()"
+        },
+        "Boolean get_IndexPlanFullFidelity()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_IndexPlanFullFidelity()"
+        },
+        "Boolean IndexPlanFullFidelity[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"IndexPreciseSet\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String FilterExpression[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"FilterExpression\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_FilterExpression()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_FilterExpression()"
+        },
+        "System.String get_IndexDocumentExpression()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_IndexDocumentExpression()"
+        },
+        "System.String IndexDocumentExpression[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"IndexSpec\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String, System.String, Boolean, Boolean)[Newtonsoft.Json.JsonConstructorAttribute()]": {
+          "Type": "Constructor",
+          "Attributes": [
+            "JsonConstructorAttribute"
+          ],
+          "MethodInfo": "Void .ctor(System.String, System.String, Boolean, Boolean)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "IndexUtilizationInfo": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo CreateFromString(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo CreateFromString(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo Empty": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_PotentialIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_PotentialIndexes()"
+        },
+        "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_UtilizedIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_UtilizedIndexes()"
+        },
+        "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] PotentialIndexes": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] UtilizedIndexes": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData], System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData])[Newtonsoft.Json.JsonConstructorAttribute()]": {
+          "Type": "Constructor",
+          "Attributes": [
+            "JsonConstructorAttribute"
+          ],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData], System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData])"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo)"
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo ToIndexUtilizationInfo(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo ToIndexUtilizationInfo(Accumulator)"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_PotentialIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_PotentialIndexes()"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_UtilizedIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] get_UtilizedIndexes()"
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] PotentialIndexes": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData] UtilizedIndexes": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData], System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData], System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationData])"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "PartitionedQueryMetrics": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean ContainsKey(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean ContainsKey(System.String)"
+        },
+        "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics ByRef)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean TryGetValue(System.String, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics ByRef)"
+        },
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics Add(Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics Add(Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics[])"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics])"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics op_Addition(Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics op_Addition(Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.PartitionedQueryMetrics)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics get_Item(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics get_Item(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics Item [System.String]": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics] get_Values()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics] get_Values()"
+        },
+        "System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics] Values": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_Keys()"
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] Keys": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics]] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[System.Collections.Generic.KeyValuePair`2[System.String,Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics]] GetEnumerator()"
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IReadOnlyDictionary`2[System.String,Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryMetrics": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics BackendMetrics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics get_BackendMetrics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics get_BackendMetrics()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics ClientSideMetrics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics get_ClientSideMetrics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics get_ClientSideMetrics()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo get_IndexUtilizationInfo()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo get_IndexUtilizationInfo()"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo IndexUtilizationInfo": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics CreateFromIEnumerable(System.Collections.Generic.IEnumerable`1[Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics])"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics op_Addition(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics op_Addition(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)"
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ToString()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String ToString()"
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo, Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Query.Core.Metrics.BackendMetrics, Microsoft.Azure.Cosmos.Query.Core.Metrics.IndexUtilizationInfo, Microsoft.Azure.Cosmos.Query.Core.Metrics.ClientSideMetrics)"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)"
+            },
+            "Accumulator BackendMetricsAccumulator": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Accumulator ClientSideMetricsAccumulator": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Accumulator get_BackendMetricsAccumulator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Accumulator get_BackendMetricsAccumulator()"
+            },
+            "Accumulator get_ClientSideMetricsAccumulator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Accumulator get_ClientSideMetricsAccumulator()"
+            },
+            "Accumulator get_IndexUtilizationInfoAccumulator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Accumulator get_IndexUtilizationInfoAccumulator()"
+            },
+            "Accumulator IndexUtilizationInfoAccumulator": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics ToQueryMetrics(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics ToQueryMetrics(Accumulator)"
+            },
+            "Void .ctor(Accumulator, Accumulator, Accumulator)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(Accumulator, Accumulator, Accumulator)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "QueryMetricsDelimitedStringWriter": {
+      "Subclasses": {},
+      "Members": {
+        "Void .ctor(System.Text.StringBuilder)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Text.StringBuilder)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryMetricsTextWriter": {
+      "Subclasses": {},
+      "Members": {
+        "Void .ctor(System.Text.StringBuilder)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Text.StringBuilder)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryMetricsWriter": {
+      "Subclasses": {
+        "QueryMetricsDelimitedStringWriter": {
+          "Subclasses": {},
+          "Members": {
+            "Void .ctor(System.Text.StringBuilder)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Text.StringBuilder)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "QueryMetricsTextWriter": {
+          "Subclasses": {},
+          "Members": {
+            "Void .ctor(System.Text.StringBuilder)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Text.StringBuilder)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Void WriteQueryMetrics(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void WriteQueryMetrics(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryMetrics)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryPreparationTimes": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes Zero": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.TimeSpan get_LogicalPlanBuildTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_LogicalPlanBuildTime()"
+        },
+        "System.TimeSpan get_PhysicalPlanBuildTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_PhysicalPlanBuildTime()"
+        },
+        "System.TimeSpan get_QueryCompilationTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_QueryCompilationTime()"
+        },
+        "System.TimeSpan get_QueryOptimizationTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_QueryOptimizationTime()"
+        },
+        "System.TimeSpan LogicalPlanBuildTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan PhysicalPlanBuildTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan QueryCompilationTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan QueryOptimizationTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan, System.TimeSpan)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan, System.TimeSpan)"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes)"
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes ToQueryPreparationTimes(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.QueryPreparationTimes ToQueryPreparationTimes(Accumulator)"
+            },
+            "System.TimeSpan get_LogicalPlanBuildTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_LogicalPlanBuildTime()"
+            },
+            "System.TimeSpan get_PhysicalPlanBuildTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_PhysicalPlanBuildTime()"
+            },
+            "System.TimeSpan get_QueryCompilationTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_QueryCompilationTime()"
+            },
+            "System.TimeSpan get_QueryOptimizationTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_QueryOptimizationTime()"
+            },
+            "System.TimeSpan LogicalPlanBuildTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan PhysicalPlanBuildTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan QueryCompilationTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan QueryOptimizationTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan, System.TimeSpan)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan, System.TimeSpan)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "RuntimeExecutionTimes": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes Empty": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes+Accumulator[System.Runtime.CompilerServices.IsByRefLikeAttribute()]-[System.ObsoleteAttribute(\"Types with embedded references are not supported in this version of your compiler.\", (Boolean)True)]": {
+          "Type": "NestedType",
+          "Attributes": [
+            "IsByRefLikeAttribute",
+            "ObsoleteAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.TimeSpan get_QueryEngineExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_QueryEngineExecutionTime()"
+        },
+        "System.TimeSpan get_SystemFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_SystemFunctionExecutionTime()"
+        },
+        "System.TimeSpan get_UserDefinedFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_UserDefinedFunctionExecutionTime()"
+        },
+        "System.TimeSpan QueryEngineExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan SystemFunctionExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.TimeSpan UserDefinedFunctionExecutionTime": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)"
+        }
+      },
+      "NestedTypes": {
+        "Accumulator": {
+          "Subclasses": {},
+          "Members": {
+            "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Accumulator Accumulate(Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes)"
+            },
+            "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes ToRuntimeExecutionTimes(Accumulator)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Query.Core.Metrics.RuntimeExecutionTimes ToRuntimeExecutionTimes(Accumulator)"
+            },
+            "System.TimeSpan get_QueryEngineExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_QueryEngineExecutionTime()"
+            },
+            "System.TimeSpan get_SystemFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_SystemFunctionExecutionTime()"
+            },
+            "System.TimeSpan get_UserDefinedFunctionExecutionTime()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.TimeSpan get_UserDefinedFunctionExecutionTime()"
+            },
+            "System.TimeSpan QueryEngineExecutionTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan SystemFunctionExecutionTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.TimeSpan UserDefinedFunctionExecutionTime": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.TimeSpan, System.TimeSpan, System.TimeSpan)"
+            },
+            "Void set_QueryEngineExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_QueryEngineExecutionTime(System.TimeSpan)"
+            },
+            "Void set_SystemFunctionExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_SystemFunctionExecutionTime(System.TimeSpan)"
+            },
+            "Void set_UserDefinedFunctionExecutionTime(System.TimeSpan)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_UserDefinedFunctionExecutionTime(System.TimeSpan)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "TextTable": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.Metrics.TextTable+Column": {
+          "Type": "NestedType",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String BottomLine": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_BottomLine()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_BottomLine()"
+        },
+        "System.String get_Header()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Header()"
+        },
+        "System.String get_MiddleLine()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_MiddleLine()"
+        },
+        "System.String get_TopLine()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_TopLine()"
+        },
+        "System.String GetRow(System.Object[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String GetRow(System.Object[])"
+        },
+        "System.String Header": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String MiddleLine": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String TopLine": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(Column[])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Column[])"
+        }
+      },
+      "NestedTypes": {
+        "Column": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 ColumnWidth": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.String ColumnName": {
+              "Type": "Field",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.String, Int32)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.String, Int32)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      }
+    },
+    "Column": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 ColumnWidth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ColumnName": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String, Int32)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, Int32)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryResponseCore": {
+      "Subclasses": {},
+      "Members": {},
+      "NestedTypes": {}
+    },
+    "QueryFeatures": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures Aggregate": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures CompositeAggregate": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures Distinct": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures GroupBy": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures MultipleAggregates": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures MultipleOrderBy": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures None": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures NonValueAggregate": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures OffsetAndLimit": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures OrderBy": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryFeatures Top": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "UInt64 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryDefinition": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)"
+        },
+        "System.String get_QueryText()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_QueryText()"
+        },
+        "System.String QueryText": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryRequestOptions": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_PartitionKey()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_PartitionKey()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] PartitionKey": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Boolean] EnableLowPrecisionOrderBy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Boolean] EnableScanInQuery": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Boolean] get_EnableLowPrecisionOrderBy()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Boolean] get_EnableLowPrecisionOrderBy()"
+        },
+        "System.Nullable`1[System.Boolean] get_EnableScanInQuery()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Boolean] get_EnableScanInQuery()"
+        },
+        "System.Nullable`1[System.Int32] get_MaxBufferedItemCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxBufferedItemCount()"
+        },
+        "System.Nullable`1[System.Int32] get_MaxConcurrency()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxConcurrency()"
+        },
+        "System.Nullable`1[System.Int32] get_MaxItemCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxItemCount()"
+        },
+        "System.Nullable`1[System.Int32] get_ResponseContinuationTokenLimitInKb()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_ResponseContinuationTokenLimitInKb()"
+        },
+        "System.Nullable`1[System.Int32] MaxBufferedItemCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] MaxConcurrency": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] MaxItemCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] ResponseContinuationTokenLimitInKb": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SessionToken()"
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+        },
+        "Void set_EnableLowPrecisionOrderBy(System.Nullable`1[System.Boolean])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EnableLowPrecisionOrderBy(System.Nullable`1[System.Boolean])"
+        },
+        "Void set_EnableScanInQuery(System.Nullable`1[System.Boolean])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EnableScanInQuery(System.Nullable`1[System.Boolean])"
+        },
+        "Void set_MaxBufferedItemCount(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxBufferedItemCount(System.Nullable`1[System.Int32])"
+        },
+        "Void set_MaxConcurrency(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxConcurrency(System.Nullable`1[System.Int32])"
+        },
+        "Void set_MaxItemCount(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxItemCount(System.Nullable`1[System.Int32])"
+        },
+        "Void set_PartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])"
+        },
+        "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])"
+        },
+        "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_SessionToken(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "System.IO.Stream Content": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.IO.Stream get_Content()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream get_Content()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "QueryResponse`1": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerable`1[T] get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[T] get_Resource()"
+        },
+        "System.Collections.Generic.IEnumerable`1[T] Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IEnumerator`1[T] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[T] GetEnumerator()"
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ContinuationToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ContinuationToken()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Regions": {
+      "Subclasses": {},
+      "Members": {
+        "System.String AustraliaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaCentral2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaSoutheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String BrazilSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUSEUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2EUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNortheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyWestCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SoutheastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAECentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAENorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovArizona": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovTexas": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovVirginia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "RequestHandler": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.RequestHandler get_InnerHandler()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.RequestHandler get_InnerHandler()"
+        },
+        "Microsoft.Azure.Cosmos.RequestHandler InnerHandler": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] SendAsync(Microsoft.Azure.Cosmos.RequestMessage, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.RequestHandler+<SendAsync>d__4))]": {
+          "Type": "Method",
+          "Attributes": [
+            "AsyncStateMachineAttribute"
+          ],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] SendAsync(Microsoft.Azure.Cosmos.RequestMessage, System.Threading.CancellationToken)"
+        },
+        "Void set_InnerHandler(Microsoft.Azure.Cosmos.RequestHandler)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_InnerHandler(Microsoft.Azure.Cosmos.RequestHandler)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "RequestMessage": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Headers get_Headers()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.Dictionary`2[System.String,System.Object] get_Properties()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.Dictionary`2[System.String,System.Object] get_Properties()"
+        },
+        "System.Collections.Generic.Dictionary`2[System.String,System.Object] Properties": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.IO.Stream Content": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.IO.Stream get_Content()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream get_Content()"
+        },
+        "System.Net.Http.HttpMethod get_Method()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.Http.HttpMethod get_Method()"
+        },
+        "System.Net.Http.HttpMethod Method": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Uri get_RequestUri()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Uri get_RequestUri()"
+        },
+        "System.Uri RequestUri": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.Net.Http.HttpMethod, System.Uri)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Net.Http.HttpMethod, System.Uri)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
+        },
+        "Void set_Content(System.IO.Stream)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Content(System.IO.Stream)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "RequestOptions": {
+      "Subclasses": {
+        "ContainerRequestOptions": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean get_PopulateQuotaInfo()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Boolean get_PopulateQuotaInfo()"
+            },
+            "Boolean PopulateQuotaInfo": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor()": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor()"
+            },
+            "Void set_PopulateQuotaInfo(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_PopulateQuotaInfo(Boolean)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "ItemRequestOptions": {
+          "Subclasses": {},
+          "Members": {
+            "System.Collections.Generic.IEnumerable`1[System.String] get_PostTriggers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_PostTriggers()"
+            },
+            "System.Collections.Generic.IEnumerable`1[System.String] get_PreTriggers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] get_PreTriggers()"
+            },
+            "System.Collections.Generic.IEnumerable`1[System.String] PostTriggers": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Collections.Generic.IEnumerable`1[System.String] PreTriggers": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] IndexingDirective": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_SessionToken()"
+            },
+            "System.String SessionToken": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor()": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor()"
+            },
+            "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+            },
+            "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])"
+            },
+            "Void set_PostTriggers(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_PostTriggers(System.Collections.Generic.IEnumerable`1[System.String])"
+            },
+            "Void set_PreTriggers(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_PreTriggers(System.Collections.Generic.IEnumerable`1[System.String])"
+            },
+            "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_SessionToken(System.String)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "QueryRequestOptions": {
+          "Subclasses": {},
+          "Members": {
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_PartitionKey()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] get_PartitionKey()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey] PartitionKey": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Boolean] EnableLowPrecisionOrderBy": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Boolean] EnableScanInQuery": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Boolean] get_EnableLowPrecisionOrderBy()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Boolean] get_EnableLowPrecisionOrderBy()"
+            },
+            "System.Nullable`1[System.Boolean] get_EnableScanInQuery()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Boolean] get_EnableScanInQuery()"
+            },
+            "System.Nullable`1[System.Int32] get_MaxBufferedItemCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Int32] get_MaxBufferedItemCount()"
+            },
+            "System.Nullable`1[System.Int32] get_MaxConcurrency()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Int32] get_MaxConcurrency()"
+            },
+            "System.Nullable`1[System.Int32] get_MaxItemCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Int32] get_MaxItemCount()"
+            },
+            "System.Nullable`1[System.Int32] get_ResponseContinuationTokenLimitInKb()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[System.Int32] get_ResponseContinuationTokenLimitInKb()"
+            },
+            "System.Nullable`1[System.Int32] MaxBufferedItemCount": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Int32] MaxConcurrency": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Int32] MaxItemCount": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[System.Int32] ResponseContinuationTokenLimitInKb": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_SessionToken()"
+            },
+            "System.String SessionToken": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor()": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor()"
+            },
+            "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+            },
+            "Void set_EnableLowPrecisionOrderBy(System.Nullable`1[System.Boolean])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_EnableLowPrecisionOrderBy(System.Nullable`1[System.Boolean])"
+            },
+            "Void set_EnableScanInQuery(System.Nullable`1[System.Boolean])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_EnableScanInQuery(System.Nullable`1[System.Boolean])"
+            },
+            "Void set_MaxBufferedItemCount(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_MaxBufferedItemCount(System.Nullable`1[System.Int32])"
+            },
+            "Void set_MaxConcurrency(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_MaxConcurrency(System.Nullable`1[System.Int32])"
+            },
+            "Void set_MaxItemCount(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_MaxItemCount(System.Nullable`1[System.Int32])"
+            },
+            "Void set_PartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_PartitionKey(System.Nullable`1[Microsoft.Azure.Cosmos.PartitionKey])"
+            },
+            "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])"
+            },
+            "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_SessionToken(System.String)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "StoredProcedureRequestOptions": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean EnableScriptLogging": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Boolean get_EnableScriptLogging()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Boolean get_EnableScriptLogging()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+            },
+            "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_SessionToken()"
+            },
+            "System.String SessionToken": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor()": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor()"
+            },
+            "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+            },
+            "Void set_EnableScriptLogging(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_EnableScriptLogging(Boolean)"
+            },
+            "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_SessionToken(System.String)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "TransactionalBatchItemRequestOptions": {
+          "Subclasses": {},
+          "Members": {
+            "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()"
+            },
+            "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] IndexingDirective": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void .ctor()": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor()"
+            },
+            "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "System.String get_IfMatchEtag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_IfMatchEtag()"
+        },
+        "System.String get_IfNoneMatchEtag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_IfNoneMatchEtag()"
+        },
+        "System.String IfMatchEtag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String IfNoneMatchEtag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_IfMatchEtag(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IfMatchEtag(System.String)"
+        },
+        "Void set_IfNoneMatchEtag(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IfNoneMatchEtag(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Response`1": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "T get_Resource()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T get_Resource()"
+        },
+        "T op_Implicit(Microsoft.Azure.Cosmos.Response`1[T])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "T op_Implicit(Microsoft.Azure.Cosmos.Response`1[T])"
+        },
+        "T Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ResponseMessage": {
+      "Subclasses": {
+        "QueryResponse": {
+          "Subclasses": {},
+          "Members": {
+            "Int32 Count": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Int32 get_Count()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Int32 get_Count()"
+            },
+            "System.IO.Stream Content": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "System.IO.Stream get_Content()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "System.IO.Stream get_Content()"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Boolean get_IsSuccessStatusCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsSuccessStatusCode()"
+        },
+        "Boolean IsSuccessStatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.RequestMessage get_RequestMessage()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.RequestMessage get_RequestMessage()"
+        },
+        "Microsoft.Azure.Cosmos.RequestMessage RequestMessage": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ResponseMessage EnsureSuccessStatusCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ResponseMessage EnsureSuccessStatusCode()"
+        },
+        "System.IO.Stream Content": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.IO.Stream get_Content()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream get_Content()"
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ContinuationToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ErrorMessage": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ContinuationToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ContinuationToken()"
+        },
+        "System.String get_ErrorMessage()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ErrorMessage()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.Net.HttpStatusCode, Microsoft.Azure.Cosmos.RequestMessage, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Net.HttpStatusCode, Microsoft.Azure.Cosmos.RequestMessage, System.String)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
+        },
+        "Void set_Content(System.IO.Stream)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Content(System.IO.Stream)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Scripts": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.FeedIterator GetStoredProcedureQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetStoredProcedureQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetStoredProcedureQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetStoredProcedureQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetTriggerQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetTriggerQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetTriggerQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetTriggerQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetUserDefinedFunctionQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetUserDefinedFunctionQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator GetUserDefinedFunctionQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator GetUserDefinedFunctionQueryStreamIterator(System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetStoredProcedureQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetStoredProcedureQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetStoredProcedureQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetStoredProcedureQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetTriggerQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetTriggerQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetTriggerQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetTriggerQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserDefinedFunctionQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserDefinedFunctionQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserDefinedFunctionQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetUserDefinedFunctionQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ExecuteStoredProcedureStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, System.Object[], Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ExecuteStoredProcedureStreamAsync(System.String, Microsoft.Azure.Cosmos.PartitionKey, System.Object[], Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ExecuteStoredProcedureStreamAsync(System.String, System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ExecuteStoredProcedureStreamAsync(System.String, System.IO.Stream, Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureExecuteResponse`1[TOutput]] ExecuteStoredProcedureAsync[TOutput](System.String, Microsoft.Azure.Cosmos.PartitionKey, System.Object[], Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureExecuteResponse`1[TOutput]] ExecuteStoredProcedureAsync[TOutput](System.String, Microsoft.Azure.Cosmos.PartitionKey, System.Object[], Microsoft.Azure.Cosmos.Scripts.StoredProcedureRequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] CreateStoredProcedureAsync(Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] CreateStoredProcedureAsync(Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] DeleteStoredProcedureAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] DeleteStoredProcedureAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] ReadStoredProcedureAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] ReadStoredProcedureAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] ReplaceStoredProcedureAsync(Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse] ReplaceStoredProcedureAsync(Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] CreateTriggerAsync(Microsoft.Azure.Cosmos.Scripts.TriggerProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] CreateTriggerAsync(Microsoft.Azure.Cosmos.Scripts.TriggerProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] DeleteTriggerAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] DeleteTriggerAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] ReadTriggerAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] ReadTriggerAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] ReplaceTriggerAsync(Microsoft.Azure.Cosmos.Scripts.TriggerProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.TriggerResponse] ReplaceTriggerAsync(Microsoft.Azure.Cosmos.Scripts.TriggerProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] CreateUserDefinedFunctionAsync(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] CreateUserDefinedFunctionAsync(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] DeleteUserDefinedFunctionAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] DeleteUserDefinedFunctionAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] ReadUserDefinedFunctionAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] ReadUserDefinedFunctionAsync(System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] ReplaceUserDefinedFunctionAsync(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse] ReplaceUserDefinedFunctionAsync(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "StoredProcedureExecuteResponse`1": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_ScriptLog()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ScriptLog()"
+        },
+        "System.String get_SessionToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_SessionToken()"
+        },
+        "System.String ScriptLog": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "T get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "T get_Resource()"
+        },
+        "T Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "StoredProcedureProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String Body[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"body\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Body()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Body()"
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String)"
+        },
+        "Void set_Body(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Body(System.String)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "StoredProcedureRequestOptions": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean EnableScriptLogging": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Boolean get_EnableScriptLogging()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_EnableScriptLogging()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] ConsistencyLevel": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel] get_ConsistencyLevel()"
+        },
+        "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SessionToken()"
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConsistencyLevel(System.Nullable`1[Microsoft.Azure.Cosmos.ConsistencyLevel])"
+        },
+        "Void set_EnableScriptLogging(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EnableScriptLogging(Boolean)"
+        },
+        "Void set_SessionToken(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_SessionToken(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "StoredProcedureResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.StoredProcedureResponse)"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.StoredProcedureProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_SessionToken()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_SessionToken()"
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TriggerOperation": {
+      "Subclasses": {},
+      "Members": {
+        "Int16 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation All": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation Create": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation Delete": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation Replace": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation Update": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TriggerProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation get_TriggerOperation()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.TriggerOperation get_TriggerOperation()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerOperation TriggerOperation[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"triggerOperation\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerType get_TriggerType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.TriggerType get_TriggerType()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerType TriggerType[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"triggerType\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String Body[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"body\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Body()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Body()"
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Body(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Body(System.String)"
+        },
+        "Void set_Id(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Id(System.String)"
+        },
+        "Void set_TriggerOperation(Microsoft.Azure.Cosmos.Scripts.TriggerOperation)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_TriggerOperation(Microsoft.Azure.Cosmos.Scripts.TriggerOperation)"
+        },
+        "Void set_TriggerType(Microsoft.Azure.Cosmos.Scripts.TriggerType)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_TriggerType(Microsoft.Azure.Cosmos.Scripts.TriggerType)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TriggerResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.TriggerProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.TriggerResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.TriggerProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.TriggerResponse)"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TriggerType": {
+      "Subclasses": {},
+      "Members": {
+        "Byte value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerType Post": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.TriggerType Pre": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UserDefinedFunctionProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.String Body[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"body\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Body()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Body()"
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_Body(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Body(System.String)"
+        },
+        "Void set_Id(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UserDefinedFunctionResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties op_Implicit(Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionResponse)"
+        },
+        "Microsoft.Azure.Cosmos.Scripts.UserDefinedFunctionProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "BoundingBox": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.BoundingBox)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.BoundingBox)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position get_Max()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Position get_Max()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position get_Min()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Position get_Min()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position Max[System.Runtime.Serialization.DataMemberAttribute(Name = \"max\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position Min[System.Runtime.Serialization.DataMemberAttribute(Name = \"min\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.Position)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.Position)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Crs": {
+      "Subclasses": {
+        "LinkedCrs": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinkedCrs)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinkedCrs)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "System.String get_Href()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_Href()"
+            },
+            "System.String get_HrefType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_HrefType()"
+            },
+            "System.String Href[System.Runtime.Serialization.DataMemberAttribute(Name = \"href\")]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute"
+              ],
+              "MethodInfo": null
+            },
+            "System.String HrefType[System.Runtime.Serialization.DataMemberAttribute(Name = \"hrefType\")]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute"
+              ],
+              "MethodInfo": null
+            }
+          },
+          "NestedTypes": {}
+        },
+        "NamedCrs": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.NamedCrs)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.NamedCrs)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "System.String get_Name()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.String get_Name()"
+            },
+            "System.String Name[System.Runtime.Serialization.DataMemberAttribute(Name = \"name\")]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute"
+              ],
+              "MethodInfo": null
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Microsoft.Azure.Cosmos.Spatial.Crs Default": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs get_Default()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Crs get_Default()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs get_Unspecified()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Crs get_Unspecified()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs Unspecified": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.CrsType get_Type()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.CrsType get_Type()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.CrsType Type[System.Runtime.Serialization.DataMemberAttribute(Name = \"type\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.LinkedCrs Linked(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.LinkedCrs Linked(System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.LinkedCrs Linked(System.String, System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.LinkedCrs Linked(System.String, System.String)"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.NamedCrs Named(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.NamedCrs Named(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CrsType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.CrsType Linked": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.CrsType Named": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.CrsType Unspecified": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Geometry": {
+      "Subclasses": {
+        "LineString": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LineString)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LineString)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] Positions[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute",
+                "JsonPropertyAttribute"
+              ],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])"
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "MultiPolygon": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.MultiPolygon)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.MultiPolygon)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] get_Polygons()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] get_Polygons()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] Polygons[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute",
+                "JsonPropertyAttribute"
+              ],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates])"
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "Point": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Point)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Point)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "Microsoft.Azure.Cosmos.Spatial.Position get_Position()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Position get_Position()"
+            },
+            "Microsoft.Azure.Cosmos.Spatial.Position Position[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute",
+                "JsonPropertyAttribute"
+              ],
+              "MethodInfo": null
+            },
+            "Void .ctor(Double, Double)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(Double, Double)"
+            },
+            "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position)"
+            },
+            "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "Polygon": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Polygon)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Polygon)"
+            },
+            "Boolean Equals(System.Object)": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Boolean Equals(System.Object)"
+            },
+            "Int32 GetHashCode()": {
+              "Type": "Method",
+              "Attributes": [],
+              "MethodInfo": "Int32 GetHashCode()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()"
+            },
+            "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] Rings[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+              "Type": "Property",
+              "Attributes": [
+                "DataMemberAttribute",
+                "JsonPropertyAttribute"
+              ],
+              "MethodInfo": null
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])"
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+            },
+            "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])": {
+              "Type": "Constructor",
+              "Attributes": [],
+              "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean Intersects(Microsoft.Azure.Cosmos.Spatial.Geometry)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Intersects(Microsoft.Azure.Cosmos.Spatial.Geometry)"
+        },
+        "Boolean IsValid()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean IsValid()"
+        },
+        "Boolean Within(Microsoft.Azure.Cosmos.Spatial.Geometry)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Within(Microsoft.Azure.Cosmos.Spatial.Geometry)"
+        },
+        "Double Distance(Microsoft.Azure.Cosmos.Spatial.Geometry)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double Distance(Microsoft.Azure.Cosmos.Spatial.Geometry)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.BoundingBox BoundingBox[System.Runtime.Serialization.DataMemberAttribute(Name = \"bbox\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"bbox\", DefaultValueHandling = 1, Order = 3)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.BoundingBox get_BoundingBox()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.BoundingBox get_BoundingBox()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs Crs": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs get_Crs()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Crs get_Crs()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType get_Type()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.GeometryType get_Type()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType Type[System.Runtime.Serialization.DataMemberAttribute(Name = \"type\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"type\", Order = 0, Required = 2)]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryValidationResult IsValidDetailed()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.GeometryValidationResult IsValidDetailed()"
+        },
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[Newtonsoft.Json.JsonExtensionDataAttribute()]-[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonExtensionDataAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] get_AdditionalProperties()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IDictionary`2[System.String,System.Object] get_AdditionalProperties()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeometryParams": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Spatial.BoundingBox BoundingBox[System.Runtime.Serialization.DataMemberAttribute(Name = \"bbox\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.BoundingBox get_BoundingBox()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.BoundingBox get_BoundingBox()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs Crs[System.Runtime.Serialization.DataMemberAttribute(Name = \"crs\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Crs get_Crs()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Crs get_Crs()"
+        },
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] AdditionalProperties[System.Runtime.Serialization.DataMemberAttribute(Name = \"properties\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.Generic.IDictionary`2[System.String,System.Object] get_AdditionalProperties()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IDictionary`2[System.String,System.Object] get_AdditionalProperties()"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_AdditionalProperties(System.Collections.Generic.IDictionary`2[System.String,System.Object])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_AdditionalProperties(System.Collections.Generic.IDictionary`2[System.String,System.Object])"
+        },
+        "Void set_BoundingBox(Microsoft.Azure.Cosmos.Spatial.BoundingBox)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_BoundingBox(Microsoft.Azure.Cosmos.Spatial.BoundingBox)"
+        },
+        "Void set_Crs(Microsoft.Azure.Cosmos.Spatial.Crs)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Crs(Microsoft.Azure.Cosmos.Spatial.Crs)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeometryShape": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape GeometryCollection": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape MultiLineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape MultiPoint": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryShape Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeometryType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType GeometryCollection": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType MultiLineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType MultiPoint": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Spatial.GeometryType Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "GeometryValidationResult": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_IsValid()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_IsValid()"
+        },
+        "Boolean IsValid[System.Runtime.Serialization.DataMemberAttribute(Name = \"valid\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"valid\", Order = 0, Required = 2)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Reason()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Reason()"
+        },
+        "System.String Reason[System.Runtime.Serialization.DataMemberAttribute(Name = \"reason\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"reason\", Order = 1)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "LinearRing": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinearRing)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinearRing)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] Positions[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "LineString": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LineString)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LineString)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] get_Positions()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.Position] Positions[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])"
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "LinkedCrs": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinkedCrs)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.LinkedCrs)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.String get_Href()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Href()"
+        },
+        "System.String get_HrefType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_HrefType()"
+        },
+        "System.String Href[System.Runtime.Serialization.DataMemberAttribute(Name = \"href\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String HrefType[System.Runtime.Serialization.DataMemberAttribute(Name = \"hrefType\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "MultiPolygon": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.MultiPolygon)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.MultiPolygon)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] get_Polygons()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] get_Polygons()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates] Polygons[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates])"
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "NamedCrs": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.NamedCrs)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.NamedCrs)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.String get_Name()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Name()"
+        },
+        "System.String Name[System.Runtime.Serialization.DataMemberAttribute(Name = \"name\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Point": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Point)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Point)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position get_Position()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Spatial.Position get_Position()"
+        },
+        "Microsoft.Azure.Cosmos.Spatial.Position Position[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(Double, Double)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Double, Double)"
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position)"
+        },
+        "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Spatial.Position, Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Polygon": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Polygon)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Polygon)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] Rings[System.Runtime.Serialization.DataMemberAttribute(Name = \"coordinates\")]-[Newtonsoft.Json.JsonPropertyAttribute(\"coordinates\", Order = 1, Required = 2)]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])"
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing], Microsoft.Azure.Cosmos.Spatial.GeometryParams)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing], Microsoft.Azure.Cosmos.Spatial.GeometryParams)"
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.Position])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "PolygonCoordinates": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.PolygonCoordinates)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] get_Rings()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[Microsoft.Azure.Cosmos.Spatial.LinearRing] Rings[System.Runtime.Serialization.DataMemberAttribute(Name = \"rings\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[Microsoft.Azure.Cosmos.Spatial.LinearRing])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Position": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Position)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.Spatial.Position)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Double get_Latitude()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_Latitude()"
+        },
+        "Double get_Longitude()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_Longitude()"
+        },
+        "Double Latitude": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Double Longitude": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[System.Double] Coordinates[System.Runtime.Serialization.DataMemberAttribute(Name = \"Coordinates\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "DataMemberAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Collections.ObjectModel.ReadOnlyCollection`1[System.Double] get_Coordinates()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.ReadOnlyCollection`1[System.Double] get_Coordinates()"
+        },
+        "System.Nullable`1[System.Double] Altitude": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Double] get_Altitude()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Double] get_Altitude()"
+        },
+        "Void .ctor(Double, Double)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Double, Double)"
+        },
+        "Void .ctor(Double, Double, System.Nullable`1[System.Double])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(Double, Double, System.Nullable`1[System.Double])"
+        },
+        "Void .ctor(System.Collections.Generic.IList`1[System.Double])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IList`1[System.Double])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "SpatialPath": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.BoundingBoxProperties BoundingBox[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"boundingBox\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.BoundingBoxProperties get_BoundingBox()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.BoundingBoxProperties get_BoundingBox()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] get_SpatialTypes()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] get_SpatialTypes()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.SpatialType] SpatialTypes[Newtonsoft.Json.JsonPropertyAttribute(ItemConverterType = typeof(Newtonsoft.Json.Converters.StringEnumConverter), PropertyName = \"types\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_Path()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Path()"
+        },
+        "System.String Path[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"path\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_BoundingBox(Microsoft.Azure.Cosmos.BoundingBoxProperties)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_BoundingBox(Microsoft.Azure.Cosmos.BoundingBoxProperties)"
+        },
+        "Void set_Path(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Path(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "SpatialType": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.SpatialType LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.SpatialType MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.SpatialType Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.SpatialType Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ThroughputProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_Throughput()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_Throughput()"
+        },
+        "System.Nullable`1[System.Int32] Throughput": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "ThroughputResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.ThroughputProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ThroughputProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.ThroughputProperties op_Implicit(Microsoft.Azure.Cosmos.ThroughputResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ThroughputProperties op_Implicit(Microsoft.Azure.Cosmos.ThroughputResponse)"
+        },
+        "Microsoft.Azure.Cosmos.ThroughputProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Boolean] get_IsReplacePending()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Boolean] get_IsReplacePending()"
+        },
+        "System.Nullable`1[System.Boolean] IsReplacePending": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_MinThroughput()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MinThroughput()"
+        },
+        "System.Nullable`1[System.Int32] MinThroughput": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TransactionalBatch": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.TransactionalBatch CreateItem[T](T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch CreateItem[T](T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch CreateItemStream(System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch CreateItemStream(System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch DeleteItem(System.String, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch DeleteItem(System.String, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch ReadItem(System.String, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch ReadItem(System.String, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItem[T](System.String, T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItem[T](System.String, T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItemStream(System.String, System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch ReplaceItemStream(System.String, System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch UpsertItem[T](T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch UpsertItem[T](T, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatch UpsertItemStream(System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatch UpsertItemStream(System.IO.Stream, Microsoft.Azure.Cosmos.TransactionalBatchItemRequestOptions)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.TransactionalBatchResponse] ExecuteAsync(System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.TransactionalBatchResponse] ExecuteAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TransactionalBatchItemRequestOptions": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] get_IndexingDirective()"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective] IndexingDirective": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_IndexingDirective(System.Nullable`1[Microsoft.Azure.Cosmos.IndexingDirective])"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TransactionalBatchOperationResult": {
+      "Subclasses": {
+        "TransactionalBatchOperationResult`1": {
+          "Subclasses": {},
+          "Members": {
+            "T get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "T get_Resource()"
+            },
+            "T Resource": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": null
+            },
+            "Void set_Resource(T)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_Resource(T)"
+            }
+          },
+          "NestedTypes": {}
+        }
+      },
+      "Members": {
+        "Boolean get_IsSuccessStatusCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsSuccessStatusCode()"
+        },
+        "Boolean IsSuccessStatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.IO.Stream get_ResourceStream()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.IO.Stream get_ResourceStream()"
+        },
+        "System.IO.Stream ResourceStream": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.TimeSpan get_RetryAfter()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.TimeSpan get_RetryAfter()"
+        },
+        "System.TimeSpan RetryAfter": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TransactionalBatchOperationResult`1": {
+      "Subclasses": {},
+      "Members": {
+        "T get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "T get_Resource()"
+        },
+        "T Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void set_Resource(T)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Resource(T)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "TransactionalBatchResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_IsSuccessStatusCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean get_IsSuccessStatusCode()"
+        },
+        "Boolean IsSuccessStatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 Count": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 get_Count()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 get_Count()"
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatchOperationResult get_Item(Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatchOperationResult get_Item(Int32)"
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatchOperationResult Item [Int32]": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.TransactionalBatchOperationResult`1[T] GetOperationResultAtIndex[T](Int32)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.TransactionalBatchOperationResult`1[T] GetOperationResultAtIndex[T](Int32)"
+        },
+        "System.Collections.Generic.IEnumerable`1[System.String] GetActivityIds()[System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.TransactionalBatchResponse+<GetActivityIds>d__47))]": {
+          "Type": "Method",
+          "Attributes": [
+            "IteratorStateMachineAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IEnumerable`1[System.String] GetActivityIds()"
+        },
+        "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.TransactionalBatchOperationResult] GetEnumerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IEnumerator`1[Microsoft.Azure.Cosmos.TransactionalBatchOperationResult] GetEnumerator()"
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.TimeSpan] get_RetryAfter()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_RetryAfter()"
+        },
+        "System.Nullable`1[System.TimeSpan] RetryAfter": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ErrorMessage": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ErrorMessage()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ErrorMessage()"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UniqueKey": {
+      "Subclasses": {},
+      "Members": {
+        "System.Collections.ObjectModel.Collection`1[System.String] get_Paths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[System.String] get_Paths()"
+        },
+        "System.Collections.ObjectModel.Collection`1[System.String] Paths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"paths\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UniqueKeyPolicy": {
+      "Subclasses": {},
+      "Members": {
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.UniqueKey] get_UniqueKeys()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.UniqueKey] get_UniqueKeys()"
+        },
+        "System.Collections.ObjectModel.Collection`1[Microsoft.Azure.Cosmos.UniqueKey] UniqueKeys[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"uniqueKeys\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "User": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetPermissionQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetPermissionQueryIterator[T](Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetPermissionQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.FeedIterator`1[T] GetPermissionQueryIterator[T](System.String, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)"
+        },
+        "Microsoft.Azure.Cosmos.Permission GetPermission(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Permission GetPermission(System.String)"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] CreatePermissionAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] CreatePermissionAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] UpsertPermissionAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.PermissionResponse] UpsertPermissionAsync(Microsoft.Azure.Cosmos.PermissionProperties, System.Nullable`1[System.Int32], Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] DeleteAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] ReadAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] ReadAsync(Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        },
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] ReplaceAsync(Microsoft.Azure.Cosmos.UserProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.UserResponse] ReplaceAsync(Microsoft.Azure.Cosmos.UserProperties, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UserProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified[Newtonsoft.Json.JsonConverterAttribute(typeof(Microsoft.Azure.Documents.UnixDateTimeConverter))]-[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_ts\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String ETag[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_etag\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ETag()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_SelfLink()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SelfLink()"
+        },
+        "System.String Id[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"id\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "System.String SelfLink[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"_self\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": null
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "UserResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Double get_RequestCharge()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double get_RequestCharge()"
+        },
+        "Double RequestCharge": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics Diagnostics": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosDiagnostics get_Diagnostics()"
+        },
+        "Microsoft.Azure.Cosmos.Headers get_Headers()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Headers get_Headers()"
+        },
+        "Microsoft.Azure.Cosmos.Headers Headers": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.User get_User()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.User get_User()"
+        },
+        "Microsoft.Azure.Cosmos.User op_Implicit(Microsoft.Azure.Cosmos.UserResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.User op_Implicit(Microsoft.Azure.Cosmos.UserResponse)"
+        },
+        "Microsoft.Azure.Cosmos.User User": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.UserProperties get_Resource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.UserProperties get_Resource()"
+        },
+        "Microsoft.Azure.Cosmos.UserProperties Resource": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Net.HttpStatusCode get_StatusCode()"
+        },
+        "System.Net.HttpStatusCode StatusCode": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ActivityId": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_ActivityId()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ActivityId()"
+        },
+        "System.String get_ETag()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_ETag()"
+        }
+      },
+      "NestedTypes": {}
+    }
+  },
+  "Members": {
+    "Boolean Equals(System.Object)": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "Boolean Equals(System.Object)"
+    },
+    "Boolean Equals(System.Object, System.Object)": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "Boolean Equals(System.Object, System.Object)"
+    },
+    "Boolean ReferenceEquals(System.Object, System.Object)": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "Boolean ReferenceEquals(System.Object, System.Object)"
+    },
+    "Int32 GetHashCode()": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "Int32 GetHashCode()"
+    },
+    "System.String ToString()": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "System.String ToString()"
+    },
+    "System.Type GetType()": {
+      "Type": "Method",
+      "Attributes": [],
+      "MethodInfo": "System.Type GetType()"
+    },
+    "Void .ctor()": {
+      "Type": "Constructor",
+      "Attributes": [],
+      "MethodInfo": "Void .ctor()"
+    }
+  },
+  "NestedTypes": {}
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/Microsoft.Azure.Cosmos.Tests.Internal.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/Microsoft.Azure.Cosmos.Tests.Internal.csproj
@@ -1,0 +1,44 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Platform>AnyCPU</Platform>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="testbaseline.cmd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="DotNetSDKAPI.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  
+</Project>
+

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/testbaseline.cmd
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/testbaseline.cmd
@@ -1,0 +1,113 @@
+@echo off
+
+set COMMAND=
+set TEST_OUTPUT_PATH=
+set TEST_BASELINE_PATH=
+set TEST_BASELINE_SOURCE_PATH=
+
+:parse_parameters_loop
+if /I "%1"=="" goto :done_parse_parameters
+if /I "%1"=="/?" goto :usage
+if /I "%1"=="-?" goto :usage
+
+if /I "%1"=="/diff" set COMMAND=diff
+if /I "%1"=="/update" set COMMAND=update
+
+if /I "%1"=="/outputpath" (
+  set TEST_OUTPUT_PATH=%2
+  shift
+)
+
+if /I "%1"=="/baselinepath" (
+  set TEST_BASELINE_PATH=%2
+  shift
+)
+
+if /I "%1"=="/baselinesourcepath" (
+  set TEST_BASELINE_SOURCE_PATH=%2
+  shift
+)
+shift
+goto :parse_parameters_loop
+:done_parse_parameters
+if "%COMMAND%"=="" goto :usage
+
+:setup
+if "%TEST_BASELINE_PATH%"=="" (
+  if EXIST "bin\Debug\netcoreapp2.0\DotNetSDKAPI.json" (
+    set TEST_BASELINE_PATH=bin\Debug\netcoreapp2.0
+  ) else (
+    set TEST_BASELINE_PATH=bin\Release\netcoreapp2.0
+  )
+)
+
+if "%TEST_OUTPUT_PATH%"=="" (
+  if EXIST "bin\Debug\netcoreapp2.0\DotNetSDKAPIChanges.json" (
+    set TEST_OUTPUT_PATH=bin\Debug\netcoreapp2.0
+  ) else (
+    set TEST_OUTPUT_PATH=bin\Release\netcoreapp2.0
+  )
+)
+
+if "%TEST_BASELINE_SOURCE_PATH%"=="" (
+  set TEST_BASELINE_SOURCE_PATH=%cd%
+)
+
+echo Settings:
+set TEST_BASELINE_PATH
+set TEST_OUTPUT_PATH
+
+:done_setup
+
+@rem ---------------------------------------------------------------------------
+:run
+if "%COMMAND%"=="diff" call :do_diff
+if "%COMMAND%"=="update" call :do_update
+goto :eof
+@rem ---------------------------------------------------------------------------
+
+@rem ---------------------------------------------------------------------------
+@rem PROCEDURE :usage
+@rem ---------------------------------------------------------------------------
+:usage
+echo usage: testbaselines.cmd [options...]
+echo options:
+echo   /diff                Compares the test outputs with the expected baselines.
+echo   /update              Updates the expected baselines. 
+echo                        This will copy test outputs and override the expected baselines.
+echo   /outputpath ^<path^>   Specifies the test output path.
+echo                        If not specified, default path will be used. 
+echo   /baselinepath ^<path^> Specifies the expected baselines path.
+echo                        If not specified, default path will be used.
+echo   /baselinesourcepath ^<path^> Specifies the expected baselines source path / project path.
+echo                        If not specified, default path will be used.
+goto :eof
+@rem ---------------------------------------------------------------------------
+
+
+@rem ---------------------------------------------------------------------------
+@rem PROCEDURE :do_diff
+@rem ---------------------------------------------------------------------------
+:do_diff
+echo Calling windiff...
+call windiff "%TEST_BASELINE_PATH%\DotNetSDKAPI.json" "%TEST_OUTPUT_PATH%\DotNetSDKAPIChanges.json"
+
+echo Done.
+goto :eof
+@rem ---------------------------------------------------------------------------
+
+@rem ---------------------------------------------------------------------------
+@rem PROCEDURE :do_update
+@rem ---------------------------------------------------------------------------
+:do_update
+echo Calling Updating baselines...
+
+echo .tmp >__exclude.tmp
+echo xcopy "%TEST_OUTPUT_PATH%\DotNetSDKAPIChanges.json" "%TEST_BASELINE_SOURCE_PATH%\DotNetSDKAPI.json" /Q /Y
+xcopy "%TEST_OUTPUT_PATH%\DotNetSDKAPIChanges.json" "%TEST_BASELINE_SOURCE_PATH%\DotNetSDKAPI.json" /Q /Y 
+
+echo Done.
+goto :eof
+@rem ---------------------------------------------------------------------------
+
+

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -28,6 +28,26 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.Tests
       
 - job:
+  displayName: Tests.Internal ${{ parameters.BuildConfiguration }}
+  pool:
+    vmImage: ${{ parameters.VmImage }}
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  - task: DotNetCoreCLI@2
+    displayName: Microsoft.Azure.Cosmos.Tests.Internal
+    condition: succeeded()
+    inputs:
+      command: test
+      projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Internal/*.csproj'
+      arguments: ${{ parameters.Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      publishTestResults: true
+      nugetConfigPath: NuGet.config
+      testRunTitle: Microsoft.Azure.Cosmos.Tests.Internal
+      
+- job:
   displayName: PerformanceTests ${{ parameters.BuildConfiguration }}
   pool:
     vmImage: ${{ parameters.VmImage }}


### PR DESCRIPTION
## Description

This PR adds a new test project that verifies contract breaking changes for methods and properties using `INTERNAL` build constant.