### PR TITLE
Diagnostics: Fix diagnostics to always show correct total time

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 this.remainingWorkEstimator = new RemainingWorkEstimatorCore(
                    this.documentServiceLeaseStoreManager.LeaseContainer,
                    feedCreator,
-                   this.monitoredContainer.ClientContext.Client.ClientOptions?.GatewayModeMaxConnectionLimit ?? 1);
+                   this.monitoredContainer.ClientContext.ClientOptions?.GatewayModeMaxConnectionLimit ?? 1);
             }
 
             ChangeFeedEstimatorDispatcher estimatorDispatcher = new ChangeFeedEstimatorDispatcher(this.initialEstimateDelegate, this.estimatorPeriod);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                 CultureInfo.InvariantCulture,
                 "{0}{1}_{2}",
                 optionsPrefix,
-                ((ContainerCore)monitoredContainer).ClientContext.Client.Endpoint.Host,
+                ((ContainerCore)monitoredContainer).ClientContext.Endpoint.Host,
                 monitoredContainerRid);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -104,7 +104,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             }
 
             string containerRid = await ((ContainerCore)monitoredContainer).GetRIDAsync(cancellationToken);
-            string databaseRid = await ((DatabaseCore)((ContainerCore)monitoredContainer).Database).GetRIDAsync(cancellationToken);
+            string databaseRid = await ((ContainerInlineCore)monitoredContainer).DatabaseInlineCore.GetRIDAsync(
+                EmptyCosmosDiagnosticsContext.Singleton,
+                cancellationToken);
+
             return $"{databaseRid}_{containerRid}";
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -95,6 +95,18 @@ namespace Microsoft.Azure.Cosmos
     {
         private readonly CosmosClientCore cosmosClientCore;
 
+        static CosmosClient()
+        {
+            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
+            HttpConstants.Versions.CurrentVersionUTF8 = Encoding.UTF8.GetBytes(HttpConstants.Versions.CurrentVersion);
+
+            // V3 always assumes assemblies exists
+            // Shall revisit on feedback
+            // NOTE: Native ServiceInteropWrapper.AssembliesExist has appsettings dependency which are proofed for CTL (native dll entry) scenarios.
+            // Revert of this depends on handling such in direct assembly
+            ServiceInteropWrapper.AssembliesExist = new Lazy<bool>(() => true);
+        }
+
         /// <summary>
         /// Create a new CosmosClient used for mock testing
         /// </summary>
@@ -248,7 +260,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="id">The Cosmos database id</param>
         /// <remarks>
         /// <see cref="Database"/> proxy reference doesn't guarantee existence.
-        /// Please ensure database exists through <see cref="CosmosClient.CreateDatabaseAsync(DatabaseProperties, int?, RequestOptions, CancellationToken)"/> 
+        /// Please ensure database exists through <see cref="CosmosClient.CreateDatabaseAsync(string, int?, RequestOptions, CancellationToken)"/> 
         /// or <see cref="CosmosClient.CreateDatabaseIfNotExistsAsync(string, int?, RequestOptions, CancellationToken)"/>, before
         /// operating on it.
         /// </remarks>
@@ -499,7 +511,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return new FeedIteratorInlineCore<T>(
-                this.cosmosClientCore.GetDatabaseQueryIterator< T>(
+                this.cosmosClientCore.GetDatabaseQueryIterator<T>(
                     queryDefinition,
                     continuationToken,
                     requestOptions));
@@ -547,7 +559,7 @@ namespace Microsoft.Azure.Cosmos
         {
             return new FeedIteratorInlineCore(
                 this.cosmosClientCore.GetDatabaseQueryStreamIterator(
-                    queryDefinition,
+                    queryText,
                     continuationToken,
                     requestOptions));
         }
@@ -581,6 +593,7 @@ namespace Microsoft.Azure.Cosmos
                     databaseProperties,
                     throughput,
                     requestOptions,
+                    diagnostics,
                     cancellationToken));
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientCore.cs
@@ -1,0 +1,404 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Handlers;
+    using Microsoft.Azure.Documents;
+
+    internal sealed class CosmosClientCore : IDisposable
+    {
+        private readonly Uri DatabaseRootUri = new Uri(Paths.Databases_Root, UriKind.Relative);
+        private ConsistencyLevel? accountConsistencyLevel;
+        private bool isDisposed = false;
+
+        static CosmosClientCore()
+        {
+            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
+            HttpConstants.Versions.CurrentVersionUTF8 = Encoding.UTF8.GetBytes(HttpConstants.Versions.CurrentVersion);
+
+            // V3 always assumes assemblies exists
+            // Shall revisit on feedback
+            // NOTE: Native ServiceInteropWrapper.AssembliesExist has appsettings dependency which are proofed for CTL (native dll entry) scenarios.
+            // Revert of this depends on handling such in direct assembly
+            ServiceInteropWrapper.AssembliesExist = new Lazy<bool>(() => true);
+        }
+
+        public CosmosClientCore(
+            string accountEndpoint,
+            string authKeyOrResourceToken,
+            CosmosClientOptions clientOptions)
+        {
+            if (accountEndpoint == null)
+            {
+                throw new ArgumentNullException(nameof(accountEndpoint));
+            }
+
+            if (authKeyOrResourceToken == null)
+            {
+                throw new ArgumentNullException(nameof(authKeyOrResourceToken));
+            }
+
+            this.Endpoint = new Uri(accountEndpoint);
+            this.AccountKey = authKeyOrResourceToken;
+
+            this.ClientContext = ClientContextCore.Create(
+                this,
+                clientOptions);
+        }
+
+        internal CosmosClientCore(
+            string accountEndpoint,
+            string authKeyOrResourceToken,
+            CosmosClientOptions cosmosClientOptions,
+            DocumentClient documentClient)
+        {
+            if (accountEndpoint == null)
+            {
+                throw new ArgumentNullException(nameof(accountEndpoint));
+            }
+
+            if (authKeyOrResourceToken == null)
+            {
+                throw new ArgumentNullException(nameof(authKeyOrResourceToken));
+            }
+
+            if (cosmosClientOptions == null)
+            {
+                throw new ArgumentNullException(nameof(cosmosClientOptions));
+            }
+
+            if (documentClient == null)
+            {
+                throw new ArgumentNullException(nameof(documentClient));
+            }
+
+            this.Endpoint = new Uri(accountEndpoint);
+            this.AccountKey = authKeyOrResourceToken;
+
+            this.ClientContext = ClientContextCore.Create(
+                 this,
+                 documentClient,
+                 cosmosClientOptions);
+        }
+
+        public CosmosClientOptions ClientOptions => this.ClientContext.ClientOptions;
+        public Uri Endpoint { get; }
+        internal string AccountKey { get; }
+        internal DocumentClient DocumentClient => this.ClientContext.DocumentClient;
+        internal RequestInvokerHandler RequestHandler => this.ClientContext.RequestHandler;
+        internal CosmosClientContext ClientContext { get; }
+
+        public Task<AccountProperties> ReadAccountAsync()
+        {
+            return ((IDocumentClientInternal)this.DocumentClient).GetDatabaseAccountInternalAsync(this.Endpoint);
+        }
+
+        internal DatabaseInlineCore GetDatabase(string id)
+        {
+            return new DatabaseInlineCore(this.ClientContext, id);
+        }
+
+        public Container GetContainer(string databaseId, string containerId)
+        {
+            if (string.IsNullOrEmpty(databaseId))
+            {
+                throw new ArgumentNullException(nameof(databaseId));
+            }
+
+            if (string.IsNullOrEmpty(containerId))
+            {
+                throw new ArgumentNullException(nameof(containerId));
+            }
+
+            return this.GetDatabase(databaseId).GetContainer(containerId);
+        }
+
+        public Task<DatabaseResponse> CreateDatabaseAsync(
+                string id,
+                int? throughput,
+                RequestOptions requestOptions,
+                CosmosDiagnosticsContext diagnostics,
+                CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
+            return this.CreateDatabaseAsync(
+                databaseProperties: databaseProperties,
+                throughput: throughput,
+                requestOptions: requestOptions,
+                diagnostics: diagnostics,
+                cancellationToken: cancellationToken);
+        }
+
+        public async Task<DatabaseResponse> CreateDatabaseIfNotExistsAsync(
+            string id,
+            int? throughput,
+            RequestOptions requestOptions,
+            CosmosDiagnosticsContext diagnosticsContext,
+            CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            // Doing a Read before Create will give us better latency for existing databases
+            DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
+            DatabaseInlineCore databaseInlineCore = this.GetDatabase(id);
+            DatabaseCore databaseCore = databaseInlineCore.DatabaseCore;
+            ResponseMessage readResponse = await databaseCore.ReadStreamAsync(
+                requestOptions: requestOptions,
+                diagnosticsContext: diagnosticsContext,
+                cancellationToken: cancellationToken);
+
+            if (readResponse.StatusCode != HttpStatusCode.NotFound)
+            {
+                return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(databaseInlineCore, Task.FromResult(readResponse));
+            }
+
+            ResponseMessage createResponse = await this.CreateDatabaseStreamAsync(
+                databaseProperties,
+                throughput,
+                requestOptions,
+                diagnosticsContext,
+                cancellationToken);
+
+            // Merge the diagnostics with the first read request.
+            createResponse.DiagnosticsContext.AddDiagnosticsInternal(readResponse.DiagnosticsContext);
+            if (createResponse.StatusCode != HttpStatusCode.Conflict)
+            {
+                return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(databaseInlineCore, Task.FromResult(createResponse));
+            }
+
+            // This second Read is to handle the race condition when 2 or more threads have Read the database and only one succeeds with Create
+            // so for the remaining ones we should do a Read instead of throwing Conflict exception
+            ResponseMessage readResponseAfterConflict = await databaseCore.ReadStreamAsync(
+                requestOptions: requestOptions,
+                diagnosticsContext: diagnosticsContext,
+                cancellationToken: cancellationToken);
+
+            return await this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(databaseInlineCore, Task.FromResult(readResponseAfterConflict));
+        }
+
+        public FeedIterator<T> GetDatabaseQueryIterator<T>(
+            QueryDefinition queryDefinition,
+            string continuationToken,
+            QueryRequestOptions requestOptions)
+        {
+            return this.GetDatabaseQueryIteratorHelper<T>(
+                    queryDefinition,
+                    continuationToken,
+                    requestOptions);
+        }
+
+        public FeedIterator GetDatabaseQueryStreamIterator(
+            QueryDefinition queryDefinition,
+            string continuationToken,
+            QueryRequestOptions requestOptions)
+        {
+            return this.GetDatabaseQueryStreamIteratorHelper(
+                    queryDefinition,
+                    continuationToken,
+                    requestOptions);
+        }
+
+        public FeedIterator<T> GetDatabaseQueryIterator<T>(
+            string queryText,
+            string continuationToken,
+            QueryRequestOptions requestOptions)
+        {
+            QueryDefinition queryDefinition = null;
+            if (queryText != null)
+            {
+                queryDefinition = new QueryDefinition(queryText);
+            }
+
+            return this.GetDatabaseQueryIteratorHelper<T>(
+                    queryDefinition,
+                    continuationToken,
+                    requestOptions);
+        }
+
+        public FeedIterator GetDatabaseQueryStreamIterator(
+            string queryText,
+            string continuationToken,
+            QueryRequestOptions requestOptions)
+        {
+            QueryDefinition queryDefinition = null;
+            if (queryText != null)
+            {
+                queryDefinition = new QueryDefinition(queryText);
+            }
+
+            return this.GetDatabaseQueryStreamIterator(
+                    queryDefinition,
+                    continuationToken,
+                    requestOptions);
+        }
+
+        public Task<ResponseMessage> CreateDatabaseStreamAsync(
+            DatabaseProperties databaseProperties,
+            int? throughput,
+            RequestOptions requestOptions,
+            CosmosDiagnosticsContext diagnosticsContext,
+            CancellationToken cancellationToken)
+        {
+            if (databaseProperties == null)
+            {
+                throw new ArgumentNullException(nameof(databaseProperties));
+            }
+
+            this.ClientContext.ValidateResource(databaseProperties.Id);
+            Stream streamPayload = this.ClientContext.SerializerCore.ToStream<DatabaseProperties>(databaseProperties);
+
+            return this.CreateDatabaseStreamInternalAsync(
+                    streamPayload,
+                    throughput,
+                    requestOptions,
+                    diagnosticsContext,
+                    cancellationToken);
+        }
+
+        internal async Task<ConsistencyLevel> GetAccountConsistencyLevelAsync()
+        {
+            if (!this.accountConsistencyLevel.HasValue)
+            {
+                this.accountConsistencyLevel = await this.DocumentClient.GetDefaultConsistencyLevelAsync();
+            }
+
+            return this.accountConsistencyLevel.Value;
+        }
+
+        internal DatabaseProperties PrepareDatabaseProperties(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            DatabaseProperties databaseProperties = new DatabaseProperties()
+            {
+                Id = id
+            };
+
+            this.ClientContext.ValidateResource(databaseProperties.Id);
+            return databaseProperties;
+        }
+
+        internal Task<DatabaseResponse> CreateDatabaseAsync(
+                    DatabaseProperties databaseProperties,
+                    int? throughput,
+                    RequestOptions requestOptions,
+                    CosmosDiagnosticsContext diagnostics,
+                    CancellationToken cancellationToken)
+        {
+            Task<ResponseMessage> response = this.CreateDatabaseStreamInternalAsync(
+                streamPayload: this.ClientContext.SerializerCore.ToStream<DatabaseProperties>(databaseProperties),
+                throughput: throughput,
+                requestOptions: requestOptions,
+                diagnostics: diagnostics,
+                cancellationToken: cancellationToken);
+
+            return this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this.GetDatabase(databaseProperties.Id), response);
+        }
+
+        private Task<ResponseMessage> CreateDatabaseStreamInternalAsync(
+                Stream streamPayload,
+                int? throughput,
+                RequestOptions requestOptions,
+                CosmosDiagnosticsContext diagnostics,
+                CancellationToken cancellationToken)
+        {
+            return this.ClientContext.ProcessResourceOperationStreamAsync(
+                resourceUri: this.DatabaseRootUri,
+                resourceType: ResourceType.Database,
+                operationType: OperationType.Create,
+                requestOptions: requestOptions,
+                cosmosContainerCore: null,
+                partitionKey: null,
+                streamPayload: streamPayload,
+                requestEnricher: (httpRequestMessage) => httpRequestMessage.AddThroughputHeader(throughput),
+                diagnosticsContext: diagnostics,
+                cancellationToken: cancellationToken);
+        }
+
+        private FeedIteratorInternal<T> GetDatabaseQueryIteratorHelper<T>(
+           QueryDefinition queryDefinition,
+           string continuationToken,
+           QueryRequestOptions requestOptions)
+        {
+            if (!(this.GetDatabaseQueryStreamIteratorHelper(
+                queryDefinition,
+                continuationToken,
+                requestOptions) is FeedIteratorInternal databaseStreamIterator))
+            {
+                throw new InvalidOperationException($"Expected a FeedIteratorInternal.");
+            }
+
+            return new FeedIteratorCore<T>(
+                    databaseStreamIterator,
+                    (response) => this.ClientContext.ResponseFactory.CreateQueryFeedResponse<T>(
+                        responseMessage: response,
+                        resourceType: ResourceType.Database));
+        }
+
+        private FeedIteratorInternal GetDatabaseQueryStreamIteratorHelper(
+            QueryDefinition queryDefinition,
+            string continuationToken,
+            QueryRequestOptions requestOptions)
+        {
+            return FeedIteratorCore.CreateForNonPartitionedResource(
+               clientContext: this.ClientContext,
+               resourceLink: this.DatabaseRootUri,
+               resourceType: ResourceType.Database,
+               queryDefinition: queryDefinition,
+               continuationToken: continuationToken,
+               options: requestOptions);
+        }
+
+        /// <summary>
+        /// Dispose of cosmos client
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        /// <summary>
+        /// Dispose of cosmos client
+        /// </summary>
+        /// <param name="disposing">True if disposing</param>
+        private void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    this.ClientContext.Dispose();
+                }
+
+                this.isDisposed = true;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException($"Accessing {nameof(CosmosClient)} after it is disposed is invalid.");
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/CosmosClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientCore.cs
@@ -19,18 +19,6 @@ namespace Microsoft.Azure.Cosmos
         private ConsistencyLevel? accountConsistencyLevel;
         private bool isDisposed = false;
 
