### PR TITLE
[Internal] Documentation: Fix documentation example and links

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexingPolicy.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos
     /// Indexing policies can used to configure which properties (JSON paths) are included/excluded, whether the index is updated consistently
     /// or offline (lazy), automatic vs. opt-in per-document, as well as the precision and type of index per path.
     /// <para>
-    /// Refer to <see>http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/</see> for additional information on how to specify
+    /// Refer to https://docs.microsoft.com/azure/cosmos-db/index-policy for additional information on how to specify
     /// indexing policies.
     /// </para>
     /// </remarks>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/UniqueKeyPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/UniqueKeyPolicy.cs
@@ -10,54 +10,14 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Represents the unique key policy configuration for specifying uniqueness constraints on documents in the collection in the Azure Cosmos DB service.
     /// </summary>
-    /// <example>
-    /// <![CDATA[
-    /// var collectionSpec = new DocumentCollection
-    /// {
-    ///     Id = "Collection with unique keys",
-    ///     UniqueKeyPolicy = new UniqueKeyPolicy
-    ///     {
-    ///         UniqueKeys = new Collection<UniqueKey> {
-    ///             // pair </name/first, name/last> is unique.
-    ///             new UniqueKey { Paths = new Collection<string> { "/name/first", "/name/last" } },
-    ///             // /address is unique.
-    ///             new UniqueKey { Paths = new Collection<string> { "/address" } },
-    ///         }
-    ///     }
-    /// };
-    /// DocumentCollection collection = await client.CreateDocumentCollectionAsync(databaseLink, collectionSpec });
-    ///
-    /// var doc = JObject.Parse("{\"name\": { \"first\": \"John\", \"last\": \"Smith\" }, \"alias\":\"johnsmith\" }");
-    /// await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///
-    /// doc = JObject.Parse("{\"name\": { \"first\": \"James\", \"last\": \"Smith\" }, \"alias\":\"jamessmith\" }");
-    /// await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///
-    /// try
-    /// {
-    ///     // Error: first+last name is not unique.
-    ///     doc = JObject.Parse("{\"name\": { \"first\": \"John\", \"last\": \"Smith\" }, \"alias\":\"johnsmith1\" }");
-    ///     await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///     throw new Exception("CreateDocumentAsync should have thrown exception/conflict");
-    /// }
-    /// catch (DocumentClientException ex)
-    /// {
-    ///     if (ex.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-    /// }
-    ///
-    /// try
-    /// {
-    ///     // Error: alias is not unique.
-    ///     doc = JObject.Parse("{\"name\": { \"first\": \"James Jr\", \"last\": \"Smith\" }, \"alias\":\"jamessmith\" }");
-    ///     await client.CreateDocumentAsync(collection.SelfLink, doc);
-    ///     throw new Exception("CreateDocumentAsync should have thrown exception/conflict");
-    /// }
-    /// catch (DocumentClientException ex)
-    /// {
-    ///     if (ex.StatusCode != System.Net.HttpStatusCode.Conflict) throw;
-    /// }
-    /// ]]>
-    /// </example>
+    /// <remarks>
+    /// Unique key policies add a layer of data integrity to an Azure Cosmos container. They cannot be modified once the container is created.
+    /// <para>
+    /// Refer to <see>https://docs.microsoft.com/en-us/azure/cosmos-db/unique-keys</see> for additional information on how to specify
+    /// unique key policies.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="ContainerProperties"/>
     public sealed class UniqueKeyPolicy
     {
         /// <summary>


### PR DESCRIPTION
This PR fixes old links and removes old examples coming from V2 SDK on UniqueKey and IndexingPolicy.

Mirror change from https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1367

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

