### PR TITLE
Response type: Fix deadlock on scenarios with SynchronizationContext for remaining Response.ResourceType

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Conflict/ConflictsInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Conflict/ConflictsInlineCore.cs
@@ -9,18 +9,15 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
 
     // This class acts as a wrapper for environments that use SynchronizationContext.
-    internal sealed class ConflictsInlineCore : Conflicts
+    internal sealed class ConflictsInlineCore : ConflictsCore
     {
-        private readonly ConflictsCore conflicts;
-
-        internal ConflictsInlineCore(ConflictsCore conflicts)
+        internal ConflictsInlineCore(
+            CosmosClientContext clientContext,
+            ContainerInternal container)
+            : base(
+                  clientContext,
+                  container)
         {
-            if (conflicts == null)
-            {
-                throw new ArgumentNullException(nameof(conflicts));
-            }
-
-            this.conflicts = conflicts;
         }
 
         public override Task<ResponseMessage> DeleteAsync(
@@ -28,7 +25,7 @@ namespace Microsoft.Azure.Cosmos
             PartitionKey partitionKey,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.conflicts.DeleteAsync(conflict, partitionKey, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteAsync(conflict, partitionKey, cancellationToken));
         }
 
         public override FeedIterator GetConflictQueryStreamIterator(
@@ -36,7 +33,7 @@ namespace Microsoft.Azure.Cosmos
            string continuationToken = null,
            QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.conflicts.GetConflictQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetConflictQueryStreamIterator(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -47,7 +44,7 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.conflicts.GetConflictQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetConflictQueryIterator<T>(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -58,7 +55,7 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.conflicts.GetConflictQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetConflictQueryStreamIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -69,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.conflicts.GetConflictQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetConflictQueryIterator<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -80,12 +77,12 @@ namespace Microsoft.Azure.Cosmos
             PartitionKey partitionKey,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.conflicts.ReadCurrentAsync<T>(cosmosConflict, partitionKey, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadCurrentAsync<T>(cosmosConflict, partitionKey, cancellationToken));
         }
 
         public override T ReadConflictContent<T>(ConflictProperties cosmosConflict)
         {
-            return this.conflicts.ReadConflictContent<T>(cosmosConflict);
+            return base.ReadConflictContent<T>(cosmosConflict);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.Cosmos
                 id: containerId);
 
             this.Database = database;
-            this.Conflicts = new ConflictsInlineCore(new ConflictsCore(this.ClientContext, this));
-            this.Scripts = new ScriptsInlineCore(new ScriptsCore(this, this.ClientContext));
+            this.Conflicts = new ConflictsInlineCore(this.ClientContext, this);
+            this.Scripts = new ScriptsInlineCore(this, this.ClientContext);
             this.cachedUriSegmentWithoutId = this.GetResourceSegmentUriWithoutId();
             this.queryClient = cosmosQueryClient ?? new CosmosQueryClientCore(this.ClientContext, this);
             this.lazyBatchExecutor = new Lazy<BatchAsyncContainerExecutor>(() => this.ClientContext.GetExecutorForContainer(this));

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -457,10 +457,10 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(id));
             }
 
-            return new UserInlineCore(new UserCore(
+            return new UserInlineCore(
                     this.ClientContext,
                     this,
-                    id));
+                    id);
         }
 
         public Task<ResponseMessage> CreateUserStreamAsync(

--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionCore.cs
@@ -17,12 +17,8 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal class PermissionCore : Permission
     {
-        /// <summary>
-        /// Only used for unit testing
-        /// </summary>
-        internal PermissionCore()
-        {
-        }
+        private readonly Uri linkUri;
+        private readonly CosmosClientContext clientContext;
 
         internal PermissionCore(
             CosmosClientContext clientContext,
@@ -30,26 +26,15 @@ namespace Microsoft.Azure.Cosmos
             string userId)
         {
             this.Id = userId;
-            this.ClientContext = clientContext;
-            this.LinkUri = clientContext.CreateLink(
+            this.clientContext = clientContext;
+            this.linkUri = clientContext.CreateLink(
                 parentLink: user.LinkUri.OriginalString,
                 uriPathSegment: Paths.PermissionsPathSegment,
                 id: userId);
-
-            this.User = user;
         }
 
         /// <inheritdoc/>
         public override string Id { get; }
-
-        /// <summary>
-        /// Returns a reference to a user object. 
-        /// </summary>
-        public User User { get; }
-
-        internal virtual Uri LinkUri { get; }
-
-        internal virtual CosmosClientContext ClientContext { get; }
 
         /// <inheritdoc/>
         public override Task<PermissionResponse> DeleteAsync(RequestOptions requestOptions = null,
@@ -59,11 +44,12 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
+            return this.clientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
         }
 
-        public Task<ResponseMessage> DeletePermissionStreamAsync(RequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public Task<ResponseMessage> DeletePermissionStreamAsync(
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
             return this.ProcessStreamAsync(
                 streamPayload: null,
@@ -82,7 +68,7 @@ namespace Microsoft.Azure.Cosmos
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
+            return this.clientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
         }
 
         public Task<ResponseMessage> ReadPermissionStreamAsync(int? tokenExpiryInSeconds = null,
@@ -108,14 +94,14 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(permissionProperties));
             }
 
-            this.ClientContext.ValidateResource(permissionProperties.Id);
+            this.clientContext.ValidateResource(permissionProperties.Id);
             Task<ResponseMessage> response = this.ReplaceStreamInternalAsync(
-                streamPayload: this.ClientContext.SerializerCore.ToStream(permissionProperties),
+                streamPayload: this.clientContext.SerializerCore.ToStream(permissionProperties),
                 tokenExpiryInSeconds: tokenExpiryInSeconds,
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
 
-            return this.ClientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
+            return this.clientContext.ResponseFactory.CreatePermissionResponseAsync(this, response);
         }
 
         public Task<ResponseMessage> ReplacePermissionStreamAsync(PermissionProperties permissionProperties,
@@ -127,9 +113,9 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(permissionProperties));
             }
 
-            this.ClientContext.ValidateResource(permissionProperties.Id);
+            this.clientContext.ValidateResource(permissionProperties.Id);
             return this.ReplaceStreamInternalAsync(
-                streamPayload: this.ClientContext.SerializerCore.ToStream(permissionProperties),
+                streamPayload: this.clientContext.SerializerCore.ToStream(permissionProperties),
                 requestOptions: requestOptions,
                 cancellationToken: cancellationToken);
         }
@@ -158,7 +144,7 @@ namespace Microsoft.Azure.Cosmos
             return this.ProcessResourceOperationStreamAsync(
                 streamPayload: streamPayload,
                 operationType: operationType,
-                linkUri: this.LinkUri,
+                linkUri: this.linkUri,
                 resourceType: ResourceType.Permission,
                 tokenExpiryInSeconds: tokenExpiryInSeconds,
                 requestOptions: requestOptions,
@@ -174,7 +160,7 @@ namespace Microsoft.Azure.Cosmos
            RequestOptions requestOptions = null,
            CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.ClientContext.ProcessResourceOperationStreamAsync(
+            return this.clientContext.ProcessResourceOperationStreamAsync(
               resourceUri: linkUri,
               resourceType: resourceType,
               operationType: operationType,

--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/PermissionInlineCore.cs
@@ -4,25 +4,21 @@
 
 namespace Microsoft.Azure.Cosmos
 {
-    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
     // This class acts as a wrapper for environments that use SynchronizationContext.
-    internal sealed class PermissionInlineCore : Permission
+    internal sealed class PermissionInlineCore : PermissionCore
     {
-        private readonly PermissionCore permission;
-
-        public override string Id => this.permission.Id;
-
-        internal PermissionInlineCore(PermissionCore database)
+        internal PermissionInlineCore(
+           CosmosClientContext clientContext,
+           UserCore user,
+           string userId)
+            : base(
+               clientContext,
+               user,
+               userId)
         {
-            if (database == null)
-            {
-                throw new ArgumentNullException(nameof(database));
-            }
-
-            this.permission = database;
         }
 
         public override Task<PermissionResponse> ReadAsync(
@@ -30,7 +26,7 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.ReadAsync(tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadAsync(tokenExpiryInSeconds, requestOptions, cancellationToken));
         }
 
         public override Task<PermissionResponse> ReplaceAsync(
@@ -39,14 +35,14 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.ReplaceAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReplaceAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
         }
 
         public override Task<PermissionResponse> DeleteAsync(
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.permission.DeleteAsync(requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteAsync(requestOptions, cancellationToken));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsCore.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
 
-    internal sealed class ScriptsCore : Scripts
+    internal class ScriptsCore : Scripts
     {
         private readonly ContainerInternal container;
         private readonly CosmosClientContext clientContext;

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/ScriptsInlineCore.cs
@@ -10,18 +10,15 @@ namespace Microsoft.Azure.Cosmos.Scripts
     using System.Threading.Tasks;
 
     // This class acts as a wrapper for environments that use SynchronizationContext.
-    internal sealed class ScriptsInlineCore : Scripts
+    internal sealed class ScriptsInlineCore : ScriptsCore
     {
-        private readonly ScriptsCore scripts;
-
-        internal ScriptsInlineCore(ScriptsCore scripts)
+        internal ScriptsInlineCore(
+            ContainerInternal container,
+            CosmosClientContext clientContext)
+            : base(
+                  container,
+                  clientContext)
         {
-            if (scripts == null)
-            {
-                throw new ArgumentNullException(nameof(scripts));
-            }
-
-            this.scripts = scripts;
         }
 
         public override Task<StoredProcedureResponse> CreateStoredProcedureAsync(
@@ -29,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.CreateStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
         }
 
         public override FeedIterator<T> GetStoredProcedureQueryIterator<T>(
@@ -37,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetStoredProcedureQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetStoredProcedureQueryIterator<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -48,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetStoredProcedureQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetStoredProcedureQueryStreamIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -59,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetStoredProcedureQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetStoredProcedureQueryIterator<T>(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -70,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetStoredProcedureQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetStoredProcedureQueryStreamIterator(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -81,7 +78,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadStoredProcedureAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadStoredProcedureAsync(id, requestOptions, cancellationToken));
         }
 
         public override Task<StoredProcedureResponse> ReplaceStoredProcedureAsync(
@@ -89,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReplaceStoredProcedureAsync(storedProcedureProperties, requestOptions, cancellationToken));
         }
 
         public override Task<StoredProcedureResponse> DeleteStoredProcedureAsync(
@@ -97,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteStoredProcedureAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteStoredProcedureAsync(id, requestOptions, cancellationToken));
         }
 
         public override Task<StoredProcedureExecuteResponse<TOutput>> ExecuteStoredProcedureAsync<TOutput>(
@@ -107,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureAsync<TOutput>(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ExecuteStoredProcedureAsync<TOutput>(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
         }
 
         public override Task<ResponseMessage> ExecuteStoredProcedureStreamAsync(
@@ -117,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ExecuteStoredProcedureStreamAsync(storedProcedureId, partitionKey, parameters, requestOptions, cancellationToken));
         }
 
         public override Task<ResponseMessage> ExecuteStoredProcedureStreamAsync(
@@ -127,7 +124,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             StoredProcedureRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ExecuteStoredProcedureStreamAsync(storedProcedureId, streamPayload, partitionKey, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ExecuteStoredProcedureStreamAsync(storedProcedureId, streamPayload, partitionKey, requestOptions, cancellationToken));
         }
 
         public override Task<TriggerResponse> CreateTriggerAsync(
@@ -135,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateTriggerAsync(triggerProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.CreateTriggerAsync(triggerProperties, requestOptions, cancellationToken));
         }
 
         public override FeedIterator<T> GetTriggerQueryIterator<T>(
@@ -143,7 +140,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetTriggerQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetTriggerQueryIterator<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -154,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetTriggerQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetTriggerQueryStreamIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -165,7 +162,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetTriggerQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetTriggerQueryIterator<T>(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -176,7 +173,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetTriggerQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetTriggerQueryStreamIterator(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -187,7 +184,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadTriggerAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadTriggerAsync(id, requestOptions, cancellationToken));
         }
 
         public override Task<TriggerResponse> ReplaceTriggerAsync(
@@ -195,7 +192,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceTriggerAsync(triggerProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReplaceTriggerAsync(triggerProperties, requestOptions, cancellationToken));
         }
 
         public override Task<TriggerResponse> DeleteTriggerAsync(
@@ -203,7 +200,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteTriggerAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteTriggerAsync(id, requestOptions, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> CreateUserDefinedFunctionAsync(
@@ -211,7 +208,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.CreateUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.CreateUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
         }
 
         public override FeedIterator<T> GetUserDefinedFunctionQueryIterator<T>(
@@ -219,7 +216,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetUserDefinedFunctionQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetUserDefinedFunctionQueryIterator<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -230,7 +227,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetUserDefinedFunctionQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetUserDefinedFunctionQueryStreamIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
@@ -241,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.scripts.GetUserDefinedFunctionQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetUserDefinedFunctionQueryIterator<T>(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -252,7 +249,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore(this.scripts.GetUserDefinedFunctionQueryStreamIterator(
+            return new FeedIteratorInlineCore(base.GetUserDefinedFunctionQueryStreamIterator(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -263,7 +260,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReadUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> ReplaceUserDefinedFunctionAsync(
@@ -271,7 +268,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.ReplaceUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReplaceUserDefinedFunctionAsync(userDefinedFunctionProperties, requestOptions, cancellationToken));
         }
 
         public override Task<UserDefinedFunctionResponse> DeleteUserDefinedFunctionAsync(
@@ -279,7 +276,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.scripts.DeleteUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteUserDefinedFunctionAsync(id, requestOptions, cancellationToken));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/User/UserCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/UserCore.cs
@@ -17,13 +17,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal class UserCore : User
     {
-        /// <summary>
-        /// Only used for unit testing
-        /// </summary>
-        internal UserCore()
-        {
-        }
-
         internal UserCore(
             CosmosClientContext clientContext,
             DatabaseInternal database,
@@ -136,10 +129,10 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(id));
             }
 
-            return new PermissionInlineCore(new PermissionCore(
+            return new PermissionInlineCore(
                     this.ClientContext,
                     this,
-                    id));
+                    id);
         }
 
         /// <inheritdoc/>

--- a/Microsoft.Azure.Cosmos/src/Resource/User/UserInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/UserInlineCore.cs
@@ -9,27 +9,24 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
 
     // This class acts as a wrapper for environments that use SynchronizationContext.
-    internal sealed class UserInlineCore : User
+    internal sealed class UserInlineCore : UserCore
     {
-        private readonly UserCore user;
-
-        public override string Id => this.user.Id;
-
-        internal UserInlineCore(UserCore database)
+        internal UserInlineCore(
+            CosmosClientContext clientContext,
+            DatabaseInternal database,
+            string userId)
+            : base(
+                  clientContext,
+                  database,
+                  userId)
         {
-            if (database == null)
-            {
-                throw new ArgumentNullException(nameof(database));
-            }
-
-            this.user = database;
         }
 
         public override Task<UserResponse> ReadAsync(
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.user.ReadAsync(requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReadAsync(requestOptions, cancellationToken));
         }
 
         public override Task<UserResponse> ReplaceAsync(
@@ -37,19 +34,19 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.user.ReplaceAsync(userProperties, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.ReplaceAsync(userProperties, requestOptions, cancellationToken));
         }
 
         public override Task<UserResponse> DeleteAsync(
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.user.DeleteAsync(requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.DeleteAsync(requestOptions, cancellationToken));
         }
 
         public override Permission GetPermission(string id)
         {
-            return this.user.GetPermission(id);
+            return base.GetPermission(id);
         }
 
         public override Task<PermissionResponse> CreatePermissionAsync(
@@ -58,7 +55,7 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.user.CreatePermissionAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.CreatePermissionAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
         }
 
         public override Task<PermissionResponse> UpsertPermissionAsync(
@@ -67,7 +64,7 @@ namespace Microsoft.Azure.Cosmos
             RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.user.UpsertPermissionAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
+            return TaskHelper.RunInlineIfNeededAsync(() => base.UpsertPermissionAsync(permissionProperties, tokenExpiryInSeconds, requestOptions, cancellationToken));
         }
 
         public override FeedIterator<T> GetPermissionQueryIterator<T>(
@@ -75,7 +72,7 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.user.GetPermissionQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetPermissionQueryIterator<T>(
                 queryText,
                 continuationToken,
                 requestOptions));
@@ -86,12 +83,10 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {
-            return new FeedIteratorInlineCore<T>(this.user.GetPermissionQueryIterator<T>(
+            return new FeedIteratorInlineCore<T>(base.GetPermissionQueryIterator<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions));
         }
-
-        public static implicit operator UserCore(UserInlineCore userInlineCore) => userInlineCore.user;
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This is a continuation of PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1401 to fix all the remaining types.

The `UserResponse.Database` is returning `UserCore` instead of the correct `UserInlineCore`. To fix this issue the type was converted to inheritance instead of composition. 

Composition created a circle reference where UserInlineCore needed UserCore for the actual implementation, but UserCore needed the UserInlineCore for the response creation.


Current model
```C#
public abstract User
internal UserCore : User
internal UserInlineCore : User
```

New model
```C#
public abstract User
internal UserCore : User
internal UserInlineCore : UserCore 
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