-        static CosmosClientCore()
-        {
-            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
-            HttpConstants.Versions.CurrentVersionUTF8 = Encoding.UTF8.GetBytes(HttpConstants.Versions.CurrentVersion);
-
-            // V3 always assumes assemblies exists
-            // Shall revisit on feedback
-            // NOTE: Native ServiceInteropWrapper.AssembliesExist has appsettings dependency which are proofed for CTL (native dll entry) scenarios.
-            // Revert of this depends on handling such in direct assembly
-            ServiceInteropWrapper.AssembliesExist = new Lazy<bool>(() => true);
-        }
-
         public CosmosClientCore(
             string accountEndpoint,
             string authKeyOrResourceToken,
@@ -50,7 +38,8 @@ namespace Microsoft.Azure.Cosmos
             this.AccountKey = authKeyOrResourceToken;
 
             this.ClientContext = ClientContextCore.Create(
-                this,
+                this.Endpoint,
+                this.AccountKey,
                 clientOptions);
         }
 
@@ -84,7 +73,7 @@ namespace Microsoft.Azure.Cosmos
             this.AccountKey = authKeyOrResourceToken;
 
             this.ClientContext = ClientContextCore.Create(
-                 this,
+                 this.Endpoint,
                  documentClient,
                  cosmosClientOptions);
         }

