### PR TITLE
[vNext] PartitionKey: Add IEquatable support

### DIFF
--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -131,6 +131,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A 32-bit signed integer hash code.</returns>
         public override int GetHashCode()
         {
+            if (this.InternalKey == null)
+            {
+                return PartitionKey.NullPartitionKeyInternal.GetHashCode();
+            }
+
             return this.InternalKey.GetHashCode();
         }
 
@@ -141,7 +146,19 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
         public bool Equals(PartitionKey other)
         {
-            return this.InternalKey.Equals(other.InternalKey);
+            PartitionKeyInternal partitionKeyInternal = this.InternalKey;
+            PartitionKeyInternal otherPartitionKeyInternal = other.InternalKey;
+            if (partitionKeyInternal == null)
+            {
+                partitionKeyInternal = PartitionKey.NullPartitionKeyInternal;
+            }
+
+            if (otherPartitionKeyInternal == null)
+            {
+                otherPartitionKeyInternal = PartitionKey.NullPartitionKeyInternal;
+            }
+
+            return partitionKeyInternal.Equals(otherPartitionKeyInternal);
         }
 
         /// <summary>
@@ -150,6 +167,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The string representation of the partition key value</returns>
         public override string ToString()
         {
+            if (this.InternalKey == null)
+            {
+                return PartitionKey.NullPartitionKeyInternal.ToJsonString();
+            }
+
             return this.InternalKey.ToJsonString();
         }
 

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Represents a partition key value in the Azure Cosmos DB service.
     /// </summary>
