### PR TITLE
Response Headers: Add RetryAfter as Public Property

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -42,8 +42,6 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal TimeSpan? RetryAfter;
-
         internal SubStatusCodes SubStatusCode
         {
             get
@@ -130,6 +128,12 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.Location)]
         public virtual string Location { get; internal set; }
+        
+        /// <summary>
+        /// Gets the amount of time to wait to retry the operation after an initial operation received HTTP status code 429 and was throttled.
+        /// </summary>
+        [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.RetryAfter)]
+        public virtual TimeSpan? RetryAfter { get; internal set; }
 
         [CosmosKnownHeaderAttribute(HeaderName = WFConstants.BackendHeaders.SubStatus)]
         internal string SubStatusCodeLiteral


### PR DESCRIPTION
When using stream methods on a container (CreateItemStreamAsync, DeleteItemStreamAsync, etc.), a 429 (RequestRateTooLarge) return code will not throw an exception. Currently, the only public place to get the RetryAfter TimeSpan is in the CosmosException. This will allow users of the Cosmos package to properly implement backoff throttling.