--- a/Microsoft.Azure.Cosmos/src/Encryption/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Encryption/EncryptionProcessor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos
         public async Task<Stream> EncryptAsync(
             Stream input,
             EncryptionOptions encryptionOptions,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             EncryptionKeyWrapProvider encryptionKeyWrapProvider,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Cosmos
 
         public async Task<Stream> DecryptAsync(
             Stream input,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             EncryptionKeyWrapProvider encryptionKeyWrapProvider,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos
 
         public async Task<CosmosObject> DecryptAsync(
             CosmosObject document,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             EncryptionKeyWrapProvider encryptionKeyWrapProvider,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task<JObject> DecryptContentAsync(
             EncryptionProperties encryptionProperties,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Cosmos
 
     internal class ClientPipelineBuilder
     {
-        private readonly CosmosClient client;
+        private readonly DocumentClient client;
         private readonly ConsistencyLevel? requestedClientConsistencyLevel;
         private readonly RequestHandler invalidPartitionExceptionRetryHandler;
         private readonly RequestHandler transportHandler;
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos
         private RequestHandler retryHandler;
 
         public ClientPipelineBuilder(
-            CosmosClient client,
+            DocumentClient client,
             ConsistencyLevel? requestedClientConsistencyLevel,
             IReadOnlyCollection<RequestHandler> customHandlers)
         {

--- a/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs
@@ -28,15 +28,15 @@ namespace Microsoft.Azure.Cosmos.Handlers
     /// </summary>
     internal class PartitionKeyRangeHandler : RequestHandler
     {
-        private readonly CosmosClient client;
+        private readonly DocumentClient documentClient;
         private PartitionRoutingHelper partitionRoutingHelper;
-        public PartitionKeyRangeHandler(CosmosClient client, PartitionRoutingHelper partitionRoutingHelper = null)
+        public PartitionKeyRangeHandler(DocumentClient client, PartitionRoutingHelper partitionRoutingHelper = null)
         {
             if (client == null)
             {
                 throw new ArgumentNullException(nameof(client));
             }
-            this.client = client;
+            this.documentClient = client;
             this.partitionRoutingHelper = partitionRoutingHelper ?? new PartitionRoutingHelper();
         }
 
@@ -81,8 +81,8 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 DocumentServiceRequest serviceRequest = request.ToDocumentServiceRequest();
 
-                PartitionKeyRangeCache routingMapProvider = await this.client.DocumentClient.GetPartitionKeyRangeCacheAsync();
-                CollectionCache collectionCache = await this.client.DocumentClient.GetCollectionCacheAsync();
+                PartitionKeyRangeCache routingMapProvider = await this.documentClient.GetPartitionKeyRangeCacheAsync();
+                CollectionCache collectionCache = await this.documentClient.GetCollectionCacheAsync();
                 ContainerProperties collectionFromCache =
                     await collectionCache.ResolveCollectionAsync(serviceRequest, CancellationToken.None);
 

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal async Task AssertPartitioningDetailsAsync(CosmosClient client, CancellationToken cancellationToken)
+        internal async Task AssertPartitioningDetailsAsync(DocumentClient documentClient, CancellationToken cancellationToken)
         {
             if (this.IsMasterOperation())
             {
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Cosmos
 #if DEBUG
             try
             {
-                CollectionCache collectionCache = await client.DocumentClient.GetCollectionCacheAsync();
+                CollectionCache collectionCache = await documentClient.GetCollectionCacheAsync();
                 ContainerProperties collectionFromCache =
                     await collectionCache.ResolveCollectionAsync(this.ToDocumentServiceRequest(), cancellationToken);
                 if (collectionFromCache.PartitionKey?.Paths?.Count > 0)

--- a/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.Cosmos.Handlers
     /// </summary>
     internal class RetryHandler : AbstractRetryHandler
     {
-        private readonly CosmosClient client;
+        private readonly DocumentClient client;
 
-        public RetryHandler(CosmosClient client)
+        public RetryHandler(DocumentClient client)
         {
             if (client == null)
             {
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
         internal override Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(RequestMessage request)
         {
-            IDocumentClientRetryPolicy retryPolicyInstance = this.client.DocumentClient.ResetSessionTokenRetryPolicy.GetRequestPolicy();
+            IDocumentClientRetryPolicy retryPolicyInstance = this.client.ResetSessionTokenRetryPolicy.GetRequestPolicy();
             Debug.Assert(request.OnBeforeSendRequestActions == null, "Cosmos Request message only supports a single retry policy");
             return Task.FromResult(retryPolicyInstance);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Cosmos
 
                     CosmosObject decryptedDocument = await this.clientContext.EncryptionProcessor.DecryptAsync(
                         documentObject,
-                        (DatabaseCore)this.cosmosContainerCore.Database,
+                        this.cosmosContainerCore.Database,
                         this.clientContext.ClientOptions.EncryptionKeyWrapProvider,
                         message.DiagnosticsContext,
                         cancellationToken);

--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/ConflictsInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/ConflictsInlineCore.cs
@@ -28,7 +28,9 @@ namespace Microsoft.Azure.Cosmos
             PartitionKey partitionKey,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.conflicts.DeleteAsync(conflict, partitionKey, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: null,
+                (diagnostics) => this.conflicts.DeleteAsync(conflict, partitionKey, diagnostics, cancellationToken));
         }
 
         public override FeedIterator GetConflictQueryStreamIterator(
@@ -80,7 +82,9 @@ namespace Microsoft.Azure.Cosmos
             PartitionKey partitionKey,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.conflicts.ReadCurrentAsync<T>(cosmosConflict, partitionKey, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: null,
+                (diagnostics) => this.conflicts.ReadCurrentAsync<T>(cosmosConflict, partitionKey, diagnostics, cancellationToken));
         }
 
         public override T ReadConflictContent<T>(ConflictProperties cosmosConflict)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -767,7 +767,7 @@ namespace Microsoft.Azure.Cosmos
                     streamPayload = await this.ClientContext.EncryptionProcessor.EncryptAsync(
                         streamPayload,
                         requestOptions.EncryptionOptions,
-                        (DatabaseCore)this.Database,
+                        this.Database,
                         this.ClientContext.ClientOptions.EncryptionKeyWrapProvider,
                         diagnosticsContext,
                         cancellationToken);
@@ -793,7 +793,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     responseMessage.Content = await this.ClientContext.EncryptionProcessor.DecryptAsync(
                         responseMessage.Content,
-                        (DatabaseCore)this.Database,
+                        this.Database,
                         this.ClientContext.ClientOptions.EncryptionKeyWrapProvider,
                         diagnosticsContext,
                         cancellationToken);

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal ContainerCore(
             CosmosClientContext clientContext,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             string containerId,
             CosmosQueryClient cosmosQueryClient = null)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override string Id { get; }
 
-        public Database Database { get; }
+        public DatabaseInlineCore Database { get; }
 
         internal virtual Uri LinkUri { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Cosmos
                 .ContinueWith(ridTask =>
                 {
                     collectionRID = ridTask.Result;
-                    return this.ClientContext.Client.DocumentClient.GetPartitionKeyRangeCacheAsync();
+                    return this.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 })
                 .Unwrap()
                 .ContinueWith(partitionKeyRangeCachetask =>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInlineCore.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Azure.Cosmos
 
         internal Uri LinkUri => this.container.LinkUri;
 
+        internal DatabaseInlineCore DatabaseInlineCore => this.container.Database;
+
         internal ContainerInlineCore(ContainerCore container)
         {
             if (container == null)

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
@@ -20,10 +20,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal abstract class CosmosClientContext : IDisposable
     {
-        /// <summary>
-        /// The Cosmos client that is used for the request
-        /// </summary>
-        internal abstract CosmosClient Client { get; }
+        internal abstract Uri Endpoint { get; }
 
         internal abstract DocumentClient DocumentClient { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
@@ -113,5 +113,16 @@ namespace Microsoft.Azure.Cosmos
            CancellationToken cancellationToken);
 
         public abstract void Dispose();
+
+        public static async Task<TResult> ProcessHelperAsync<TResult>(
+            RequestOptions requestOptions,
+            Func<CosmosDiagnosticsContext, Task<TResult>> task)
+        {
+            CosmosDiagnosticsContext diagnosticsContext = CosmosDiagnosticsContextCore.Create(requestOptions);
+            using (diagnosticsContext.GetOverallScope())
+            {
+                return await TaskHelper.RunInlineIfNeededAsync(() => task(diagnosticsContext));
+            }
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/DataEncryptionKey/DataEncryptionKeyCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/DataEncryptionKey/DataEncryptionKeyCore.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal DataEncryptionKeyCore(
             CosmosClientContext clientContext,
-            DatabaseCore database,
+            DatabaseInlineCore database,
             string keyId)
         {
             this.Id = keyId;
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns a reference to a database object that contains this encryption key. 
         /// </summary>
-        public Database Database { get; }
+        public DatabaseInlineCore Database { get; }
 
         internal virtual Uri LinkUri { get; }
 
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos
             return response;
         }
 
-        internal static Uri CreateLinkUri(CosmosClientContext clientContext, DatabaseCore database, string keyId)
+        internal static Uri CreateLinkUri(CosmosClientContext clientContext, DatabaseInlineCore database, string keyId)
         {
             return clientContext.CreateLink(
                 parentLink: database.LinkUri.OriginalString,

--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionInlineCore.cs
@@ -15,14 +15,21 @@ namespace Microsoft.Azure.Cosmos
 
         public override string Id => this.permission.Id;
 
-        internal PermissionInlineCore(PermissionCore database)
+        internal PermissionInlineCore(
+            CosmosClientContext clientContext,
+            UserInlineCore user,
+            string userId)
         {
-            if (database == null)
+            if (clientContext == null)
             {
-                throw new ArgumentNullException(nameof(database));
+                throw new ArgumentNullException(nameof(clientContext));
             }
 
-            this.permission = database;
+            this.permission = new PermissionCore(
+                this,
+                clientContext,
+                user,
+                userId);
         }
 
         public override Task<PermissionResponse> ReadAsync(
@@ -30,7 +37,9 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.ReadAsync(tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.permission.ReadAsync(tokenExpiryInSeconds, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<PermissionResponse> ReplaceAsync(
@@ -39,14 +48,18 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.ReplaceAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.permission.ReplaceAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<PermissionResponse> DeleteAsync(
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.DeleteAsync(requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.permission.DeleteAsync(requestOptions, diagnostics, cancellationToken));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsInlineCore.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.CreateStoredProcedureAsync(storedProcedureProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override FeedIterator<T> GetStoredProcedureQueryIterator<T>(
@@ -81,7 +83,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadStoredProcedureAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReadStoredProcedureAsync(id, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<StoredProcedureResponse> ReplaceStoredProcedureAsync(
@@ -89,7 +93,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReplaceStoredProcedureAsync(storedProcedureProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<StoredProcedureResponse> DeleteStoredProcedureAsync(
@@ -97,7 +103,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteStoredProcedureAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.DeleteStoredProcedureAsync(id, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<StoredProcedureExecuteResponse<TOutput>> ExecuteStoredProcedureAsync<TOutput>(
@@ -107,7 +115,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureAsync<TOutput>(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ExecuteStoredProcedureAsync<TOutput>(storedProcedureId, partitionKey, parameters, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<ResponseMessage> ExecuteStoredProcedureStreamAsync(
@@ -117,7 +127,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, partitionKey, parameters, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<ResponseMessage> ExecuteStoredProcedureStreamAsync(
@@ -127,7 +139,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, streamPayload, partitionKey, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, streamPayload, partitionKey, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<TriggerResponse> CreateTriggerAsync(
@@ -135,7 +149,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateTriggerAsync(triggerProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.CreateTriggerAsync(triggerProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override FeedIterator<T> GetTriggerQueryIterator<T>(
@@ -187,7 +203,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadTriggerAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReadTriggerAsync(id, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<TriggerResponse> ReplaceTriggerAsync(
@@ -195,7 +213,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceTriggerAsync(triggerProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReplaceTriggerAsync(triggerProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<TriggerResponse> DeleteTriggerAsync(
@@ -203,7 +223,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteTriggerAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.DeleteTriggerAsync(id, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> CreateUserDefinedFunctionAsync(
@@ -211,7 +233,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.CreateUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
@@ -263,7 +287,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReadUserDefinedFunctionAsync(id, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> ReplaceUserDefinedFunctionAsync(
@@ -271,7 +297,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.ReplaceUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, diagnostics, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> DeleteUserDefinedFunctionAsync(
@@ -279,7 +307,9 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
+            return CosmosClientContext.ProcessHelperAsync(
+                requestOptions: requestOptions,
+                (diagnostics) => this.scripts.DeleteUserDefinedFunctionAsync(id, requestOptions, diagnostics, cancellationToken));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task UserTests(bool directMode)
         {
             CosmosClient client = directMode ? DirectCosmosClient : GatewayCosmosClient;
-            DatabaseCore database = (DatabaseInlineCore)client.GetDatabase(DatabaseId);
+            DatabaseInlineCore database = (DatabaseInlineCore)client.GetDatabase(DatabaseId);
             List<string> createdIds = new List<string>();
 
             try
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<string> createdPermissionIds = new List<string>();
             List<string> createdContainerIds = new List<string>();
             string userId = Guid.NewGuid().ToString();
-            UserCore user = null;
+            UserInlineCore user = null;
 
             try
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(databaseSettings.LastModified.HasValue);
             Assert.IsTrue(databaseSettings.LastModified.Value > new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), databaseSettings.LastModified.Value.ToString());
 
-            DatabaseCore databaseCore = response.Database as DatabaseInlineCore;
+            DatabaseInlineCore databaseCore = response.Database as DatabaseInlineCore;
             Assert.IsNotNull(databaseCore);
             Assert.IsNotNull(databaseCore.LinkUri);
             Assert.IsFalse(databaseCore.LinkUri.ToString().StartsWith("/"));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 Container tokenGatewayQueryPlan = new ContainerCore(
                     containerCore.ClientContext,
-                    (DatabaseCore)containerCore.Database,
+                    containerCore.Database,
                     containerCore.Id,
                     mock);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
                     ContainerCore containerWithForcedPlan = new ContainerCore(
                         containerCore.ClientContext,
-                        (DatabaseCore)containerCore.Database,
+                        containerCore.Database,
                         containerCore.Id,
                         cosmosQueryClientCore);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorCacheTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
 
             return ClientContextCore.Create(
-                mockClient.Object,
+                new Uri("http://localhost"),
                 new MockDocumentClient(),
                 new CosmosClientOptions() { AllowBulkExecution = allowBulkExecution });
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorCacheTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext context = this.MockClientContext();
 
-            DatabaseCore db = new DatabaseCore(context, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(context, "test");
 
             List<Task<ContainerCore>> tasks = new List<Task<ContainerCore>>();
             for (int i = 0; i < 20; i++)
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext context = this.MockClientContext();
 
-            DatabaseCore db = new DatabaseCore(context, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(context, "test");
 
             List<Task<ContainerCore>> tasks = new List<Task<ContainerCore>>();
             for (int i = 0; i < 20; i++)
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext context = this.MockClientContext(allowBulkExecution: false);
 
-            DatabaseCore db = new DatabaseCore(context, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(context, "test");
             ContainerCore container = new ContainerCore(context, db, "test");
             Assert.IsNull(container.BatchExecutor);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchUnitTests.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 client = MockCosmosUtil.CreateMockCosmosClient();
             }
 
-            DatabaseCore database = new DatabaseCore(client.ClientContext, BatchUnitTests.DatabaseId);
+            DatabaseInlineCore database = new DatabaseInlineCore(client.ClientContext, BatchUnitTests.DatabaseId);
             ContainerCore container = new ContainerCore(client.ClientContext, database, BatchUnitTests.ContainerId);
             return container;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorCoreTests.cs
@@ -161,13 +161,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
         private static CosmosClientContext GetMockedClientContext()
         {
-            Mock<CosmosClient> mockClient = new Mock<CosmosClient>();
-            mockClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
-
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
-            mockContext.Setup(x => x.Client).Returns(mockClient.Object);
-            //mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             return mockContext.Object;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -224,14 +224,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
         private static CosmosClientContext GetMockedClientContext()
         {
-            Mock<CosmosClient> mockClient = new Mock<CosmosClient>();
-            mockClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
-
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(mockClient.Object);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             return mockContext.Object;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .Returns(Task.FromResult(firstResponse))
                 .Returns(Task.FromResult(secondResponse));
 
-            DatabaseCore databaseCore = new DatabaseCore(mockContext.Object, "mydb");
+            DatabaseInlineCore databaseCore = new DatabaseInlineCore(mockContext.Object, "mydb");
 
             StandByFeedIteratorCore iterator = new StandByFeedIteratorCore(
                 mockContext.Object, new ContainerCore(mockContext.Object, databaseCore, "myColl"), null, 10, new ChangeFeedRequestOptions());
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .Returns(Task.FromResult(firstResponse))
                 .Returns(Task.FromResult(secondResponse));
 
-            DatabaseCore databaseCore = new DatabaseCore(mockContext.Object, "mydb");
+            DatabaseInlineCore databaseCore = new DatabaseInlineCore(mockContext.Object, "mydb");
 
             StandByFeedIteratorCore iterator = new StandByFeedIteratorCore(
                 mockContext.Object, new ContainerCore(mockContext.Object, databaseCore, "myColl"), null, 10, new ChangeFeedRequestOptions());
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .Returns(Task.FromResult(secondResponse))
                 .Returns(Task.FromResult(thirdResponse));
 
-            DatabaseCore databaseCore = new DatabaseCore(mockContext.Object, "mydb");
+            DatabaseInlineCore databaseCore = new DatabaseInlineCore(mockContext.Object, "mydb");
 
             StandByFeedIteratorCore iterator = new StandByFeedIteratorCore(
                 mockContext.Object, new ContainerCore(mockContext.Object, databaseCore, "myColl"), null, 10, new ChangeFeedRequestOptions());
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(firstResponse));
 
-            DatabaseCore databaseCore = new DatabaseCore(mockContext.Object, "mydb");
+            DatabaseInlineCore databaseCore = new DatabaseInlineCore(mockContext.Object, "mydb");
 
             StandByFeedIteratorCore iterator = new StandByFeedIteratorCore(
                 mockContext.Object, new ContainerCore(mockContext.Object, databaseCore, "myColl"), null, 10, new ChangeFeedRequestOptions());
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.Client).Returns(client);
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(UriFactory.CreateDocumentCollectionUri("test", "test"));
 
-            DatabaseCore db = new DatabaseCore(mockContext.Object, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(mockContext.Object, "test");
             ContainerCore container = new ContainerCore(mockContext.Object, db, "test");
             IEnumerable<string> tokens = await container.GetChangeFeedTokensAsync();
             Assert.AreEqual(3, tokens.Count());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeedResultSetIteratorTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("/dbs/test/colls/test", UriKind.Relative));
 
             ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("/dbs/test/colls/test", UriKind.Relative));
 
             ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("/dbs/test/colls/test", UriKind.Relative));
 
             ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(new MockDocumentClient());
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(new Uri("/dbs/test/colls/test", UriKind.Relative));
 
             ResponseMessage firstResponse = new ResponseMessage(HttpStatusCode.NotModified);
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockContext.Setup(x => x.ClientOptions).Returns(MockCosmosUtil.GetDefaultConfiguration());
             mockContext.Setup(x => x.DocumentClient).Returns(documentClient);
             mockContext.Setup(x => x.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(x => x.Client).Returns(client);
+            mockContext.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
             mockContext.Setup(x => x.CreateLink(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(UriFactory.CreateDocumentCollectionUri("test", "test"));
 
             DatabaseInlineCore db = new DatabaseInlineCore(mockContext.Object, "test");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             mockClient.Setup(x => x.Endpoint).Returns(new Uri("http://localhost"));
 
             return ClientContextCore.Create(
-                mockClient.Object,
+                new Uri("http://localhost"),
                 new MockDocumentClient(),
                 new CosmosClientOptions() { AllowBulkExecution = allowBulkExecution });
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             string crId = "cr42";
 
             CosmosClientContext context = this.CreateMockClientContext();
-            DatabaseCore db = new DatabaseCore(context, databaseId);
+            DatabaseInlineCore db = new DatabaseInlineCore(context, databaseId);
             Assert.AreEqual(db.LinkUri.OriginalString, "dbs/" + databaseId);
 
             ContainerCore container = new ContainerCore(context, db, crId);
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             string crId = "cr42";
 
             CosmosClientContext context = this.CreateMockClientContext();
-            DatabaseCore db = new DatabaseCore(context, databaseId);
+            DatabaseInlineCore db = new DatabaseInlineCore(context, databaseId);
             ContainerCore container = new ContainerCore(context, db, crId);
             Assert.IsNull(container.BatchExecutor);
         }
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
 
             CosmosClientContext context = this.CreateMockClientContext(allowBulkExecution: true);
 
-            DatabaseCore db = new DatabaseCore(context, databaseId);
+            DatabaseInlineCore db = new DatabaseInlineCore(context, databaseId);
             ContainerCore container = new ContainerCore(context, db, crId);
             Assert.IsNotNull(container.BatchExecutor);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConflictTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosConflictTests.cs
@@ -99,12 +99,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
             CosmosClientContext clientContext = ClientContextCore.Create(
-               client,
+               client.Endpoint,
                new MockDocumentClient(),
                new CosmosClientOptions());
 
             Mock<PartitionRoutingHelper> partitionRoutingHelperMock = MockCosmosUtil.GetPartitionRoutingHelperMock("0");
-            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(client, partitionRoutingHelperMock.Object);
+            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(clientContext.DocumentClient, partitionRoutingHelperMock.Object);
 
             TestHandler testHandler = new TestHandler(handlerFunc);
             partitionKeyRangeHandler.InnerHandler = testHandler;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -251,7 +251,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -386,7 +386,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClientContext cosmosClientContext = this.CreateMockBulkCosmosClientContext();
 
-            DatabaseCore db = new DatabaseCore(cosmosClientContext, "test");
+            DatabaseInlineCore db = new DatabaseInlineCore(cosmosClientContext, "test");
             ExecutorContainerCore container = new ExecutorContainerCore(cosmosClientContext, db, "test");
 
             dynamic testItem = new
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             public readonly Mock<BatchAsyncContainerExecutor> MockedExecutor = new Mock<BatchAsyncContainerExecutor>();
             public ExecutorContainerCore(
                 CosmosClientContext clientContext,
-                DatabaseCore database,
+                DatabaseInlineCore database,
                 string containerId) : base (clientContext, database, containerId)
             {
                 this.MockedExecutor
@@ -672,7 +672,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             public readonly Mock<BatchAsyncContainerExecutor> MockedExecutor = new Mock<BatchAsyncContainerExecutor>();
             public ExecutorWithThrottlingContainerCore(
                 CosmosClientContext clientContext,
-                DatabaseCore database,
+                DatabaseInlineCore database,
                 string containerId) : base(clientContext, database, containerId)
             {
                 this.MockedExecutor

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -480,7 +480,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient cosmosClient = MockCosmosUtil.CreateMockCosmosClient();
             return ClientContextCore.Create(
-               cosmosClient,
+               cosmosClient.Endpoint,
                new MockDocumentClient(),
                new CosmosClientOptions() { AllowBulkExecution = true });
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1350,11 +1350,9 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Uri get_Endpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "System.Uri get_Endpoint()": {
           "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "System.Uri get_Endpoint()"
         },
         "Void .ctor(System.String, Microsoft.Azure.Cosmos.CosmosClientOptions)": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
@@ -220,8 +220,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             internalClient.DocumentClient.StoreModel = MockServerStoreModel(internalClient.DocumentClient.Session, sendDirectFunc);
 
 
-            RetryHandler retryHandler = new RetryHandler(internalClient);
-            MockTransportHandler transportHandler = new MockTransportHandler(internalClient);
+            RetryHandler retryHandler = new RetryHandler(internalClient.DocumentClient);
+            MockTransportHandler transportHandler = new MockTransportHandler(internalClient.DocumentClient);
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient(
                 (builder) => {
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             public bool ProcessMessagesAsyncThrew { get; private set; }
             public int SendAsyncCalls { get; private set; }
 
-            public MockTransportHandler(CosmosClient client): base(client)
+            public MockTransportHandler(DocumentClient client): base(client)
             {
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
             CosmosClientContext clientContext = ClientContextCore.Create(
-               client,
+               client.Endpoint,
                new MockDocumentClient(),
                new CosmosClientOptions());
             Mock<PartitionRoutingHelper> partitionRoutingHelperMock = MockCosmosUtil.GetPartitionRoutingHelperMock("0");
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestHandler[] feedPipeline = new RequestHandler[]
                 {
                     new NamedCacheRetryHandler(),
-                    new PartitionKeyRangeHandler(client),
+                    new PartitionKeyRangeHandler(client.DocumentClient),
                     testHandler,
                 };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedToken/ReadFeedTokenIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedToken/ReadFeedTokenIteratorCoreTests.cs
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
             CosmosClientContext clientContext = ClientContextCore.Create(
-               client,
+               client.Endpoint,
                new MockDocumentClient(),
                new CosmosClientOptions());
             Mock<PartitionRoutingHelper> partitionRoutingHelperMock = MockCosmosUtil.GetPartitionRoutingHelperMock("0");
@@ -404,7 +404,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestHandler[] feedPipeline = new RequestHandler[]
                 {
                     new NamedCacheRetryHandler(),
-                    new PartitionKeyRangeHandler(client),
+                    new PartitionKeyRangeHandler(client.DocumentClient),
                     testHandler,
                 };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = testHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         return TestHandler.ReturnSuccess();
                     });
 
-                    RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+                    RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
                     invoker.InnerHandler = testHandler;
 
                     RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = testHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return TestHandler.ReturnSuccess();
             });
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: client.ClientOptions.ConsistencyLevel);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: client.ClientOptions.ConsistencyLevel);
             invoker.InnerHandler = testHandler;
 
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return TestHandler.ReturnSuccess();
             });
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = testHandler;
 
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = testHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task VerifySendUsesOringianlContinuationOnNonSuccessfulResponse()
         {
             Mock<PartitionRoutingHelper> partitionRoutingHelperMock = this.GetPartitionRoutingHelperMock();
-            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(MockCosmosUtil.CreateMockCosmosClient(), partitionRoutingHelperMock.Object);
+            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(MockCosmosUtil.CreateMockCosmosClient().DocumentClient, partitionRoutingHelperMock.Object);
 
             TestHandler testHandler = new TestHandler(async (request, cancellationToken) => {
                 ResponseMessage errorResponse = await TestHandler.ReturnStatusCode(HttpStatusCode.Gone);
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<RntbdConstants.RntdbEnumerationDirection>()
             )).ThrowsAsync(new DocumentClientException("error", HttpStatusCode.ServiceUnavailable, SubStatusCodes.Unknown));
 
-            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(MockCosmosUtil.CreateMockCosmosClient(), partitionRoutingHelperMock.Object);
+            PartitionKeyRangeHandler partitionKeyRangeHandler = new PartitionKeyRangeHandler(MockCosmosUtil.CreateMockCosmosClient().DocumentClient, partitionRoutingHelperMock.Object);
 
             TestHandler testHandler = new TestHandler(async (request, cancellationToken) => {
                 ResponseMessage successResponse = await TestHandler.ReturnSuccess();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RetryHandler retryHandler = new RetryHandler(client);
+            RetryHandler retryHandler = new RetryHandler(client.DocumentClient);
             int handlerCalls = 0;
             int expectedHandlerCalls = 1;
             TestHandler testHandler = new TestHandler((request, cancellationToken) => {
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Delete, RetryHandlerTests.TestUri);
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RetryHandler retryHandler = new RetryHandler(client);
+            RetryHandler retryHandler = new RetryHandler(client.DocumentClient);
             int handlerCalls = 0;
             int expectedHandlerCalls = 2;
             TestHandler testHandler = new TestHandler((request, cancellationToken) => {
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Delete, RetryHandlerTests.TestUri);
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RetryHandler retryHandler = new RetryHandler(client);
+            RetryHandler retryHandler = new RetryHandler(client.DocumentClient);
             int handlerCalls = 0;
             int expectedHandlerCalls = 2;
             TestHandler testHandler = new TestHandler((request, cancellationToken) => {
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             mockRetryPolicy.Setup(m => m.GetRequestPolicy())
                 .Returns(() => mockClientRetryPolicy.Object);
 
-            RetryHandler retryHandler = new RetryHandler(client);
+            RetryHandler retryHandler = new RetryHandler(client.DocumentClient);
             int handlerCalls = 0;
             int expectedHandlerCalls = 2;
             TestHandler testHandler = new TestHandler((request, response) => {
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"));
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -186,10 +186,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
-            RetryHandler retryHandler = new RetryHandler(client);
+            RetryHandler retryHandler = new RetryHandler(client.DocumentClient);
             retryHandler.InnerHandler = testHandler;
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Delete, RetryHandlerTests.TestUri);
             requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new Uri("https://dummy.documents.azure.com:443/dbs"));
             await invoker.SendAsync(requestMessage, new CancellationToken());
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(client.DocumentClient, requestedClientConsistencyLevel: null);
             invoker.InnerHandler = retryHandler;
             RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new Uri("https://dummy.documents.azure.com:443/dbs"));
             

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
@@ -56,12 +56,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             return mockContainer;
         }
 
-        public static Mock<DatabaseCore> CreateMockDatabase(string dbName = "myDb")
+        public static Mock<DatabaseInlineCore> CreateMockDatabase(string dbName = "myDb")
         {
             Uri link = new Uri($"/dbs/{dbName}", UriKind.Relative);
-            Mock<DatabaseCore> mockDB = new Mock<DatabaseCore>();
+            Mock<DatabaseInlineCore> mockDB = new Mock<DatabaseInlineCore>();
             mockDB.Setup(x => x.LinkUri).Returns(link);
-            mockDB.Setup(x => x.GetRIDAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(dbName));
+            mockDB.Setup(x => x.GetRIDAsync(It.IsAny<CosmosDiagnosticsContext>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(dbName));
             return mockDB;
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR standardizes the diagnostic context creation, and ensure the total time is accurate.

1. DiagnosticContext is now generated in the *InlineCore classes along with the TaskHelper logic.
2. Container will be done in a separate PR to reduce PR size.
3. *InlineCore will be used as a contract class for internal teams using Friends. The implementation will remain in *Core classes. This allows a clean contract between Friends and internal SDK.
4. Adding APIs to get InlineCore vs Core to reduce all the casting. 
5. Fixes a bug for some API calls where the response object would return the DatabaseCore instead of the correct DatabaseInlineCore.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


