### PR TITLE
Query Diagnostics: Fix get query plan diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Cosmos
             SqlQuerySpec sqlQuerySpec,
             PartitionKey? partitionKey,
             string supportedQueryFeatures,
-            CosmosDiagnosticsContext diagnosticsContextFactory,
+            CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo;
@@ -230,7 +230,7 @@ namespace Microsoft.Azure.Cosmos
                     requestMessage.Headers.Add(HttpConstants.HttpHeaders.QueryVersion, new Version(major: 1, minor: 0).ToString());
                     requestMessage.UseGatewayMode = true;
                 },
-                diagnosticsContext: null,
+                diagnosticsContext: diagnosticsContext,
                 cancellationToken: cancellationToken))
             {
                 // Syntax exception are argument exceptions and thrown to the user.

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -15,14 +15,12 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Cosmos.Query.Core.Metrics;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
-    using Newtonsoft.Json;
     using static Microsoft.Azure.Documents.RuntimeConstants;
 
     internal class CosmosQueryClientCore : CosmosQueryClient

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -4,7 +4,9 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
+    using Microsoft.Azure.Cosmos.EmulatorTests.Query;
     using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Services.Management.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using Newtonsoft.Json.Linq;
@@ -102,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                   requestOptions: requestOptions);
                 Assert.Fail("Should have thrown a request timeout exception");
             }
-            catch(CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.RequestTimeout)
+            catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.RequestTimeout)
             {
                 string exception = ce.ToString();
                 Assert.IsNotNull(exception);
@@ -229,7 +231,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             TransactionalBatch batch = this.Container.CreateTransactionalBatch(new PartitionKey(pkValue));
 
             List<ToDoActivity> createItems = new List<ToDoActivity>();
-            for(int i = 0; i < 50; i++)
+            for (int i = 0; i < 50; i++)
             {
                 ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
                 createItems.Add(item);
@@ -243,7 +245,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             RequestOptions requestOptions = disableDiagnostics ? RequestOptionDisableDiagnostic : null;
             TransactionalBatchResponse response = await ((BatchCore)batch).ExecuteAsync(requestOptions);
-            
+
             Assert.IsNotNull(response);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
                 diagnostics: response.Diagnostics,
@@ -274,6 +276,50 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 CosmosDiagnosticsTests.VerifyPointDiagnostics(
                     diagnostics: itemResponse.Diagnostics,
                     disableDiagnostics: false);
+            }
+        }
+
+        [TestMethod]
+        public async Task GatewayQueryPlanDiagnostic()
+        {
+            int totalItems = 3;
+            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(
+                this.Container,
+                pkCount: totalItems,
+                perPKItemCount: 1,
+                randomPartitionKey: true);
+
+            ContainerCore containerCore = (ContainerInlineCore)this.Container;
+            MockCosmosQueryClient gatewayQueryPlanClient = new MockCosmosQueryClient(
+                   clientContext: containerCore.ClientContext,
+                   cosmosContainerCore: containerCore,
+                   forceQueryPlanGatewayElseServiceInterop: true);
+
+            Container gatewayQueryPlanContainer = new ContainerCore(
+                containerCore.ClientContext,
+                (DatabaseCore)containerCore.Database,
+                containerCore.Id,
+                gatewayQueryPlanClient);
+
+            QueryRequestOptions queryRequestOptions = new QueryRequestOptions()
+            {
+                MaxItemCount = 1,
+                MaxBufferedItemCount = 0
+            };
+
+            FeedIterator<ToDoActivity> feedIterator = gatewayQueryPlanContainer.GetItemQueryIterator<ToDoActivity>(
+                    "select * from ToDoActivity t ORDER BY t.cost",
+                    requestOptions: queryRequestOptions);
+
+            List<ToDoActivity> results = new List<ToDoActivity>();
+            bool isFirstPage = true;
+            while (feedIterator.HasMoreResults)
+            {
+                FeedResponse<ToDoActivity> response = await feedIterator.ReadNextAsync();
+                results.AddRange(response);
+                CosmosDiagnosticsContext diagnosticsContext = (response.Diagnostics as CosmosDiagnosticsCore).Context;
+                DiagnosticValidator.ValidateQueryGatewayPlanDiagnostics(diagnosticsContext, isFirstPage);
+                isFirstPage = false;
             }
         }
 
@@ -383,11 +429,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 return;
             }
 
-   
             CosmosDiagnosticsContext diagnosticsContext = (diagnostics as CosmosDiagnosticsCore).Context;
 
             // If all the pages are buffered then several of the normal summary validation will fail.
-            if(diagnosticsContext.TotalRequestCount > 0)
+            if (diagnosticsContext.TotalRequestCount > 0)
             {
                 DiagnosticValidator.ValidateCosmosDiagnosticsContext(diagnosticsContext);
             }
@@ -461,7 +506,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 FeedResponse<ToDoActivity> response = await feedIterator.ReadNextAsync();
                 results.AddRange(response);
-                if(queryText == null)
+                if (queryText == null)
                 {
                     CosmosDiagnosticsTests.VerifyPointDiagnostics(
                         response.Diagnostics,
@@ -474,7 +519,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                        isFirst,
                        disableDiagnostics);
                 }
-               
+
                 isFirst = false;
             }
 


### PR DESCRIPTION
# Pull Request Template

## Description

The code currently tells if it the query plan is from gateway or service interop. This fixes get query plan from gateway to include the diagnostics from that call. This allows to see if there are retries or other exceptions that might cause a delay in the get query plan call.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


