### PR TITLE
[vNext] Contract: Add prefix for discoverability

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -54,7 +54,7 @@
 
   <!--SDK V3 dependencies-->
   <ItemGroup>
-    <Compile Include="..\src\Resource\Settings\Enums\*.cs">
+    <Compile Include="..\src\Resource\Settings\Enums\*.cs" Exclude="..\src\Resource\Settings\Enums\DataType.cs">
       <Link>Resource\Settings\Enums\%(Filename)%(Extension)</Link>
     </Compile>
     <Compile Include="..\src\Handler\*.cs" Exclude="..\src\Handler\RequestMessage.cs;..\src\Handler\ResponseMessage.cs;..\src\Handler\RequestInvokerHandler.cs;..\src\Handler\PartitionKeyRangeHandler.cs;">

--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -99,9 +99,6 @@
     <Compile Include="..\src\RetryOptions.cs">
       <Link>%(Filename)%(Extension)</Link>
     </Compile>
-    <Compile Include="..\src\Regions.cs">
-      <Link>%(Filename)%(Extension)</Link>
-    </Compile>
     <Compile Include="..\src\DocumentClientEventSource.cs">
       <Link>%(Filename)%(Extension)</Link>
     </Compile>

--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -108,7 +108,7 @@
     <Compile Include="..\src\CosmosElements\**\*.cs">
       <Link>CosmosElements\%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
-    <Compile Include="..\src\ChangeFeedProcessor\**\*.cs" Exclude="..\src\ChangeFeedProcessor\FeedManagement\RemainingWorkEstimatorCore.cs;..\src\ChangeFeedProcessor\FeedProcessing\ChangeFeedObserverContextCore.cs;..\src\ChangeFeedProcessor\FeedProcessing\FeedProcessorCore.cs;..\src\ChangeFeedProcessor\Utils\CosmosContainerExtensions.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseContainerCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseUpdaterCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseStoreCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseCore.cs">
+    <Compile Include="..\src\ChangeFeedProcessor\**\*.cs" Exclude="..\src\ChangeFeedProcessor\ChangeFeedProcessorCore.cs;..\src\ChangeFeedProcessor\FeedManagement\RemainingWorkEstimatorCore.cs;..\src\ChangeFeedProcessor\FeedProcessing\ChangeFeedObserverContextCore.cs;..\src\ChangeFeedProcessor\FeedProcessing\FeedProcessorCore.cs;..\src\ChangeFeedProcessor\Utils\CosmosContainerExtensions.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseContainerCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseUpdaterCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseStoreCosmos.cs;..\src\ChangeFeedProcessor\LeaseManagement\DocumentServiceLeaseCore.cs">
       <Link>ChangeFeedProcessor\%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
     <Compile Include="..\src\Headers\*.cs" Exclude="..\src\Headers\Headers.cs;..\src\Headers\CosmosMessageHeadersInternal.cs">

--- a/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -1,7 +1,7 @@
 ﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
