### PR TITLE
Headers: Add item count to header for query and change feed

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -131,6 +131,11 @@ namespace Microsoft.Azure.Cosmos
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.Location)]
         public virtual string Location { get; internal set; }
 
+        /// <summary>
+        /// Gets the item count for feed operations like query. The value is null for point operations.
+        /// </summary>
+        public virtual int? ItemCount { get; internal set; }
+
         [CosmosKnownHeaderAttribute(HeaderName = WFConstants.BackendHeaders.SubStatus)]
         internal string SubStatusCodeLiteral
         {
@@ -175,6 +180,19 @@ namespace Microsoft.Azure.Cosmos
 
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.PageSize)]
         internal string PageSize { get; set; }
+
+        [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.ItemCount)]
+        private string itemCount
+        {
+            get
+            {
+                return this.ItemCount.HasValue ? this.ItemCount.ToString() : null; 
+            }
+            set
+            {
+                this.ItemCount = string.IsNullOrEmpty(value) ? (int?)null : int.Parse(value, CultureInfo.InvariantCulture);
+            }
+        }
 
         [CosmosKnownHeaderAttribute(HeaderName = HttpConstants.HttpHeaders.QueryMetrics)]
         internal string QueryMetricsText { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -146,7 +146,6 @@ namespace Microsoft.Azure.Cosmos.Query
 
                     return QueryResponse.CreateSuccess(
                         result: decryptedCosmosElements ?? responseCore.CosmosElements,
-                        count: responseCore.CosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
                         diagnostics: diagnostics,
                         serializationOptions: this.cosmosSerializationFormatOptions,

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.Cosmos
 
         private QueryResponse(
             IReadOnlyList<CosmosElement> result,
-            int count,
             long responseLengthBytes,
             CosmosQueryResponseMessageHeaders responseHeaders,
             HttpStatusCode statusCode,
@@ -52,13 +51,14 @@ namespace Microsoft.Azure.Cosmos
                 diagnostics: diagnostics)
         {
             this.CosmosElements = result;
-            this.Count = count;
+            this.Headers.ItemCount = result.Count;
             this.ResponseLengthBytes = responseLengthBytes;
             this.memoryStream = memoryStream;
             this.CosmosSerializationOptions = serializationOptions;
+            
         }
 
-        public int Count { get; }
+        public int Count => this.Headers.ItemCount ?? 0;
 
         public override Stream Content
         {
@@ -89,17 +89,11 @@ namespace Microsoft.Azure.Cosmos
 
         internal static QueryResponse CreateSuccess(
             IReadOnlyList<CosmosElement> result,
-            int count,
             long responseLengthBytes,
             CosmosQueryResponseMessageHeaders responseHeaders,
             CosmosDiagnosticsContext diagnostics,
             CosmosSerializationFormatOptions serializationOptions)
         {
-            if (count < 0)
-            {
-                throw new ArgumentOutOfRangeException("count must be positive");
-            }
-
             if (responseLengthBytes < 0)
             {
                 throw new ArgumentOutOfRangeException("responseLengthBytes must be positive");
@@ -113,7 +107,6 @@ namespace Microsoft.Azure.Cosmos
 
             QueryResponse cosmosQueryResponse = new QueryResponse(
                result: result,
-               count: count,
                responseLengthBytes: responseLengthBytes,
                responseHeaders: responseHeaders,
                diagnostics: diagnostics,
@@ -135,7 +128,6 @@ namespace Microsoft.Azure.Cosmos
         {
             QueryResponse cosmosQueryResponse = new QueryResponse(
                     result: new List<CosmosElement>(),
-                    count: 0,
                     responseLengthBytes: 0,
                     responseHeaders: responseHeaders,
                     diagnostics: diagnostics,

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/ReadFeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/ReadFeedResponse.cs
@@ -4,10 +4,9 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System.Collections.Generic;
-    using System.IO;
+    using System.Diagnostics;
     using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Json;
 
     internal class ReadFeedResponse<T> : FeedResponse<T>
     {
@@ -18,7 +17,7 @@ namespace Microsoft.Azure.Cosmos
             Headers responseMessageHeaders,
             CosmosDiagnostics diagnostics)
         {
-            this.Count = cosmosArray != null ? cosmosArray.Count : 0;
+            Debug.Assert(cosmosArray.Count == responseMessageHeaders.ItemCount.Value);
             this.Headers = responseMessageHeaders;
             this.StatusCode = httpStatusCode;
             this.Diagnostics = diagnostics;
@@ -27,7 +26,7 @@ namespace Microsoft.Azure.Cosmos
                 serializerCore: serializerCore);
         }
 
-        public override int Count { get; }
+        public override int Count => this.Headers.ItemCount ?? 0;
 
         public override string ContinuationToken => this.Headers?.ContinuationToken;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -682,14 +682,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage response = await feedStreamIterator.ReadNextAsync();
                 response.EnsureSuccessStatusCode();
                 Assert.AreEqual(expectedStatus, response.StatusCode);
-
+                
                 StreamReader sr = new StreamReader(response.Content);
                 string result = await sr.ReadToEndAsync();
                 ICollection<T> responseResults;
                 responseResults = JsonConvert.DeserializeObject<CosmosFeedResponseUtil<T>>(result).Data;
 
                 Assert.IsTrue(responseResults.Count <= 1);
-
+                Assert.AreEqual(responseResults.Count, response.Headers.ItemCount);
                 streamResults.AddRange(responseResults);
             }
 
@@ -702,8 +702,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 response.EnsureSuccessStatusCode();
                 Assert.AreEqual(expectedStatus, response.StatusCode);
 
-                IEnumerable<T> responseResults = TestCommon.SerializerCore.FromStream<CosmosFeedResponseUtil<T>>(response.Content).Data;
-                Assert.IsTrue(responseResults.Count() <= 1);
+                List<T> responseResults = TestCommon.SerializerCore.FromStream<CosmosFeedResponseUtil<T>>(response.Content).Data.ToList();
+                Assert.IsTrue(responseResults.Count <= 1);
+                Assert.AreEqual(responseResults.Count, response.Headers.ItemCount);
 
                 pagedStreamResults.AddRange(responseResults);
                 continuationToken = response.Headers.ContinuationToken;
@@ -729,7 +730,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(expectedStatus, response.StatusCode);
                 Assert.IsTrue(response.Count <= 1);
                 Assert.IsTrue(response.Resource.Count() <= 1);
-
+                Assert.AreEqual(response.Count, response.Headers.ItemCount);
                 results.AddRange(response);
             }
 
@@ -742,6 +743,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(expectedStatus, response.StatusCode);
                 Assert.IsTrue(response.Count <= 1);
                 Assert.IsTrue(response.Resource.Count() <= 1);
+                Assert.AreEqual(response.Count, response.Headers.ItemCount);
+
                 pagedResults.AddRange(response);
                 continuationToken = response.ContinuationToken;
             } while (continuationToken != null);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1211,6 +1211,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             catch (CosmosException exception) when (exception.StatusCode == HttpStatusCode.BadRequest)
             {
+                string message = exception.ToString();
                 Assert.IsTrue(exception.Message.Contains("continuation token limit specified is not large enough"), exception.Message);
             }
 
@@ -1267,6 +1268,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, e.StatusCode, e.Message);
                 Assert.AreNotEqual(e.ActivityId, Guid.Empty);
                 Assert.IsTrue(e.RequestCharge > 0);
+                string message = e.ToString();
                 Assert.AreEqual($"{{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}}", e.ResponseBody);
                 string expectedMessage = $"Response status code does not indicate success: PreconditionFailed (412); Substatus: 0; ActivityId: {e.ActivityId}; Reason: ({{{Environment.NewLine}  \"Errors\": [{Environment.NewLine}    \"One of the specified pre-condition is not met\"{Environment.NewLine}  ]{Environment.NewLine}}});";
                 Assert.AreEqual(expectedMessage, e.Message);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             QueryResponse queryResponse = QueryResponse.CreateSuccess(
                         result: responseCore.CosmosElements,
-                        count: responseCore.CosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
                         serializationOptions: null,
                         responseHeaders: new CosmosQueryResponseMessageHeaders(
@@ -119,7 +118,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             QueryResponse queryResponse = QueryResponse.CreateSuccess(
                         result: cosmosElements,
-                        count: cosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
                         serializationOptions: null,
                         responseHeaders: new CosmosQueryResponseMessageHeaders(
@@ -160,7 +158,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             QueryResponse queryResponse = QueryResponse.CreateSuccess(
                         result: cosmosElements,
-                        count: cosmosElements.Count,
                         responseLengthBytes: responseCore.ResponseLengthBytes,
                         serializationOptions: null,
                         responseHeaders: new CosmosQueryResponseMessageHeaders(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2856,6 +2856,18 @@
           "Attributes": [],
           "MethodInfo": "System.Collections.Generic.IEnumerator`1[System.String] GetEnumerator()"
         },
+        "System.Nullable`1[System.Int32] get_ItemCount()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_ItemCount()"
+        },
+        "System.Nullable`1[System.Int32] ItemCount": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
         "System.String ActivityId[Microsoft.Azure.Cosmos.CosmosKnownHeaderAttribute(HeaderName = \"x-ms-activity-id\")]": {
           "Type": "Property",
           "Attributes": [

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Scenarios/GremlinScenarioTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Scenarios/GremlinScenarioTests.cs
@@ -642,7 +642,6 @@ namespace Microsoft.Azure.Cosmos.Scenarios
                 });
             QueryResponse queryResponse = QueryResponse.CreateSuccess(
                 vertexArray,
-                count: 2,
                 responseLengthBytes: vertex1JsonWriterResult.Length + vertex2JsonWriterResult.Length,
                 serializationOptions: null,
                 responseHeaders: CosmosQueryResponseMessageHeaders.ConvertToQueryHeaders(
@@ -724,7 +723,6 @@ namespace Microsoft.Azure.Cosmos.Scenarios
                 });
             QueryResponse queryResponse = QueryResponse.CreateSuccess(
                 vertexArray,
-                count: 2,
                 responseLengthBytes: vertex1JsonWriterResult.Length + vertex2JsonWriterResult.Length,
                 serializationOptions: null,
                 responseHeaders: CosmosQueryResponseMessageHeaders.ConvertToQueryHeaders(


### PR DESCRIPTION
# Pull Request Template

## Description

This adds a item count property to the headers. This allows query stream users to get the item count in the stream. This fixes a gap where in change feed and read feed have a header value, but the query pipeline does not set it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update