### PR TITLE
Container: Add a database reference to the container

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -33,6 +33,11 @@ namespace Microsoft.Azure.Cosmos
         public abstract string Id { get; }
 
         /// <summary>
+        /// Returns the parent Database reference
+        /// </summary>
+        public abstract Database Database { get; }
+
+        /// <summary>
         /// Returns the conflicts
         /// </summary>
         public abstract Conflicts Conflicts { get; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal abstract class ContainerInternal : Container
     {
-        public abstract Database Database { get; }
-
         internal abstract Uri LinkUri { get; }
 
         internal abstract CosmosClientContext ClientContext { get; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Operations for reading or deleting an existing database.
     ///
-    /// See <see cref="CosmosClient"/> for creating new databases, and reading/querying all databases; use `client.Databases`.
+    /// See <see cref="Client"/> for creating new databases, and reading/querying all databases; use `client.Databases`.
     /// </summary>
     /// <remarks>
     /// Note: all these operations make calls against a fixed budget.
@@ -26,6 +26,11 @@ namespace Microsoft.Azure.Cosmos
         /// The Id of the Cosmos database
         /// </summary>
         public abstract string Id { get; }
+
+        /// <summary>
+        /// The parent Cosmos client instance related the database instance
+        /// </summary>
+        public abstract CosmosClient Client { get; }
 
         /// <summary>
         /// Reads a <see cref="DatabaseProperties"/> from the Azure Cosmos service as an asynchronous operation.

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Operations for reading or deleting an existing database.
     ///
-    /// <see cref="CosmosClient"/> for or creating new databases, and reading/querying all databases; use `client.Databases`.
+    /// <see cref="Client"/> for or creating new databases, and reading/querying all databases; use `client.Databases`.
     /// </summary>
     internal class DatabaseCore : DatabaseInternal
     {
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override string Id { get; }
+
+        public override CosmosClient Client => this.ClientContext.Client;
 
         internal override Uri LinkUri { get; }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -58,6 +58,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public void ParentResourceTest()
+        {
+            Assert.AreEqual(this.database, this.Container.Database);
+            Assert.AreEqual(this.cosmosClient, this.Container.Database.Client);
+        }
+
+        [TestMethod]
         public async Task CreateDropItemTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2025,6 +2025,16 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.Container GetContainer(System.String)"
         },
+        "Microsoft.Azure.Cosmos.CosmosClient Client": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.CosmosClient get_Client()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.CosmosClient get_Client()"
+        },
         "Microsoft.Azure.Cosmos.FeedIterator GetContainerQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
           "Type": "Method",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -677,6 +677,16 @@
           "Attributes": [],
           "MethodInfo": null
         },
+        "Microsoft.Azure.Cosmos.Database Database": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": null
+        },
+        "Microsoft.Azure.Cosmos.Database get_Database()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Database get_Database()"
+        },
         "Microsoft.Azure.Cosmos.FeedIterator GetItemQueryStreamIterator(Microsoft.Azure.Cosmos.QueryDefinition, System.String, Microsoft.Azure.Cosmos.QueryRequestOptions)": {
           "Type": "Method",
           "Attributes": [],


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a Database reference to the Container, and a CosmosClient reference to the database. This will allow users to only pass the Container around, and still get access to the parent CosmosClient. This prevents customer from needing to pass the Client, Database, and Container to all APIs.

`Container.Database`
`Database.Client`
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