-namespace Microsoft.Azure.Cosmos.ChangeFeed
+namespace Azure.Cosmos.ChangeFeed
 {
     using System;
     using System.Threading.Tasks;
@@ -85,13 +85,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         {
             if (documentServiceLeaseStoreManager == null)
             {
-                ContainerProperties containerProperties = await leaseContainer.ReadContainerAsync().ConfigureAwait(false);
+                CosmosContainerProperties containerProperties = await leaseContainer.ReadContainerAsync().ConfigureAwait(false);
 
                 bool isPartitioned =
                     containerProperties.PartitionKey != null &&
                     containerProperties.PartitionKey.Paths != null &&
                     containerProperties.PartitionKey.Paths.Count > 0;
-                bool isMigratedFixed = (containerProperties.PartitionKey?.IsSystemKey == true);
+                bool isMigratedFixed = containerProperties.PartitionKey?.IsSystemKey == true;
                 if (isPartitioned
                     && !isMigratedFixed
                     && (containerProperties.PartitionKey.Paths.Count != 1 || containerProperties.PartitionKey.Paths[0] != "/id"))

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -409,7 +409,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public virtual Task<DatabaseResponse> CreateDatabaseAsync(
+        public virtual Task<CosmosDatabaseResponse> CreateDatabaseAsync(
                 string id,
                 int? throughput = null,
                 RequestOptions requestOptions = null,
@@ -460,7 +460,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public virtual async Task<DatabaseResponse> CreateDatabaseIfNotExistsAsync(
+        public virtual async Task<CosmosDatabaseResponse> CreateDatabaseIfNotExistsAsync(
             string id,
             int? throughput = null,
             RequestOptions requestOptions = null,
@@ -719,7 +719,7 @@ namespace Azure.Cosmos
             return databaseProperties;
         }
 
-        internal Task<DatabaseResponse> CreateDatabaseAsync(
+        internal Task<CosmosDatabaseResponse> CreateDatabaseAsync(
                     CosmosDatabaseProperties databaseProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -405,7 +405,7 @@ namespace Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a database in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) A set of options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the resource record.</returns>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
@@ -420,7 +420,7 @@ namespace Azure.Cosmos
                 throw new ArgumentNullException(nameof(id));
             }
 
-            DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
+            CosmosDatabaseProperties databaseProperties = this.PrepareCosmosDatabaseProperties(id);
             return this.CreateDatabaseAsync(
                 databaseProperties: databaseProperties,
                 throughput: throughput,
@@ -445,7 +445,7 @@ namespace Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a database in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) A set of additional options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the resource record.</returns>
         /// <list>
         ///     <listheader>
         ///         <term>StatusCode</term><description>Common success StatusCodes for the CreateDatabaseIfNotExistsAsync operation</description>
@@ -472,7 +472,7 @@ namespace Azure.Cosmos
             }
 
             // Doing a Read before Create will give us better latency for existing databases
-            DatabaseProperties databaseProperties = this.PrepareDatabaseProperties(id);
+            CosmosDatabaseProperties databaseProperties = this.PrepareCosmosDatabaseProperties(id);
             CosmosDatabase database = this.GetDatabase(id);
             Response response = await database.ReadStreamAsync(requestOptions: requestOptions, cancellationToken: cancellationToken);
             if (response.Status != (int)HttpStatusCode.NotFound)
@@ -629,12 +629,12 @@ namespace Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a database in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) A set of options that can be set.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="DatabaseProperties"/> containing the resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the resource record.</returns>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
         public virtual Task<Response> CreateDatabaseStreamAsync(
-                DatabaseProperties databaseProperties,
+                CosmosDatabaseProperties databaseProperties,
                 int? throughput = null,
                 RequestOptions requestOptions = null,
                 CancellationToken cancellationToken = default(CancellationToken))
@@ -645,7 +645,7 @@ namespace Azure.Cosmos
             }
 
             this.ClientContext.ValidateResource(databaseProperties.Id);
-            Stream streamPayload = this.ClientContext.PropertiesSerializer.ToStream<DatabaseProperties>(databaseProperties);
+            Stream streamPayload = this.ClientContext.PropertiesSerializer.ToStream<CosmosDatabaseProperties>(databaseProperties);
 
             return this.CreateDatabaseStreamInternalAsync(streamPayload, throughput, requestOptions, cancellationToken);
         }
@@ -703,14 +703,14 @@ namespace Azure.Cosmos
             return this.accountConsistencyLevel.Value;
         }
 
-        internal DatabaseProperties PrepareDatabaseProperties(string id)
+        internal CosmosDatabaseProperties PrepareCosmosDatabaseProperties(string id)
         {
             if (string.IsNullOrWhiteSpace(id))
             {
                 throw new ArgumentNullException(nameof(id));
             }
 
-            DatabaseProperties databaseProperties = new DatabaseProperties()
+            CosmosDatabaseProperties databaseProperties = new CosmosDatabaseProperties()
             {
                 Id = id
             };
@@ -720,13 +720,13 @@ namespace Azure.Cosmos
         }
 
         internal Task<DatabaseResponse> CreateDatabaseAsync(
-                    DatabaseProperties databaseProperties,
+                    CosmosDatabaseProperties databaseProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken))
         {
             Task<Response> response = this.CreateDatabaseStreamInternalAsync(
-                streamPayload: this.ClientContext.PropertiesSerializer.ToStream<DatabaseProperties>(databaseProperties),
+                streamPayload: this.ClientContext.PropertiesSerializer.ToStream<CosmosDatabaseProperties>(databaseProperties),
                 throughput: throughput,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosRegions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosRegions.cs
@@ -2,297 +2,297 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos
+namespace Azure.Cosmos
 {
     /// <summary>
     /// The LocationNames class contains the names of Azure regions that
     /// are currently supported by the Azure Cosmos DB service.
     /// </summary>
-    public static class Regions
+    public static class CosmosRegions
     {
         /// <summary>
         /// Name of the Azure West US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string WestUS = "West US";
+        public static readonly string WestUS = "West US";
 
         /// <summary>
         /// Name of the Azure West US 2 region in the Azure Cosmos DB service.
         /// </summary>
-        public const string WestUS2 = "West US 2";
+        public static readonly string WestUS2 = "West US 2";
 
         /// <summary>
         /// Name of the Azure West Central US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string WestCentralUS = "West Central US";
+        public static readonly string WestCentralUS = "West Central US";
 
         /// <summary>
         /// Name of the Azure East US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string EastUS = "East US";
+        public static readonly string EastUS = "East US";
 
         /// <summary>
         /// Name of the Azure East US 2 region in the Azure Cosmos DB service.
         /// </summary>
-        public const string EastUS2 = "East US 2";
+        public static readonly string EastUS2 = "East US 2";
 
         /// <summary>
         /// Name of the Azure Central US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string CentralUS = "Central US";
+        public static readonly string CentralUS = "Central US";
 
         /// <summary>
         /// Name of the Azure Sourth Central US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SouthCentralUS = "South Central US";
+        public static readonly string SouthCentralUS = "South Central US";
 
         /// <summary>
         /// Name of the Azure North Central US region in the Azure Cosmos DB service.
         /// </summary>
-        public const string NorthCentralUS = "North Central US";
+        public static readonly string NorthCentralUS = "North Central US";
 
         /// <summary>
         /// Name of the Azure West Europe region in the Azure Cosmos DB service.
         /// </summary>
-        public const string WestEurope = "West Europe";
+        public static readonly string WestEurope = "West Europe";
 
         /// <summary>
         /// Name of the Azure North Europe region in the Azure Cosmos DB service.
         /// </summary>
-        public const string NorthEurope = "North Europe";
+        public static readonly string NorthEurope = "North Europe";
 
         /// <summary>
         /// Name of the Azure East Asia region in the Azure Cosmos DB service.
         /// </summary>
-        public const string EastAsia = "East Asia";
+        public static readonly string EastAsia = "East Asia";
 
         /// <summary>
         /// Name of the Azure Southeast Asia region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SoutheastAsia = "Southeast Asia";
+        public static readonly string SoutheastAsia = "Southeast Asia";
 
         /// <summary>
         /// Name of the Azure Japan East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string JapanEast = "Japan East";
+        public static readonly string JapanEast = "Japan East";
 
         /// <summary>
         /// Name of the Azure Japan West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string JapanWest = "Japan West";
+        public static readonly string JapanWest = "Japan West";
 
         /// <summary>
         /// Name of the Azure Australia East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string AustraliaEast = "Australia East";
+        public static readonly string AustraliaEast = "Australia East";
 
         /// <summary>
         /// Name of the Azure Australia Southeast region in the Azure Cosmos DB service.
         /// </summary>
-        public const string AustraliaSoutheast = "Australia Southeast";
+        public static readonly string AustraliaSoutheast = "Australia Southeast";
 
         /// <summary>
         /// Name of the Azure Central India region in the Azure Cosmos DB service.
         /// </summary>
-        public const string CentralIndia = "Central India";
+        public static readonly string CentralIndia = "Central India";
 
         /// <summary>
         /// Name of the Azure South India region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SouthIndia = "South India";
+        public static readonly string SouthIndia = "South India";
 
         /// <summary>
         /// Name of the Azure West India region in the Azure Cosmos DB service.
         /// </summary>
-        public const string WestIndia = "West India";
+        public static readonly string WestIndia = "West India";
 
         /// <summary>
         /// Name of the Azure Canada East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string CanadaEast = "Canada East";
+        public static readonly string CanadaEast = "Canada East";
 
         /// <summary>
         /// Name of the Azure Canada Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string CanadaCentral = "Canada Central";
+        public static readonly string CanadaCentral = "Canada Central";
 
         /// <summary>
         /// Name of the Azure Germany Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string GermanyCentral = "Germany Central";
+        public static readonly string GermanyCentral = "Germany Central";
 
         /// <summary>
         /// Name of the Azure Germany Northeast region in the Azure Cosmos DB service.
         /// </summary>
-        public const string GermanyNortheast = "Germany Northeast";
+        public static readonly string GermanyNortheast = "Germany Northeast";
 
         /// <summary>
         /// Name of the Azure China North region in the Azure Cosmos DB service.
         /// </summary>
-        public const string ChinaNorth = "China North";
+        public static readonly string ChinaNorth = "China North";
 
         /// <summary>
         /// Name of the Azure China East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string ChinaEast = "China East";
+        public static readonly string ChinaEast = "China East";
 
         /// <summary>
         /// Name of the Azure China North 2 region in the Azure Cosmos DB service.
         /// </summary>
-        public const string ChinaNorth2 = "China North 2";
+        public static readonly string ChinaNorth2 = "China North 2";
 
         /// <summary>
         /// Name of the Azure China East 2 region in the Azure Cosmos DB service.
         /// </summary>
-        public const string ChinaEast2 = "China East 2";
+        public static readonly string ChinaEast2 = "China East 2";
 
         /// <summary>
         /// Name of the Azure Korea South region in the Azure Cosmos DB service.
         /// </summary>
-        public const string KoreaSouth = "Korea South";
+        public static readonly string KoreaSouth = "Korea South";
 
         /// <summary>
         /// Name of the Azure Korea Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string KoreaCentral = "Korea Central";
+        public static readonly string KoreaCentral = "Korea Central";
 
         /// <summary>
         /// Name of the Azure UK West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string UKWest = "UK West";
+        public static readonly string UKWest = "UK West";
 
         /// <summary>
         /// Name of the Azure UK South region in the Azure Cosmos DB service.
         /// </summary>
-        public const string UKSouth = "UK South";
+        public static readonly string UKSouth = "UK South";
 
         /// <summary>
         /// Name of the Azure Brazil South region in the Azure Cosmos DB service.
         /// </summary>
-        public const string BrazilSouth = "Brazil South";
+        public static readonly string BrazilSouth = "Brazil South";
 
         /// <summary>
         /// Name of the Azure USGov Arizona region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USGovArizona = "USGov Arizona";
+        public static readonly string USGovArizona = "USGov Arizona";
 
         /// <summary>
         /// Name of the Azure USGov Texas region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USGovTexas = "USGov Texas";
+        public static readonly string USGovTexas = "USGov Texas";
 
         /// <summary>
         /// Name of the Azure USGov Virginia region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USGovVirginia = "USGov Virginia";
+        public static readonly string USGovVirginia = "USGov Virginia";
 
         /// <summary>
         /// Name of the Azure East US 2 EUAP region in the Azure Cosmos DB service.
         /// </summary>
-        public const string EastUS2EUAP = "East US 2 EUAP";
+        public static readonly string EastUS2EUAP = "East US 2 EUAP";
 
         /// <summary>
         /// Name of the Azure Central US EUAP region in the Azure Cosmos DB service.
         /// </summary>
-        public const string CentralUSEUAP = "Central US EUAP";
+        public static readonly string CentralUSEUAP = "Central US EUAP";
 
         /// <summary>
         /// Name of the Azure France Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string FranceCentral = "France Central";
+        public static readonly string FranceCentral = "France Central";
 
         /// <summary>
         /// Name of the Azure France South region in the Azure Cosmos DB service.
         /// </summary>
-        public const string FranceSouth = "France South";
+        public static readonly string FranceSouth = "France South";
 
         /// <summary>
         /// Name of the Azure DoD Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USDoDCentral = "USDoD Central";
+        public static readonly string USDoDCentral = "USDoD Central";
 
         /// <summary>
         /// Name of the Azure DoD East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USDoDEast = "USDoD East";
+        public static readonly string USDoDEast = "USDoD East";
 
         /// <summary>
         /// Name of the Azure Australia Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string AustraliaCentral = "Australia Central";
+        public static readonly string AustraliaCentral = "Australia Central";
 
         /// <summary>
         /// Name of the Azure Australia Central 2 region in the Azure Cosmos DB service.
         /// </summary>
-        public const string AustraliaCentral2 = "Australia Central 2";
+        public static readonly string AustraliaCentral2 = "Australia Central 2";
 
         /// <summary>
         /// Name of the Azure South Africa North region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SouthAfricaNorth = "South Africa North";
+        public static readonly string SouthAfricaNorth = "South Africa North";
 
         /// <summary>
         /// Name of the Azure South Africa West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SouthAfricaWest = "South Africa West";
+        public static readonly string SouthAfricaWest = "South Africa West";
 
         /// <summary>
         /// Name of the Azure UAE Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string UAECentral = "UAE Central";
+        public static readonly string UAECentral = "UAE Central";
 
         /// <summary>
         /// Name of the Azure UAE North region in the Azure Cosmos DB service.
         /// </summary>
-        public const string UAENorth = "UAE North";
+        public static readonly string UAENorth = "UAE North";
 
         /// <summary>
         /// Name of the Azure USNat East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USNatEast = "USNat East";
+        public static readonly string USNatEast = "USNat East";
 
         /// <summary>
         /// Name of the Azure USNat West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USNatWest = "USNat West";
+        public static readonly string USNatWest = "USNat West";
 
         /// <summary>
         /// Name of the Azure USSec East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USSecEast = "USSec East";
+        public static readonly string USSecEast = "USSec East";
 
         /// <summary>
         /// Name of the Azure USNat West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string USSecWest = "USSec West";
+        public static readonly string USSecWest = "USSec West";
 
         /// <summary>
         /// Name of the Azure Switzerland North region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SwitzerlandNorth = "Switzerland North";
+        public static readonly string SwitzerlandNorth = "Switzerland North";
 
         /// <summary>
         /// Name of the Azure Switzerland West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string SwitzerlandWest = "Switzerland West";
+        public static readonly string SwitzerlandWest = "Switzerland West";
 
         /// <summary>
         /// Name of the Azure Germany North region in the Azure Cosmos DB service.
         /// </summary>
-        public const string GermanyNorth = "Germany North";
+        public static readonly string GermanyNorth = "Germany North";
 
         /// <summary>
         /// Name of the Azure Germany West Central region in the Azure Cosmos DB service.
         /// </summary>
-        public const string GermanyWestCentral = "Germany West Central";
+        public static readonly string GermanyWestCentral = "Germany West Central";
 
         /// <summary>
         /// Name of the Azure Norway East region in the Azure Cosmos DB service.
         /// </summary>
-        public const string NorwayEast = "Norway East";
+        public static readonly string NorwayEast = "Norway East";
 
         /// <summary>
         /// Name of the Azure Norway West region in the Azure Cosmos DB service.
         /// </summary>
-        public const string NorwayWest = "Norway West";
+        public static readonly string NorwayWest = "Norway West";
     }
 }

--- a/Microsoft.Azure.Cosmos/azuredata/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/DocumentClient.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Documents.Collections;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
+    using ContainerProperties = global::Azure.Cosmos.CosmosContainerProperties;
 
     /// <summary>
     /// Provides a client-side logical representation for the Azure Cosmos DB service.

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
@@ -126,7 +126,7 @@ namespace Azure.Cosmos.Fluent
         /// <summary>
         /// Set the preferred geo-replicated region to be used in the Azure Cosmos DB service. 
         /// </summary>
-        /// <param name="applicationRegion">Azure region where application is running. <see cref="Regions"/> lists valid Cosmos DB regions.</param>
+        /// <param name="applicationRegion">Azure region where application is running. <see cref="CosmosRegions"/> lists valid Cosmos DB regions.</param>
         /// <example>
         /// The example below creates a new <see cref="CosmosClientBuilder"/> with a of preferred region.
         /// <code language="c#">

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerBuilder.cs
@@ -68,7 +68,7 @@ namespace Azure.Cosmos.Fluent
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public async Task<ContainerResponse> CreateAsync(int? throughput = null)
+        public async Task<CosmosContainerResponse> CreateAsync(int? throughput = null)
         {
             CosmosContainerProperties containerProperties = this.Build();
 
@@ -83,7 +83,7 @@ namespace Azure.Cosmos.Fluent
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public async Task<ContainerResponse> CreateIfNotExistsAsync(int? throughput = null)
+        public async Task<CosmosContainerResponse> CreateIfNotExistsAsync(int? throughput = null)
         {
             CosmosContainerProperties containerProperties = this.Build();
 

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerBuilder.cs
@@ -70,7 +70,7 @@ namespace Azure.Cosmos.Fluent
         /// </remarks>
         public async Task<ContainerResponse> CreateAsync(int? throughput = null)
         {
-            ContainerProperties containerProperties = this.Build();
+            CosmosContainerProperties containerProperties = this.Build();
 
             return await this.database.CreateContainerAsync(containerProperties, throughput);
         }
@@ -85,7 +85,7 @@ namespace Azure.Cosmos.Fluent
         /// </remarks>
         public async Task<ContainerResponse> CreateIfNotExistsAsync(int? throughput = null)
         {
-            ContainerProperties containerProperties = this.Build();
+            CosmosContainerProperties containerProperties = this.Build();
 
             return await this.database.CreateContainerIfNotExistsAsync(containerProperties, throughput);
         }
@@ -93,10 +93,10 @@ namespace Azure.Cosmos.Fluent
         /// <summary>
         /// Applies the current Fluent definition and creates a container configuration.
         /// </summary>
-        /// <returns>Builds the current Fluent configuration into an instance of <see cref="ContainerProperties"/>.</returns>
-        public new ContainerProperties Build()
+        /// <returns>Builds the current Fluent configuration into an instance of <see cref="CosmosContainerProperties"/>.</returns>
+        public new CosmosContainerProperties Build()
         {
-            ContainerProperties containerProperties = base.Build();
+            CosmosContainerProperties containerProperties = base.Build();
 
             if (this.uniqueKeyPolicy != null)
             {

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
@@ -45,7 +45,7 @@ namespace Azure.Cosmos.Fluent
         /// </summary>
         /// <param name="partitionKeyDefinitionVersion">The partition key definition version</param>
         /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="ContainerProperties.PartitionKeyDefinitionVersion"/>
+        /// <seealso cref="CosmosContainerProperties.PartitionKeyDefinitionVersion"/>
         public T WithPartitionKeyDefinitionVersion(PartitionKeyDefinitionVersion partitionKeyDefinitionVersion)
         {
             this.partitionKeyDefinitionVersion = partitionKeyDefinitionVersion;
@@ -53,12 +53,12 @@ namespace Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// <see cref="ContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
+        /// <see cref="CosmosContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </summary>
         /// <param name="defaultTtlTimeSpan">The default Time To Live.</param>
         /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="ContainerProperties.DefaultTimeToLive"/>
+        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLive"/>
         public T WithDefaultTimeToLive(TimeSpan defaultTtlTimeSpan)
         {
             if (defaultTtlTimeSpan == null)
@@ -71,12 +71,12 @@ namespace Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// <see cref="ContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
+        /// <see cref="CosmosContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </summary>
         /// <param name="defaulTtlInSeconds">The default Time To Live.</param>
         /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="ContainerProperties.DefaultTimeToLive"/>
+        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLive"/>
         public T WithDefaultTimeToLive(int defaulTtlInSeconds)
         {
             if (defaulTtlInSeconds < -1)
@@ -108,10 +108,10 @@ namespace Azure.Cosmos.Fluent
         /// <summary>
         /// Applies the current Fluent definition and creates a container configuration.
         /// </summary>
-        /// <returns>Builds the current Fluent configuration into an instance of <see cref="ContainerProperties"/>.</returns>
-        public ContainerProperties Build()
+        /// <returns>Builds the current Fluent configuration into an instance of <see cref="CosmosContainerProperties"/>.</returns>
+        public CosmosContainerProperties Build()
         {
-            ContainerProperties containerProperties = new ContainerProperties(id: this.containerName, partitionKeyPath: this.partitionKeyPath);
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(id: this.containerName, partitionKeyPath: this.partitionKeyPath);
             if (this.indexingPolicy != null)
             {
                 containerProperties.IndexingPolicy = this.indexingPolicy;

--- a/Microsoft.Azure.Cosmos/azuredata/Handler/PartitionKeyRangeHandler.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/PartitionKeyRangeHandler.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 PartitionKeyRangeCache routingMapProvider = await this.clientPipelineBuilderContext.GetPartitionKeyRangeCacheAsync();
                 CollectionCache collectionCache = await this.clientPipelineBuilderContext.GetCollectionCacheAsync();
-                ContainerProperties collectionFromCache =
+                CosmosContainerProperties collectionFromCache =
                     await collectionCache.ResolveCollectionAsync(serviceRequest, CancellationToken.None);
 
                 //direction is not expected to change  between continuations.

--- a/Microsoft.Azure.Cosmos/azuredata/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/RequestMessage.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Cosmos
             try
             {
                 CollectionCache collectionCache = await getCollectionCacheAsync();
-                ContainerProperties collectionFromCache =
+                CosmosContainerProperties collectionFromCache =
                     await collectionCache.ResolveCollectionAsync(this.ToDocumentServiceRequest(), cancellationToken);
                 if (collectionFromCache.PartitionKey?.Paths?.Count > 0)
                 {

--- a/Microsoft.Azure.Cosmos/azuredata/Policies/PartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Policies/PartitionKeyRangeGoneRetryPolicy.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Cosmos
                     null,
                     AuthorizationTokenType.PrimaryMasterKey))
                 {
-                    ContainerProperties collection = await this.collectionCache.ResolveCollectionAsync(request, cancellationToken);
+                    CosmosContainerProperties collection = await this.collectionCache.ResolveCollectionAsync(request, cancellationToken);
                     CollectionRoutingMap routingMap = await this.partitionKeyRangeCache.TryLookupAsync(collection.ResourceId, null, request, cancellationToken);
                     if (routingMap != null)
                     {

--- a/Microsoft.Azure.Cosmos/azuredata/Policies/RenameCollectionAwareClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Policies/RenameCollectionAwareClientRetryPolicy.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Cosmos
 
                     try
                     {
-                        ContainerProperties collectionInfo = await this.collectionCache.ResolveCollectionAsync(this.request, cancellationToken);
+                        CosmosContainerProperties collectionInfo = await this.collectionCache.ResolveCollectionAsync(this.request, cancellationToken);
 
                         if (collectionInfo == null)
                         {

--- a/Microsoft.Azure.Cosmos/azuredata/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Query/v3Query/CosmosQueryClientCore.cs
@@ -49,7 +49,7 @@ namespace Azure.Cosmos.Query
             Cosmos.PartitionKey? partitionKey,
             CancellationToken cancellationToken)
         {
-            ContainerProperties containerProperties = await this.clientContext.GetCachedContainerPropertiesAsync(
+            CosmosContainerProperties containerProperties = await this.clientContext.GetCachedContainerPropertiesAsync(
                 containerLink.OriginalString,
                 cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/ClientContextCore.cs
@@ -86,7 +86,7 @@ namespace Azure.Cosmos
             return new Uri(stringBuilder.ToString(), UriKind.Relative);
         }
 
-        internal override async Task<ContainerProperties> GetCachedContainerPropertiesAsync(string containerUri, CancellationToken cancellationToken = default)
+        internal override async Task<CosmosContainerProperties> GetCachedContainerPropertiesAsync(string containerUri, CancellationToken cancellationToken = default)
         {
             ClientCollectionCache collectionCache = await this.DocumentClient.GetCollectionCacheAsync();
             try

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.cs
@@ -77,7 +77,7 @@ namespace Azure.Cosmos
         }
 
         public override Task<ContainerResponse> ReplaceContainerAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -184,7 +184,7 @@ namespace Azure.Cosmos
         }
 
         public override async Task<Response> ReplaceContainerStreamAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -205,8 +205,8 @@ namespace Azure.Cosmos
         /// In case the cache does not have information about this container, it may end up making a server call to fetch the data.
         /// </summary>
         /// <param name="cancellationToken"><see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing the <see cref="ContainerProperties"/> for this container.</returns>
-        internal async Task<ContainerProperties> GetCachedContainerPropertiesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        /// <returns>A <see cref="Task"/> containing the <see cref="CosmosContainerProperties"/> for this container.</returns>
+        internal async Task<CosmosContainerProperties> GetCachedContainerPropertiesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             ClientCollectionCache collectionCache = await this.ClientContext.DocumentClient.GetCollectionCacheAsync();
             try
@@ -222,7 +222,7 @@ namespace Azure.Cosmos
         // Name based look-up, needs re-computation and can't be cached
         internal async Task<string> GetRIDAsync(CancellationToken cancellationToken)
         {
-            ContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
+            CosmosContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
             return containerProperties?.ResourceId;
         }
 
@@ -239,7 +239,7 @@ namespace Azure.Cosmos
         /// <returns>Returns the partition key path</returns>
         internal virtual async Task<string[]> GetPartitionKeyPathTokensAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            ContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
+            CosmosContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
             if (containerProperties == null)
             {
                 throw new ArgumentOutOfRangeException($"Container {this.LinkUri.ToString()} not found");
@@ -265,7 +265,7 @@ namespace Azure.Cosmos
         /// </remarks>
         internal async Task<PartitionKeyInternal> GetNonePartitionKeyValueAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            ContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
+            CosmosContainerProperties containerProperties = await this.GetCachedContainerPropertiesAsync(cancellationToken);
             return containerProperties.GetNoneValue();
         }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.cs
@@ -65,7 +65,7 @@ namespace Azure.Cosmos
 
         public override Scripts.CosmosScripts Scripts { get; }
 
-        public override async Task<ContainerResponse> ReadContainerAsync(
+        public override async Task<CosmosContainerResponse> ReadContainerAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -76,7 +76,7 @@ namespace Azure.Cosmos
             return await this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response, cancellationToken);
         }
 
-        public override Task<ContainerResponse> ReplaceContainerAsync(
+        public override Task<CosmosContainerResponse> ReplaceContainerAsync(
             CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -95,7 +95,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this, response, cancellationToken);
         }
 
-        public override Task<ContainerResponse> DeleteContainerAsync(
+        public override Task<CosmosContainerResponse> DeleteContainerAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerResponse.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerResponse.cs
@@ -7,7 +7,7 @@ namespace Azure.Cosmos
     /// <summary>
     /// The cosmos container response
     /// </summary>
-    public class ContainerResponse : Response<ContainerProperties>
+    public class ContainerResponse : Response<CosmosContainerProperties>
     {
         private readonly Response rawResponse;
 
@@ -25,7 +25,7 @@ namespace Azure.Cosmos
         /// </summary>
         internal ContainerResponse(
             Response response,
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             CosmosContainer container)
         {
             this.rawResponse = response;
@@ -40,7 +40,7 @@ namespace Azure.Cosmos
         public virtual CosmosContainer Container { get; private set; }
 
         /// <inheritdoc/>
-        public override ContainerProperties Value { get; }
+        public override CosmosContainerProperties Value { get; }
 
         /// <inheritdoc/>
         public override Response GetRawResponse() => this.rawResponse;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
@@ -42,12 +42,12 @@ namespace Azure.Cosmos
         public abstract Scripts.CosmosScripts Scripts { get; }
 
         /// <summary>
-        /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Reads a <see cref="CosmosContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.
+        /// A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the read resource record.
         /// </returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
         /// <list type="table">
@@ -75,7 +75,7 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Reads a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Reads a <see cref="CosmosContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
@@ -95,13 +95,13 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Replace a <see cref="CosmosContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
+        /// <param name="containerProperties">The <see cref="CosmosContainerProperties"/> object.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the replace resource record.
+        /// A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the replace resource record.
         /// </returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
         /// <list type="table">
@@ -128,14 +128,14 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         public abstract Task<ContainerResponse> ReplaceContainerAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Replace a <see cref="ContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Replace a <see cref="CosmosContainerProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/>.</param>
+        /// <param name="containerProperties">The <see cref="CosmosContainerProperties"/>.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
@@ -152,12 +152,12 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         public abstract Task<Response> ReplaceContainerStreamAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// Delete a <see cref="CosmosContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
@@ -185,7 +185,7 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete a <see cref="ContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// Delete a <see cref="CosmosContainerProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
@@ -70,7 +70,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<ContainerResponse> ReadContainerAsync(
+        public abstract Task<CosmosContainerResponse> ReadContainerAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -127,7 +127,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<ContainerResponse> ReplaceContainerAsync(
+        public abstract Task<CosmosContainerResponse> ReplaceContainerAsync(
             CosmosContainerProperties containerProperties,
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -180,7 +180,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<ContainerResponse> DeleteContainerAsync(
+        public abstract Task<CosmosContainerResponse> DeleteContainerAsync(
             ContainerRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainerResponse.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainerResponse.cs
@@ -7,14 +7,14 @@ namespace Azure.Cosmos
     /// <summary>
     /// The cosmos container response
     /// </summary>
-    public class ContainerResponse : Response<CosmosContainerProperties>
+    public class CosmosContainerResponse : Response<CosmosContainerProperties>
     {
         private readonly Response rawResponse;
 
         /// <summary>
-        /// Create a <see cref="ContainerResponse"/> as a no-op for mock testing
+        /// Create a <see cref="CosmosContainerResponse"/> as a no-op for mock testing
         /// </summary>
-        protected ContainerResponse()
+        protected CosmosContainerResponse()
             : base()
         {
         }
@@ -23,7 +23,7 @@ namespace Azure.Cosmos
         /// A private constructor to ensure the factory is used to create the object.
         /// This will prevent memory leaks when handling the HttpResponseMessage
         /// </summary>
-        internal ContainerResponse(
+        internal CosmosContainerResponse(
             Response response,
             CosmosContainerProperties containerProperties,
             CosmosContainer container)
@@ -46,10 +46,10 @@ namespace Azure.Cosmos
         public override Response GetRawResponse() => this.rawResponse;
 
         /// <summary>
-        /// Get <see cref="Cosmos.CosmosContainer"/> implicitly from <see cref="ContainerResponse"/>
+        /// Get <see cref="Cosmos.CosmosContainer"/> implicitly from <see cref="CosmosContainerResponse"/>
         /// </summary>
         /// <param name="response">ContainerResponse</param>
-        public static implicit operator CosmosContainer(ContainerResponse response)
+        public static implicit operator CosmosContainer(CosmosContainerResponse response)
         {
             return response.Container;
         }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosClientContext.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosClientContext.cs
@@ -55,7 +55,7 @@ namespace Azure.Cosmos
 
         internal abstract void ValidateResource(string id);
 
-        internal abstract Task<ContainerProperties> GetCachedContainerPropertiesAsync(
+        internal abstract Task<CosmosContainerProperties> GetCachedContainerPropertiesAsync(
             string containerUri,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
@@ -93,7 +93,7 @@ namespace Azure.Cosmos
             });
         }
 
-        internal Task<DatabaseResponse> CreateDatabaseResponseAsync(
+        internal Task<CosmosDatabaseResponse> CreateDatabaseResponseAsync(
             CosmosDatabase database,
             Task<Response> cosmosResponseMessageTask,
             CancellationToken cancellationToken)
@@ -104,7 +104,7 @@ namespace Azure.Cosmos
                     cosmosResponseMessage,
                     this.propertiesSerializer);
 
-                return new DatabaseResponse(
+                return new CosmosDatabaseResponse(
                     cosmosResponseMessage,
                     databaseProperties,
                     database);

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
@@ -82,7 +82,7 @@ namespace Azure.Cosmos
         {
             return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
-                ContainerProperties containerProperties = CosmosResponseFactory.ToObjectInternal<ContainerProperties>(
+                CosmosContainerProperties containerProperties = CosmosResponseFactory.ToObjectInternal<CosmosContainerProperties>(
                     cosmosResponseMessage,
                     this.propertiesSerializer);
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
@@ -75,7 +75,7 @@ namespace Azure.Cosmos
                        serializer);
         }
 
-        internal Task<ContainerResponse> CreateContainerResponseAsync(
+        internal Task<CosmosContainerResponse> CreateContainerResponseAsync(
             CosmosContainer container,
             Task<Response> cosmosResponseMessageTask,
             CancellationToken cancellationToken)
@@ -86,7 +86,7 @@ namespace Azure.Cosmos
                     cosmosResponseMessage,
                     this.propertiesSerializer);
 
-                return new ContainerResponse(
+                return new CosmosContainerResponse(
                     cosmosResponseMessage,
                     containerProperties,
                     container);

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/CosmosResponseFactory.cs
@@ -100,7 +100,7 @@ namespace Azure.Cosmos
         {
             return this.ProcessMessageAsync(cosmosResponseMessageTask, (cosmosResponseMessage) =>
             {
-                DatabaseProperties databaseProperties = CosmosResponseFactory.ToObjectInternal<DatabaseProperties>(
+                CosmosDatabaseProperties databaseProperties = CosmosResponseFactory.ToObjectInternal<CosmosDatabaseProperties>(
                     cosmosResponseMessage,
                     this.propertiesSerializer);
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
@@ -257,11 +257,11 @@ namespace Azure.Cosmos
         /// <summary>
         /// Creates a container as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
+        /// <param name="containerProperties">The <see cref="CosmosContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If either <paramref name="containerProperties"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
@@ -276,7 +276,7 @@ namespace Azure.Cosmos
         ///         <term>403</term><description>Forbidden - This means you attempted to exceed your quota for containers. Contact support to have this quota increased.</description>
         ///     </item>
         ///     <item>
-        ///         <term>409</term><description>Conflict - This means a <see cref="ContainerProperties"/> with an id matching the id you supplied already existed.</description>
+        ///         <term>409</term><description>Conflict - This means a <see cref="CosmosContainerProperties"/> with an id matching the id you supplied already existed.</description>
         ///     </item>
         /// </list>
         /// </exception>
@@ -284,7 +284,7 @@ namespace Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// CosmosContainerProperties containerProperties = new ContainerProperties()
         /// {
         ///     Id = Guid.NewGuid().ToString(),
         ///     PartitionKeyPath = "/pk",
@@ -303,7 +303,7 @@ namespace Azure.Cosmos
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
         public abstract Task<ContainerResponse> CreateContainerAsync(
-                    ContainerProperties containerProperties,
+                    CosmosContainerProperties containerProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken));
@@ -316,7 +316,7 @@ namespace Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
@@ -331,7 +331,7 @@ namespace Azure.Cosmos
         ///         <term>403</term><description>Forbidden - This means you attempted to exceed your quota for containers. Contact support to have this quota increased.</description>
         ///     </item>
         ///     <item>
-        ///         <term>409</term><description>Conflict - This means a <see cref="ContainerProperties"/> with an id matching the id you supplied already existed.</description>
+        ///         <term>409</term><description>Conflict - This means a <see cref="CosmosContainerProperties"/> with an id matching the id you supplied already existed.</description>
         ///     </item>
         /// </list>
         /// </exception>
@@ -357,11 +357,11 @@ namespace Azure.Cosmos
         /// <para>Check if a container exists, and if it doesn't, create it.
         /// Only the container id is used to verify if there is an existing container. Other container properties such as throughput are not validated and can be different then the passed properties.</para>
         /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
+        /// <param name="containerProperties">The <see cref="CosmosContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Requests Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If either <paramref name="containerProperties"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
@@ -376,7 +376,7 @@ namespace Azure.Cosmos
         ///         <term>403</term><description>Forbidden - This means you attempted to exceed your quota for containers. Contact support to have this quota increased.</description>
         ///     </item>
         ///     <item>
-        ///         <term>409</term><description>Conflict - This means a <see cref="ContainerProperties"/> with an id matching the id you supplied already existed.</description>
+        ///         <term>409</term><description>Conflict - This means a <see cref="CosmosContainerProperties"/> with an id matching the id you supplied already existed.</description>
         ///     </item>
         /// </list>
         /// </exception>
@@ -395,7 +395,7 @@ namespace Azure.Cosmos
         ///
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// CosmosContainerProperties containerProperties = new ContainerProperties()
         /// {
         ///     Id = Guid.NewGuid().ToString(),
         ///     PartitionKeyPath = "/pk",
@@ -414,7 +414,7 @@ namespace Azure.Cosmos
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
         public abstract Task<ContainerResponse> CreateContainerIfNotExistsAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -428,7 +428,7 @@ namespace Azure.Cosmos
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="ContainerProperties"/> containing the read resource record.</returns>
+        /// <returns>A <see cref="Task"/> containing a <see cref="Response"/> which wraps a <see cref="CosmosContainerProperties"/> containing the read resource record.</returns>
         /// <exception cref="ArgumentNullException">If <paramref name="id"/> is not set.</exception>
         /// <exception cref="System.AggregateException">Represents a consolidation of failures that occurred during async processing. Look within InnerExceptions to find the actual exception(s).</exception>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a container are:
@@ -443,7 +443,7 @@ namespace Azure.Cosmos
         ///         <term>403</term><description>Forbidden - This means you attempted to exceed your quota for containers. Contact support to have this quota increased.</description>
         ///     </item>
         ///     <item>
-        ///         <term>409</term><description>Conflict - This means a <see cref="ContainerProperties"/> with an id matching the id you supplied already existed.</description>
+        ///         <term>409</term><description>Conflict - This means a <see cref="CosmosContainerProperties"/> with an id matching the id you supplied already existed.</description>
         ///     </item>
         /// </list>
         /// </exception>
@@ -468,7 +468,7 @@ namespace Azure.Cosmos
         /// <summary>
         /// Creates a container as an asynchronous operation in the Azure Cosmos service.
         /// </summary>
-        /// <param name="containerProperties">The <see cref="ContainerProperties"/> object.</param>
+        /// <param name="containerProperties">The <see cref="CosmosContainerProperties"/> object.</param>
         /// <param name="throughput">(Optional) The throughput provisioned for a container in measurement of Request Units per second in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
@@ -477,7 +477,7 @@ namespace Azure.Cosmos
         /// Creates a container as an asynchronous operation in the Azure Cosmos service and return stream response.
         /// <code language="c#">
         /// <![CDATA[
-        /// ContainerProperties containerProperties = new ContainerProperties()
+        /// CosmosContainerProperties containerProperties = new ContainerProperties()
         /// {
         ///     Id = Guid.NewGuid().ToString(),
         ///     PartitionKeyPath = "/pk",
@@ -493,7 +493,7 @@ namespace Azure.Cosmos
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
         public abstract Task<Response> CreateContainerStreamAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
@@ -34,7 +34,7 @@ namespace Azure.Cosmos
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the read resource record.
+        /// A <see cref="Task"/> containing a <see cref="CosmosDatabaseResponse"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the read resource record.
         /// </returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
         /// <list>
@@ -64,7 +64,7 @@ namespace Azure.Cosmos
         /// Doing a read of a resource is the most efficient way to get a resource from the Database. If you know the resource's ID, do a read instead of a query by ID.
         /// </para>
         /// </remarks>
-        public abstract Task<DatabaseResponse> ReadAsync(
+        public abstract Task<CosmosDatabaseResponse> ReadAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken));
 
@@ -93,7 +93,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract Task<DatabaseResponse> DeleteAsync(
+        public abstract Task<CosmosDatabaseResponse> DeleteAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
@@ -302,7 +302,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public abstract Task<ContainerResponse> CreateContainerAsync(
+        public abstract Task<CosmosContainerResponse> CreateContainerAsync(
                     CosmosContainerProperties containerProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,
@@ -346,7 +346,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public abstract Task<ContainerResponse> CreateContainerAsync(
+        public abstract Task<CosmosContainerResponse> CreateContainerAsync(
             string id,
             string partitionKeyPath,
             int? throughput = null,
@@ -413,7 +413,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public abstract Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        public abstract Task<CosmosContainerResponse> CreateContainerIfNotExistsAsync(
             CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
@@ -458,7 +458,7 @@ namespace Azure.Cosmos
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units"/> for details on provision throughput.
         /// </remarks>
-        public abstract Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        public abstract Task<CosmosContainerResponse> CreateContainerIfNotExistsAsync(
             string id,
             string partitionKeyPath,
             int? throughput = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
@@ -29,12 +29,12 @@ namespace Azure.Cosmos
         public abstract string Id { get; }
 
         /// <summary>
-        /// Reads a <see cref="DatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Reads a <see cref="CosmosDatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>
-        /// A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="DatabaseProperties"/> containing the read resource record.
+        /// A <see cref="Task"/> containing a <see cref="DatabaseResponse"/> which wraps a <see cref="CosmosDatabaseProperties"/> containing the read resource record.
         /// </returns>
         /// <exception cref="CosmosException">This exception can encapsulate many different types of errors. To determine the specific error always look at the StatusCode property. Some common codes you may get when creating a Document are:
         /// <list>
@@ -69,7 +69,7 @@ namespace Azure.Cosmos
                     CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete a <see cref="DatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// Delete a <see cref="CosmosDatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
@@ -145,7 +145,7 @@ namespace Azure.Cosmos
         /// The following example shows how to get the throughput
         /// <code language="c#">
         /// <![CDATA[
-        ///  RequestOptions requestOptions = new RequestOptions();
+        /// RequestOptions requestOptions = new RequestOptions();
         /// ThroughputProperties throughputProperties = await database.ReadThroughputAsync(requestOptions);
         /// Console.WriteLine($"Throughput: {throughputProperties?.Throughput}");
         /// ]]>
@@ -194,7 +194,7 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Reads a <see cref="DatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
+        /// Reads a <see cref="CosmosDatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
@@ -216,7 +216,7 @@ namespace Azure.Cosmos
                     CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Delete a <see cref="DatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
+        /// Delete a <see cref="CosmosDatabaseProperties"/> from the Azure Cosmos DB service as an asynchronous operation.
         /// </summary>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="RequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabaseResponse.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabaseResponse.cs
@@ -7,14 +7,14 @@ namespace Azure.Cosmos
     /// <summary>
     /// The cosmos database response
     /// </summary>
-    public class DatabaseResponse : Response<CosmosDatabaseProperties>
+    public class CosmosDatabaseResponse : Response<CosmosDatabaseProperties>
     {
         private readonly Response rawResponse;
 
         /// <summary>
-        /// Create a <see cref="DatabaseResponse"/> as a no-op for mock testing
+        /// Create a <see cref="CosmosDatabaseResponse"/> as a no-op for mock testing
         /// </summary>
-        protected DatabaseResponse()
+        protected CosmosDatabaseResponse()
             : base()
         {
         }
@@ -23,7 +23,7 @@ namespace Azure.Cosmos
         /// A private constructor to ensure the factory is used to create the object.
         /// This will prevent memory leaks when handling the HttpResponseMessage
         /// </summary>
-        internal DatabaseResponse(
+        internal CosmosDatabaseResponse(
             Response response,
             CosmosDatabaseProperties databaseProperties,
             CosmosDatabase database)
@@ -46,10 +46,10 @@ namespace Azure.Cosmos
         public override Response GetRawResponse() => this.rawResponse;
 
         /// <summary>
-        /// Get <see cref="Cosmos.CosmosDatabase"/> implicitly from <see cref="DatabaseResponse"/>
+        /// Get <see cref="Cosmos.CosmosDatabase"/> implicitly from <see cref="CosmosDatabaseResponse"/>
         /// </summary>
         /// <param name="response">DatabaseResponse</param>
-        public static implicit operator CosmosDatabase(DatabaseResponse response)
+        public static implicit operator CosmosDatabase(CosmosDatabaseResponse response)
         {
             return response.Database;
         }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
@@ -47,7 +47,7 @@ namespace Azure.Cosmos
 
         internal CosmosClientContext ClientContext { get; }
 
-        public override Task<DatabaseResponse> ReadAsync(
+        public override Task<CosmosDatabaseResponse> ReadAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -58,7 +58,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateDatabaseResponseAsync(this, response, cancellationToken);
         }
 
-        public override Task<DatabaseResponse> DeleteAsync(
+        public override Task<CosmosDatabaseResponse> DeleteAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken))
         {
@@ -574,7 +574,7 @@ namespace Azure.Cosmos
 
         internal virtual async Task<string> GetRIDAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            DatabaseResponse databaseResponse = await this.ReadAsync(cancellationToken: cancellationToken);
+            CosmosDatabaseResponse databaseResponse = await this.ReadAsync(cancellationToken: cancellationToken);
             return databaseResponse.Value?.ResourceId;
         }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
@@ -146,7 +146,7 @@ namespace Azure.Cosmos
         }
 
         public override Task<ContainerResponse> CreateContainerAsync(
-                    ContainerProperties containerProperties,
+                    CosmosContainerProperties containerProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default(CancellationToken))
@@ -184,7 +184,7 @@ namespace Azure.Cosmos
                 throw new ArgumentNullException(nameof(partitionKeyPath));
             }
 
-            ContainerProperties containerProperties = new ContainerProperties(id, partitionKeyPath);
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(id, partitionKeyPath);
 
             return this.CreateContainerAsync(
                 containerProperties,
@@ -194,7 +194,7 @@ namespace Azure.Cosmos
         }
 
         public override async Task<ContainerResponse> CreateContainerIfNotExistsAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -254,7 +254,7 @@ namespace Azure.Cosmos
                 throw new ArgumentNullException(nameof(partitionKeyPath));
             }
 
-            ContainerProperties containerProperties = new ContainerProperties(id, partitionKeyPath);
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(id, partitionKeyPath);
             return this.CreateContainerIfNotExistsAsync(containerProperties, throughput, requestOptions, cancellationToken);
         }
 
@@ -272,7 +272,7 @@ namespace Azure.Cosmos
         }
 
         public override Task<Response> CreateContainerStreamAsync(
-            ContainerProperties containerProperties,
+            CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -514,7 +514,7 @@ namespace Azure.Cosmos
             return new ContainerBuilder(this, this.ClientContext, name, partitionKeyPath);
         }
 
-        internal void ValidateContainerProperties(ContainerProperties containerProperties)
+        internal void ValidateContainerProperties(CosmosContainerProperties containerProperties)
         {
             containerProperties.ValidateRequiredProperties();
             this.ClientContext.ValidateResource(containerProperties.Id);

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
@@ -145,7 +145,7 @@ namespace Azure.Cosmos
                 cancellationToken);
         }
 
-        public override Task<ContainerResponse> CreateContainerAsync(
+        public override Task<CosmosContainerResponse> CreateContainerAsync(
                     CosmosContainerProperties containerProperties,
                     int? throughput = null,
                     RequestOptions requestOptions = null,
@@ -167,7 +167,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this.GetContainer(containerProperties.Id), response, cancellationToken);
         }
 
-        public override Task<ContainerResponse> CreateContainerAsync(
+        public override Task<CosmosContainerResponse> CreateContainerAsync(
             string id,
             string partitionKeyPath,
             int? throughput = null,
@@ -193,7 +193,7 @@ namespace Azure.Cosmos
                 cancellationToken);
         }
 
-        public override async Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        public override async Task<CosmosContainerResponse> CreateContainerIfNotExistsAsync(
             CosmosContainerProperties containerProperties,
             int? throughput = null,
             RequestOptions requestOptions = null,
@@ -210,7 +210,7 @@ namespace Azure.Cosmos
             Response response = await container.ReadContainerStreamAsync(cancellationToken: cancellationToken);
             if (response.Status != (int)HttpStatusCode.NotFound)
             {
-                ContainerResponse retrivedContainerResponse = await this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this.GetContainer(containerProperties.Id), Task.FromResult(response), cancellationToken);
+                CosmosContainerResponse retrivedContainerResponse = await this.ClientContext.ResponseFactory.CreateContainerResponseAsync(this.GetContainer(containerProperties.Id), Task.FromResult(response), cancellationToken);
                 if (!retrivedContainerResponse.Value.PartitionKeyPath.Equals(containerProperties.PartitionKeyPath))
                 {
                     throw new ArgumentException(
@@ -237,7 +237,7 @@ namespace Azure.Cosmos
             return await container.ReadContainerAsync(cancellationToken: cancellationToken);
         }
 
-        public override Task<ContainerResponse> CreateContainerIfNotExistsAsync(
+        public override Task<CosmosContainerResponse> CreateContainerIfNotExistsAsync(
             string id,
             string partitionKeyPath,
             int? throughput = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseResponse.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseResponse.cs
@@ -7,7 +7,7 @@ namespace Azure.Cosmos
     /// <summary>
     /// The cosmos database response
     /// </summary>
-    public class DatabaseResponse : Response<DatabaseProperties>
+    public class DatabaseResponse : Response<CosmosDatabaseProperties>
     {
         private readonly Response rawResponse;
 
@@ -25,7 +25,7 @@ namespace Azure.Cosmos
         /// </summary>
         internal DatabaseResponse(
             Response response,
-            DatabaseProperties databaseProperties,
+            CosmosDatabaseProperties databaseProperties,
             CosmosDatabase database)
         {
             this.rawResponse = response;
@@ -40,7 +40,7 @@ namespace Azure.Cosmos
         public virtual CosmosDatabase Database { get; }
 
         /// <inheritdoc/>
-        public override DatabaseProperties Value { get; }
+        public override CosmosDatabaseProperties Value { get; }
 
         /// <inheritdoc/>
         public override Response GetRawResponse() => this.rawResponse;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosContainerProperties.cs
@@ -24,7 +24,7 @@ namespace Azure.Cosmos
     /// <code language="c#">
     /// <![CDATA[
     ///     CosmosContainer container = await client.GetDatabase("dbName"].Containers.CreateAsync("MyCollection", "/country", 50000} );
-    ///     ContainerProperties containerProperties = container.Resource;
+    ///     CosmosContainerProperties containerProperties = container.Resource;
     /// ]]>
     /// </code>
     /// </example>
@@ -32,12 +32,12 @@ namespace Azure.Cosmos
     /// The example below creates a new container with a custom indexing policy.
     /// <code language="c#">
     /// <![CDATA[
-    ///     ContainerProperties containerProperties = new ContainerProperties("MyCollection", "/country");
+    ///     CosmosContainerProperties containerProperties = new ContainerProperties("MyCollection", "/country");
     ///     containerProperties.IndexingPolicy.Automatic = true;
     ///     containerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
     ///     
     ///     CosmosContainerResponse containerCreateResponse = await client.GetDatabase("dbName"].CreateContainerAsync(containerProperties, 50000);
-    ///     ContainerProperties createdContainerProperties = containerCreateResponse.Container;
+    ///     CosmosContainerProperties createdContainerProperties = containerCreateResponse.Container;
     /// ]]>
     /// </code>
     /// </example>
@@ -45,14 +45,14 @@ namespace Azure.Cosmos
     /// The example below deletes this container.
     /// <code language="c#">
     /// <![CDATA[
-    ///     Container container = client.GetDatabase("dbName"].Containers["MyCollection"];
+    ///     CosmosContainer container = client.GetDatabase("dbName"].Containers["MyCollection"];
     ///     await container.DeleteAsync();
     /// ]]>
     /// </code>
     /// </example>
     /// <seealso cref="IndexingPolicy"/>
     /// <seealso cref="UniqueKeyPolicy"/>
-    public class ContainerProperties
+    public class CosmosContainerProperties
     {
         private static readonly char[] partitionKeyTokenDelimeter = new char[] { '/' };
 
@@ -66,18 +66,18 @@ namespace Azure.Cosmos
         private string id;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContainerProperties"/> class for the Azure Cosmos DB service.
+        /// Initializes a new instance of the <see cref="CosmosContainerProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
-        public ContainerProperties()
+        public CosmosContainerProperties()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContainerProperties"/> class for the Azure Cosmos DB service.
+        /// Initializes a new instance of the <see cref="CosmosContainerProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
         /// <param name="partitionKeyPath">The path to the partition key. Example: /location</param>
-        public ContainerProperties(string id, string partitionKeyPath)
+        public CosmosContainerProperties(string id, string partitionKeyPath)
         {
             this.Id = id;
             this.PartitionKeyPath = partitionKeyPath;
@@ -186,7 +186,7 @@ namespace Azure.Cosmos
         public ETag? ETag { get; internal set; }
 
         /// <summary>
-        /// Gets the last modified time stamp associated with <see cref="ContainerProperties" /> from the Azure Cosmos DB service.
+        /// Gets the last modified time stamp associated with <see cref="CosmosContainerProperties" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified time stamp associated with the resource.</value>
         public DateTime? LastModified { get; internal set; }
@@ -321,26 +321,26 @@ namespace Azure.Cosmos
         /// Only collection cache needs this contract. None are expected to use it. 
         /// </summary>
         /// <param name="resourceId">The resource identifier for the container.</param>
-        /// <returns>An instance of <see cref="ContainerProperties"/>.</returns>
-        internal static ContainerProperties CreateWithResourceId(string resourceId)
+        /// <returns>An instance of <see cref="CosmosContainerProperties"/>.</returns>
+        internal static CosmosContainerProperties CreateWithResourceId(string resourceId)
         {
             if (string.IsNullOrEmpty(resourceId))
             {
                 throw new ArgumentNullException(nameof(resourceId));
             }
 
-            return new ContainerProperties()
+            return new CosmosContainerProperties()
             {
                 ResourceId = resourceId,
             };
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ContainerProperties"/> class for the Azure Cosmos DB service.
+        /// Initializes a new instance of the <see cref="CosmosContainerProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
         /// <param name="partitionKeyDefinition">The partition key <see cref="PartitionKeyDefinition"/></param>
-        internal ContainerProperties(string id, PartitionKeyDefinition partitionKeyDefinition)
+        internal CosmosContainerProperties(string id, PartitionKeyDefinition partitionKeyDefinition)
         {
             this.Id = id;
             this.PartitionKey = partitionKeyDefinition;
@@ -390,7 +390,7 @@ namespace Azure.Cosmos
                     throw new ArgumentOutOfRangeException($"Container {this.Id} is not partitioned");
                 }
 
-                this.partitionKeyPathTokens = this.PartitionKeyPath.Split(ContainerProperties.partitionKeyTokenDelimeter, StringSplitOptions.RemoveEmptyEntries);
+                this.partitionKeyPathTokens = this.PartitionKeyPath.Split(CosmosContainerProperties.partitionKeyTokenDelimeter, StringSplitOptions.RemoveEmptyEntries);
                 return this.partitionKeyPathTokens;
             }
         }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosDatabaseProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosDatabaseProperties.cs
@@ -26,22 +26,22 @@ namespace Azure.Cosmos
     /// </code>
     /// </example>
     /// <seealso cref="CosmosContainerProperties"/>
-    public class DatabaseProperties
+    public class CosmosDatabaseProperties
     {
         private string id;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DatabaseProperties"/> class for the Azure Cosmos DB service.
+        /// Initializes a new instance of the <see cref="CosmosDatabaseProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
-        public DatabaseProperties()
+        public CosmosDatabaseProperties()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DatabaseProperties"/> class for the Azure Cosmos DB service.
+        /// Initializes a new instance of the <see cref="CosmosDatabaseProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
-        public DatabaseProperties(string id)
+        public CosmosDatabaseProperties(string id)
         {
             this.Id = id;
         }
@@ -84,7 +84,7 @@ namespace Azure.Cosmos
         public ETag? ETag { get; internal set; }
 
         /// <summary>
-        /// Gets the last modified time stamp associated with <see cref="DatabaseProperties" /> from the Azure Cosmos DB service.
+        /// Gets the last modified time stamp associated with <see cref="CosmosDatabaseProperties" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified time stamp associated with the resource.</value>
         public DateTime? LastModified { get; internal set; }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/DatabaseProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/DatabaseProperties.cs
@@ -18,42 +18,14 @@ namespace Azure.Cosmos
     /// The example below creates a new Database with an Id property of 'MyDatabase'.
     /// <code language="c#">
     /// <![CDATA[ 
-    /// using (DocumentClient client = new DocumentClient(new Uri("service endpoint"), "auth key"))
+    /// using (CosmosClient client = new CosmosClient("connection string"))
     /// {
-    ///     Database db = await client.CreateDatabaseAsync(new Database { Id = "MyDatabase" });
+    ///     CosmosDatabase db = await client.CreateDatabaseAsync(new Database { Id = "MyDatabase" });
     /// }
     /// ]]>
     /// </code>
     /// </example>
-    /// <example> 
-    /// The example below creates a collection within this database with OfferThroughput set to 10000.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// DocumentCollection coll = await client.CreateDocumentCollectionAsync(db.SelfLink,
-    ///     new DocumentCollection { Id = "MyCollection" }, 
-    ///     10000);
-    /// ]]>
-    /// </code>
-    /// </example>
-    /// <example>
-    /// The example below queries for a Database by Id to retrieve the SelfLink.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// using Microsoft.Azure.Cosmos.Linq;
-    /// Database database = client.CreateDatabaseQuery().Where(d => d.Id == "MyDatabase").AsEnumerable().FirstOrDefault();
-    /// string databaseLink = database.SelfLink;
-    /// ]]>
-    /// </code>
-    /// </example>    
-    /// <example>
-    /// The example below deletes the database using its SelfLink property.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// await client.DeleteDatabaseAsync(db.SelfLink);
-    /// ]]>
-    /// </code>
-    /// </example>
-    /// <seealso cref="ContainerProperties"/>
+    /// <seealso cref="CosmosContainerProperties"/>
     public class DatabaseProperties
     {
         private string id;

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Enums/CosmosDataType.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Enums/CosmosDataType.cs
@@ -1,12 +1,12 @@
 ﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
-namespace Microsoft.Azure.Cosmos
+namespace Azure.Cosmos
 {
     /// <summary>
     /// Defines the target data type of an index path specification in the Azure Cosmos DB service.
     /// </summary>
-    public enum DataType
+    public enum CosmosDataType
     {
         /// <summary>
         /// Represents a numeric data type.

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/HashIndex.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/HashIndex.cs
@@ -28,11 +28,11 @@ namespace Azure.Cosmos
         /// Here is an example to instantiate HashIndex class passing in the DataType:
         /// <code language="c#">
         /// <![CDATA[
-        /// HashIndex hashIndex = new HashIndex(DataType.String);
+        /// HashIndex hashIndex = new HashIndex(CosmosDataType.String);
         /// ]]>
         /// </code>
         /// </example>
-        public HashIndex(DataType dataType)
+        public HashIndex(CosmosDataType dataType)
             : this()
         {
             this.DataType = dataType;
@@ -48,11 +48,11 @@ namespace Azure.Cosmos
         /// Here is an example to instantiate HashIndex class passing in the DataType and precision:
         /// <code language="c#">
         /// <![CDATA[
-        /// HashIndex hashIndex = new HashIndex(DataType.String, 3);
+        /// HashIndex hashIndex = new HashIndex(CosmosDataType.String, 3);
         /// ]]>
         /// </code>
         /// </example>
-        public HashIndex(DataType dataType, short precision)
+        public HashIndex(CosmosDataType dataType, short precision)
             : this(dataType)
         {
             this.Precision = precision;
@@ -65,7 +65,7 @@ namespace Azure.Cosmos
         /// The data type for which this index should be applied.
         /// </value>
         /// <remarks>Refer to <a href="http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy">Customizing the indexing policy of a collection</a> for valid ranges of values.</remarks>
-        public DataType DataType { get; set; }
+        public CosmosDataType DataType { get; set; }
 
         /// <summary>
         /// Gets or sets the precision for this particular index in the Azure Cosmos DB service.

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Index.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/Index.cs
@@ -30,7 +30,7 @@ namespace Azure.Cosmos
         /// </summary>
         /// <param name="dataType">Specifies the target data type for the index path specification.</param>
         /// <returns>An instance of <see cref="RangeIndex"/> type.</returns>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to create RangeIndex instance passing in the DataType:
         /// <code language="c#">
@@ -39,7 +39,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public static RangeIndex Range(DataType dataType)
+        public static RangeIndex Range(CosmosDataType dataType)
         {
             return new RangeIndex(dataType);
         }
@@ -50,16 +50,16 @@ namespace Azure.Cosmos
         /// <param name="dataType">Specifies the target data type for the index path specification.</param>
         /// <param name="precision">Specifies the precision to be used for the data type associated with this index.</param>
         /// <returns>An instance of <see cref="RangeIndex"/> type.</returns>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to create RangeIndex instance passing in the DataType and precision:
         /// <code language="c#">
         /// <![CDATA[
-        /// RangeIndex rangeIndex = Index.Range(DataType.Number, -1);
+        /// RangeIndex rangeIndex = Index.Range(CosmosDataType.Number, -1);
         /// ]]>
         /// </code>
         /// </example>
-        public static RangeIndex Range(DataType dataType, short precision)
+        public static RangeIndex Range(CosmosDataType dataType, short precision)
         {
             return new RangeIndex(dataType, precision);
         }
@@ -69,16 +69,16 @@ namespace Azure.Cosmos
         /// </summary>
         /// <param name="dataType">Specifies the target data type for the index path specification.</param>
         /// <returns>An instance of <see cref="HashIndex"/> type.</returns>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to create HashIndex instance passing in the DataType:
         /// <code language="c#">
         /// <![CDATA[
-        /// HashIndex hashIndex = Index.Hash(DataType.String);
+        /// HashIndex hashIndex = Index.Hash(CosmosDataType.String);
         /// ]]>
         /// </code>
         /// </example>
-        public static HashIndex Hash(DataType dataType)
+        public static HashIndex Hash(CosmosDataType dataType)
         {
             return new HashIndex(dataType);
         }
@@ -89,16 +89,16 @@ namespace Azure.Cosmos
         /// <param name="dataType">Specifies the target data type for the index path specification.</param>
         /// <param name="precision">Specifies the precision to be used for the data type associated with this index.</param>
         /// <returns>An instance of <see cref="HashIndex"/> type.</returns>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to create HashIndex instance passing in the DataType and precision:
         /// <code language="c#">
         /// <![CDATA[
-        /// HashIndex hashIndex = Index.Hash(DataType.String, 3);
+        /// HashIndex hashIndex = Index.Hash(CosmosDataType.String, 3);
         /// ]]>
         /// </code>
         /// </example>
-        public static HashIndex Hash(DataType dataType, short precision)
+        public static HashIndex Hash(CosmosDataType dataType, short precision)
         {
             return new HashIndex(dataType, precision);
         }
@@ -108,16 +108,16 @@ namespace Azure.Cosmos
         /// </summary>
         /// <param name="dataType">Specifies the target data type for the index path specification.</param>
         /// <returns>An instance of <see cref="SpatialIndex"/> type.</returns>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to create SpatialIndex instance passing in the DataType:
         /// <code language="c#">
         /// <![CDATA[
-        /// SpatialIndex spatialIndex = Index.Spatial(DataType.Point);
+        /// SpatialIndex spatialIndex = Index.Spatial(CosmosDataType.Point);
         /// ]]>
         /// </code>
         /// </example>
-        public static SpatialIndex Spatial(DataType dataType)
+        public static SpatialIndex Spatial(CosmosDataType dataType)
         {
             return new SpatialIndex(dataType);
         }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
@@ -20,7 +20,7 @@ namespace Azure.Cosmos
     /// indexing policies.
     /// </para>
     /// </remarks>
-    /// <seealso cref="ContainerProperties"/>
+    /// <seealso cref="CosmosContainerProperties"/>
     public sealed class IndexingPolicy
     {
         internal const string DefaultPath = "/*";

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/RangeIndex.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/RangeIndex.cs
@@ -28,11 +28,11 @@ namespace Azure.Cosmos
         /// Here is an example to instantiate RangeIndex class passing in the DataType:
         /// <code language="c#">
         /// <![CDATA[
-        /// RangeIndex rangeIndex = new RangeIndex(DataType.Number);
+        /// RangeIndex rangeIndex = new RangeIndex(CosmosDataType.Number);
         /// ]]>
         /// </code>
         /// </example>
-        public RangeIndex(DataType dataType)
+        public RangeIndex(CosmosDataType dataType)
             : this()
         {
             this.DataType = dataType;
@@ -48,11 +48,11 @@ namespace Azure.Cosmos
         /// Here is an example to instantiate RangeIndex class passing in the DataType and precision:
         /// <code language="c#">
         /// <![CDATA[
-        /// RangeIndex rangeIndex = new RangeIndex(DataType.Number, -1);
+        /// RangeIndex rangeIndex = new RangeIndex(CosmosDataType.Number, -1);
         /// ]]>
         /// </code>
         /// </example>
-        public RangeIndex(DataType dataType, short precision)
+        public RangeIndex(CosmosDataType dataType, short precision)
             : this(dataType)
         {
             this.Precision = precision;
@@ -65,7 +65,7 @@ namespace Azure.Cosmos
         /// The data type for which this index should be applied.
         /// </value>
         /// <remarks>Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for valid ranges of values.</remarks>
-        public DataType DataType { get; set; }
+        public CosmosDataType DataType { get; set; }
 
         /// <summary>
         /// Gets or sets the precision for this particular index in the Azure Cosmos DB service.

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialIndex.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialIndex.cs
@@ -18,16 +18,16 @@ namespace Azure.Cosmos
         /// Initializes a new instance of the <see cref="SpatialIndex"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="dataType">Specifies the target data type for the index path specification</param>
-        /// <seealso cref="DataType"/>
+        /// <seealso cref="CosmosDataType"/>
         /// <example>
         /// Here is an example to instantiate SpatialIndex class passing in the DataType
         /// <code language="c#">
         /// <![CDATA[
-        /// SpatialIndex spatialIndex = new SpatialIndex(DataType.Point);
+        /// SpatialIndex spatialIndex = new SpatialIndex(CosmosDataType.Point);
         /// ]]>
         /// </code>
         /// </example>
-        public SpatialIndex(DataType dataType)
+        public SpatialIndex(CosmosDataType dataType)
             : this()
         {
             this.DataType = dataType;
@@ -40,6 +40,6 @@ namespace Azure.Cosmos
         /// The data type for which this index should be applied.
         /// </value>
         /// <remarks>Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for valid ranges of values.</remarks>
-        public DataType DataType { get; set; }
+        public CosmosDataType DataType { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ThroughputProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/ThroughputProperties.cs
@@ -37,7 +37,7 @@ namespace Azure.Cosmos
         public ETag? ETag { get; internal set; }
 
         /// <summary>
-        /// Gets the last modified time stamp associated with <see cref="DatabaseProperties" /> from the Azure Cosmos DB service.
+        /// Gets the last modified time stamp associated with <see cref="CosmosDatabaseProperties" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified time stamp associated with the resource.</value>
         public DateTime? LastModified { get; internal set; }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UniqueKeyPolicy.cs
@@ -15,7 +15,7 @@ namespace Azure.Cosmos
     /// unique key policies.
     /// </para>
     /// </remarks>
-    /// <seealso cref="ContainerProperties"/>
+    /// <seealso cref="CosmosContainerProperties"/>
     public sealed class UniqueKeyPolicy
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/UserProperties.cs
@@ -65,7 +65,7 @@ namespace Azure.Cosmos
         public ETag? ETag { get; internal set; }
 
         /// <summary>
-        /// Gets the last modified time stamp associated with <see cref="DatabaseProperties" /> from the Azure Cosmos DB service.
+        /// Gets the last modified time stamp associated with <see cref="CosmosDatabaseProperties" /> from the Azure Cosmos DB service.
         /// </summary>
         /// <value>The last modified time stamp associated with the resource.</value>
         public DateTime? LastModified { get; internal set; }

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonContainerPropertiesConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonContainerPropertiesConverter.cs
@@ -11,9 +11,9 @@ namespace Azure.Cosmos
     using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
-    internal class TextJsonContainerPropertiesConverter : JsonConverter<ContainerProperties>
+    internal class TextJsonContainerPropertiesConverter : JsonConverter<CosmosContainerProperties>
     {
-        public override ContainerProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override CosmosContainerProperties Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             if (reader.TokenType == JsonTokenType.Null)
             {
@@ -27,7 +27,7 @@ namespace Azure.Cosmos
 
             using JsonDocument json = JsonDocument.ParseValue(ref reader);
             JsonElement root = json.RootElement;
-            ContainerProperties setting = new ContainerProperties();
+            CosmosContainerProperties setting = new CosmosContainerProperties();
 
             foreach (JsonProperty property in root.EnumerateObject())
             {
@@ -37,7 +37,7 @@ namespace Azure.Cosmos
             return setting;
         }
 
-        public override void Write(Utf8JsonWriter writer, ContainerProperties setting, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, CosmosContainerProperties setting, JsonSerializerOptions options)
         {
             if (setting == null)
             {
@@ -107,7 +107,7 @@ namespace Azure.Cosmos
             writer.WriteEndObject();
         }
 
-        private static void ReadPropertyValue(ContainerProperties setting, JsonProperty property)
+        private static void ReadPropertyValue(CosmosContainerProperties setting, JsonProperty property)
         {
             if (property.NameEquals(JsonEncodedStrings.Id.EncodedUtf8Bytes))
             {

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonDatabasePropertiesConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonDatabasePropertiesConverter.cs
@@ -10,9 +10,9 @@ namespace Azure.Cosmos
     using System.Text.Json.Serialization;
     using Microsoft.Azure.Documents;
 
-    internal class TextJsonDatabasePropertiesConverter : JsonConverter<DatabaseProperties>
+    internal class TextJsonDatabasePropertiesConverter : JsonConverter<CosmosDatabaseProperties>
     {
-        public override DatabaseProperties Read(
+        public override CosmosDatabaseProperties Read(
             ref Utf8JsonReader reader,
             Type typeToConvert,
             JsonSerializerOptions options)
@@ -29,7 +29,7 @@ namespace Azure.Cosmos
 
             using JsonDocument json = JsonDocument.ParseValue(ref reader);
             JsonElement root = json.RootElement;
-            DatabaseProperties setting = new DatabaseProperties();
+            CosmosDatabaseProperties setting = new CosmosDatabaseProperties();
 
             foreach (JsonProperty property in root.EnumerateObject())
             {
@@ -41,7 +41,7 @@ namespace Azure.Cosmos
 
         public override void Write(
             Utf8JsonWriter writer,
-            DatabaseProperties setting,
+            CosmosDatabaseProperties setting,
             JsonSerializerOptions options)
         {
             if (setting == null)
@@ -62,7 +62,7 @@ namespace Azure.Cosmos
         }
 
         private static void ReadPropertyValue(
-            DatabaseProperties setting,
+            CosmosDatabaseProperties setting,
             JsonProperty property)
         {
             if (property.NameEquals(JsonEncodedStrings.Id.EncodedUtf8Bytes))

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonIndexConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonIndexConverter.cs
@@ -110,8 +110,8 @@ namespace Azure.Cosmos
                 throw new JsonException(string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, indexKindElement.GetRawText()));
             }
 
-            DataType dataType = DataType.Number;
-            if (!TextJsonSettingsHelper.TryParseEnum<DataType>(dataTypeElement, type => dataType = type))
+            CosmosDataType dataType = CosmosDataType.Number;
+            if (!TextJsonSettingsHelper.TryParseEnum<CosmosDataType>(dataTypeElement, type => dataType = type))
             {
                 throw new JsonException(string.Format(CultureInfo.CurrentCulture, RMResources.InvalidIndexKindValue, dataTypeElement.GetRawText()));
             }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -92,8 +92,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         {
             if (documentServiceLeaseStoreManager == null)
             {
-                ContainerResponse cosmosContainerResponse = await leaseContainer.ReadContainerAsync().ConfigureAwait(false);
-                ContainerProperties containerProperties = cosmosContainerResponse;
+                ContainerProperties containerProperties = await leaseContainer.ReadContainerAsync().ConfigureAwait(false);
 
                 bool isPartitioned =
                     containerProperties.PartitionKey != null &&

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -10,6 +10,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
+#if AZURECORE
+    using ContainerProperties = CosmosContainerProperties;
+#endif
 
     internal sealed class ChangeFeedProcessorCore<T> : ChangeFeedProcessor
     {

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/DataType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/DataType.cs
@@ -10,7 +10,11 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Defines the target data type of an index path specification in the Azure Cosmos DB service.
     /// </summary>
+#if AZURECORE
+    public enum CosmosDataType
+#else
     public enum DataType
+#endif
     {
         /// <summary>
         /// Represents a numeric data type.

--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
+#if AZURECORE
+    using ContainerProperties = CosmosContainerProperties;
+#endif
 
     /// <summary>
     /// Abstracts out the logic to resolve physical replica addresses for the given <see cref="DocumentServiceRequest"/>.

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Routing
     using System.Threading.Tasks;
 #if AZURECORE
     using global::Azure.Cosmos;
+    using ContainerProperties = global::Azure.Cosmos.CosmosContainerProperties;
 #endif
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Documents;

--- a/Microsoft.Azure.Cosmos/src/Routing/CollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/CollectionCache.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Common
     using Microsoft.Azure.Cosmos.Core.Trace;
 #if AZURECORE
     using global::Azure.Cosmos;
+    using ContainerProperties = global::Azure.Cosmos.CosmosContainerProperties;
 #endif
 #if !NETSTANDARD16
     using System.Diagnostics;

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Routing
     using System.Threading.Tasks;
 #if AZURECORE
     using global::Azure.Cosmos;
+    using ContainerProperties = global::Azure.Cosmos.CosmosContainerProperties;
 #endif
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Core.Trace;

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Routing
     using System.Threading.Tasks;
 #if AZURECORE
     using global::Azure.Cosmos;
+    using ContainerProperties = global::Azure.Cosmos.CosmosContainerProperties;
 #endif
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Documents;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             CosmosContainerProperties containerSettings = new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 containerSettings,
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            ContainerProperties containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 containerSettings,
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -19,7 +19,7 @@ namespace Azure.Cosmos.EmulatorTests.ChangeFeed
         {
             await base.TestInit();
             string PartitionKey = "/id";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: "monitored", partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             this.Container = response;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -20,13 +20,13 @@ namespace Azure.Cosmos.EmulatorTests.ChangeFeed
             await base.TestInit();
             string PartitionKey = "/id";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: "monitored", partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: "monitored", partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             this.Container = response;
 
 
             response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: "leases", partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: "leases", partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
 
             this.LeaseContainer = response;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Cosmos.EmulatorTests.ChangeFeed
 
             string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 10000,
                 cancellationToken: this.cancellationToken);
             this.Container = response;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Cosmos.EmulatorTests.ChangeFeed
             await base.ChangeFeedTestInit();
 
             string PartitionKey = "/pk";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 10000,
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -111,7 +111,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse createResponse = await database.CreateContainerIfNotExistsAsync(id: "BasicQueryContainer1", partitionKeyPath: "/pk");
+                CosmosContainerResponse createResponse = await database.CreateContainerIfNotExistsAsync(id: "BasicQueryContainer1", partitionKeyPath: "/pk");
                 createdIds.Add(createResponse.Container.Id);
 
                 createResponse = await database.CreateContainerIfNotExistsAsync(id: "BasicQueryContainer2", partitionKeyPath: "/pk2");
@@ -468,7 +468,7 @@ namespace Azure.Cosmos.EmulatorTests
                 Assert.AreEqual((int)HttpStatusCode.Created, createUserResponse.GetRawResponse().Status);
                 user = (UserCore)createUserResponse.User;
 
-                ContainerResponse createContainerResponse = await database.CreateContainerIfNotExistsAsync(Guid.NewGuid().ToString(), partitionKeyPath: "/pk");
+                CosmosContainerResponse createContainerResponse = await database.CreateContainerIfNotExistsAsync(Guid.NewGuid().ToString(), partitionKeyPath: "/pk");
                 CosmosContainer container = createContainerResponse.Container;
                 PermissionResponse permissionResponse = await user.CreatePermissionAsync(new PermissionProperties("BasicQueryPermission1", PermissionMode.All, container));
                 createdContainerIds.Add(createContainerResponse.Container.Id);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                DatabaseResponse createResponse = await client.CreateDatabaseIfNotExistsAsync(id: "BasicQueryDb1");
+                CosmosDatabaseResponse createResponse = await client.CreateDatabaseIfNotExistsAsync(id: "BasicQueryDb1");
                 deleteList.Add(createResponse.Database);
                 createdIds.Add(createResponse.Database.Id);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -121,18 +121,18 @@ namespace Azure.Cosmos.EmulatorTests
                 createdIds.Add(createResponse.Container.Id);
 
                 //Read All
-                List<ContainerProperties> results = await this.ToListAsync(
+                List<CosmosContainerProperties> results = await this.ToListAsync(
                     database.GetContainerQueryStreamIterator,
-                    database.GetContainerQueryIterator<ContainerProperties>,
+                    database.GetContainerQueryIterator<CosmosContainerProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
                 //Basic query
-                List<ContainerProperties> queryResults = await this.ToListAsync(
+                List<CosmosContainerProperties> queryResults = await this.ToListAsync(
                     database.GetContainerQueryStreamIterator,
-                    database.GetContainerQueryIterator<ContainerProperties>,
+                    database.GetContainerQueryIterator<CosmosContainerProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryContainer\")",
                     CosmosBasicQueryTests.RequestOptions);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -74,18 +74,18 @@ namespace Azure.Cosmos.EmulatorTests
                 createdIds.Add(createResponse.Database.Id);
 
                 //Read All
-                List<DatabaseProperties> results = await this.ToListAsync(
+                List<CosmosDatabaseProperties> results = await this.ToListAsync(
                     client.GetDatabaseQueryStreamIterator,
-                    client.GetDatabaseQueryIterator<DatabaseProperties>,
+                    client.GetDatabaseQueryIterator<CosmosDatabaseProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions);
 
                 CollectionAssert.IsSubsetOf(createdIds, results.Select(x => x.Id).ToList());
 
                 //Basic query
-                List<DatabaseProperties> queryResults = await this.ToListAsync(
+                List<CosmosDatabaseProperties> queryResults = await this.ToListAsync(
                     client.GetDatabaseQueryStreamIterator,
-                    client.GetDatabaseQueryIterator<DatabaseProperties>,
+                    client.GetDatabaseQueryIterator<CosmosDatabaseProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryDb\")",
                     CosmosBasicQueryTests.RequestOptions);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Cosmos.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient();
 
             string databaseName = Guid.NewGuid().ToString();
-            DatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
+            CosmosDatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
             this.cosmosDatabase = cosmosDatabaseResponse;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -62,7 +62,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
             };
 
-            ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
+            CosmosContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
             CosmosContainer container = response;
             CosmosContainerProperties existingCosmosContainerProperties = response.Value;
 
@@ -78,7 +78,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             while(true)
             {
-                ContainerResponse readResponse = await container.ReadContainerAsync(requestOptions);
+                CosmosContainerResponse readResponse = await container.ReadContainerAsync(requestOptions);
                 Assert.IsTrue(readResponse.GetRawResponse().Headers.TryGetValue("x-ms-documentdb-collection-index-transformation-progress", out string indexTransformationStatus));
                 Assert.IsNotNull(indexTransformationStatus);
 
@@ -94,7 +94,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ContainerContractTest()
         {
-            ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(new Guid().ToString(), "/id");
+            CosmosContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(new Guid().ToString(), "/id");
             this.ValidateCreateContainerResponseContract(response);
         }
 
@@ -117,7 +117,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
@@ -173,7 +173,7 @@ namespace Azure.Cosmos.EmulatorTests
             CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyPath);
             settings.PartitionKeyDefinitionVersion = PartitionKeyDefinitionVersion.V1;
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
 
@@ -190,7 +190,7 @@ namespace Azure.Cosmos.EmulatorTests
             partitionKeyDefinition.Paths.Add(partitionKeyPath);
 
             CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyDefinition);
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
@@ -207,7 +207,7 @@ namespace Azure.Cosmos.EmulatorTests
             string partitionKeyPath1 = "/users";
 
             CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyPath1);
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
@@ -309,7 +309,7 @@ namespace Azure.Cosmos.EmulatorTests
             partitionKeyDefinition.Paths.Add("/test");
 
             CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyDefinition);
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
             Assert.Fail("Multiple partition keys should have caused an exception.");
         }
@@ -341,7 +341,7 @@ namespace Azure.Cosmos.EmulatorTests
             CosmosContainerProperties settings = new CosmosContainerProperties() { Id = containerName };
             try
             {
-                ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
+                CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -351,7 +351,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
+                CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -361,7 +361,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(id: containerName, partitionKeyPath: null);
+                CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(id: containerName, partitionKeyPath: null);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -371,7 +371,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(id: containerName, partitionKeyPath: null);
+                CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(id: containerName, partitionKeyPath: null);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -386,7 +386,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
@@ -406,7 +406,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
@@ -439,7 +439,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerName, partitionKeyPath);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(containerName, containerResponse.Value.Id);
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
@@ -479,7 +479,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse containerResponse = await container.DeleteContainerAsync();
+                CosmosContainerResponse containerResponse = await container.DeleteContainerAsync();
                 Assert.Fail();
             }
             catch (CosmosException ex)
@@ -494,7 +494,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             CosmosContainer container = this.cosmosDatabase.GetContainer(containerName);
 
@@ -511,7 +511,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             CosmosContainer container = this.cosmosDatabase.GetContainer(containerName);
 
@@ -617,7 +617,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             CosmosContainer container = containerResponse;
             CosmosContainerProperties containerSettings = containerResponse;
             Assert.IsNotNull(container);
@@ -630,7 +630,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsNull(containerSettings);
         }
 
-        private void ValidateCreateContainerResponseContract(ContainerResponse containerResponse)
+        private void ValidateCreateContainerResponseContract(CosmosContainerResponse containerResponse)
         {
             Assert.IsNotNull(containerResponse);
             ResponseHeaders headers = containerResponse.GetRawResponse().Headers;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ReIndexingTest()
         {
-            ContainerProperties cp = new ContainerProperties()
+            CosmosContainerProperties cp = new CosmosContainerProperties()
             {
                 Id = "ReIndexContainer",
                 PartitionKeyPath = "/pk",
@@ -64,13 +64,13 @@ namespace Azure.Cosmos.EmulatorTests
 
             ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
             CosmosContainer container = response;
-            ContainerProperties existingContainerProperties = response.Value;
+            CosmosContainerProperties existingCosmosContainerProperties = response.Value;
 
             // Turn on indexing
-            existingContainerProperties.IndexingPolicy.Automatic = true;
-            existingContainerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
+            existingCosmosContainerProperties.IndexingPolicy.Automatic = true;
+            existingCosmosContainerProperties.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
-            await container.ReplaceContainerAsync(existingContainerProperties);
+            await container.ReplaceContainerAsync(existingCosmosContainerProperties);
 
             // Check progress
             ContainerRequestOptions requestOptions = new ContainerRequestOptions();
@@ -127,7 +127,7 @@ namespace Azure.Cosmos.EmulatorTests
             //Assert.IsFalse(string.IsNullOrEmpty(diagnostics));
             //Assert.IsTrue(diagnostics.Contains("StatusCode"));
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyPath)
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyPath)
             {
                 IndexingPolicy = new IndexingPolicy()
                 {
@@ -170,7 +170,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyPath);
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyPath);
             settings.PartitionKeyDefinitionVersion = PartitionKeyDefinitionVersion.V1;
 
             ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
@@ -189,7 +189,7 @@ namespace Azure.Cosmos.EmulatorTests
             Microsoft.Azure.Documents.PartitionKeyDefinition partitionKeyDefinition = new Microsoft.Azure.Documents.PartitionKeyDefinition();
             partitionKeyDefinition.Paths.Add(partitionKeyPath);
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyDefinition);
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyDefinition);
             ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
@@ -206,7 +206,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath1 = "/users";
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyPath1);
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyPath1);
             ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
 
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
@@ -224,7 +224,7 @@ namespace Azure.Cosmos.EmulatorTests
             string partitionKeyPath2 = "/users2";
             try
             {
-                settings = new ContainerProperties(containerName, partitionKeyPath2);
+                settings = new CosmosContainerProperties(containerName, partitionKeyPath2);
                 containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(settings);
                 Assert.Fail("Should through ArgumentException on partition key path");
             }
@@ -248,14 +248,14 @@ namespace Azure.Cosmos.EmulatorTests
             Microsoft.Azure.Documents.PartitionKeyDefinition partitionKeyDefinition = new Microsoft.Azure.Documents.PartitionKeyDefinition();
             partitionKeyDefinition.Paths.Add("/test");
             partitionKeyDefinition.IsSystemKey = false;
-            ContainerProperties containerPropertiesWithSystemKey = new ContainerProperties()
+            CosmosContainerProperties containerPropertiesWithSystemKey = new CosmosContainerProperties()
             {
                 Id = v2ContainerName,
                 PartitionKey = partitionKeyDefinition,
             };
             await this.cosmosDatabase.CreateContainerAsync(containerPropertiesWithSystemKey);
 
-            ContainerProperties containerProperties = new ContainerProperties(v2ContainerName, "/test");
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(v2ContainerName, "/test");
             containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerProperties);
             Assert.AreEqual((int)HttpStatusCode.OK, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(v2ContainerName, containerResponse.Value.Id);
@@ -267,7 +267,7 @@ namespace Azure.Cosmos.EmulatorTests
             containerPropertiesWithSystemKey.PartitionKey.IsSystemKey = true;
             await this.cosmosDatabase.CreateContainerAsync(containerPropertiesWithSystemKey);
 
-            containerProperties = new ContainerProperties(v2ContainerName, "/test");
+            containerProperties = new CosmosContainerProperties(v2ContainerName, "/test");
             containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerProperties);
             Assert.AreEqual((int)HttpStatusCode.OK, containerResponse.GetRawResponse().Status);
             Assert.AreEqual(v2ContainerName, containerResponse.Value.Id);
@@ -286,7 +286,7 @@ namespace Azure.Cosmos.EmulatorTests
             Microsoft.Azure.Documents.PartitionKeyDefinition partitionKeyDefinition = new Microsoft.Azure.Documents.PartitionKeyDefinition();
             partitionKeyDefinition.Paths.Add(partitionKeyPath);
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyDefinition);
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyDefinition);
             using (Response containerResponse = await this.cosmosDatabase.CreateContainerStreamAsync(settings))
             {
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.Status);
@@ -308,7 +308,7 @@ namespace Azure.Cosmos.EmulatorTests
             partitionKeyDefinition.Paths.Add("/users");
             partitionKeyDefinition.Paths.Add("/test");
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyDefinition);
+            CosmosContainerProperties settings = new CosmosContainerProperties(containerName, partitionKeyDefinition);
             ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
             Assert.Fail("Multiple partition keys should have caused an exception.");
@@ -320,7 +320,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             try
             {
-                new ContainerProperties(id: containerName, partitionKeyPath: null);
+                new CosmosContainerProperties(id: containerName, partitionKeyPath: null);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -330,7 +330,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                new ContainerProperties(id: containerName, partitionKeyDefinition: null);
+                new CosmosContainerProperties(id: containerName, partitionKeyDefinition: null);
                 Assert.Fail("Create should throw null ref exception");
             }
             catch (ArgumentNullException ae)
@@ -338,7 +338,7 @@ namespace Azure.Cosmos.EmulatorTests
                 Assert.IsNotNull(ae);
             }
 
-            ContainerProperties settings = new ContainerProperties() { Id = containerName };
+            CosmosContainerProperties settings = new CosmosContainerProperties() { Id = containerName };
             try
             {
                 ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
@@ -412,7 +412,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
 
             HashSet<string> containerIds = new HashSet<string>();
-            await foreach (ContainerProperties setting in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>())
+            await foreach (CosmosContainerProperties setting in this.cosmosDatabase.GetContainerQueryIterator<CosmosContainerProperties>())
             {
                 if (!containerIds.Contains(setting.Id))
                 {
@@ -423,7 +423,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsTrue(containerIds.Count > 0, "The iterator did not find any containers.");
             Assert.IsTrue(containerIds.Contains(containerName), "The iterator did not find the created container");
 
-            await foreach (Page<ContainerProperties> page in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>($"select * from c where c.id = \"{containerName}\"").AsPages())
+            await foreach (Page<CosmosContainerProperties> page in this.cosmosDatabase.GetContainerQueryIterator<CosmosContainerProperties>($"select * from c where c.id = \"{containerName}\"").AsPages())
             {
                 Assert.AreEqual(1, page.Values.Count);
                 Assert.AreEqual(containerName, page.Values.First().Id);
@@ -619,7 +619,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerIfNotExistsAsync(containerName, partitionKeyPath);
             CosmosContainer container = containerResponse;
-            ContainerProperties containerSettings = containerResponse;
+            CosmosContainerProperties containerSettings = containerResponse;
             Assert.IsNotNull(container);
             Assert.IsNotNull(containerSettings);
 
@@ -641,7 +641,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsTrue(headers.TryGetValue(Microsoft.Azure.Documents.HttpConstants.HttpHeaders.ActivityId, out string activityId));
             Assert.IsNotNull(activityId);
 
-            ContainerProperties containerSettings = containerResponse.Value;
+            CosmosContainerProperties containerSettings = containerResponse.Value;
             Assert.IsNotNull(containerSettings.Id);
             Assert.IsNotNull(containerSettings.ResourceId);
             Assert.IsNotNull(containerSettings.ETag);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -46,7 +46,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task DatabaseContractTest()
         {
-            DatabaseResponse response = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse response = await this.CreateDatabaseHelper();
             Assert.IsNotNull(response);
             Assert.IsTrue(response.GetRawResponse().Headers.GetRequestCharge() > 0);
             Assert.IsNotNull(response.GetRawResponse().Headers);
@@ -71,7 +71,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task CreateDropDatabase()
         {
-            DatabaseResponse response = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse response = await this.CreateDatabaseHelper();
             Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
             //Assert.IsNotNull(response.Diagnostics);
             //string diagnostics = response.Diagnostics.ToString();
@@ -155,7 +155,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task CreateConflict()
         {
-            DatabaseResponse response = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse response = await this.CreateDatabaseHelper();
             Assert.AreEqual((int)HttpStatusCode.Created, response.GetRawResponse().Status);
 
             try
@@ -175,7 +175,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ImplicitConversion()
         {
-            DatabaseResponse cosmosDatabaseResponse = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse cosmosDatabaseResponse = await this.CreateDatabaseHelper();
             Cosmos.CosmosDatabase cosmosDatabase = cosmosDatabaseResponse;
             CosmosDatabaseProperties cosmosDatabaseSettings = cosmosDatabaseResponse;
             Assert.IsNotNull(cosmosDatabase);
@@ -193,7 +193,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             try
             {
-                DatabaseResponse response = await this.cosmosClient.GetDatabase(Guid.NewGuid().ToString()).DeleteAsync(cancellationToken: this.cancellationToken);
+                CosmosDatabaseResponse response = await this.cosmosClient.GetDatabase(Guid.NewGuid().ToString()).DeleteAsync(cancellationToken: this.cancellationToken);
                 Assert.Fail();
             }
             catch (CosmosException ex)
@@ -205,8 +205,8 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ReadDatabase()
         {
-            DatabaseResponse createResponse = await this.CreateDatabaseHelper();
-            DatabaseResponse readResponse = await createResponse.Database.ReadAsync(cancellationToken: this.cancellationToken);
+            CosmosDatabaseResponse createResponse = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse readResponse = await createResponse.Database.ReadAsync(cancellationToken: this.cancellationToken);
 
             Assert.AreEqual(createResponse.Database.Id, readResponse.Database.Id);
             Assert.AreEqual(createResponse.Value.Id, readResponse.Value.Id);
@@ -218,7 +218,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task CreateIfNotExists()
         {
-            DatabaseResponse createResponse = await this.CreateDatabaseHelper();
+            CosmosDatabaseResponse createResponse = await this.CreateDatabaseHelper();
             Assert.AreEqual((int)HttpStatusCode.Created, createResponse.GetRawResponse().Status);
 
             createResponse = await this.CreateDatabaseHelper(createResponse.Value.Id, databaseExists: true);
@@ -233,7 +233,7 @@ namespace Azure.Cosmos.EmulatorTests
         public async Task NoThroughputTests()
         {
             string databaseId = Guid.NewGuid().ToString();
-            DatabaseResponse createResponse = await this.CreateDatabaseHelper(databaseId, databaseExists: false);
+            CosmosDatabaseResponse createResponse = await this.CreateDatabaseHelper(databaseId, databaseExists: false);
             Assert.AreEqual((int)HttpStatusCode.Created, createResponse.GetRawResponse().Status);
 
             Cosmos.CosmosDatabase cosmosDatabase = createResponse;
@@ -260,7 +260,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             string databaseId = Guid.NewGuid().ToString();
             int throughput = 10000;
-            DatabaseResponse createResponse = await client.CreateDatabaseAsync(databaseId, throughput, null);
+            CosmosDatabaseResponse createResponse = await client.CreateDatabaseAsync(databaseId, throughput, null);
             Assert.AreEqual((int)HttpStatusCode.Created, createResponse.GetRawResponse().Status);
 
             Cosmos.CosmosDatabase cosmosDatabase = createResponse;
@@ -330,7 +330,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 for (int i = 0; i < 3; i++)
                 {
-                    DatabaseResponse createResponse = await this.CreateDatabaseHelper();
+                    CosmosDatabaseResponse createResponse = await this.CreateDatabaseHelper();
                     deleteList.Add(createResponse.Database);
                     databaseIds.Add(createResponse.Value.Id);
                 }
@@ -367,11 +367,11 @@ namespace Azure.Cosmos.EmulatorTests
                 string secondDb = "Bcdefgh";
                 string thirdDb = "Zoo";
 
-                DatabaseResponse createResponse2 = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(secondDb);
+                CosmosDatabaseResponse createResponse2 = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(secondDb);
                 deleteList.Add(createResponse2.Database);
-                DatabaseResponse createResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(firstDb);
+                CosmosDatabaseResponse createResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(firstDb);
                 deleteList.Add(createResponse.Database);
-                DatabaseResponse createResponse3 = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(thirdDb);
+                CosmosDatabaseResponse createResponse3 = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(thirdDb);
                 deleteList.Add(createResponse3.Database);
 
                 int iterations = 0;
@@ -396,17 +396,17 @@ namespace Azure.Cosmos.EmulatorTests
             }
         }
 
-        private Task<DatabaseResponse> CreateDatabaseHelper()
+        private Task<CosmosDatabaseResponse> CreateDatabaseHelper()
         {
             return this.CreateDatabaseHelper(Guid.NewGuid().ToString(), databaseExists: false);
         }
 
-        private async Task<DatabaseResponse> CreateDatabaseHelper(
+        private async Task<CosmosDatabaseResponse> CreateDatabaseHelper(
             string databaseId,
             int? throughput = null,
             bool databaseExists = false)
         {
-            DatabaseResponse response = null;
+            CosmosDatabaseResponse response = null;
             if (databaseExists)
             {
                 response = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(
@@ -458,7 +458,7 @@ namespace Azure.Cosmos.EmulatorTests
             return this.cosmosClient.GetDatabase(databaseId);
         }
 
-        private void ValidateHeaders(DatabaseResponse cosmosDatabaseResponse)
+        private void ValidateHeaders(CosmosDatabaseResponse cosmosDatabaseResponse)
         {
             // Test emulator is regression and commented out to unblock
             // Assert.IsNotNull(cosmosDatabaseResponse.MaxResourceQuota);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -283,7 +283,7 @@ namespace Azure.Cosmos.EmulatorTests
             // Database must have a container before it can be scaled
             string containerId = Guid.NewGuid().ToString();
             string partitionPath = "/users";
-            ContainerResponse containerResponse = await cosmosDatabase.CreateContainerAsync(containerId, partitionPath, throughput: null);
+            CosmosContainerResponse containerResponse = await cosmosDatabase.CreateContainerAsync(containerId, partitionPath, throughput: null);
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
 
             ThroughputResponse replaceThroughputResponse = await cosmosDatabase.ReplaceThroughputAsync(readThroughputResponse.Value.Throughput.Value + 1000);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsNotNull(response.GetRawResponse().Headers);
             Assert.IsNotNull(response.GetRawResponse().Headers.GetActivityId());
 
-            DatabaseProperties databaseSettings = response.Value;
+            CosmosDatabaseProperties databaseSettings = response.Value;
             Assert.IsNotNull(databaseSettings.Id);
             Assert.IsNotNull(databaseSettings.ResourceId);
             Assert.IsNotNull(databaseSettings.ETag);
@@ -115,7 +115,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task StreamCreateConflictTestAsync()
         {
-            DatabaseProperties databaseSettings = new DatabaseProperties()
+            CosmosDatabaseProperties databaseSettings = new CosmosDatabaseProperties()
             {
                 Id = Guid.NewGuid().ToString()
             };
@@ -177,7 +177,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             DatabaseResponse cosmosDatabaseResponse = await this.CreateDatabaseHelper();
             Cosmos.CosmosDatabase cosmosDatabase = cosmosDatabaseResponse;
-            DatabaseProperties cosmosDatabaseSettings = cosmosDatabaseResponse;
+            CosmosDatabaseProperties cosmosDatabaseSettings = cosmosDatabaseResponse;
             Assert.IsNotNull(cosmosDatabase);
             Assert.IsNotNull(cosmosDatabaseSettings);
 
@@ -335,7 +335,7 @@ namespace Azure.Cosmos.EmulatorTests
                     databaseIds.Add(createResponse.Value.Id);
                 }
 
-                await foreach(DatabaseProperties databaseSettings in this.cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>(
+                await foreach(CosmosDatabaseProperties databaseSettings in this.cosmosClient.GetDatabaseQueryIterator<CosmosDatabaseProperties>(
                     queryDefinition: null,
                     continuationToken: null,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 2 }))
@@ -375,7 +375,7 @@ namespace Azure.Cosmos.EmulatorTests
                 deleteList.Add(createResponse3.Database);
 
                 int iterations = 0;
-                await foreach(Page<DatabaseProperties> iterator in this.cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>(
+                await foreach(Page<CosmosDatabaseProperties> iterator in this.cosmosClient.GetDatabaseQueryIterator<CosmosDatabaseProperties>(
                         new QueryDefinition("select c.id From c where c.id = @id ")
                         .WithParameter("@id", createResponse.Database.Id),
                         requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }).AsPages())
@@ -444,7 +444,7 @@ namespace Azure.Cosmos.EmulatorTests
                 databaseId = Guid.NewGuid().ToString();
             }
 
-            DatabaseProperties databaseSettings = new DatabaseProperties() { Id = databaseId };
+            CosmosDatabaseProperties databaseSettings = new CosmosDatabaseProperties() { Id = databaseId };
             Response response = await this.cosmosClient.CreateDatabaseStreamAsync(
                 databaseSettings,
                 throughput: 400);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -32,14 +32,14 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);
             Assert.IsNotNull(response.Value);
 
             ContainerResponse largerContainer = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 20000,
                 cancellationToken: this.cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -31,14 +31,14 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);
             Assert.IsNotNull(response.Value);
 
-            ContainerResponse largerContainer = await this.database.CreateContainerAsync(
+            CosmosContainerResponse largerContainer = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 20000,
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Cosmos.EmulatorTests
     public class CosmosItemTests : BaseCosmosClientHelper
     {
         private CosmosContainer Container = null;
-        private ContainerProperties containerSettings = null;
+        private CosmosContainerProperties containerSettings = null;
 
         private static readonly string nonPartitionItemId = "fixed-Container-Item";
         private static readonly string undefinedPartitionItemId = "undefined-partition-Item";
@@ -44,7 +44,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
+            this.containerSettings = new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             this.containerSettings = new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
@@ -1022,7 +1022,7 @@ namespace Azure.Cosmos.EmulatorTests
             try
             {
                 // Create a container large enough to have at least 2 partitions
-                ContainerResponse containerResponse = await this.database.CreateContainerAsync(
+                CosmosContainerResponse containerResponse = await this.database.CreateContainerAsync(
                     id: Guid.NewGuid().ToString(),
                     partitionKeyPath: "/pk",
                     throughput: 15000);
@@ -1253,7 +1253,7 @@ namespace Azure.Cosmos.EmulatorTests
                 await NonPartitionedContainerHelper.CreateItemInNonPartitionedContainer(fixedContainer, nonPartitionItemId);
                 await NonPartitionedContainerHelper.CreateUndefinedPartitionItem((ContainerCore)this.Container, undefinedPartitionItemId);
 
-                ContainerResponse containerResponse = await fixedContainer.ReadContainerAsync();
+                CosmosContainerResponse containerResponse = await fixedContainer.ReadContainerAsync();
                 Assert.IsTrue(containerResponse.Value.PartitionKey.Paths.Count > 0);
                 Assert.AreEqual(PartitionKey.SystemKeyPath, containerResponse.Value.PartitionKey.Paths[0]);
 
@@ -1380,7 +1380,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 // Read the container metadata
-                ContainerResponse containerResponse = await fixedContainer.ReadContainerAsync();
+                CosmosContainerResponse containerResponse = await fixedContainer.ReadContainerAsync();
 
                 // Query items on the container that have no partition key value
                 int resultsFetched = 0;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             this.container = response;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -83,14 +83,14 @@ namespace Azure.Cosmos.EmulatorTests
             // Create should fail if the database does not exist
             if (dbNotExist)
             {
-                ContainerProperties newcontainerSettings = new ContainerProperties(id: DoesNotExist, partitionKeyPath: "/pk");
+                CosmosContainerProperties newcontainerSettings = new CosmosContainerProperties(id: DoesNotExist, partitionKeyPath: "/pk");
                 this.VerifyNotFoundResponse(await database.CreateContainerStreamAsync(newcontainerSettings, throughput: 500));
             }
 
             CosmosContainer doesNotExistContainer = database.GetContainer(DoesNotExist);
             this.VerifyNotFoundResponse(await doesNotExistContainer.ReadContainerStreamAsync());
 
-            ContainerProperties containerSettings = new ContainerProperties(id: DoesNotExist, partitionKeyPath: "/pk");
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties(id: DoesNotExist, partitionKeyPath: "/pk");
             this.VerifyNotFoundResponse(await doesNotExistContainer.ReplaceContainerStreamAsync(containerSettings));
             this.VerifyNotFoundResponse(await doesNotExistContainer.DeleteContainerStreamAsync());
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Cosmos.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient();
 
             string databaseName = Guid.NewGuid().ToString();
-            DatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
+            CosmosDatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
             this.cosmosDatabase = cosmosDatabaseResponse;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Cosmos.EmulatorTests
         public async Task CRUDTest()
         {
             string containerId = Guid.NewGuid().ToString();
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
 
             string userId = Guid.NewGuid().ToString();
@@ -113,7 +113,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             //create resource
             string containerId = Guid.NewGuid().ToString();
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             CosmosContainer container = containerResponse.Container;
             
@@ -131,7 +131,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 try
                 {
-                    ContainerResponse response = await tokenCosmosClient
+                    CosmosContainerResponse response = await tokenCosmosClient
                     .GetDatabase(this.cosmosDatabase.Id)
                     .GetContainer(containerId)
                     .DeleteContainerAsync();
@@ -151,7 +151,7 @@ namespace Azure.Cosmos.EmulatorTests
             //delete resource with PermissionMode.All
             using (CosmosClient tokenCosmosClient = TestCommon.CreateCosmosClient(options: null, resourceToken: permission.Token))
             {
-                ContainerResponse response = await tokenCosmosClient
+                CosmosContainerResponse response = await tokenCosmosClient
                     .GetDatabase(this.cosmosDatabase.Id)
                     .GetContainer(containerId)
                     .DeleteContainerAsync();
@@ -171,7 +171,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             //create resource
             string containerId = Guid.NewGuid().ToString();
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
+            CosmosContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(containerId, "/id");
             Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
             CosmosContainer container = containerResponse.Container;
             string itemId = Guid.NewGuid().ToString();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Cosmos.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 50000,
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
@@ -25,7 +25,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 50000,
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosSpatialTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosSpatialTests.cs
@@ -32,7 +32,7 @@
 
             string PartitionKey = "/partitionKey";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosSpatialTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosSpatialTests.cs
@@ -31,7 +31,7 @@
                 cancellationToken: this.cancellationToken);
 
             string PartitionKey = "/partitionKey";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosUserTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosUserTests.cs
@@ -22,7 +22,7 @@ namespace Azure.Cosmos.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient();
 
             string databaseName = Guid.NewGuid().ToString();
-            DatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
+            CosmosDatabaseResponse cosmosDatabaseResponse = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(databaseName);
             this.cosmosDatabase = cosmosDatabaseResponse;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -190,8 +190,8 @@ namespace Azure.Cosmos.EmulatorTests
                                 Path = "/*",
                                 Indexes = new Collection<Cosmos.Index>
                                 {
-                                    Cosmos.Index.Range(Cosmos.DataType.Number),
-                                    Cosmos.Index.Range(Cosmos.DataType.String),
+                                    Cosmos.Index.Range(Cosmos.CosmosDataType.Number),
+                                    Cosmos.Index.Range(Cosmos.CosmosDataType.String),
                                 }
                             }
                         }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -105,7 +105,7 @@ namespace Azure.Cosmos.EmulatorTests
             HttpConstants.Versions.CurrentVersionUTF8 = Encoding.UTF8.GetBytes(apiVersion);
         }
 
-        private async Task<IReadOnlyList<PartitionKeyRange>> GetPartitionKeyRanges(ContainerProperties container)
+        private async Task<IReadOnlyList<PartitionKeyRange>> GetPartitionKeyRanges(CosmosContainerProperties container)
         {
             Range<string> fullRange = new Range<string>(
                 PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
@@ -178,7 +178,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual((int)HttpStatusCode.OK, responseMessage.Status);
 
             ContainerResponse containerResponse = await this.database.CreateContainerAsync(
-                new ContainerProperties
+                new CosmosContainerProperties
                 {
                     Id = Guid.NewGuid().ToString() + "container",
                     IndexingPolicy = indexingPolicy == null ? new Cosmos.IndexingPolicy
@@ -3017,7 +3017,7 @@ namespace Azure.Cosmos.EmulatorTests
             IDictionary<string, string> idToRangeMinKeyMap = new Dictionary<string, string>();
             IRoutingMapProvider routingMapProvider = await this.Client.DocumentClient.GetPartitionKeyRangeCacheAsync();
 
-            ContainerProperties containerSettings = await container.ReadContainerAsync();
+            CosmosContainerProperties containerSettings = await container.ReadContainerAsync();
             foreach (Document document in documents)
             {
                 IReadOnlyList<PartitionKeyRange> targetRanges = await routingMapProvider.TryGetOverlappingRangesAsync(
@@ -3809,7 +3809,7 @@ namespace Azure.Cosmos.EmulatorTests
             CosmosContainer container,
             IEnumerable<Document> documents)
         {
-            ContainerProperties containerSettings = await container.ReadContainerAsync();
+            CosmosContainerProperties containerSettings = await container.ReadContainerAsync();
             // For every composite index
             foreach (Collection<Cosmos.CompositePath> compositeIndex in containerSettings.IndexingPolicy.CompositeIndexes)
             {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -123,7 +123,7 @@ namespace Azure.Cosmos.EmulatorTests
             string partitionKey = "/id",
             Azure.Cosmos.IndexingPolicy indexingPolicy = null)
         {
-            ContainerResponse containerResponse = await this.CreatePartitionedContainer(
+            CosmosContainerResponse containerResponse = await this.CreatePartitionedContainer(
                 throughput: 25000,
                 partitionKey: partitionKey,
                 indexingPolicy: indexingPolicy);
@@ -140,7 +140,7 @@ namespace Azure.Cosmos.EmulatorTests
             string partitionKey = "/id",
             Azure.Cosmos.IndexingPolicy indexingPolicy = null)
         {
-            ContainerResponse containerResponse = await this.CreatePartitionedContainer(
+            CosmosContainerResponse containerResponse = await this.CreatePartitionedContainer(
                 throughput: 4000,
                 partitionKey: partitionKey,
                 indexingPolicy: indexingPolicy);
@@ -168,7 +168,7 @@ namespace Azure.Cosmos.EmulatorTests
             return this.database.GetContainer(containerName);
         }
 
-        private async Task<ContainerResponse> CreatePartitionedContainer(
+        private async Task<CosmosContainerResponse> CreatePartitionedContainer(
             int throughput,
             string partitionKey = "/id",
             Azure.Cosmos.IndexingPolicy indexingPolicy = null)
@@ -177,7 +177,7 @@ namespace Azure.Cosmos.EmulatorTests
             Response responseMessage = await this.database.ReadStreamAsync();
             Assert.AreEqual((int)HttpStatusCode.OK, responseMessage.Status);
 
-            ContainerResponse containerResponse = await this.database.CreateContainerAsync(
+            CosmosContainerResponse containerResponse = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties
                 {
                     Id = Guid.NewGuid().ToString() + "container",
@@ -528,7 +528,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                     await Task.WhenAll(queryTasks);
 
-                    List<Task<ContainerResponse>> deleteContainerTasks = new List<Task<ContainerResponse>>();
+                    List<Task<CosmosContainerResponse>> deleteContainerTasks = new List<Task<CosmosContainerResponse>>();
                     foreach (CosmosContainer container in collectionsAndDocuments.Select(tuple => tuple.Item1))
                     {
                         deleteContainerTasks.Add(container.DeleteContainerAsync());

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -332,9 +332,9 @@ namespace Azure.Cosmos.EmulatorTests
 
         private static async Task CleanUp(CosmosClient client)
         {
-            AsyncPageable<DatabaseProperties> allDatabases = client.GetDatabaseQueryIterator<DatabaseProperties>();
+            AsyncPageable<CosmosDatabaseProperties> allDatabases = client.GetDatabaseQueryIterator<CosmosDatabaseProperties>();
 
-            await foreach (DatabaseProperties db in allDatabases)
+            await foreach (CosmosDatabaseProperties db in allDatabases)
             {
                 await client.GetDatabase(db.Id).DeleteAsync();
             }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -92,7 +92,7 @@ namespace Azure.Cosmos.EmulatorTests
             Stream stream = serializer.ToStream(containerProperties);
             CosmosContainerProperties deserialziedTest = serializer.FromStream<CosmosContainerProperties>(stream);
 
-            ContainerResponse response = await this.database.CreateContainerAsync(containerProperties);
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(containerProperties);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.GetRawResponse().Headers);
             Assert.IsNotNull(response.GetRawResponse().Headers.GetActivityId());
@@ -143,7 +143,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                ContainerResponse response = await this.database.CreateContainerAsync(containerProperties);
+                CosmosContainerResponse response = await this.database.CreateContainerAsync(containerProperties);
                 Assert.Fail("Should require spatial type");
             }
             catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.BadRequest)
@@ -231,7 +231,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse =
+            CosmosContainerResponse containerResponse =
                 await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithIndexingPolicy()
                         .WithIndexingMode(IndexingMode.None)
@@ -263,7 +263,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse =
+            CosmosContainerResponse containerResponse =
                 await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithUniqueKey()
                         .Path("/attribute1")
@@ -304,7 +304,7 @@ namespace Azure.Cosmos.EmulatorTests
                 string containerName = "conflictResolutionContainerTest";
                 string partitionKeyPath = "/users";
 
-                ContainerResponse containerResponse =
+                CosmosContainerResponse containerResponse =
                     await databaseForConflicts.DefineContainer(containerName, partitionKeyPath)
                         .WithConflictResolution()
                             .WithLastWriterWinsResolution("/lww")
@@ -352,7 +352,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse =
+            CosmosContainerResponse containerResponse =
                 await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithIndexingPolicy()
                         .WithIncludedPaths()
@@ -406,7 +406,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse
+            CosmosContainerResponse containerResponse
                 = await this.database.DefineContainer(containerName, partitionKeyPath)
                         .CreateAsync(expectedThroughput);
 
@@ -428,7 +428,7 @@ namespace Azure.Cosmos.EmulatorTests
             string containerName = Guid.NewGuid().ToString();
             string partitionKeyPath = "/users";
 
-            ContainerResponse containerResponse
+            CosmosContainerResponse containerResponse
                 = await this.database.DefineContainer(containerName, partitionKeyPath)
                         .CreateAsync(expectedThroughput);
 
@@ -470,7 +470,7 @@ namespace Azure.Cosmos.EmulatorTests
                 string containerName = Guid.NewGuid().ToString();
                 string partitionKeyPath = "/users";
                 int timeToLiveInSeconds = 10;
-                ContainerResponse containerResponse = await this.database.DefineContainer(containerName, partitionKeyPath)
+                CosmosContainerResponse containerResponse = await this.database.DefineContainer(containerName, partitionKeyPath)
                     .WithDefaultTimeToLive(timeToLiveInSeconds)
                     .CreateAsync();
 
@@ -480,7 +480,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 Assert.AreEqual(timeToLiveInSeconds, responseSettings.DefaultTimeToLive);
 
-                ContainerResponse readResponse = await container.ReadContainerAsync();
+                CosmosContainerResponse readResponse = await container.ReadContainerAsync();
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
                 Assert.AreEqual(timeToLiveInSeconds, readResponse.Value.DefaultTimeToLive);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -38,7 +38,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ContainerContractTest()
         {
-            ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/users")
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(Guid.NewGuid().ToString(), "/users")
             {
                 IndexingPolicy = new IndexingPolicy()
                 {
@@ -90,7 +90,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             CosmosTextJsonSerializer serializer = CosmosTextJsonSerializer.CreatePropertiesSerializer();
             Stream stream = serializer.ToStream(containerProperties);
-            ContainerProperties deserialziedTest = serializer.FromStream<ContainerProperties>(stream);
+            CosmosContainerProperties deserialziedTest = serializer.FromStream<CosmosContainerProperties>(stream);
 
             ContainerResponse response = await this.database.CreateContainerAsync(containerProperties);
             Assert.IsNotNull(response);
@@ -98,7 +98,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsNotNull(response.GetRawResponse().Headers.GetActivityId());
             Assert.IsTrue(response.GetRawResponse().Headers.GetRequestCharge() > 0);
 
-            ContainerProperties responseProperties = response.Value;
+            CosmosContainerProperties responseProperties = response.Value;
             Assert.IsNotNull(responseProperties.Id);
             Assert.IsNotNull(responseProperties.ResourceId);
             Assert.IsNotNull(responseProperties.ETag);
@@ -127,7 +127,7 @@ namespace Azure.Cosmos.EmulatorTests
         [TestMethod]
         public async Task ContainerNegativeSpatialIndexTest()
         {
-            ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/users")
+            CosmosContainerProperties containerProperties = new CosmosContainerProperties(Guid.NewGuid().ToString(), "/users")
             {
                 IndexingPolicy = new IndexingPolicy()
                 {
@@ -187,7 +187,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         //    // Verify v3 can add composite indexes and update the container
         //    Container container = this.database.GetContainer(containerName);
-        //    ContainerProperties containerProperties = await container.ReadContainerAsync();
+        //    CosmosContainerProperties containerProperties = await container.ReadContainerAsync();
         //    string cPath0 = "/address/city";
         //    string cPath1 = "/address/state";
         //    containerProperties.IndexingPolicy.CompositeIndexes.Add(new Collection<CompositePath>()
@@ -211,7 +211,7 @@ namespace Azure.Cosmos.EmulatorTests
         //            SpatialTypes = new Collection<SpatialType>() { SpatialType.Point }
         //        });
 
-        //    ContainerProperties propertiesAfterReplace = await container.ReplaceContainerAsync(containerProperties);
+        //    CosmosContainerProperties propertiesAfterReplace = await container.ReplaceContainerAsync(containerProperties);
         //    Assert.AreEqual(0, propertiesAfterReplace.IndexingPolicy.IncludedPaths.First().Indexes.Count);
         //    Assert.AreEqual(1, propertiesAfterReplace.IndexingPolicy.CompositeIndexes.Count);
         //    Collection<CompositePath> compositePaths = propertiesAfterReplace.IndexingPolicy.CompositeIndexes.First();
@@ -314,7 +314,7 @@ namespace Azure.Cosmos.EmulatorTests
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
                 Assert.AreEqual(containerName, containerResponse.Value.Id);
                 Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
-                ContainerProperties containerSettings = containerResponse.Value;
+                CosmosContainerProperties containerSettings = containerResponse.Value;
                 Assert.IsNotNull(containerSettings.ConflictResolutionPolicy);
                 Assert.AreEqual(ConflictResolutionMode.LastWriterWins, containerSettings.ConflictResolutionPolicy.Mode);
                 Assert.AreEqual("/lww", containerSettings.ConflictResolutionPolicy.ResolutionPath);
@@ -476,7 +476,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
                 CosmosContainer container = containerResponse;
-                ContainerProperties responseSettings = containerResponse;
+                CosmosContainerProperties responseSettings = containerResponse;
 
                 Assert.AreEqual(timeToLiveInSeconds, responseSettings.DefaultTimeToLive);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
@@ -343,7 +343,7 @@ namespace Azure.Cosmos.EmulatorTests
             };
 
             Cosmos.CosmosDatabase cosmosDatabase = await cosmosClient.CreateDatabaseIfNotExistsAsync(IndexingPolicyTests.database.Id);
-            ContainerResponse cosmosContainerResponse = await cosmosDatabase.CreateContainerAsync(containerSetting);
+            CosmosContainerResponse cosmosContainerResponse = await cosmosDatabase.CreateContainerAsync(containerSetting);
 
             Assert.IsTrue(IndexingPolicyTests.indexingPolicyEqualityComparer.Equals(indexingPolicy, containerSetting.IndexingPolicy));
         }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
@@ -130,8 +130,8 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new Cosmos.RangeIndex(Cosmos.DataType.Number, -1),
-                        new Cosmos.HashIndex(Cosmos.DataType.String, 3),
+                        new Cosmos.RangeIndex(Cosmos.CosmosDataType.Number, -1),
+                        new Cosmos.HashIndex(Cosmos.CosmosDataType.String, 3),
                     }
                 }
             };
@@ -150,8 +150,8 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new Cosmos.RangeIndex(Cosmos.DataType.Number, -1),
-                        new Cosmos.RangeIndex(Cosmos.DataType.String, -1),
+                        new Cosmos.RangeIndex(Cosmos.CosmosDataType.Number, -1),
+                        new Cosmos.RangeIndex(Cosmos.CosmosDataType.String, -1),
                     }
                 }
             };
@@ -170,8 +170,8 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new Cosmos.HashIndex(Cosmos.DataType.Number, -1),
-                        new Cosmos.HashIndex(Cosmos.DataType.String, -1),
+                        new Cosmos.HashIndex(Cosmos.CosmosDataType.Number, -1),
+                        new Cosmos.HashIndex(Cosmos.CosmosDataType.String, -1),
                     }
                 }
             };
@@ -190,8 +190,8 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new Cosmos.HashIndex(Cosmos.DataType.Number, 3),
-                        new Cosmos.RangeIndex(Cosmos.DataType.String, -1),
+                        new Cosmos.HashIndex(Cosmos.CosmosDataType.Number, 3),
+                        new Cosmos.RangeIndex(Cosmos.CosmosDataType.String, -1),
                     }
                 }
             };
@@ -210,7 +210,7 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new Cosmos.SpatialIndex(Cosmos.DataType.Point),
+                        new Cosmos.SpatialIndex(Cosmos.CosmosDataType.Point),
                     }
                 }
             };
@@ -229,9 +229,9 @@ namespace Azure.Cosmos.EmulatorTests
                     Path = DefaultPath,
                     Indexes = new Collection<Cosmos.Index>()
                     {
-                        new  Cosmos.SpatialIndex(Cosmos.DataType.LineString),
-                        new  Cosmos.SpatialIndex(Cosmos.DataType.Point),
-                        new  Cosmos.SpatialIndex(Cosmos.DataType.Polygon),
+                        new  Cosmos.SpatialIndex(Cosmos.CosmosDataType.LineString),
+                        new  Cosmos.SpatialIndex(Cosmos.CosmosDataType.Point),
+                        new  Cosmos.SpatialIndex(Cosmos.CosmosDataType.Polygon),
                     }
                 }
             };
@@ -384,8 +384,8 @@ namespace Azure.Cosmos.EmulatorTests
                         Path = DefaultPath,
                         Indexes = new Collection<Cosmos.Index>()
                         {
-                            new  Cosmos.RangeIndex( Cosmos.DataType.Number, -1),
-                            new  Cosmos.RangeIndex( Cosmos.DataType.String, -1),
+                            new  Cosmos.RangeIndex( Cosmos.CosmosDataType.Number, -1),
+                            new  Cosmos.RangeIndex( Cosmos.CosmosDataType.String, -1),
                         }
                     }
                 },

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyTests.cs
@@ -323,7 +323,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await cosmosClient.CreateDatabaseIfNotExistsAsync(database.Id);
             Cosmos.IndexingPolicy indexingPolicy = IndexingPolicyTests.CreateDefaultIndexingPolicy();
-            ContainerProperties cosmosContainerSettings = new ContainerProperties()
+            CosmosContainerProperties cosmosContainerSettings = new CosmosContainerProperties()
             {
                 Id = Guid.NewGuid().ToString(),
                 IndexingPolicy = indexingPolicy,
@@ -335,7 +335,7 @@ namespace Azure.Cosmos.EmulatorTests
         private static async Task RoundTripWithLocal(Cosmos.IndexingPolicy indexingPolicy)
         {
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
-            ContainerProperties containerSetting = new ContainerProperties()
+            CosmosContainerProperties containerSetting = new CosmosContainerProperties()
             {
                 Id = Guid.NewGuid().ToString(),
                 IndexingPolicy = indexingPolicy,

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/SmokeTests.cs
@@ -269,20 +269,20 @@ namespace Azure.Cosmos.EmulatorTests
             CosmosDatabase createdDatabase = await this.client.CreateDatabaseIfNotExistsAsync(databaseId);
 
             string collectionId = Guid.NewGuid().ToString();
-            ContainerProperties collection = new ContainerProperties(collectionId, "/id");
+            CosmosContainerProperties collection = new CosmosContainerProperties(collectionId, "/id");
 
-            ContainerProperties createdCollection = await createdDatabase.CreateContainerIfNotExistsAsync(collection);
+            CosmosContainerProperties createdCollection = await createdDatabase.CreateContainerIfNotExistsAsync(collection);
 
             // CreateDocumentCollectionIfNotExistsAsync should create the new collection
             Assert.AreEqual(collectionId, createdCollection.Id);
 
             string collectionId2 = Guid.NewGuid().ToString();
-            collection = new ContainerProperties(collectionId2, "/id");
+            collection = new CosmosContainerProperties(collectionId2, "/id");
 
             // Pre-create the collection with this unique id
             createdCollection = await createdDatabase.CreateContainerIfNotExistsAsync(collection);
 
-            ContainerProperties readCollection = await createdDatabase.CreateContainerIfNotExistsAsync(collection);
+            CosmosContainerProperties readCollection = await createdDatabase.CreateContainerIfNotExistsAsync(collection);
 
             // CreateDocumentCollectionIfNotExistsAsync should return the same collection
             Assert.AreEqual(createdCollection.Id, readCollection.Id);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
 
             string containerName = Guid.NewGuid().ToString();
-            ContainerResponse cosmosContainerResponse = await this.database
+            CosmosContainerResponse cosmosContainerResponse = await this.database
                 .CreateContainerIfNotExistsAsync(containerName, "/user");
             this.container = cosmosContainerResponse;
             this.scripts = this.container.Scripts;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await base.TestInit();
             string PartitionKey = "/status";
-            ContainerResponse response = await this.database.CreateContainerAsync(
+            CosmosContainerResponse response = await this.database.CreateContainerAsync(
                 new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Cosmos.EmulatorTests
             await base.TestInit();
             string PartitionKey = "/status";
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
+                new CosmosContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -224,9 +224,9 @@ namespace Azure.Cosmos.EmulatorTests
         public static async Task DeleteDatabaseCollectionAsync(CosmosClient client, Cosmos.CosmosDatabase database)
         {
             //Delete them in chunks of 10.
-            AsyncPageable<ContainerProperties> resultSetIterator = database.GetContainerQueryIterator<ContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
+            AsyncPageable<CosmosContainerProperties> resultSetIterator = database.GetContainerQueryIterator<CosmosContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
             List<Task> deleteCollectionTasks = new List<Task>(10);
-            await foreach (ContainerProperties container in resultSetIterator)
+            await foreach (CosmosContainerProperties container in resultSetIterator)
             {
                 Logger.LogLine("Deleting Collection with following info Id:{0}, database Id: {1}", container.Id, database.Id);
                 deleteCollectionTasks.Add(TestCommon.AsyncRetryRateLimiting(() => database.GetContainer(container.Id).DeleteContainerAsync()));

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -195,14 +195,14 @@ namespace Azure.Cosmos.EmulatorTests
         {
             IList<Cosmos.CosmosDatabase> databases = new List<Cosmos.CosmosDatabase>();
 
-            AsyncPageable<DatabaseProperties> resultSetIterator = client.GetDatabaseQueryIterator<DatabaseProperties>(
+            AsyncPageable<CosmosDatabaseProperties> resultSetIterator = client.GetDatabaseQueryIterator<CosmosDatabaseProperties>(
                 queryDefinition: null,
                 continuationToken: null,
                 requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
 
             List<Task> deleteTasks = new List<Task>(10); //Delete in chunks of 10
             int totalCount = 0;
-            await foreach (DatabaseProperties database in resultSetIterator)
+            await foreach (CosmosDatabaseProperties database in resultSetIterator)
             {
                 deleteTasks.Add(TestCommon.DeleteDatabaseAsync(client, client.GetDatabase(database.Id)));
                 totalCount++;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -224,7 +224,7 @@ namespace Azure.Cosmos.EmulatorTests
         public static async Task DeleteDatabaseCollectionAsync(CosmosClient client, Cosmos.CosmosDatabase database)
         {
             //Delete them in chunks of 10.
-            AsyncPageable<ContainerProperties> resultSetIterator = database.GetDatabaseQueryResultsAsync<ContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
+            AsyncPageable<CosmosContainerProperties> resultSetIterator = database.GetContainerQueryResultsAsync<CosmosContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
             List<Task> deleteCollectionTasks = new List<Task>(10);
             await foreach (CosmosContainerProperties container in resultSetIterator)
             {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Cosmos.Tests
         {
             string endpoint = AccountEndpoint;
             string key = Guid.NewGuid().ToString();
-            string region = Regions.WestCentralUS;
+            string region = CosmosRegions.WestCentralUS;
             ConnectionMode connectionMode = ConnectionMode.Gateway;
             TimeSpan requestTimeout = TimeSpan.FromDays(1);
             int maxConnections = 9001;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void DefaultIncludesPopulated()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("TestContainer", "/partitionKey");
             Assert.IsNotNull(containerSettings.IndexingPolicy);
 
             containerSettings.IndexingPolicy = new IndexingPolicy();
@@ -35,9 +35,9 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void ValidateSerialization()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
-            Stream basic = MockCosmosUtil.Serializer.ToStream<ContainerProperties>(containerSettings);
-            ContainerProperties response = MockCosmosUtil.Serializer.FromStream<ContainerProperties>(basic);
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("TestContainer", "/partitionKey");
+            Stream basic = MockCosmosUtil.Serializer.ToStream<CosmosContainerProperties>(containerSettings);
+            CosmosContainerProperties response = MockCosmosUtil.Serializer.FromStream<CosmosContainerProperties>(basic);
             Assert.AreEqual(containerSettings.Id, response.Id);
             Assert.AreEqual(containerSettings.PartitionKeyPath, response.PartitionKeyPath);
         }
@@ -45,7 +45,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void DefaultIncludesShouldNotBePopulated()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("TestContainer", "/partitionKey");
             Assert.IsNotNull(containerSettings.IndexingPolicy);
 
             // Any exclude path should not auto-generate default indexing
@@ -70,7 +70,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void DefaultSameAsDocumentCollection()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("TestContainer", "/partitionKey");
 
             Microsoft.Azure.Documents.DocumentCollection dc = new Microsoft.Azure.Documents.DocumentCollection()
             {
@@ -89,7 +89,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void DefaultIndexingPolicySameAsDocumentCollection()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey")
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("TestContainer", "/partitionKey")
             {
                 IndexingPolicy = new IndexingPolicy()
             };
@@ -124,7 +124,7 @@ namespace Azure.Cosmos.Tests
             }
         }
 
-        private static void AssertSerializedPayloads(ContainerProperties settings, Microsoft.Azure.Documents.DocumentCollection documentCollection)
+        private static void AssertSerializedPayloads(CosmosContainerProperties settings, Microsoft.Azure.Documents.DocumentCollection documentCollection)
         {
             // HAKC: Work-around till BE fixes defautls 
             settings.ValidateRequiredProperties();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
@@ -129,7 +129,7 @@ namespace Azure.Cosmos.Tests
             mockUserJsonSerializer.VerifyAll();
 
             // Test the system specified response
-            ContainerProperties containerSettings = new ContainerProperties("mockId", "/pk");
+            CosmosContainerProperties containerSettings = new CosmosContainerProperties("mockId", "/pk");
             DatabaseProperties databaseSettings = new DatabaseProperties()
             {
                 Id = "mock"
@@ -151,7 +151,7 @@ namespace Azure.Cosmos.Tests
             };
 
             mockDefaultJsonSerializer.Setup(x => x.FromStream<DatabaseProperties>(databaseResponse.ContentStream)).Returns(databaseSettings);
-            mockDefaultJsonSerializer.Setup(x => x.FromStream<ContainerProperties>(containerResponse.ContentStream)).Returns(containerSettings);
+            mockDefaultJsonSerializer.Setup(x => x.FromStream<CosmosContainerProperties>(containerResponse.ContentStream)).Returns(containerSettings);
 
             Mock<CosmosContainer> mockContainer = new Mock<CosmosContainer>();
             Mock<CosmosDatabase> mockDatabase = new Mock<CosmosDatabase>();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
@@ -130,7 +130,7 @@ namespace Azure.Cosmos.Tests
 
             // Test the system specified response
             CosmosContainerProperties containerSettings = new CosmosContainerProperties("mockId", "/pk");
-            DatabaseProperties databaseSettings = new DatabaseProperties()
+            CosmosDatabaseProperties databaseSettings = new CosmosDatabaseProperties()
             {
                 Id = "mock"
             };
@@ -150,7 +150,7 @@ namespace Azure.Cosmos.Tests
                 Id = "mock"
             };
 
-            mockDefaultJsonSerializer.Setup(x => x.FromStream<DatabaseProperties>(databaseResponse.ContentStream)).Returns(databaseSettings);
+            mockDefaultJsonSerializer.Setup(x => x.FromStream<CosmosDatabaseProperties>(databaseResponse.ContentStream)).Returns(databaseSettings);
             mockDefaultJsonSerializer.Setup(x => x.FromStream<CosmosContainerProperties>(containerResponse.ContentStream)).Returns(containerSettings);
 
             Mock<CosmosContainer> mockContainer = new Mock<CosmosContainer>();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosVirtualUnitTest.cs
@@ -54,7 +54,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public async Task VerifyClientMock()
         {
-            Mock<DatabaseResponse> mockDbResponse = new Mock<DatabaseResponse>();
+            Mock<CosmosDatabaseResponse> mockDbResponse = new Mock<CosmosDatabaseResponse>();
 
             Mock<CosmosClient> mockClient = new Mock<CosmosClient>();
             mockClient.Setup(x => x.CreateDatabaseAsync(
@@ -65,7 +65,7 @@ namespace Azure.Cosmos.Tests
                 .Returns(Task.FromResult(mockDbResponse.Object));
 
             CosmosClient client = mockClient.Object;
-            DatabaseResponse response = await client.CreateDatabaseAsync(Guid.NewGuid().ToString());
+            CosmosDatabaseResponse response = await client.CreateDatabaseAsync(Guid.NewGuid().ToString());
             Assert.IsTrue(object.ReferenceEquals(mockDbResponse.Object, response));
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DirectContractTests.cs
@@ -51,7 +51,7 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void MappedRegionsTest()
         {
-            string[] cosmosRegions = typeof(Regions)
+            string[] cosmosRegions = typeof(CosmosRegions)
                             .GetMembers(BindingFlags.Static | BindingFlags.Public)
                             .Select(e => e.Name)
                             .ToArray();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -399,155 +399,6 @@
       },
       "NestedTypes": {}
     },
-    "ContainerProperties": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.ConflictResolutionPolicy ConflictResolutionPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()"
-        },
-        "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()"
-        },
-        "Azure.Cosmos.IndexingPolicy IndexingPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()"
-        },
-        "Azure.Cosmos.UniqueKeyPolicy UniqueKeyPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()"
-        },
-        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] PartitionKeyDefinitionVersion": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] ETag": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
-        },
-        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
-        },
-        "System.Nullable`1[System.DateTime] LastModified": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[System.Int32] DefaultTimeToLive": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
-        },
-        "System.String get_Id()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_Id()"
-        },
-        "System.String get_PartitionKeyPath()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_PartitionKeyPath()"
-        },
-        "System.String Id": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String PartitionKeyPath": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Void .ctor()": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor()"
-        },
-        "Void .ctor(System.String, System.String)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.String, System.String)"
-        },
-        "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)"
-        },
-        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
-        },
-        "Void set_Id(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_Id(System.String)"
-        },
-        "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)"
-        },
-        "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])"
-        },
-        "Void set_PartitionKeyPath(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_PartitionKeyPath(System.String)"
-        },
-        "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)"
-        }
-      },
-      "NestedTypes": {}
-    },
     "ContainerRequestOptions": {
       "Subclasses": {},
       "Members": {
@@ -574,46 +425,6 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_PopulateQuotaInfo(Boolean)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "ContainerResponse": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.ContainerProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties get_Value()"
-        },
-        "Azure.Cosmos.ContainerProperties Value": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosContainer Container": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosContainer get_Container()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.CosmosContainer get_Container()"
-        },
-        "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.ContainerResponse)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.ContainerResponse)"
-        },
-        "Azure.Response GetRawResponse()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Response GetRawResponse()"
         }
       },
       "NestedTypes": {}
@@ -658,22 +469,22 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.AccountProperties] ReadAccountAsync()"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__38))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__38))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.CosmosDatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.CosmosDatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Uri Endpoint": {
           "Type": "Property",
@@ -1079,20 +890,20 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReplaceContainerAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReplaceContainerAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.ItemResponse`1[T]] CreateItemAsync[T](T, System.Nullable`1[Azure.Cosmos.PartitionKey], Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1154,10 +965,10 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReadItemStreamAsync(System.String, Azure.Cosmos.PartitionKey, Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Response] ReplaceItemStreamAsync(System.IO.Stream, System.String, Azure.Cosmos.PartitionKey, Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1173,6 +984,195 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosContainerProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.ConflictResolutionPolicy ConflictResolutionPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()"
+        },
+        "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()"
+        },
+        "Azure.Cosmos.IndexingPolicy IndexingPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()"
+        },
+        "Azure.Cosmos.UniqueKeyPolicy UniqueKeyPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()"
+        },
+        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] PartitionKeyDefinitionVersion": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] DefaultTimeToLive": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_PartitionKeyPath()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_PartitionKeyPath()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String PartitionKeyPath": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String)"
+        },
+        "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)"
+        },
+        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        },
+        "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)"
+        },
+        "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])"
+        },
+        "Void set_PartitionKeyPath(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyPath(System.String)"
+        },
+        "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosContainerResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosContainer Container": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosContainer get_Container()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosContainer get_Container()"
+        },
+        "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.CosmosContainerResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.CosmosContainerResponse)"
+        },
+        "Azure.Cosmos.CosmosContainerProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties get_Value()"
+        },
+        "Azure.Cosmos.CosmosContainerProperties Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Response GetRawResponse()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Response GetRawResponse()"
         }
       },
       "NestedTypes": {}
@@ -1235,35 +1235,35 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1285,10 +1285,10 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.UserResponse] UpsertUserAsync(System.String, Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Response] DeleteStreamAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1304,6 +1304,142 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDatabaseProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[Azure.ETag] ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDatabaseResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosDatabase Database": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDatabase get_Database()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabase get_Database()"
+        },
+        "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.CosmosDatabaseResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.CosmosDatabaseResponse)"
+        },
+        "Azure.Cosmos.CosmosDatabaseProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabaseProperties get_Value()"
+        },
+        "Azure.Cosmos.CosmosDatabaseProperties Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Response GetRawResponse()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Response GetRawResponse()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDataType": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosDataType LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
         }
       },
       "NestedTypes": {}
@@ -1372,6 +1508,297 @@
       },
       "NestedTypes": {}
     },
+    "CosmosRegions": {
+      "Subclasses": {},
+      "Members": {
+        "System.String AustraliaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaCentral2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaSoutheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String BrazilSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUSEUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2EUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNortheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyWestCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SoutheastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAECentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAENorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovArizona": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovTexas": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovVirginia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
     "CosmosUser": {
       "Subclasses": {},
       "Members": {
@@ -1424,142 +1851,6 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.UserResponse] ReplaceAsync(Azure.Cosmos.UserProperties, Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DatabaseProperties": {
-      "Subclasses": {},
-      "Members": {
-        "System.Nullable`1[Azure.ETag] ETag": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
-        },
-        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
-        },
-        "System.Nullable`1[System.DateTime] LastModified": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String get_Id()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_Id()"
-        },
-        "System.String Id": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Void .ctor()": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor()"
-        },
-        "Void .ctor(System.String)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.String)"
-        },
-        "Void set_Id(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_Id(System.String)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DatabaseResponse": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.CosmosDatabase Database": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosDatabase get_Database()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.CosmosDatabase get_Database()"
-        },
-        "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.DatabaseResponse)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.DatabaseResponse)"
-        },
-        "Azure.Cosmos.DatabaseProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.DatabaseProperties get_Value()"
-        },
-        "Azure.Cosmos.DatabaseProperties Value": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Response GetRawResponse()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Response GetRawResponse()"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DataType": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.DataType LineString": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType MultiPolygon": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Number": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Point": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Polygon": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType String": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Int32 value__": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
         }
       },
       "NestedTypes": {}
@@ -1639,10 +1930,10 @@
     "ContainerBuilder": {
       "Subclasses": {},
       "Members": {
-        "Azure.Cosmos.ContainerProperties Build()": {
+        "Azure.Cosmos.CosmosContainerProperties Build()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties Build()"
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties Build()"
         },
         "Azure.Cosmos.Fluent.ConflictResolutionDefinition WithConflictResolution()": {
           "Type": "Method",
@@ -1654,19 +1945,19 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.Fluent.UniqueKeyDefinition WithUniqueKey()"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateAsync>d__9))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateAsync>d__9))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateAsync(System.Nullable`1[System.Int32])"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateIfNotExistsAsync>d__10))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateIfNotExistsAsync>d__10))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])"
         }
       },
       "NestedTypes": {}
@@ -1674,10 +1965,10 @@
     "ContainerDefinition`1": {
       "Subclasses": {},
       "Members": {
-        "Azure.Cosmos.ContainerProperties Build()": {
+        "Azure.Cosmos.CosmosContainerProperties Build()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties Build()"
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties Build()"
         },
         "Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingPolicy()": {
           "Type": "Method",
@@ -2672,297 +2963,6 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "Regions": {
-      "Subclasses": {},
-      "Members": {
-        "System.String AustraliaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaCentral2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaSoutheast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String BrazilSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CanadaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CanadaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralUSEUAP": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastAsia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS2EUAP": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String FranceCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String FranceSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyNortheast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyWestCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String JapanEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String JapanWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String KoreaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String KoreaSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorthCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorthEurope": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorwayEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorwayWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthAfricaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthAfricaWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SoutheastAsia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SwitzerlandNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SwitzerlandWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UAECentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UAENorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UKSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UKWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USDoDCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USDoDEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovArizona": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovTexas": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovVirginia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USNatEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USNatWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USSecEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USSecWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestEurope": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestUS2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -399,155 +399,6 @@
       },
       "NestedTypes": {}
     },
-    "ContainerProperties": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.ConflictResolutionPolicy ConflictResolutionPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()"
-        },
-        "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()"
-        },
-        "Azure.Cosmos.IndexingPolicy IndexingPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()"
-        },
-        "Azure.Cosmos.UniqueKeyPolicy UniqueKeyPolicy": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()"
-        },
-        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] PartitionKeyDefinitionVersion": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] ETag": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
-        },
-        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
-        },
-        "System.Nullable`1[System.DateTime] LastModified": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[System.Int32] DefaultTimeToLive": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
-        },
-        "System.String get_Id()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_Id()"
-        },
-        "System.String get_PartitionKeyPath()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_PartitionKeyPath()"
-        },
-        "System.String Id": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String PartitionKeyPath": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Void .ctor()": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor()"
-        },
-        "Void .ctor(System.String, System.String)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.String, System.String)"
-        },
-        "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)"
-        },
-        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
-        },
-        "Void set_Id(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_Id(System.String)"
-        },
-        "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)"
-        },
-        "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])"
-        },
-        "Void set_PartitionKeyPath(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_PartitionKeyPath(System.String)"
-        },
-        "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)"
-        }
-      },
-      "NestedTypes": {}
-    },
     "ContainerRequestOptions": {
       "Subclasses": {},
       "Members": {
@@ -574,46 +425,6 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_PopulateQuotaInfo(Boolean)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "ContainerResponse": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.ContainerProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties get_Value()"
-        },
-        "Azure.Cosmos.ContainerProperties Value": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosContainer Container": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosContainer get_Container()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.CosmosContainer get_Container()"
-        },
-        "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.ContainerResponse)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.ContainerResponse)"
-        },
-        "Azure.Response GetRawResponse()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Response GetRawResponse()"
         }
       },
       "NestedTypes": {}
