### PR TITLE
[Internal] Documentation: Add notes and test for memory optimization

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -80,6 +80,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task MemoryStreamBufferIsAccessibleOnResponse()
+        {
+            ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.SerializerCore.ToStream(testItem), partitionKey: new Cosmos.PartitionKey(testItem.status));
+            Assert.IsNotNull(response);
+            Assert.IsTrue((response.Content as MemoryStream).TryGetBuffer(out _));
+        }
+
+        [TestMethod]
         public async Task CustomSerilizerTest()
         {
             string id1 = "MyCustomSerilizerTestId1";

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#1398](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1398) Reduced memory allocations on query deserialization.
 
 ## <a name="3.9.0-preview"/> [3.9.0-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.9.0-preview) - 2020-04-17
 


### PR DESCRIPTION
Direct 3.9.0 brings MemoryStream with TryGetBuffer support on DocumentServiceResponse, which benefits any code path that uses TryGetBuffer on the response Content to avoid Array allocations, like the query CosmosElementSerializer (https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementSerializer.cs#L84). It should yield a reduced memory allocation and reduced CPU (due to less GC work).

## Type of change

- [X] New feature (non-breaking change which adds functionality)