-    public struct PartitionKey
+    public readonly struct PartitionKey : IEquatable<PartitionKey>
     {
         private static readonly PartitionKeyInternal NullPartitionKeyInternal = new Microsoft.Azure.Documents.PartitionKey(null).InternalKey;
         private static readonly PartitionKeyInternal TruePartitionKeyInternal = new Microsoft.Azure.Documents.PartitionKey(true).InternalKey;
@@ -111,6 +111,40 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">An object to compare.</param>
+        /// <returns>true if the specified object is equal to the current object; otherwise, false.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is PartitionKey partitionkey)
+            {
+                return this.Equals(partitionkey);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the hash code for this partition key.
+        /// </summary>
+        /// <returns>A 32-bit signed integer hash code.</returns>
+        public override int GetHashCode()
+        {
+            return this.InternalKey.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified partition key.
+        /// </summary>
+        /// <param name="other">A partition key value to compare to this instance.</param>
+        /// <returns>true if <paramref name="other"/> has the same value as this instance; otherwise, false.</returns>
+        public bool Equals(PartitionKey other)
+        {
+            return this.InternalKey.Equals(other.InternalKey);
+        }
+
+        /// <summary>
         /// Gets the string representation of the partition key value.
         /// </summary>
         /// <returns>The string representation of the partition key value</returns>
@@ -150,6 +184,28 @@ namespace Microsoft.Azure.Cosmos
                 partitionKey = default(PartitionKey);
                 return false;
             }
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of the PartitionKey are equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> represent the same partition key; otherwise, false.</returns>
+        public static bool operator ==(PartitionKey left, PartitionKey right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Determines whether two specified instances of the PartitionKey are not equal.
+        /// </summary>
+        /// <param name="left">The first object to compare.</param>
+        /// <param name="right">The second object to compare.</param>
+        /// <returns>true if <paramref name="left"/> and <paramref name="right"/> do not represent the same partition key; otherwise, false.</returns>
+        public static bool operator !=(PartitionKey left, PartitionKey right)
+        {
+            return !left.Equals(right);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2271,6 +2271,31 @@
           "Attributes": [],
           "MethodInfo": null
         },
+        "Boolean Equals(Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean op_Equality(Azure.Cosmos.PartitionKey, Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Equality(Azure.Cosmos.PartitionKey, Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean op_Inequality(Azure.Cosmos.PartitionKey, Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Inequality(Azure.Cosmos.PartitionKey, Azure.Cosmos.PartitionKey)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
         "System.String SystemKeyName": {
           "Type": "Field",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -1,0 +1,137 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Azure.Cosmos.Tests
+{
+    using System;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class PartitionKeyTests
+    {
+        [TestMethod]
+        public void NullValue()
+        {
+            new PartitionKey(null);
+        }
+
+        [TestMethod]
+        public void ToStringGetsJsonString()
+        {
+            const string somePK = "somePK";
+            string expected = $"[\"{somePK}\"]";
+            Cosmos.PartitionKey pk = new Cosmos.PartitionKey(somePK);
+            Assert.AreEqual(expected, pk.ToString());
+        }
+
+        [TestMethod]
+        public void TestPartitionKeyValues()
+        {
+            Tuple<dynamic, string>[] testcases =
+            {
+                Tuple.Create<dynamic, string>(Undefined.Value, "[{}]"),
+                Tuple.Create<dynamic, string>(Undefined.Value, "[{}]"),
+                Tuple.Create<dynamic, string>(false, "[false]"),
+                Tuple.Create<dynamic, string>(true, "[true]"),
+                Tuple.Create<dynamic, string>(123.456, "[123.456]"),
+                Tuple.Create<dynamic, string>("PartitionKeyValue", "[\"PartitionKeyValue\"]"),
+            };
+
+            foreach (Tuple<object, string> testcase in testcases)
+            {
+                Assert.AreEqual(testcase.Item2, new PartitionKey(testcase.Item1).ToString());
+            }
+        }
+
+        [TestMethod]
+        public void TestPartitionKeyDefinitionAreEquivalent()
+        {
+            //Different partition key path test
+            PartitionKeyDefinition definition1 = new PartitionKeyDefinition();
+            definition1.Paths.Add("/pk1");
+
+            PartitionKeyDefinition definition2 = new PartitionKeyDefinition();
+            definition2.Paths.Add("/pk2");
+
+            Assert.IsFalse(PartitionKeyDefinition.AreEquivalent(definition1, definition2));
+
+            //Different partition kind test
+            definition1 = new PartitionKeyDefinition();
+            definition1.Paths.Add("/pk1");
+            definition1.Kind = PartitionKind.Hash;
+
+            definition2 = new PartitionKeyDefinition();
+            definition2.Paths.Add("/pk1");
+            definition2.Kind = PartitionKind.Range;
+
+            Assert.IsFalse(PartitionKeyDefinition.AreEquivalent(definition1, definition2));
+
+            //Different partition version test
+            definition1 = new PartitionKeyDefinition();
+            definition1.Paths.Add("/pk1");
+            definition1.Version = PartitionKeyDefinitionVersion.V1;
+
+            definition2 = new PartitionKeyDefinition();
+            definition2.Paths.Add("/pk1");
+            definition2.Version = PartitionKeyDefinitionVersion.V2;
+
+            Assert.IsFalse(PartitionKeyDefinition.AreEquivalent(definition1, definition2));
+
+            //Same partition key path test
+            definition1 = new PartitionKeyDefinition();
+            definition1.Paths.Add("/pk1");
+
+            definition2 = new PartitionKeyDefinition();
+            definition2.Paths.Add("/pk1");
+
+            Assert.IsTrue(PartitionKeyDefinition.AreEquivalent(definition1, definition2));
+        }
+
+        [TestMethod]
+        public void RoundTripTests()
+        {
+            Cosmos.PartitionKey[] partitionKeys = new Cosmos.PartitionKey[]
+            {
+                // None partition key is not serializable.
+                // Cosmos.PartitionKey.None,
+                Cosmos.PartitionKey.Null,
+                new Cosmos.PartitionKey(true),
+                new Cosmos.PartitionKey(false),
+                new Cosmos.PartitionKey(42),
+                new Cosmos.PartitionKey("asdf"),
+            };
+
+            foreach (Cosmos.PartitionKey partitionKey in partitionKeys)
+            {
+                string serializedPartitionKey = partitionKey.ToJsonString();
+                Assert.IsTrue(Cosmos.PartitionKey.TryParseJsonString(serializedPartitionKey, out Cosmos.PartitionKey parsedPartitionKey));
+                Assert.AreEqual(parsedPartitionKey.ToJsonString(), serializedPartitionKey);
+            }
+
+            Assert.IsFalse(Cosmos.PartitionKey.TryParseJsonString("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
+        }
+
+        [TestMethod]
+        public void TestCosmosPartitionKeyComparison()
+        {
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("other_pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").GetHashCode() == new Cosmos.PartitionKey("pk").GetHashCode());
+
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("other_pk"));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(Cosmos.PartitionKey.None.Equals(Cosmos.PartitionKey.None));
+            Assert.IsTrue(Cosmos.PartitionKey.Null.Equals(Cosmos.PartitionKey.Null));
+            Assert.IsTrue(default(Cosmos.PartitionKey).Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(Cosmos.PartitionKey.None.Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(Cosmos.PartitionKey.None));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(new Cosmos.PartitionKey("pk")));
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -3401,6 +3401,31 @@
     "PartitionKey": {
       "Subclasses": {},
       "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object)"
+        },
+        "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Equality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean op_Inequality(Microsoft.Azure.Cosmos.PartitionKey, Microsoft.Azure.Cosmos.PartitionKey)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
         "Microsoft.Azure.Cosmos.PartitionKey None": {
           "Type": "Field",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -4,8 +4,8 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class PartitionKeyTests
@@ -110,6 +110,21 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
 
             Assert.IsFalse(Cosmos.PartitionKey.TryParseJsonString("Ceci n'est pas une partition key.", out Cosmos.PartitionKey thisNotAPartitionKey));
+        }
+
+        [TestMethod]
+        public void TestCosmosPartitionKeyComparison()
+        {
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("pk")));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("other_pk"));
+            Assert.IsTrue(new Cosmos.PartitionKey("pk").GetHashCode() == new Cosmos.PartitionKey("pk").GetHashCode());
+
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals((object) new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("other_pk")));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("other_pk"));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("pk"));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -125,6 +125,13 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(new Cosmos.PartitionKey("other_pk")));
             Assert.IsFalse(new Cosmos.PartitionKey("pk") == new Cosmos.PartitionKey("other_pk"));
             Assert.IsFalse(new Cosmos.PartitionKey("pk") != new Cosmos.PartitionKey("pk"));
+            Assert.IsTrue(Cosmos.PartitionKey.None.Equals(Cosmos.PartitionKey.None));
+            Assert.IsTrue(Cosmos.PartitionKey.Null.Equals(Cosmos.PartitionKey.Null));
+            Assert.IsTrue(default(Cosmos.PartitionKey).Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(Cosmos.PartitionKey.None.Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(new Cosmos.PartitionKey("pk").Equals(default(Cosmos.PartitionKey)));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(Cosmos.PartitionKey.None));
+            Assert.IsFalse(default(Cosmos.PartitionKey).Equals(new Cosmos.PartitionKey("pk")));
         }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1257](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1257) Explicit CosmosClient constructors for most common scenarios
 - [#1283](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1283) Removed JsonConverter from the public API surface
 
+- [#1233](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1265) PartitionKey now supports operators ==, != for equality comparison.
+
 ### Fixed
 
 ## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09

--- a/changelog.md
+++ b/changelog.md
@@ -14,8 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1257](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1257) Explicit CosmosClient constructors for most common scenarios
 - [#1283](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1283) Removed JsonConverter from the public API surface
 
-- [#1233](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1265) PartitionKey now supports operators ==, != for equality comparison.
-
 ### Fixed
 
 ## <a name="4.0.0-preview3"/> [4.0.0-preview3](https://www.nuget.org/packages/Azure.Cosmos/4.0.0-preview3) - 2020-01-09


### PR DESCRIPTION
## Description

This PR ports https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1265 and https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1312 to support IEquatable<PartitionKey> as required per API review.

## Type of change

Please delete options that are not relevant.

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