@@ -658,22 +469,22 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.AccountProperties] ReadAccountAsync()"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__38))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<CreateDatabaseIfNotExistsAsync>d__38))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] CreateDatabaseIfNotExistsAsync(System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.CosmosDatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.DatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateDatabaseStreamAsync(Azure.Cosmos.CosmosDatabaseProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Uri Endpoint": {
           "Type": "Property",
@@ -1079,20 +890,20 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] DeleteContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReadContainerAsync(Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReplaceContainerAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] ReplaceContainerAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] ReplaceContainerAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.ItemResponse`1[T]] CreateItemAsync[T](T, System.Nullable`1[Azure.Cosmos.PartitionKey], Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1154,10 +965,10 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReadItemStreamAsync(System.String, Azure.Cosmos.PartitionKey, Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.ContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] ReplaceContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, Azure.Cosmos.ContainerRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Response] ReplaceItemStreamAsync(System.IO.Stream, System.String, Azure.Cosmos.PartitionKey, Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1173,6 +984,195 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosContainerProperties": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.ConflictResolutionPolicy ConflictResolutionPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.ConflictResolutionPolicy get_ConflictResolutionPolicy()"
+        },
+        "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.IndexingPolicy get_IndexingPolicy()"
+        },
+        "Azure.Cosmos.IndexingPolicy IndexingPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.UniqueKeyPolicy get_UniqueKeyPolicy()"
+        },
+        "Azure.Cosmos.UniqueKeyPolicy UniqueKeyPolicy": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] get_PartitionKeyDefinitionVersion()"
+        },
+        "System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion] PartitionKeyDefinitionVersion": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] DefaultTimeToLive": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String get_PartitionKeyPath()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_PartitionKeyPath()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String PartitionKeyPath": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String, System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String, System.String)"
+        },
+        "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)"
+        },
+        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        },
+        "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_IndexingPolicy(Azure.Cosmos.IndexingPolicy)"
+        },
+        "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyDefinitionVersion(System.Nullable`1[Azure.Cosmos.PartitionKeyDefinitionVersion])"
+        },
+        "Void set_PartitionKeyPath(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PartitionKeyPath(System.String)"
+        },
+        "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_UniqueKeyPolicy(Azure.Cosmos.UniqueKeyPolicy)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosContainerResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosContainer Container": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosContainer get_Container()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosContainer get_Container()"
+        },
+        "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.CosmosContainerResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.CosmosContainer op_Implicit(Azure.Cosmos.CosmosContainerResponse)"
+        },
+        "Azure.Cosmos.CosmosContainerProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties get_Value()"
+        },
+        "Azure.Cosmos.CosmosContainerProperties Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Response GetRawResponse()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Response GetRawResponse()"
         }
       },
       "NestedTypes": {}
