### PR TITLE
NonNullable<T>

### DIFF
--- a/Microsoft.Azure.Cosmos/src/NonNullable.cs
+++ b/Microsoft.Azure.Cosmos/src/NonNullable.cs
@@ -1,0 +1,57 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    internal readonly struct NonNullable<T> : IEquatable<NonNullable<T>>
+        where T : class
+    {
+        public NonNullable(T reference)
+        {
+            if (reference == null)
+            {
+                throw new ArgumentNullException(nameof(reference));
+            }
+
+            this.Reference = reference;
+        }
+
+        public T Reference { get; }
+
+        public bool Equals(NonNullable<T> other)
+        {
+            return this.Reference.Equals(other.Reference);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is T reference)
+            {
+                return this.Equals(reference);
+            }
+
+            if (obj is NonNullable<T> nonNullable)
+            {
+                return this.Equals(nonNullable);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Reference.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return this.Reference.ToString();
+        }
+
+        public static implicit operator T(NonNullable<T> nonNullable) => nonNullable.Reference;
+        public static implicit operator NonNullable<T>(T reference) => new NonNullable<T>(reference);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/AsyncLazy.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/AsyncLazy.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core
 
     internal sealed class AsyncLazy<T>
     {
-        private readonly Func<CancellationToken, Task<T>> valueFactory;
+        private readonly NonNullable<Func<CancellationToken, Task<T>>> valueFactory;
         private T value;
 
         public AsyncLazy(Func<CancellationToken, Task<T>> valueFactory)
         {
-            this.valueFactory = valueFactory ?? throw new ArgumentNullException(nameof(valueFactory));
+            this.valueFactory = valueFactory;
         }
 
         public bool ValueInitialized { get; private set; }
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core
             cancellationToken.ThrowIfCancellationRequested();
             if (!this.ValueInitialized)
             {
-                this.value = await this.valueFactory(cancellationToken);
+                this.value = await this.valueFactory.Reference(cancellationToken);
                 this.ValueInitialized = true;
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/NonNullableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/NonNullableTests.cs
@@ -28,21 +28,23 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void ImplicitConversion_ValueToNonNullable()
         {
-            void Blah(NonNullable<object> foo)
+            void Blah(NonNullable<MyClass> foo)
             {
             }
 
-            Blah(new object());
+            Blah(new MyClass());
         }
 
         [TestMethod]
         public void ImplicitConversion_NonNullableToValue()
         {
-            void Blah(object foo)
+            void Blah(MyClass foo)
             {
             }
 
-            Blah(new NonNullable<object>(new object()));
+            NonNullable<MyClass> nonNullable = new NonNullable<MyClass>(new MyClass());
+            ((MyClass)nonNullable).Foo();
+            Blah(nonNullable);
         }
 
         [TestMethod]
@@ -67,6 +69,13 @@ namespace Microsoft.Azure.Cosmos.Tests
             object reference = new object();
             NonNullable<object> nonNullable = new NonNullable<object>(reference);
             Assert.AreEqual(nonNullable.ToString(), reference.ToString());
+        }
+
+        private sealed class MyClass
+        {
+            public void Foo()
+            {
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/NonNullableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/NonNullableTests.cs
@@ -1,0 +1,72 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class NonNullableTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Constructor_Null()
+        {
+            NonNullable<object> nonNullable = new NonNullable<object>(null);
+        }
+
+        [TestMethod]
+        public void Constructor_NonNull()
+        {
+            object nonNull = new object();
+            NonNullable<object> nonNullable = new NonNullable<object>(nonNull);
+            Assert.AreEqual(nonNull, nonNullable.Reference);
+        }
+
+        [TestMethod]
+        public void ImplicitConversion_ValueToNonNullable()
+        {
+            void Blah(NonNullable<object> foo)
+            {
+            }
+
+            Blah(new object());
+        }
+
+        [TestMethod]
+        public void ImplicitConversion_NonNullableToValue()
+        {
+            void Blah(object foo)
+            {
+            }
+
+            Blah(new NonNullable<object>(new object()));
+        }
+
+        [TestMethod]
+        public void TestEquals()
+        {
+            object reference = new object();
+            NonNullable<object> nonNullable = new NonNullable<object>(reference);
+            Assert.AreEqual(nonNullable, reference);
+        }
+
+        [TestMethod]
+        public void TestGetHashCode()
+        {
+            object reference = new object();
+            NonNullable<object> nonNullable = new NonNullable<object>(reference);
+            Assert.AreEqual(nonNullable.GetHashCode(), reference.GetHashCode());
+        }
+
+        [TestMethod]
+        public void TestToString()
+        {
+            object reference = new object();
+            NonNullable<object> nonNullable = new NonNullable<object>(reference);
+            Assert.AreEqual(nonNullable.ToString(), reference.ToString());
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/FeedOptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/FeedOptionTests.cs
@@ -21,10 +21,10 @@ namespace Microsoft.Azure.Cosmos.Query
         public async Task CheckConsistencyLevel()
         {
             FeedOptions fo = new FeedOptions();
-            var dcClient = new Mock<IDocumentQueryClient>();
+            Mock<IDocumentQueryClient> dcClient = new Mock<IDocumentQueryClient>();
             Expression<Func<int, int>> randomFunc = x => x * 2;
 
-            var cxt = new TestQueryExecutionContext(
+            TestQueryExecutionContext cxt = new TestQueryExecutionContext(
                 dcClient.Object, 
                 ResourceType.Document, 
                 typeof(TestQueryExecutionContext),


### PR DESCRIPTION
# NonNullable<T>

## Description

This PR adds a struct to enforce that a reference type is not `null`. C#8 adds this as a language feature, but it needs to be turned on through a configuration (and all kinds of compile time errors need to be fix). Usually new projects will set it from the beginning. This offers a middle ground solution where we mimic `Nullable<T>`, but instead of wrapping a struct we wrap a class and check that the reference is not `null`. We can make fields `NonNullable<T>`, which will ensure that the field never becomes `null` throughout it's lifetime. If we make a constructor parameter `NonNullable<T>`, then we are annotating to our callers that the parameter is not allowed to be `null`. Implicit conversions have been added to aid the passing of this types across function calls. The only problem is that we can't access the inner types members without going through `.Reference`, since c# doesn't allow implicit conversions to interfaces. `Equals`, `ToString`, and `GetHashCode` act as if they are reference type itself. 

A few examples have been added of wiring up `NonNullable<T>`. In the future I will be creating classes with this type.
