### PR TITLE
[Internal] Package: Add missing nuget required properties

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -11,8 +11,12 @@
     <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
     <Version Condition=" '$(VersionSuffix)' == '' ">$(EncryptionPreviewVersion)</Version>
     <Version Condition=" '$(VersionSuffix)' != '' ">$(EncryptionPreviewVersion)-$(VersionSuffix)</Version>
+    <Company>Microsoft Corporation</Company>
+    <Authors>Microsoft</Authors>
     <Description>This library provides an implementation for client-side encryption for Azure Cosmos's SQL API. For more information, refer to https://aka.ms/CosmosClientEncryption</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <Title>Microsoft Azure Cosmos DB client-side encryption library</Title>
+    <PackageId>Microsoft.Azure.Cosmos.Encryption</PackageId>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseUrl>https://aka.ms/netcoregaeula</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Azure/azure-cosmos-dotnet-v3</PackageProjectUrl>


### PR DESCRIPTION
The current CSPROJ for `Microsoft.Azure.Cosmos.Encryption` is missing required attributes for Nuget publishing.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