@@ -1235,35 +1235,35 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateContainerIfNotExistsAsync(System.String, System.String, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] DeleteAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.DatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosDatabaseResponse] ReadAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.ThroughputResponse] ReadThroughputAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1285,10 +1285,10 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.UserResponse] UpsertUserAsync(System.String, Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.ContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Response] CreateContainerStreamAsync(Azure.Cosmos.CosmosContainerProperties, System.Nullable`1[System.Int32], Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Response] DeleteStreamAsync(Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
@@ -1304,6 +1304,142 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Nullable`1[System.Int32]] ReadThroughputAsync(System.Threading.CancellationToken)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDatabaseProperties": {
+      "Subclasses": {},
+      "Members": {
+        "System.Nullable`1[Azure.ETag] ETag": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
+        },
+        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
+        },
+        "System.Nullable`1[System.DateTime] LastModified": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String get_Id()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.String get_Id()"
+        },
+        "System.String Id": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void .ctor(System.String)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.String)"
+        },
+        "Void set_Id(System.String)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_Id(System.String)"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDatabaseResponse": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosDatabase Database": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDatabase get_Database()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabase get_Database()"
+        },
+        "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.CosmosDatabaseResponse)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.CosmosDatabaseResponse)"
+        },
+        "Azure.Cosmos.CosmosDatabaseProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Azure.Cosmos.CosmosDatabaseProperties get_Value()"
+        },
+        "Azure.Cosmos.CosmosDatabaseProperties Value": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Response GetRawResponse()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Azure.Response GetRawResponse()"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "CosmosDataType": {
+      "Subclasses": {},
+      "Members": {
+        "Azure.Cosmos.CosmosDataType LineString": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType MultiPolygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Number": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Point": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType Polygon": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Azure.Cosmos.CosmosDataType String": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
         }
       },
       "NestedTypes": {}
