### PR TITLE
[Internal] Build: Add Independent version for Preview

### DIFF
--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ClientVersion>3.8.0</ClientVersion>
+    <ClientPreviewVersion>3.7.1</ClientPreviewVersion>
     <DirectVersion>3.7.1</DirectVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ClientVersion>3.8.0</ClientVersion>
+    <ClientOfficialVersion>3.8.0</ClientOfficialVersion>
     <ClientPreviewVersion>3.7.1</ClientPreviewVersion>
     <DirectVersion>3.7.1</DirectVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -7,13 +7,13 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
-    <BaseVersion Condition=" '$(IsPreview)' != 'true' ">$(ClientVersion)</BaseVersion>
-    <BaseVersion Condition=" '$(IsPreview)' == 'true' ">$(ClientPreviewVersion)</BaseVersion>
+    <ClientVersion Condition=" '$(IsPreview)' != 'true' ">$(ClientOfficialVersion)</ClientVersion>
+    <ClientVersion Condition=" '$(IsPreview)' == 'true' ">$(ClientPreviewVersion)</ClientVersion>
     <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
-    <Version Condition=" '$(VersionSuffix)' == '' ">$(BaseVersion)</Version>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(BaseVersion)-$(VersionSuffix)</Version>
-    <FileVersion>$(BaseVersion)</FileVersion>
+    <Version Condition=" '$(VersionSuffix)' == '' ">$(ClientVersion)</Version>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(ClientVersion)-$(VersionSuffix)</Version>
+    <FileVersion>$(ClientVersion)</FileVersion>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
-    <BaseVersion Condition=" '$(IsPreview)' != 'true' ">$(ClientVersion)</BaseVersion>
+    <BaseVersion Condition=" '$(IsPreview)' != 'true'  ">$(ClientVersion)</BaseVersion>
     <BaseVersion Condition=" '$(IsPreview)' == 'true' ">$(ClientPreviewVersion)</BaseVersion>
     <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -7,11 +7,13 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
+    <BaseVersion Condition=" '$(IsPreview)' != 'true' ">$(ClientVersion)</BaseVersion>
+    <BaseVersion Condition=" '$(IsPreview)' == 'true' ">$(ClientPreviewVersion)</BaseVersion>
     <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
-    <Version Condition=" '$(VersionSuffix)' == '' ">$(ClientVersion)</Version>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(ClientVersion)-$(VersionSuffix)</Version>
-    <FileVersion>$(ClientVersion)</FileVersion>
+    <Version Condition=" '$(VersionSuffix)' == '' ">$(BaseVersion)</Version>
+    <Version Condition=" '$(VersionSuffix)' != '' ">$(BaseVersion)-$(VersionSuffix)</Version>
+    <FileVersion>$(BaseVersion)</FileVersion>
     <Authors>Microsoft</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -7,7 +7,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
-    <BaseVersion Condition=" '$(IsPreview)' != 'true'  ">$(ClientVersion)</BaseVersion>
+    <BaseVersion Condition=" '$(IsPreview)' != 'true' ">$(ClientVersion)</BaseVersion>
     <BaseVersion Condition=" '$(IsPreview)' == 'true' ">$(ClientPreviewVersion)</BaseVersion>
     <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>


### PR DESCRIPTION
This PR separates package versioning for Preview releases from Official/GA releases to avoid releases using the Preview version.

The effect of the different flags on builds are below:

## Default build
![image](https://user-images.githubusercontent.com/1633401/78729999-6d551c80-78f0-11ea-8db1-d1c395de3f79.png)

## Preview build
![image](https://user-images.githubusercontent.com/1633401/78730010-7940de80-78f0-11ea-87f0-110376b789c2.png)

## Nightly build
![image](https://user-images.githubusercontent.com/1633401/78730057-9c6b8e00-78f0-11ea-9193-c26e3f2c7b9a.png)
