### PR TITLE
[vNext] Documentation: Fix Obsolete member and fix classes comments

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
@@ -16,7 +16,7 @@ namespace Azure.Cosmos
     /// Indexing policies can used to configure which properties (JSON paths) are included/excluded, whether the index is updated consistently
     /// or offline (lazy), automatic vs. opt-in per-document, as well as the precision and type of index per path.
     /// <para>
-    /// Refer to <see>http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/</see> for additional information on how to specify
+    /// Refer to  <see>https://docs.microsoft.com/azure/cosmos-db/index-policy</see> for additional information on how to specify
     /// indexing policies.
     /// </para>
     /// </remarks>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
@@ -8,54 +8,14 @@ namespace Azure.Cosmos
     /// <summary>
     /// Represents the unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
     /// </summary>
-    /// <example>
-    /// <![CDATA[
-    /// var collectionSpec = new DocumentCollection
-    /// {
-    ///     Id = "Collection with unique keys",
-    ///     UniqueKeyPolicy = new UniqueKeyPolicy
-    ///     {
-    ///         UniqueKeys = new Collection<UniqueKey> {
-    ///             // pair </name/first, name/last> is unique.
-    ///             new UniqueKey { Paths = new Collection<string> { "/name/first", "/name/last" } },
-    ///             // /address is unique.
-    ///             new UniqueKey { Paths = new Collection<string> { "/address" } },
-    ///         }
-    ///     }
-    /// };
-    /// DocumentCollection collection = await client.CreateDocumentCollectionAsync(databaseLink, collectionSpec });
-    ///
-    /// var doc = JObject.Parse("{\"name\": { \"first\": \"John\", \"last\": \"Smith\" }, \"alias\":\"johnsmith\" }");
-    /// await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///
-    /// doc = JObject.Parse("{\"name\": { \"first\": \"James\", \"last\": \"Smith\" }, \"alias\":\"jamessmith\" }");
-    /// await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///
-    /// try
-    /// {
-    ///     // Error: first+last name is not unique.
-    ///     doc = JObject.Parse("{\"name\": { \"first\": \"John\", \"last\": \"Smith\" }, \"alias\":\"johnsmith1\" }");
-    ///     await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///     throw new Exception("CreateDocumentAsync should have thrown exception/conflict");
-    /// }
-    /// catch (DocumentClientException ex)
-    /// {
-    ///     if (ex.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-    /// }
-    ///
-    /// try
-    /// {
-    ///     // Error: alias is not unique.
-    ///     doc = JObject.Parse("{\"name\": { \"first\": \"James Jr\", \"last\": \"Smith\" }, \"alias\":\"jamessmith\" }");
-    ///     await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///     throw new Exception("CreateDocumentAsync should have thrown exception/conflict");
-    /// }
-    /// catch (DocumentClientException ex)
-    /// {
-    ///     if (ex.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-    /// }
-    /// ]]>
-    /// </example>
+    /// <remarks>
+    /// Unique key policies add a layer of data integrity to an Azure Cosmos container. They cannot be modified once the container is created.
+    /// <para>
+    /// Refer to <see>https://docs.microsoft.com/en-us/azure/cosmos-db/unique-keys</see> for additional information on how to specify
+    /// unique key policies.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="ContainerProperties"/>
     public sealed class UniqueKeyPolicy
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/OperationKind.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/OperationKind.cs
@@ -8,8 +8,6 @@ namespace Azure.Cosmos
 namespace Microsoft.Azure.Cosmos
 #endif
 {
-    using System;
-
     /// <summary>
     /// These are the operation types resulted in a version conflict on a resource. 
     /// </summary>
@@ -37,12 +35,6 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// A delete operation.
         /// </summary>
-        Delete,
-
-        /// <summary>
-        /// This operation does not apply to Conflict.
-        /// </summary>
-        [ObsoleteAttribute("This item is obsolete as it does not apply to Conflict.")]
-        Read
+        Delete
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2245,13 +2245,6 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "Azure.Cosmos.OperationKind Read[System.ObsoleteAttribute(\"This item is obsolete as it does not apply to Conflict.\")]": {
-          "Type": "Field",
-          "Attributes": [
-            "ObsoleteAttribute"
-          ],
-          "MethodInfo": null
-        },
         "Azure.Cosmos.OperationKind Replace": {
           "Type": "Field",
           "Attributes": [],


### PR DESCRIPTION
This PR removes an `[Obsolete]` member in the `OperationKind` enum as part of the API Review and fixes some class documentation.