@@ -1372,6 +1508,297 @@
       },
       "NestedTypes": {}
     },
+    "CosmosRegions": {
+      "Subclasses": {},
+      "Members": {
+        "System.String AustraliaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaCentral2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String AustraliaSoutheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String BrazilSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CanadaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String CentralUSEUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaEast2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String ChinaNorth2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String EastUS2EUAP": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String FranceSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyNortheast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String GermanyWestCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String JapanWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String KoreaSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorthEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String NorwayWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthAfricaWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SoutheastAsia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SouthIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String SwitzerlandWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAECentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UAENorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String UKWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDCentral": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USDoDEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovArizona": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovTexas": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USGovVirginia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USNatWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String USSecWest": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestCentralUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestEurope": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestIndia": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "System.String WestUS2": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": null
+        }
+      },
+      "NestedTypes": {}
+    },
     "CosmosUser": {
       "Subclasses": {},
       "Members": {
@@ -1424,142 +1851,6 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.UserResponse] ReplaceAsync(Azure.Cosmos.UserProperties, Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DatabaseProperties": {
-      "Subclasses": {},
-      "Members": {
-        "System.Nullable`1[Azure.ETag] ETag": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.Nullable`1[Azure.ETag] get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[Azure.ETag] get_ETag()"
-        },
-        "System.Nullable`1[System.DateTime] get_LastModified()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.Nullable`1[System.DateTime] get_LastModified()"
-        },
-        "System.Nullable`1[System.DateTime] LastModified": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String get_Id()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_Id()"
-        },
-        "System.String Id": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Void .ctor()": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor()"
-        },
-        "Void .ctor(System.String)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.String)"
-        },
-        "Void set_Id(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_Id(System.String)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DatabaseResponse": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.CosmosDatabase Database": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.CosmosDatabase get_Database()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.CosmosDatabase get_Database()"
-        },
-        "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.DatabaseResponse)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.CosmosDatabase op_Implicit(Azure.Cosmos.DatabaseResponse)"
-        },
-        "Azure.Cosmos.DatabaseProperties get_Value()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "Azure.Cosmos.DatabaseProperties get_Value()"
-        },
-        "Azure.Cosmos.DatabaseProperties Value": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Response GetRawResponse()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Azure.Response GetRawResponse()"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "DataType": {
-      "Subclasses": {},
-      "Members": {
-        "Azure.Cosmos.DataType LineString": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType MultiPolygon": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Number": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Point": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType Polygon": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Azure.Cosmos.DataType String": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "Int32 value__": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
         }
       },
       "NestedTypes": {}
