### PR TITLE
[Internal] Autoscale: Add migration for interop layers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -176,6 +176,26 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
+        internal async Task<ThroughputResponse> MigrateThroughputToAutoscaleAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            string rid = await this.GetRIDAsync(cancellationToken);
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.MigrateThroughputToAutoscaleAsync(
+                targetRID: rid,
+                cancellationToken: cancellationToken);
+        }
+
+        internal async Task<ThroughputResponse> MigrateThroughputToManualAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            string rid = await this.GetRIDAsync(cancellationToken);
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.MigrateThroughputToManualAsync(
+                targetRID: rid,
+                cancellationToken: cancellationToken);
+        }
+
 #if PREVIEW
         public override
 #else

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -123,6 +123,26 @@ namespace Microsoft.Azure.Cosmos
                 cancellationToken: cancellationToken);
         }
 
+        internal async Task<ThroughputResponse> MigrateThroughputToAutoscaleAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            string rid = await this.GetRIDAsync(cancellationToken);
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.MigrateThroughputToAutoscaleAsync(
+                targetRID: rid,
+                cancellationToken: cancellationToken);
+        }
+
+        internal async Task<ThroughputResponse> MigrateThroughputToManualAsync(
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            string rid = await this.GetRIDAsync(cancellationToken);
+            CosmosOffers cosmosOffers = new CosmosOffers(this.ClientContext);
+            return await cosmosOffers.MigrateThroughputToManualAsync(
+                targetRID: rid,
+                cancellationToken: cancellationToken);
+        }
+
 #if PREVIEW
         public override
 #else


### PR DESCRIPTION
# Pull Request Template


## Description

This adds internal migration APIs for compute and interop layers.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

