### PR TITLE
[Internal] Tests: Add retriable TestClass decorator

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
     using Microsoft.Azure.Documents;
     using System.Threading.Tasks;
 
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqAggregateFunctionBaselineTests : BaselineTests<LinqAggregateInput, LinqAggregateOutput>
     {
         private static CosmosClient client;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAttributeContractBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAttributeContractBaselineTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
     /// <summary>
     /// Class that tests to see that we honor the attributes for members in a class / struct when we create LINQ queries.
     /// </summary>
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqAttributeContractBaselineTests : BaselineTests<LinqTestInput, LinqTestOutput>
     {
         private static Func<bool, IQueryable<Datum>> getQuery;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqGeneralBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqGeneralBaselineTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Cosmos.Scripts;
 
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqGeneralBaselineTests : BaselineTests<LinqTestInput, LinqTestOutput>
     {
         private static CosmosClient cosmosClient;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqSQLTranslationBaselineTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
     using System.Net;
     using Microsoft.Azure.Cosmos.Query.Core;
 
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqSQLTranslationBaselineTest : BaselineTests<LinqTestInput, LinqTestOutput>
     {
         static Expression Lambda<T, S>(Expression<Func<T, S>> func)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using System.Threading.Tasks;
 
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqTranslationBaselineTests : BaselineTests<LinqTestInput, LinqTestOutput>
     {
         private static CosmosClient cosmosClient;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
     /// <summary>
     /// Tests for CrossPartitionQueryTests.
     /// </summary>
-    [TestClass]
+    [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     [TestCategory("Query")]
     public abstract class QueryTestsBase
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     public static class State
     {
         public static int Iteration = 0;
+        public static int IterationForSuccess = 0;
         public static int IterationForMax = 0;
     }
 
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public void RetriableTestClassAttribute_DontRetryOnSuccess()
         {
-            if (State.Iteration++ > 0)
+            if (State.IterationForSuccess++ > 0)
             {
                 throw new Exception();
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public static int IterationForMax = 0;
     }
 
-    [RetriableTestClassAttribute]
+    [TestClass]
     public class RetriableTestClassAttributeTests
     {
         [TestMethod]
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
     }
 
-    [RetriableTestClassAttribute(3)]
+    [TestClass(3)]
     public class RetriableTestClassAttributeTestsWithMax
     {
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/RetriableTestClassAttributeTests.cs
@@ -1,0 +1,50 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public static class State
+    {
+        public static int Iteration = 0;
+        public static int IterationForMax = 0;
+    }
+
+    [RetriableTestClassAttribute]
+    public class RetriableTestClassAttributeTests
+    {
+        [TestMethod]
+        public void RetriableTestClassAttribute_RetryOnce()
+        {
+            if (State.Iteration++ == 0)
+            {
+                throw new Exception();
+            }
+        }
+
+        [TestMethod]
+        public void RetriableTestClassAttribute_DontRetryOnSuccess()
+        {
+            if (State.Iteration++ > 0)
+            {
+                throw new Exception();
+            }
+        }
+    }
+
+    [RetriableTestClassAttribute(3)]
+    public class RetriableTestClassAttributeTestsWithMax
+    {
+        [TestMethod]
+        public void RetriableTestClassAttribute_RetryUpToMax()
+        {
+            if (State.IterationForMax++ < 3)
+            {
+                throw new Exception();
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RetriableTestClass.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RetriableTestClass.cs
@@ -6,16 +6,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System.Linq;
     using Microsoft.Azure.Cosmos.Services.Management.Tests;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    public sealed class RetriableTestClassAttribute : TestClassAttribute
+
+    public sealed class TestClassAttribute : VisualStudio.TestTools.UnitTesting.TestClassAttribute
     {
         private readonly int maxRetry;
 
         /// <summary>
         /// Creates a TestClass that retries TestMethods once upon failure.
         /// </summary>
-        public RetriableTestClassAttribute()
+        public TestClassAttribute()
         {
             this.maxRetry = 1;
         }
@@ -23,38 +23,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// <summary>
         /// Creates a TestClass that retries TestMethods up to <paramref name="maxRetry"/> times.
         /// </summary>
-        public RetriableTestClassAttribute(int maxRetry)
+        public TestClassAttribute(int maxRetry)
         {
             this.maxRetry = maxRetry;
         }
 
-        public override TestMethodAttribute GetTestMethodAttribute(TestMethodAttribute testMethodAttribute)
+        public override VisualStudio.TestTools.UnitTesting.TestMethodAttribute GetTestMethodAttribute(VisualStudio.TestTools.UnitTesting.TestMethodAttribute testMethodAttribute)
         {
-            TestMethodAttribute baseTestmethod = base.GetTestMethodAttribute(testMethodAttribute);
+            VisualStudio.TestTools.UnitTesting.TestMethodAttribute baseTestmethod = base.GetTestMethodAttribute(testMethodAttribute);
             return new RetriableTestMethod(this.maxRetry, baseTestmethod);
         }
     }
 
-    public class RetriableTestMethod : TestMethodAttribute
+    public class RetriableTestMethod : VisualStudio.TestTools.UnitTesting.TestMethodAttribute
     {
-        private readonly TestMethodAttribute testMethod;
+        private readonly VisualStudio.TestTools.UnitTesting.TestMethodAttribute testMethod;
         private int maxRetry;
         public RetriableTestMethod(
             int maxRetry,
-            TestMethodAttribute testMethod)
+            VisualStudio.TestTools.UnitTesting.TestMethodAttribute testMethod)
         {
             this.maxRetry = maxRetry;
             this.testMethod = testMethod;
         }
 
-        public override TestResult[] Execute(ITestMethod testMethod) => this.ExecuteWithRetry(this.maxRetry, testMethod);
+        public override VisualStudio.TestTools.UnitTesting.TestResult[] Execute(VisualStudio.TestTools.UnitTesting.ITestMethod testMethod) => this.ExecuteWithRetry(this.maxRetry, testMethod);
 
-        private TestResult[] ExecuteWithRetry(
+        private VisualStudio.TestTools.UnitTesting.TestResult[] ExecuteWithRetry(
             int retryCount,
-            ITestMethod testMethod)
+            VisualStudio.TestTools.UnitTesting.ITestMethod testMethod)
         {
-            TestResult[] testResults = base.Execute(testMethod);
-            if (testResults.Any((tr) => tr.Outcome == UnitTestOutcome.Failed))
+            VisualStudio.TestTools.UnitTesting.TestResult[] testResults = base.Execute(testMethod);
+            if (testResults.Any((tr) => tr.Outcome == VisualStudio.TestTools.UnitTesting.UnitTestOutcome.Failed))
             {
                 if (retryCount > 0)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RetriableTestClass.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/RetriableTestClass.cs
@@ -1,0 +1,69 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System.Linq;
+    using Microsoft.Azure.Cosmos.Services.Management.Tests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    public sealed class RetriableTestClassAttribute : TestClassAttribute
+    {
+        private readonly int maxRetry;
+
+        /// <summary>
+        /// Creates a TestClass that retries TestMethods once upon failure.
+        /// </summary>
+        public RetriableTestClassAttribute()
+        {
+            this.maxRetry = 1;
+        }
+
+        /// <summary>
+        /// Creates a TestClass that retries TestMethods up to <paramref name="maxRetry"/> times.
+        /// </summary>
+        public RetriableTestClassAttribute(int maxRetry)
+        {
+            this.maxRetry = maxRetry;
+        }
+
+        public override TestMethodAttribute GetTestMethodAttribute(TestMethodAttribute testMethodAttribute)
+        {
+            TestMethodAttribute baseTestmethod = base.GetTestMethodAttribute(testMethodAttribute);
+            return new RetriableTestMethod(this.maxRetry, baseTestmethod);
+        }
+    }
+
+    public class RetriableTestMethod : TestMethodAttribute
+    {
+        private readonly TestMethodAttribute testMethod;
+        private int maxRetry;
+        public RetriableTestMethod(
+            int maxRetry,
+            TestMethodAttribute testMethod)
+        {
+            this.maxRetry = maxRetry;
+            this.testMethod = testMethod;
+        }
+
+        public override TestResult[] Execute(ITestMethod testMethod) => this.ExecuteWithRetry(this.maxRetry, testMethod);
+
+        private TestResult[] ExecuteWithRetry(
+            int retryCount,
+            ITestMethod testMethod)
+        {
+            TestResult[] testResults = base.Execute(testMethod);
+            if (testResults.Any((tr) => tr.Outcome == UnitTestOutcome.Failed))
+            {
+                if (retryCount > 0)
+                {
+                    Logger.LogLine($"Test method {testMethod.TestClassName}.{testMethod.TestMethodName} failed. Retrying ({retryCount - 1} left).");
+                    return this.ExecuteWithRetry(retryCount - 1, testMethod);
+                }
+            }
+
+            return testResults;
+        }
+    }
+}


### PR DESCRIPTION
To address transient test failures with the Emulator in our tests, this PR adds a new `[TestClass]` decorator that inherits from `VisualStudio.TestTools.UnitTesting.TestClass`.

[MSTestEx](https://github.com/pvlakshm/MSTestEx/blob/master/docs/AttributeEx/RetryAttribute.md) has a `[Retry]` attribute but it has an undesirable outcome, it retries the test but it still marks it as failed if some of the iterations failed.

This decorator will retry all `[TestMethods]` in a class and set the result to the last iteration (either success or failure).

**All existing Emulator tests will now be using the new retry behavior by default**. Some particular files had to be changed due to namespace collision with the original `TestClass`.

## Retry count

By default it retries once, but it can be customized through the constructor for a different value.

## Usage example
```
[TestClass]
public class MyTestClass
{
    [TestMethod]
    public void MyTest()
    {
    }
}

[TestClass(maxRetry: 3)]
public class MyTestClass
{
    [TestMethod]
    public void MyTest()
    {
    }
}
```