### PR TITLE
[Internal] Build: Fix Performance project step

### DIFF
--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -40,9 +40,9 @@ jobs:
     displayName: Microsoft.Azure.Cosmos.PerformanceTests
     condition: succeeded()
     inputs:
-      command: run
+      command: build
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/*.csproj'
-      arguments: --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -c Release -- -j short -f * -m --allStats --join
+      arguments: --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       publishTestResults: true
       nugetConfigPath: NuGet.config
       testRunTitle: Microsoft.Azure.Cosmos.PerformanceTests


### PR DESCRIPTION
Our YAML for tests is using `dotnet run` on the Performance project, which makes no sense and it is only slowing down gated checks.

Running microbenchmarks on Azure DevOps machines will never yield reliable results.