### PR TITLE
[Internal] Documentation: Fix text on retry builder extension

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// Sets the minimum time to wait between retry and the max number of times to retry on throttled requests.
+        /// Sets the maximum time to wait between retry and the max number of times to retry on throttled requests.
         /// </summary>
         /// <param name="maxRetryWaitTimeOnThrottledRequests">The maximum retry time in seconds for the Azure Cosmos DB service. Any interval that is smaller than a second will be ignored.</param>
         /// <param name="maxRetryAttemptsOnThrottledRequests">The number specifies the times retry requests for throttled requests.</param>


### PR DESCRIPTION
This PR fixes a documentation bug that incorrectly states that it sets the minimum, when it is the maxmium.

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

