### PR TITLE
Nullable Enable

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -114,7 +114,7 @@
     <DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
     <DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
     <DefineConstants>$(DefineConstants);DOCDBCLIENT;COSMOSCLIENT;NETSTANDARD20</DefineConstants>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate;
@@ -84,6 +83,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     /// This bubbles down until you reach a component that has a DocumentProducer that fetches a document from the backend.
     /// </para>
     /// </summary>
+#nullable enable
     internal sealed class PipelinedDocumentQueryExecutionContext : CosmosQueryExecutionContext
     {
         /// <summary>
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 };
             }
 
-            if (queryInfo.HasOffset)
+            if (queryInfo.Offset.HasValue)
             {
                 Func<CosmosElement, Task<TryCatch<IDocumentQueryExecutionComponent>>> tryCreateSourceAsync = tryCreatePipelineAsync;
                 tryCreatePipelineAsync = async (continuationToken) =>
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 };
             }
 
-            if (queryInfo.HasLimit)
+            if (queryInfo.Limit.HasValue)
             {
                 Func<CosmosElement, Task<TryCatch<IDocumentQueryExecutionComponent>>> tryCreateSourceAsync = tryCreatePipelineAsync;
                 tryCreatePipelineAsync = async (continuationToken) =>
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 };
             }
 
-            if (queryInfo.HasTop)
+            if (queryInfo.Top.HasValue)
             {
                 Func<CosmosElement, Task<TryCatch<IDocumentQueryExecutionComponent>>> tryCreateSourceAsync = tryCreatePipelineAsync;
                 tryCreatePipelineAsync = async (continuationToken) =>
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     return queryResponse;
                 }
 
-                string updatedContinuationToken;
+                string? updatedContinuationToken;
                 if (queryResponse.DisallowContinuationTokenMessage == null)
                 {
                     if (queryResponse.ContinuationToken != null)


### PR DESCRIPTION
# Nullable Enable

## Description

This PR shows the alternative way to remove null in the codebase. We can bump the lang version to 8.0 and use the `#nullable enable` macro to opt into the nullable reference feature one file at a time. When the entire code base has this set we can flip the default and remove this macro. 