@@ -1639,10 +1930,10 @@
     "ContainerBuilder": {
       "Subclasses": {},
       "Members": {
-        "Azure.Cosmos.ContainerProperties Build()": {
+        "Azure.Cosmos.CosmosContainerProperties Build()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties Build()"
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties Build()"
         },
         "Azure.Cosmos.Fluent.ConflictResolutionDefinition WithConflictResolution()": {
           "Type": "Method",
@@ -1654,19 +1945,19 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.Fluent.UniqueKeyDefinition WithUniqueKey()"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateAsync>d__9))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateAsync>d__9))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateAsync(System.Nullable`1[System.Int32])"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateAsync(System.Nullable`1[System.Int32])"
         },
-        "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateIfNotExistsAsync>d__10))]": {
+        "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Azure.Cosmos.Fluent.ContainerBuilder+<CreateIfNotExistsAsync>d__10))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.ContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Azure.Cosmos.CosmosContainerResponse] CreateIfNotExistsAsync(System.Nullable`1[System.Int32])"
         }
       },
       "NestedTypes": {}
@@ -1674,10 +1965,10 @@
     "ContainerDefinition`1": {
       "Subclasses": {},
       "Members": {
-        "Azure.Cosmos.ContainerProperties Build()": {
+        "Azure.Cosmos.CosmosContainerProperties Build()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.ContainerProperties Build()"
+          "MethodInfo": "Azure.Cosmos.CosmosContainerProperties Build()"
         },
         "Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingPolicy()": {
           "Type": "Method",
@@ -2697,297 +2988,6 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_ResponseContinuationTokenLimitInKb(System.Nullable`1[System.Int32])"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "Regions": {
-      "Subclasses": {},
-      "Members": {
-        "System.String AustraliaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaCentral2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String AustraliaSoutheast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String BrazilSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CanadaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CanadaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String CentralUSEUAP": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaEast2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String ChinaNorth2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastAsia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String EastUS2EUAP": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String FranceCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String FranceSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyNortheast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String GermanyWestCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String JapanEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String JapanWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String KoreaCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String KoreaSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorthCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorthEurope": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorwayEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String NorwayWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthAfricaNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthAfricaWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SoutheastAsia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SouthIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SwitzerlandNorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String SwitzerlandWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UAECentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UAENorth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UKSouth": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String UKWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USDoDCentral": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USDoDEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovArizona": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovTexas": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USGovVirginia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USNatEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USNatWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USSecEast": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String USSecWest": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestCentralUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestEurope": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestIndia": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestUS": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
-        },
-        "System.String WestUS2": {
-          "Type": "Field",
-          "Attributes": [],
-          "MethodInfo": null
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ExceptionlessTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ExceptionlessTests.cs
@@ -235,7 +235,7 @@ namespace Azure.Cosmos.Tests
             {
                 if (goThroughGateway)
                 {
-                    DatabaseResponse response = await client.CreateDatabaseAsync("test");
+                    CosmosDatabaseResponse response = await client.CreateDatabaseAsync("test");
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [ExpectedException(typeof(ArgumentNullException))]
         public async Task MissingPKForReplace_CallsReadAsync()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             mockContainerResponse
                 .Setup(c => c.Value)
                 .Returns(new CosmosContainerProperties() { PartitionKey = new Microsoft.Azure.Documents.PartitionKeyDefinition() { Paths = new Collection<string>() { partitionKey } } });
@@ -69,7 +69,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 containerName,
                 null);
 
-            ContainerResponse response = await containerFluentDefinitionForCreate.CreateAsync();
+            CosmosContainerResponse response = await containerFluentDefinitionForCreate.CreateAsync();
 
             mockContainer.Verify(c => c.ReadContainerAsync(It.IsAny<ContainerRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
@@ -77,7 +77,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public async Task WithThroughput()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
@@ -109,7 +109,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public async Task WithDefaultTimeToLiveTimeSpan()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
@@ -142,7 +142,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public async Task WithDefaultTimeToLiveInt()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
@@ -175,7 +175,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public async Task WithIndexingPolicy()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
@@ -211,7 +211,7 @@ namespace Azure.Cosmos.Tests.Fluent
         [TestMethod]
         public async Task WithUniqueKey()
         {
-            Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
+            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<ContainerResponse> mockContainerResponse = new Mock<ContainerResponse>();
             mockContainerResponse
                 .Setup(c => c.Value)
-                .Returns(new ContainerProperties() { PartitionKey = new Microsoft.Azure.Documents.PartitionKeyDefinition() { Paths = new Collection<string>() { partitionKey } } });
+                .Returns(new CosmosContainerProperties() { PartitionKey = new Microsoft.Azure.Documents.PartitionKeyDefinition() { Paths = new Collection<string>() { partitionKey } } });
 
             Mock<CosmosContainer> mockContainer = new Mock<CosmosContainer>();
             mockContainer
@@ -55,7 +55,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.PartitionKeyPath.Equals(partitionKey)), 
+                    It.Is<CosmosContainerProperties>((settings) => settings.PartitionKeyPath.Equals(partitionKey)), 
                     It.IsAny<int?>(), 
                     It.IsAny<RequestOptions>(), 
                     It.IsAny<CancellationToken>()))
@@ -81,7 +81,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.IsAny<ContainerProperties>(),
+                    It.IsAny<CosmosContainerProperties>(),
                     It.Is<int?>((rus) => rus == throughput),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -100,7 +100,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 .CreateAsync(2400);
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.IsAny<ContainerProperties>(),
+                    It.IsAny<CosmosContainerProperties>(),
                     It.Is<int?>((rus) => rus == throughput),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);
@@ -113,7 +113,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -133,7 +133,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);
@@ -146,7 +146,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -166,7 +166,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);
@@ -179,7 +179,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => IndexingMode.None.Equals(settings.IndexingPolicy.IndexingMode) && !settings.IndexingPolicy.Automatic),
+                    It.Is<CosmosContainerProperties>((settings) => IndexingMode.None.Equals(settings.IndexingPolicy.IndexingMode) && !settings.IndexingPolicy.Automatic),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -202,7 +202,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => IndexingMode.None.Equals(settings.IndexingPolicy.IndexingMode) && !settings.IndexingPolicy.Automatic),
+                    It.Is<CosmosContainerProperties>((settings) => IndexingMode.None.Equals(settings.IndexingPolicy.IndexingMode) && !settings.IndexingPolicy.Automatic),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);
@@ -215,7 +215,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.UniqueKeyPolicy.UniqueKeys.Count == 1 && path.Equals(settings.UniqueKeyPolicy.UniqueKeys[0].Paths[0])),
+                    It.Is<CosmosContainerProperties>((settings) => settings.UniqueKeyPolicy.UniqueKeys.Count == 1 && path.Equals(settings.UniqueKeyPolicy.UniqueKeys[0].Paths[0])),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -237,7 +237,7 @@ namespace Azure.Cosmos.Tests.Fluent
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<ContainerProperties>((settings) => settings.UniqueKeyPolicy.UniqueKeys.Count == 1 && path.Equals(settings.UniqueKeyPolicy.UniqueKeys[0].Paths[0])),
+                    It.Is<CosmosContainerProperties>((settings) => settings.UniqueKeyPolicy.UniqueKeys.Count == 1 && path.Equals(settings.UniqueKeyPolicy.UniqueKeys[0].Paths[0])),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/HandlerTests.cs
@@ -86,7 +86,7 @@ namespace Azure.Cosmos.Tests
                 options.Properties = new Dictionary<string, object>();
                 options.Properties.Add(PreProcessingTestHandler.StatusCodeName, code);
 
-                ContainerResponse response = await container.DeleteContainerAsync(options);
+                CosmosContainerResponse response = await container.DeleteContainerAsync(options);
 
                 Console.WriteLine($"Got status code {response.GetRawResponse().Status}");
                 Assert.AreEqual((int)code, response.GetRawResponse().Status);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/MockDocumentClient.cs
@@ -154,7 +154,7 @@ namespace Azure.Cosmos.Tests
                     )
                 ).Returns(() =>
                 {
-                    ContainerProperties cosmosContainerSetting = ContainerProperties.CreateWithResourceId("test");
+                    CosmosContainerProperties cosmosContainerSetting = CosmosContainerProperties.CreateWithResourceId("test");
                     cosmosContainerSetting.PartitionKey = new PartitionKeyDefinition()
                     {
                         Kind = PartitionKind.Hash,
@@ -174,7 +174,7 @@ namespace Azure.Cosmos.Tests
                         It.IsAny<CancellationToken>()
                     )
                 ).Returns(() => {
-                    ContainerProperties containerSettings = ContainerProperties.CreateWithResourceId("test");
+                    CosmosContainerProperties containerSettings = CosmosContainerProperties.CreateWithResourceId("test");
                     containerSettings.PartitionKey.Paths = new Collection<string>() { pkPath };
                     return Task.FromResult(containerSettings);
                 });
@@ -188,7 +188,7 @@ namespace Azure.Cosmos.Tests
                     )
                 ).Returns(() =>
                 {
-                    ContainerProperties cosmosContainerSetting = ContainerProperties.CreateWithResourceId("test");
+                    CosmosContainerProperties cosmosContainerSetting = CosmosContainerProperties.CreateWithResourceId("test");
                     cosmosContainerSetting.PartitionKey = new PartitionKeyDefinition()
                     {
                         Kind = PartitionKind.Hash,


### PR DESCRIPTION
## Description

Following API review, the following public contract APIs were renamed:

* ContainerProperties -> CosmosContainerProperties
* DatabaseProperties -> CosmosDatabaseProperties
* DatabaseResponse -> CosmosDatabaseResponse
* ContainerResponse -> CosmosContainerResponse
* Regions -> CosmosRegions
* DataType -> CosmosDataType

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
