### PR TITLE
ChangeFeed Resume From StartTime Test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 Assert.IsTrue(document.TryGetValue("_ts", out CosmosNumber localTimeStamp));
                 long localSecondsSinceEpoch = Number64.ToLong(localTimeStamp.Value);
-                return localSecondsSinceEpoch >= secondsSinceEpoch;
+                return localSecondsSinceEpoch > secondsSinceEpoch;
             }).Count();
 
             Assert.AreEqual(expectedCount, totalCount);


### PR DESCRIPTION
# ChangeFeed Resume From StartTime Test

## Description

Adds a test for changefeed resuming from a start time. The test inserts a bunch of documents and starts from a random documents timestamp. The result set is not as expected. It's very possible that I wrote the test incorrectly, but I think it's a bug from visual inspection.

I've marked the test as ignore. If the PR get's merged the test can be turned on to avoid regressions along with the PR that fixes the bug. 
