### PR TITLE
[vNext] Contract: Fix iterators to Async rename

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/azuredata/Azure.Cosmos.csproj
@@ -235,7 +235,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.6.13" PrivateAssets="All" />
 
     <!--Direct Dependencies-->
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />

--- a/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerCosmos.cs
@@ -48,7 +48,7 @@ namespace Azure.Cosmos.ChangeFeed
                 throw new ArgumentException("Prefix must be non-empty string", nameof(prefix));
 
             List<DocumentServiceLeaseCore> leases = new List<DocumentServiceLeaseCore>();
-            await foreach (Response page in this.container.GetItemQueryStreamIterator(
+            await foreach (Response page in this.container.GetItemQueryStreamResultsAsync(
                 "SELECT * FROM c WHERE STARTSWITH(c.id, '" + prefix + "')",
                 continuationToken: null,
                 requestOptions: queryRequestOptions))

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -97,6 +97,7 @@ namespace Azure.Cosmos
     /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/partitioning-overview" />
     /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units" />
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public class CosmosClient : IDisposable
     {
         private readonly Uri DatabaseRootUri = new Uri(Paths.Databases_Root, UriKind.Relative);
@@ -492,14 +493,14 @@ namespace Azure.Cosmos
         }
 
         /// <summary>
-        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement with parameterized values. It returns a FeedIterator.
+        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement with parameterized values. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the databases.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the databases.</returns>
         public virtual AsyncPageable<T> GetDatabaseQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
@@ -519,15 +520,15 @@ namespace Azure.Cosmos
         }
 
         /// <summary>
-        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the databases.</returns>
-        public virtual AsyncPageable<T> GetDatabaseQueryIterator<T>(
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the databases.</returns>
+        public virtual AsyncPageable<T> GetDatabaseQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -539,7 +540,7 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetDatabaseQueryIterator<T>(
+            return this.GetDatabaseQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
@@ -547,15 +548,15 @@ namespace Azure.Cosmos
         }
 
         /// <summary>
-        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement with parameterized values. It returns a FeedIterator.
+        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement with parameterized values. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the databases</returns>
-        public virtual async IAsyncEnumerable<Response> GetDatabaseStreamQueryResultsAsync(
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the databases</returns>
+        public virtual async IAsyncEnumerable<Response> GetDatabaseQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -573,15 +574,15 @@ namespace Azure.Cosmos
         }
 
         /// <summary>
-        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the databases</returns>
-        public virtual IAsyncEnumerable<Response> GetDatabaseQueryStreamIterator(
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the databases</returns>
+        public virtual IAsyncEnumerable<Response> GetDatabaseQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -593,7 +594,7 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetDatabaseQueryStreamIterator(
+            return this.GetDatabaseQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClient.cs
@@ -500,7 +500,7 @@ namespace Azure.Cosmos
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>An iterator to go through the databases.</returns>
-        public virtual AsyncPageable<T> GetDatabaseQueryIterator<T>(
+        public virtual AsyncPageable<T> GetDatabaseQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -555,7 +555,7 @@ namespace Azure.Cosmos
         /// <param name="requestOptions">(Optional) The options for the query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>An iterator to go through the databases</returns>
-        public virtual async IAsyncEnumerable<Response> GetDatabaseQueryStreamIterator(
+        public virtual async IAsyncEnumerable<Response> GetDatabaseStreamQueryResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Conflict/CosmosConflicts.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Conflict/CosmosConflicts.cs
@@ -11,7 +11,7 @@ namespace Azure.Cosmos
     /// <summary>
     /// Operations for reading/querying conflicts in a Azure Cosmos container.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable or IAsyncEnumerable are not considered Async for checkers.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public abstract class CosmosConflicts
     {
         /// <summary>
@@ -71,13 +71,13 @@ namespace Azure.Cosmos
         public abstract T ReadConflictContent<T>(ConflictProperties conflict);
 
         /// <summary>
-        /// Obtains an iterator to go through the <see cref="ConflictProperties"/> on an Azure Cosmos container.
+        /// Obtains an <see cref="AsyncPageable{T}"/> to go through the <see cref="ConflictProperties"/> on an Azure Cosmos container.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the conflicts.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
@@ -94,13 +94,13 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Gets an iterator to go through all the conflicts for the container as the original ResponseMessage
+        /// Gets an <see cref="IAsyncEnumerable{Response}"/> to go through all the conflicts for the container as streams
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the conflicts.</returns>
+        /// <returns>An async enumerable to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
@@ -117,13 +117,13 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Obtains an iterator to go through the <see cref="ConflictProperties"/> on an Azure Cosmos container.
+        /// Obtains an <see cref="AsyncPageable{T}"/> to go through the <see cref="ConflictProperties"/> on an Azure Cosmos container.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the conflicts.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[
@@ -140,13 +140,13 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Gets an iterator to go through all the conflicts for the container as the original ResponseMessage
+        /// Gets an <see cref="IAsyncEnumerable{Response}"/> to go through all the conflicts for the container as streams
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the conflicts.</returns>
+        /// <returns>An async enumerable to go through the conflicts.</returns>
         /// <example>
         /// <code language="c#">
         /// <![CDATA[

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/ContainerCore.Items.cs
@@ -221,7 +221,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateItemResponseAsync<T>(response, cancellationToken);
         }
 
-        public override IAsyncEnumerable<Response> GetItemQueryStreamIterator(
+        public override IAsyncEnumerable<Response> GetItemQueryStreamResultsAsync(
            string queryText = null,
            string continuationToken = null,
            QueryRequestOptions requestOptions = null,
@@ -233,14 +233,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetItemQueryStreamIterator(
+            return this.GetItemQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override async IAsyncEnumerable<Response> GetItemQueryStreamIterator(
+        public override async IAsyncEnumerable<Response> GetItemQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -339,7 +339,7 @@ namespace Azure.Cosmos
             return ((null, partitionedQueryExecutionInfo), (supported, queryIterator));
         }
 
-        public override AsyncPageable<T> GetItemQueryIterator<T>(
+        public override AsyncPageable<T> GetItemQueryResultsAsync<T>(
            string queryText = null,
            string continuationToken = null,
            QueryRequestOptions requestOptions = null,
@@ -351,14 +351,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetItemQueryIterator<T>(
+            return this.GetItemQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetItemQueryIterator<T>(
+        public override AsyncPageable<T> GetItemQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -470,7 +470,7 @@ namespace Azure.Cosmos
             return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive));
         }
 
-        internal async IAsyncEnumerable<Response> GetStandByFeedIterator(
+        internal async IAsyncEnumerable<Response> GetStandByFeedIteratorAsync(
             string continuationToken = null,
             int? maxItemCount = null,
             ChangeFeedRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Container/CosmosContainer.cs
@@ -24,6 +24,7 @@ namespace Azure.Cosmos
     ///  For instance, do not call `container.readAsync()` before every single `item.read()` call, to ensure the cosmosContainer exists;
     ///  do this once on application start up.
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public abstract class CosmosContainer
     {
         /// <summary>
@@ -727,14 +728,14 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the items.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
         /// </remarks>
@@ -750,7 +751,7 @@ namespace Azure.Cosmos
         /// 
         /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive")
         ///     .WithParameter("@expensive", 9000);
-        /// await foreach(Response response in this.Container.GetItemQueryStreamIterator(
+        /// await foreach(Response response in this.Container.GetItemQueryStreamResultsAsync(
         ///                                                 queryDefinition,
         ///                                                 null,
         ///                                                 new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -764,21 +765,21 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetItemQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetItemQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns an <see cref="AsyncPageable{T}"/>.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the items.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the items.</returns>
         /// <example>
         /// Create a query to get all the ToDoActivity that have a cost greater than 9000
         /// <code language="c#">
@@ -791,7 +792,7 @@ namespace Azure.Cosmos
         /// 
         /// QueryDefinition queryDefinition = new QueryDefinition("select * from ToDos t where t.cost > @expensive")
         ///     .WithParameter("@expensive", 9000);
-        /// await foreach(ToDoActivity item in this.Container.GetItemQueryIterator<ToDoActivity>(
+        /// await foreach(ToDoActivity item in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
         ///     queryDefinition,
         ///     null,
         ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -801,21 +802,21 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetItemQueryIterator<T>(
+        public abstract AsyncPageable<T> GetItemQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the items.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the items.</returns>
         /// <remarks>
         /// Query as a stream only supports single partition queries 
         /// </remarks>
@@ -829,7 +830,7 @@ namespace Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// await foreach(Response response in this.Container.GetItemQueryStreamIterator(
+        /// await foreach(Response response in this.Container.GetItemQueryStreamResultsAsync(
         ///     "select * from ToDos t where t.cost > 9000",
         ///     null,
         ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -854,7 +855,7 @@ namespace Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         ///
-        /// await foreach(Response response in this.Container.GetItemQueryStreamIterator(
+        /// await foreach(Response response in this.Container.GetItemQueryStreamResultsAsync(
         ///     null,
         ///     null,
         ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -868,21 +869,21 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetItemQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetItemQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns an <see cref="AsyncPageable{T}"/>.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the items.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the items.</returns>
         /// <example>
         /// 1. Create a query to get all the ToDoActivity that have a cost greater than 9000
         /// <code language="c#">
@@ -893,7 +894,7 @@ namespace Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         /// 
-        /// await foreach(ToDoActivity item in this.Container.GetItemQueryIterator<ToDoActivity>(
+        /// await foreach(ToDoActivity item in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
         ///     "select * from ToDos t where t.cost > 9000",
         ///     null,
         ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -913,7 +914,7 @@ namespace Azure.Cosmos
         ///     public int cost {get; set;}
         /// }
         ///
-        /// await foreach(ToDoActivity item in this.Container.GetItemQueryIterator<ToDoActivity>(
+        /// await foreach(ToDoActivity item in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
         ///     null,
         ///     null,
         ///     new QueryRequestOptions() { PartitionKey = new PartitionKey("Error")}))
@@ -923,7 +924,7 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetItemQueryIterator<T>(
+        public abstract AsyncPageable<T> GetItemQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/CosmosDatabase.cs
@@ -21,6 +21,7 @@ namespace Azure.Cosmos
     /// For instance, do not call `database.ReadAsync()` before every single `item.ReadAsync()` call, to ensure the database exists;
     /// do this once on application start up.
     /// </remarks>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public abstract class CosmosDatabase
     {
         /// <summary>
@@ -583,50 +584,48 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the containers</returns>
         /// <example>
-        /// This create the type feed iterator for containers with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testDatabaseId");
-        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(queryDefinition))
+        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryResultsAsync<ContainerProperties>(queryDefinition))
         /// {
         ///     Console.WriteLine(properties.Id);
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetContainerQueryIterator<T>(
+        public abstract AsyncPageable<T> GetContainerQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the containers</returns>
         /// <example>
-        /// This create the stream feed iterator for containers with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
-        /// await foreach(Response response in this.cosmosDatabase.GetContainerQueryStreamIterator(queryDefinition))
+        /// await foreach(Response response in this.cosmosDatabase.GetContainerQueryStreamResultsAsync(queryDefinition))
         /// {
         ///     using (StreamReader sr = new StreamReader(response.Content))
         ///     using (JsonTextReader jtr = new JsonTextReader(sr))
@@ -637,27 +636,27 @@ namespace Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetContainerQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetContainerQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the containers</returns>
         /// <example>
-        /// 1. This create the type feed iterator for containers with queryText as input,
+        /// 1. This create the enumerable for containers with queryText as input,
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
-        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>(querytext))
+        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryResultsAsync<ContainerProperties>(querytext))
         /// {
         ///     Console.WriteLine(properties.Id);
         /// }
@@ -665,37 +664,37 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         /// <example>
-        /// 2. This create the type feed iterator for containers without queryText, retrieving all containers.
+        /// 2. This create the enumerable for containers without queryText, retrieving all containers.
         /// <code language="c#">
         /// <![CDATA[
-        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>())
+        /// await foreach(ContainerProperties properties in this.cosmosDatabase.GetContainerQueryResultsAsync<ContainerProperties>())
         /// {
         ///     Console.WriteLine(properties.Id);
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetContainerQueryIterator<T>(
+        public abstract AsyncPageable<T> GetContainerQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the container request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the containers</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to go through the containers</returns>
         /// <example>
-        /// 1. This create the stream feed iterator for containers with queryText as input.
+        /// 1. This create the stream enumerable for containers with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
-        /// await foreach (Response response in this.cosmosDatabase.GetContainerQueryStreamIterator(queryText))
+        /// await foreach (Response response in this.cosmosDatabase.GetContainerQueryStreamResultsAsync(queryText))
         /// {
         ///
         /// }
@@ -703,37 +702,37 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         /// <example>
-        /// 2. This create the stream feed iterator for containers without queryText, retrieving all container.
+        /// 2. This create the stream enumerable for containers without queryText, retrieving all container.
         /// <code language="c#">
         /// <![CDATA[
-        /// await foreach (Response response in this.cosmosDatabase.GetContainerQueryStreamIterator())
+        /// await foreach (Response response in this.cosmosDatabase.GetContainerQueryStreamResultsAsync())
         /// {
         ///
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetContainerQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetContainerQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for users under an database using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the users</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the users</returns>
         /// <example>
-        /// 1. This create the type feed iterator for users with queryText as input,
+        /// 1. This create the enumerable for users with queryText as input,
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
-        /// await foreach (UserProperties properties in this.cosmosDatabase.GetUserQueryIterator<UserProperties>(queryText))
+        /// await foreach (UserProperties properties in this.cosmosDatabase.GetUserQueryResultsAsync<UserProperties>(queryText))
         /// {
         ///     
         /// }
@@ -741,46 +740,46 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         /// <example>
-        /// 2. This create the type feed iterator for users without queryText, retrieving all users.
+        /// 2. This create the enumerable for users without queryText, retrieving all users.
         /// <code language="c#">
         /// <![CDATA[
-        /// await foreach (UserProperties properties in this.cosmosDatabase.GetUserQueryIterator<ContainerProperties>())
+        /// await foreach (UserProperties properties in this.cosmosDatabase.GetUserQueryResultsAsync<ContainerProperties>())
         /// {
         /// 
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetUserQueryIterator<T>(
+        public abstract AsyncPageable<T> GetUserQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for users under an database using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the users</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the users</returns>
         /// <example>
-        /// This create the type feed iterator for users with queryDefinition as input.
+        /// This creates the enumerable for users with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testUserId");
-        /// await foreach(UserProperties properties in this.cosmosDatabase.GetUserQueryIterator<UserProperties>(queryDefinition))
+        /// await foreach(UserProperties properties in this.cosmosDatabase.GetUserQueryResultsAsync<UserProperties>(queryDefinition))
         /// {
         ///     Console.WriteLine(properties.Id);
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetUserQueryIterator<T>(
+        public abstract AsyncPageable<T> GetUserQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
@@ -479,7 +479,7 @@ namespace Azure.Cosmos
                 cancellationToken);
         }
 
-        public IAsyncEnumerable<Response> GetUserQueryResultsStreamAsync(string queryText = null,
+        public IAsyncEnumerable<Response> GetUserQueryStreamResultsAsync(string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Database/DatabaseCore.cs
@@ -362,7 +362,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreateUserResponseAsync(this.GetUser(id), response, cancellationToken);
         }
 
-        public override IAsyncEnumerable<Response> GetContainerQueryStreamIterator(
+        public override IAsyncEnumerable<Response> GetContainerQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -374,14 +374,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetContainerQueryStreamIterator(
+            return this.GetContainerQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetContainerQueryIterator<T>(
+        public override AsyncPageable<T> GetContainerQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -393,14 +393,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetContainerQueryIterator<T>(
+            return this.GetContainerQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetContainerQueryIterator<T>(
+        public override AsyncPageable<T> GetContainerQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -414,7 +414,7 @@ namespace Azure.Cosmos
             return PageResponseEnumerator.CreateAsyncPageable(continuation => pageIterator.GetPageAsync(continuation, cancellationToken));
         }
 
-        public override async IAsyncEnumerable<Response> GetContainerQueryStreamIterator(
+        public override async IAsyncEnumerable<Response> GetContainerQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -428,12 +428,12 @@ namespace Azure.Cosmos
             }
         }
 
-        public override AsyncPageable<T> GetUserQueryIterator<T>(QueryDefinition queryDefinition,
+        public override AsyncPageable<T> GetUserQueryResultsAsync<T>(QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            FeedIterator userStreamIterator = this.GetUserQueryIterator(
+            FeedIterator userStreamIterator = this.GetUserFeedIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions);
@@ -445,12 +445,12 @@ namespace Azure.Cosmos
             return PageResponseEnumerator.CreateAsyncPageable(continuation => pageIterator.GetPageAsync(continuation, cancellationToken));
         }
 
-        public async IAsyncEnumerable<Response> GetUserQueryStreamIterator(QueryDefinition queryDefinition,
+        public async IAsyncEnumerable<Response> GetUserQueryResultsStreamAsync(QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default(CancellationToken))
         {
-            FeedIterator userStreamIterator = this.GetUserQueryIterator(
+            FeedIterator userStreamIterator = this.GetUserFeedIterator(
                 queryDefinition,
                 continuationToken,
                 requestOptions);
@@ -461,7 +461,7 @@ namespace Azure.Cosmos
             }
         }
 
-        public override AsyncPageable<T> GetUserQueryIterator<T>(string queryText = null,
+        public override AsyncPageable<T> GetUserQueryResultsAsync<T>(string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -472,14 +472,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetUserQueryIterator<T>(
+            return this.GetUserQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public IAsyncEnumerable<Response> GetUserQueryStreamIterator(string queryText = null,
+        public IAsyncEnumerable<Response> GetUserQueryResultsStreamAsync(string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -490,7 +490,7 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetUserQueryStreamIterator(
+            return this.GetUserQueryResultsStreamAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
@@ -638,7 +638,7 @@ namespace Azure.Cosmos
               cancellationToken: cancellationToken);
         }
 
-        private FeedIterator GetUserQueryIterator(QueryDefinition queryDefinition,
+        private FeedIterator GetUserFeedIterator(QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null)
         {

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Scripts/CosmosScripts.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Scripts/CosmosScripts.cs
@@ -15,6 +15,7 @@ namespace Azure.Cosmos.Scripts
     /// <seealso cref="StoredProcedureProperties"/>
     /// <seealso cref="TriggerProperties"/>
     /// <seealso cref="UserDefinedFunctionProperties"/>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public abstract class CosmosScripts
     {
         /// <summary>
@@ -88,104 +89,112 @@ namespace Azure.Cosmos.Scripts
                     CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing stored procedures.</returns>
         /// <example>
-        /// This create the type feed iterator for sproc with queryDefinition as input.
+        /// This creates the enumerable for sproc with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testSprocId");
-        /// AsyncPageable<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryDefinition);
+        /// await foreach(StoredProcedureProperties storedProcedure in this.scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetStoredProcedureQueryIterator<T>(
+        public abstract AsyncPageable<T> GetStoredProcedureQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> to read through the existing stored procedures.</returns>
         /// <example>
-        /// This create the stream feed iterator for sproc with queryDefinition as input.
+        /// This creates the enumerable for sproc with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testSprocId");
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryDefinition);
+        /// await foreach(Response storedProcedureStream in this.scripts.GetStoredProcedureQueryStreamResultsAsync(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetStoredProcedureQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetStoredProcedureQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing stored procedures.</returns>
         /// <example>
-        /// This create the type feed iterator for sproc with queryText as input.
+        /// This creates the enumerable for sproc with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
-        /// AsyncPageable<StoredProcedureProperties> iter = this.scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>(queryText);
+        /// await foreach(StoredProcedureProperties storedProcedure in this.scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>(queryText))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetStoredProcedureQueryIterator<T>(
+        public abstract AsyncPageable<T> GetStoredProcedureQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to read through the existing stored procedures.</returns>
         /// <example>
-        /// This create the stream feed iterator for sproc with queryText as input.
+        /// This creates the enumerable for sproc with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM s where s.id like '%testId%'";
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetStoredProcedureQueryStreamIterator(queryText);
+        /// await foreach(Response storedProcedureStream in this.scripts.GetStoredProcedureQueryStreamResultsAsync(queryText))
+        /// {
+        /// };
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetStoredProcedureQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetStoredProcedureQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -492,104 +501,112 @@ namespace Azure.Cosmos.Scripts
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing triggers.</returns>
         /// <example>
-        /// This create the type feed iterator for Trigger with queryDefinition as input.
+        /// This creates the enumerable for Trigger with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testTriggerId");
-        /// AsyncPageable<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryDefinition);
+        /// await forach(TriggerProperties trigger in this.scripts.GetTriggerQueryResultsAsync<TriggerProperties>(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetTriggerQueryIterator<T>(
+        public abstract AsyncPageable<T> GetTriggerQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to read through the existing triggers.</returns>
         /// <example>
-        /// This create the stream feed iterator for Trigger with queryDefinition as input.
+        /// This creates the enumerable for Triggers with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testTriggerId");
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetTriggerQueryStreamIterator(queryDefinition);
+        /// await foreach(Response triggerStream in this.scripts.GetTriggerQueryStreamResultsAsync(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetTriggerQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetTriggerQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing triggers.</returns>
         /// <example>
-        /// This create the type feed iterator for Trigger with queryText as input.
+        /// This creates the enumerable for Trigger with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
-        /// AsyncPageable<TriggerProperties> iter = this.scripts.GetTriggerQueryIterator<TriggerProperties>(queryText);
+        /// await foreach(TriggerProperties trigger in this.scripts.GetTriggerQueryResultsAsync<TriggerProperties>(queryText))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetTriggerQueryIterator<T>(
+        public abstract AsyncPageable<T> GetTriggerQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to read through the existing triggers.</returns>
         /// <example>
-        /// This create the stream feed iterator for Trigger with queryText as input.
+        /// This creates the enumerable for Trigger with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM t where t.id like '%testId%'";
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetTriggerQueryStreamIterator(queryText);
+        /// await foreach(Response triggerStream in this.scripts.GetTriggerQueryStreamResultsAsync(queryText))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetTriggerQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetTriggerQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -735,7 +752,7 @@ namespace Azure.Cosmos.Scripts
         ///     .WithParameter("@expensive", 9000)
         ///     .WithParameter("@status", "Done");
         ///
-        /// await foreach (double tax in this.container.Items.GetItemsQueryIterator<double>(
+        /// await foreach (double tax in this.container.Items.GetItemsQueryResultsAsync<double>(
         ///     sqlQueryDefinition: sqlQuery,
         ///     partitionKey: "Done"))
         /// {
@@ -750,104 +767,112 @@ namespace Azure.Cosmos.Scripts
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing user defined functions.</returns>
         /// <example>
-        /// This create the type feed iterator for UDF with queryDefinition as input.
+        /// This creates the enumerable for UDF with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM u where u.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testUDFId");
-        /// AsyncPageable<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
+        /// await foreach(UserDefinedFunctionProperties udf in this.scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetUserDefinedFunctionQueryIterator<T>(
+        public abstract AsyncPageable<T> GetUserDefinedFunctionQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to read through the existing user defined functions.</returns>
         /// <example>
-        /// This create the stream feed iterator for UDF with queryDefinition as input.
+        /// This creates the enumerable for UDF with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// string queryText = "SELECT * FROM u where u.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testUdfId");
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
+        /// await foreach(Response udfStream in this.scripts.GetUserDefinedFunctionQueryStreamResultsAsync(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to read through the existing user defined functions.</returns>
         /// <example>
-        /// This create the type feed iterator for UDF with queryText as input.
+        /// This creates the enumerable for UDF with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// Scripts scripts = this.container.Scripts;
         /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
-        /// AsyncPageable<UserDefinedFunctionProperties> iter = this.scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>(queryDefinition);
+        /// await foreach(UserDefinedFunctionProperties udf in this.scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetUserDefinedFunctionQueryIterator<T>(
+        public abstract AsyncPageable<T> GetUserDefinedFunctionQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement. It returns an <see cref="IAsyncEnumerable{Response}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the item query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to read through the existing stored procedures.</returns>
+        /// <returns>An <see cref="IAsyncEnumerable{Response}"/> to read through the existing user defined functions.</returns>
         /// <example>
-        /// This create the stream feed iterator for UDF with queryText as input.
+        /// This creates the enumerable for UDF with queryText as input.
         /// <code language="c#">
         /// <![CDATA[
         /// CosmosScripts scripts = this.container.Scripts;
         /// QueryDefinition queryDefinition = new QueryDefinition("SELECT * FROM u where u.id like '%testId%'");
-        /// IAsyncEnumerable<Response> iter = this.scripts.GetUserDefinedFunctionQueryStreamIterator(queryDefinition);
+        /// await foreach(Response udfStream in this.scripts.GetUserDefinedFunctionQueryStreamResultsAsync(queryDefinition))
+        /// {
+        /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamIterator(
+        public abstract IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamResultsAsync(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Scripts/ScriptsCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Scripts/ScriptsCore.cs
@@ -38,7 +38,7 @@ namespace Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        public override IAsyncEnumerable<Response> GetStoredProcedureQueryStreamIterator(
+        public override IAsyncEnumerable<Response> GetStoredProcedureQueryStreamResultsAsync(
            string queryText = null,
            string continuationToken = null,
            QueryRequestOptions requestOptions = null,
@@ -50,14 +50,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetStoredProcedureQueryStreamIterator(
+            return this.GetStoredProcedureQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetStoredProcedureQueryIterator<T>(
+        public override AsyncPageable<T> GetStoredProcedureQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -69,14 +69,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetStoredProcedureQueryIterator<T>(
+            return this.GetStoredProcedureQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override async IAsyncEnumerable<Response> GetStoredProcedureQueryStreamIterator(
+        public override async IAsyncEnumerable<Response> GetStoredProcedureQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -89,7 +89,7 @@ namespace Azure.Cosmos.Scripts
             }
         }
 
-        public override AsyncPageable<T> GetStoredProcedureQueryIterator<T>(
+        public override AsyncPageable<T> GetStoredProcedureQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -236,7 +236,7 @@ namespace Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        public override IAsyncEnumerable<Response> GetTriggerQueryStreamIterator(
+        public override IAsyncEnumerable<Response> GetTriggerQueryStreamResultsAsync(
            string queryText = null,
            string continuationToken = null,
            QueryRequestOptions requestOptions = null,
@@ -248,14 +248,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetTriggerQueryStreamIterator(
+            return this.GetTriggerQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetTriggerQueryIterator<T>(
+        public override AsyncPageable<T> GetTriggerQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -267,14 +267,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetTriggerQueryIterator<T>(
+            return this.GetTriggerQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override async IAsyncEnumerable<Response> GetTriggerQueryStreamIterator(
+        public override async IAsyncEnumerable<Response> GetTriggerQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -290,7 +290,7 @@ namespace Azure.Cosmos.Scripts
             }
         }
 
-        public override AsyncPageable<T> GetTriggerQueryIterator<T>(
+        public override AsyncPageable<T> GetTriggerQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -400,7 +400,7 @@ namespace Azure.Cosmos.Scripts
                 cancellationToken: cancellationToken);
         }
 
-        public override IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamIterator(
+        public override IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamResultsAsync(
            string queryText = null,
            string continuationToken = null,
            QueryRequestOptions requestOptions = null,
@@ -412,14 +412,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetUserDefinedFunctionQueryStreamIterator(
+            return this.GetUserDefinedFunctionQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override AsyncPageable<T> GetUserDefinedFunctionQueryIterator<T>(
+        public override AsyncPageable<T> GetUserDefinedFunctionQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -431,14 +431,14 @@ namespace Azure.Cosmos.Scripts
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetUserDefinedFunctionQueryIterator<T>(
+            return this.GetUserDefinedFunctionQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public override async IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamIterator(
+        public override async IAsyncEnumerable<Response> GetUserDefinedFunctionQueryStreamResultsAsync(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
@@ -457,7 +457,7 @@ namespace Azure.Cosmos.Scripts
             }
         }
 
-        public override AsyncPageable<T> GetUserDefinedFunctionQueryIterator<T>(
+        public override AsyncPageable<T> GetUserDefinedFunctionQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/User/CosmosUser.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/User/CosmosUser.cs
@@ -10,6 +10,7 @@ namespace Azure.Cosmos
     /// <summary>
     /// Operations for reading, replacing, or deleting a specific existing user by id and query a user's permissions.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "VSTHRD200:Use \"Async\" suffix for async methods", Justification = "AsyncPageable is not considered Async for checkers.")]
     public abstract class CosmosUser
     {
         /// <summary>
@@ -206,20 +207,20 @@ namespace Azure.Cosmos
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for permission under a user using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for permission under a user using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the permission</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the permissions</returns>
         /// <example>
-        /// 1. This create the type feed iterator for permission with queryText as input,
+        /// 1. This create the enumerable for permission with queryText as input,
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like '%testId%'";
-        /// FeedIterator<PermissionProperties> resultSet = this.users.GetPermissionQueryIterator<PermissionProperties>(queryText);
+        /// FeedIterator<PermissionProperties> resultSet = this.users.GetPermissionQueryResultsAsync<PermissionProperties>(queryText);
         /// await foreach (PermissionProperties permissions in resultSet)
         /// {
         /// }
@@ -227,24 +228,24 @@ namespace Azure.Cosmos
         /// </code>
         /// </example>
         /// <example>
-        /// 2. This create the type feed iterator for permissions without queryText, retrieving all permissions.
+        /// 2. This create the enumerable for permissions without queryText, retrieving all permissions.
         /// <code language="c#">
         /// <![CDATA[
-        /// FeedIterator<PermissionProperties> resultSet = this.user.GetPermissionQueryIterator<PermissionProperties>();
+        /// FeedIterator<PermissionProperties> resultSet = this.user.GetPermissionQueryResultsAsync<PermissionProperties>();
         /// await foreach (PermissionProperties permissions in resultSet)
         /// {
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetPermissionQueryIterator<T>(
+        public abstract AsyncPageable<T> GetPermissionQueryResultsAsync<T>(
             string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// This method creates a query for permissions under a database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for permissions under a database using a SQL statement. It returns an <see cref="AsyncPageable{T}"/>.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <remarks>
@@ -254,22 +255,22 @@ namespace Azure.Cosmos
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
         /// <param name="requestOptions">(Optional) The options for the user query request <see cref="QueryRequestOptions"/></param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
-        /// <returns>An iterator to go through the permissions</returns>
+        /// <returns>An <see cref="AsyncPageable{T}"/> to go through the permissions</returns>
         /// <example>
-        /// This create the type feed iterator for permissions with queryDefinition as input.
+        /// This create the enumerable for permissions with queryDefinition as input.
         /// <code language="c#">
         /// <![CDATA[
         /// string queryText = "SELECT * FROM c where c.id like @testId";
         /// QueryDefinition queryDefinition = new QueryDefinition(queryText);
         /// queryDefinition.WithParameter("@testId", "testPermissionId");
-        /// FeedIterator<PermissionProperties> resultSet = this.user.GetPermissionQueryIterator<PermissionProperties>(queryDefinition);
+        /// FeedIterator<PermissionProperties> resultSet = this.user.GetPermissionQueryResultsAsync<PermissionProperties>(queryDefinition);
         /// await foreach (PermissionProperties permissions in resultSet)
         /// {
         /// }
         /// ]]>
         /// </code>
         /// </example>
-        public abstract AsyncPageable<T> GetPermissionQueryIterator<T>(
+        public abstract AsyncPageable<T> GetPermissionQueryResultsAsync<T>(
             QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/User/UserCore.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/User/UserCore.cs
@@ -206,7 +206,7 @@ namespace Azure.Cosmos
             return this.ClientContext.ResponseFactory.CreatePermissionResponseAsync(this.GetPermission(permissionProperties.Id), response, cancellationToken);
         }
 
-        public override AsyncPageable<T> GetPermissionQueryIterator<T>(QueryDefinition queryDefinition,
+        public override AsyncPageable<T> GetPermissionQueryResultsAsync<T>(QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -223,7 +223,7 @@ namespace Azure.Cosmos
             return PageResponseEnumerator.CreateAsyncPageable(continuation => pageIterator.GetPageAsync(continuation, cancellationToken));
         }
 
-        public async IAsyncEnumerable<Response> GetPermissionQueryStreamIterator(QueryDefinition queryDefinition,
+        public async IAsyncEnumerable<Response> GetPermissionQueryStreamResultsAsync(QueryDefinition queryDefinition,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             [EnumeratorCancellation] CancellationToken cancellationToken = default(CancellationToken))
@@ -239,7 +239,7 @@ namespace Azure.Cosmos
             }
         }
 
-        public override AsyncPageable<T> GetPermissionQueryIterator<T>(string queryText = null,
+        public override AsyncPageable<T> GetPermissionQueryResultsAsync<T>(string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -250,14 +250,14 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetPermissionQueryIterator<T>(
+            return this.GetPermissionQueryResultsAsync<T>(
                 queryDefinition,
                 continuationToken,
                 requestOptions,
                 cancellationToken);
         }
 
-        public IAsyncEnumerable<Response> GetPermissionQueryStreamIterator(string queryText = null,
+        public IAsyncEnumerable<Response> GetPermissionQueryStreamResultsAsync(string queryText = null,
             string continuationToken = null,
             QueryRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -268,7 +268,7 @@ namespace Azure.Cosmos
                 queryDefinition = new QueryDefinition(queryText);
             }
 
-            return this.GetPermissionQueryStreamIterator(
+            return this.GetPermissionQueryStreamResultsAsync(
                 queryDefinition,
                 continuationToken,
                 requestOptions,

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/AsyncEnumerationTests.cs
@@ -53,7 +53,7 @@ namespace Azure.Cosmos.EmulatorTests
             await this.Container.CreateItemAsync<ToDoActivity>(item: testItem2);
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            IAsyncEnumerable<Response> enumerable = this.Container.GetItemQueryStreamIterator(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token);
+            IAsyncEnumerable<Response> enumerable = this.Container.GetItemQueryStreamResultsAsync(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token);
             int iterations = 0;
             await foreach (Response response in enumerable)
             {
@@ -78,7 +78,7 @@ namespace Azure.Cosmos.EmulatorTests
             await this.Container.CreateItemAsync<ToDoActivity>(item: testItem2);
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            AsyncPageable<ToDoActivity> enumerable = this.Container.GetItemQueryIterator<ToDoActivity>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token);
+            AsyncPageable<ToDoActivity> enumerable = this.Container.GetItemQueryResultsAsync<ToDoActivity>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token);
             int iterations = 0;
             await foreach (ToDoActivity item in enumerable)
             {
@@ -102,7 +102,7 @@ namespace Azure.Cosmos.EmulatorTests
             await this.Container.CreateItemAsync<ToDoActivity>(item: testItem2);
 
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-            IAsyncEnumerable<Page<ToDoActivity>> enumerable = this.Container.GetItemQueryIterator<ToDoActivity>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token).AsPages();
+            IAsyncEnumerable<Page<ToDoActivity>> enumerable = this.Container.GetItemQueryResultsAsync<ToDoActivity>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }, cancellationToken: cancellationTokenSource.Token).AsPages();
             int iterations = 0;
             await foreach (Page<ToDoActivity> item in enumerable)
             {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -75,8 +75,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Read All
                 List<DatabaseProperties> results = await this.ToListAsync(
-                    client.GetDatabaseQueryStreamIterator,
-                    client.GetDatabaseQueryIterator<DatabaseProperties>,
+                    client.GetDatabaseQueryStreamResultsAsync,
+                    client.GetDatabaseQueryResultsAsync<DatabaseProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions);
 
@@ -84,8 +84,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Basic query
                 List<DatabaseProperties> queryResults = await this.ToListAsync(
-                    client.GetDatabaseQueryStreamIterator,
-                    client.GetDatabaseQueryIterator<DatabaseProperties>,
+                    client.GetDatabaseQueryStreamResultsAsync,
+                    client.GetDatabaseQueryResultsAsync<DatabaseProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryDb\")",
                     CosmosBasicQueryTests.RequestOptions);
 
@@ -122,8 +122,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Read All
                 List<ContainerProperties> results = await this.ToListAsync(
-                    database.GetContainerQueryStreamIterator,
-                    database.GetContainerQueryIterator<ContainerProperties>,
+                    database.GetContainerQueryStreamResultsAsync,
+                    database.GetContainerQueryResultsAsync<ContainerProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions);
 
@@ -131,8 +131,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Basic query
                 List<ContainerProperties> queryResults = await this.ToListAsync(
-                    database.GetContainerQueryStreamIterator,
-                    database.GetContainerQueryIterator<ContainerProperties>,
+                    database.GetContainerQueryStreamResultsAsync,
+                    database.GetContainerQueryResultsAsync<ContainerProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryContainer\")",
                     CosmosBasicQueryTests.RequestOptions);
 
@@ -163,8 +163,8 @@ namespace Azure.Cosmos.EmulatorTests
             };
 
             List<dynamic> queryResults = await this.ToListAsync(
-                  container.GetItemQueryStreamIterator,
-                 container.GetItemQueryIterator<dynamic>,
+                  container.GetItemQueryStreamResultsAsync,
+                 container.GetItemQueryResultsAsync<dynamic>,
                  "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
                  CosmosBasicQueryTests.RequestOptions);
 
@@ -182,8 +182,8 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 queryResults = await this.ToListAsync(
-                  container.GetItemQueryStreamIterator,
-                 container.GetItemQueryIterator<dynamic>,
+                  container.GetItemQueryStreamResultsAsync,
+                 container.GetItemQueryResultsAsync<dynamic>,
                  "select * from T where STARTSWITH(T.id, \"BasicQueryItem\")",
                  CosmosBasicQueryTests.RequestOptions);
             }
@@ -193,8 +193,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Read All
             List<dynamic> results = await this.ToListAsync(
-                container.GetItemQueryStreamIterator,
-                container.GetItemQueryIterator<dynamic>,
+                container.GetItemQueryStreamResultsAsync,
+                container.GetItemQueryResultsAsync<dynamic>,
                 null,
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -204,8 +204,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Read All with partition key
             results = await this.ToListAsync(
-               container.GetItemQueryStreamIterator,
-               container.GetItemQueryIterator<dynamic>,
+               container.GetItemQueryStreamResultsAsync,
+               container.GetItemQueryResultsAsync<dynamic>,
                null,
                new QueryRequestOptions()
                {
@@ -262,8 +262,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Basic query
             List<StoredProcedureProperties> queryResults = await this.ToListAsync(
-                scripts.GetStoredProcedureQueryStreamIterator,
-                scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
+                scripts.GetStoredProcedureQueryStreamResultsAsync,
+                scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -279,8 +279,8 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 queryResults = await this.ToListAsync(
-                    scripts.GetStoredProcedureQueryStreamIterator,
-                    scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
+                    scripts.GetStoredProcedureQueryStreamResultsAsync,
+                    scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQuerySp\")",
                     CosmosBasicQueryTests.RequestOptions);
             }
@@ -289,8 +289,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Read All
             List<StoredProcedureProperties> results = await this.ToListAsync(
-                scripts.GetStoredProcedureQueryStreamIterator,
-                scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>,
+                scripts.GetStoredProcedureQueryStreamResultsAsync,
+                scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>,
                 null,
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -314,8 +314,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Basic query
             List<UserDefinedFunctionProperties> queryResults = await this.ToListAsync(
-                scripts.GetUserDefinedFunctionQueryStreamIterator,
-                scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
+                scripts.GetUserDefinedFunctionQueryStreamResultsAsync,
+                scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -331,8 +331,8 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 queryResults = await this.ToListAsync(
-                    scripts.GetUserDefinedFunctionQueryStreamIterator,
-                    scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
+                    scripts.GetUserDefinedFunctionQueryStreamResultsAsync,
+                    scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryUdf\")",
                     CosmosBasicQueryTests.RequestOptions);
             }
@@ -341,8 +341,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Read All
             List<UserDefinedFunctionProperties> results = await this.ToListAsync(
-                scripts.GetUserDefinedFunctionQueryStreamIterator,
-                scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>,
+                scripts.GetUserDefinedFunctionQueryStreamResultsAsync,
+                scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>,
                 null,
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -366,8 +366,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Basic query
             List<TriggerProperties> queryResults = await this.ToListAsync(
-                scripts.GetTriggerQueryStreamIterator,
-                scripts.GetTriggerQueryIterator<TriggerProperties>,
+                scripts.GetTriggerQueryStreamResultsAsync,
+                scripts.GetTriggerQueryResultsAsync<TriggerProperties>,
                 "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -383,8 +383,8 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 queryResults = await this.ToListAsync(
-                    scripts.GetTriggerQueryStreamIterator,
-                    scripts.GetTriggerQueryIterator<TriggerProperties>,
+                    scripts.GetTriggerQueryStreamResultsAsync,
+                    scripts.GetTriggerQueryResultsAsync<TriggerProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryTrigger\")",
                     CosmosBasicQueryTests.RequestOptions);
             }
@@ -393,8 +393,8 @@ namespace Azure.Cosmos.EmulatorTests
 
             //Read All
             List<TriggerProperties> results = await this.ToListAsync(
-                scripts.GetTriggerQueryStreamIterator,
-                scripts.GetTriggerQueryIterator<TriggerProperties>,
+                scripts.GetTriggerQueryStreamResultsAsync,
+                scripts.GetTriggerQueryResultsAsync<TriggerProperties>,
                 null,
                 CosmosBasicQueryTests.RequestOptions);
 
@@ -423,8 +423,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Read All
                 List<UserProperties> results = await this.ToListAsync(
-                    database.GetUserQueryStreamIterator,
-                    database.GetUserQueryIterator<UserProperties>,
+                    database.GetUserQueryStreamResultsAsync,
+                    database.GetUserQueryResultsAsync<UserProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions
                 );
@@ -433,8 +433,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Basic query
                 List<UserProperties> queryResults = await this.ToListAsync(
-                    database.GetUserQueryStreamIterator,
-                    database.GetUserQueryIterator<UserProperties>,
+                    database.GetUserQueryStreamResultsAsync,
+                    database.GetUserQueryResultsAsync<UserProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryUser\")",
                     CosmosBasicQueryTests.RequestOptions
                 );
@@ -489,8 +489,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Read All
                 List<PermissionProperties> results = await this.ToListAsync(
-                    user.GetPermissionQueryStreamIterator,
-                    user.GetPermissionQueryIterator<PermissionProperties>,
+                    user.GetPermissionQueryStreamResultsAsync,
+                    user.GetPermissionQueryResultsAsync<PermissionProperties>,
                     null,
                     CosmosBasicQueryTests.RequestOptions
                 );
@@ -499,8 +499,8 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Basic query
                 List<PermissionProperties> queryResults = await this.ToListAsync(
-                    user.GetPermissionQueryStreamIterator,
-                    user.GetPermissionQueryIterator<PermissionProperties>,
+                    user.GetPermissionQueryStreamResultsAsync,
+                    user.GetPermissionQueryResultsAsync<PermissionProperties>,
                     "select * from T where STARTSWITH(T.id, \"BasicQueryPermission\")",
                     CosmosBasicQueryTests.RequestOptions
                 );

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -412,7 +412,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
 
             HashSet<string> containerIds = new HashSet<string>();
-            await foreach (ContainerProperties setting in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>())
+            await foreach (ContainerProperties setting in this.cosmosDatabase.GetContainerQueryResultsAsync<ContainerProperties>())
             {
                 if (!containerIds.Contains(setting.Id))
                 {
@@ -423,7 +423,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.IsTrue(containerIds.Count > 0, "The iterator did not find any containers.");
             Assert.IsTrue(containerIds.Contains(containerName), "The iterator did not find the created container");
 
-            await foreach (Page<ContainerProperties> page in this.cosmosDatabase.GetContainerQueryIterator<ContainerProperties>($"select * from c where c.id = \"{containerName}\"").AsPages())
+            await foreach (Page<ContainerProperties> page in this.cosmosDatabase.GetContainerQueryResultsAsync<ContainerProperties>($"select * from c where c.id = \"{containerName}\"").AsPages())
             {
                 Assert.AreEqual(1, page.Values.Count);
                 Assert.AreEqual(containerName, page.Values.First().Id);
@@ -451,7 +451,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(partitionKeyPath, containerResponse.Value.PartitionKey.Paths.First());
 
             HashSet<string> containerIds = new HashSet<string>();
-            await foreach(Response message in this.cosmosDatabase.GetContainerQueryStreamIterator(
+            await foreach(Response message in this.cosmosDatabase.GetContainerQueryStreamResultsAsync(
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }))
              {
                 Assert.AreEqual((int)HttpStatusCode.OK, message.Status);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -335,7 +335,7 @@ namespace Azure.Cosmos.EmulatorTests
                     databaseIds.Add(createResponse.Value.Id);
                 }
 
-                await foreach(DatabaseProperties databaseSettings in this.cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>(
+                await foreach(DatabaseProperties databaseSettings in this.cosmosClient.GetDatabaseQueryResultsAsync<DatabaseProperties>(
                     queryDefinition: null,
                     continuationToken: null,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 2 }))
@@ -375,7 +375,7 @@ namespace Azure.Cosmos.EmulatorTests
                 deleteList.Add(createResponse3.Database);
 
                 int iterations = 0;
-                await foreach(Page<DatabaseProperties> iterator in this.cosmosClient.GetDatabaseQueryIterator<DatabaseProperties>(
+                await foreach(Page<DatabaseProperties> iterator in this.cosmosClient.GetDatabaseQueryResultsAsync<DatabaseProperties>(
                         new QueryDefinition("select c.id From c where c.id = @id ")
                         .WithParameter("@id", createResponse.Database.Id),
                         requestOptions: new QueryRequestOptions() { MaxItemCount = 1 }).AsPages())

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -74,7 +74,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             await this.CreateRandomItems(this.Container, batchSize, randomPartitionKey: true);
             ContainerCore itemsCore = (ContainerCore)this.Container;
-            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIterator(requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIteratorAsync(requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
             await foreach(Response responseMessage in feedIterator)
             {
@@ -111,7 +111,7 @@ namespace Azure.Cosmos.EmulatorTests
             // Insert another batch of 25 and use the last continuation token from the first cycle
             await this.CreateRandomItems(this.Container, batchSize, randomPartitionKey: true);
             IAsyncEnumerable<Response> setIteratorNew =
-                itemsCore.GetStandByFeedIterator(lastcontinuation);
+                itemsCore.GetStandByFeedIteratorAsync(lastcontinuation);
 
             await foreach(Response responseMessage in setIteratorNew)
             {
@@ -158,7 +158,7 @@ namespace Azure.Cosmos.EmulatorTests
             int visitedPkRanges = 0;
 
             ContainerCore itemsCore = (ContainerCore)this.Container;
-            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIterator();
+            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIteratorAsync();
 
             await foreach(Response responseMessage in feedIterator)
             {
@@ -216,7 +216,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             ContainerCore itemsCore = (ContainerCore)this.Container;
             IAsyncEnumerable<Response> setIteratorNew =
-                itemsCore.GetStandByFeedIterator(corruptedTokenSerialized);
+                itemsCore.GetStandByFeedIteratorAsync(corruptedTokenSerialized);
 
             await foreach (Response response in setIteratorNew) { }
 
@@ -231,7 +231,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             await this.CreateRandomItems(this.Container, 2, randomPartitionKey: true);
             ContainerCore itemsCore = (ContainerCore)this.Container;
-            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+            IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIteratorAsync(maxItemCount: 1, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
 
             await foreach(Response responseMessage in feedIterator)
             {
@@ -267,7 +267,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 ChangeFeedRequestOptions requestOptions = new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue };
 
-                IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIterator(continuationToken, requestOptions: requestOptions);
+                IAsyncEnumerable<Response> feedIterator = itemsCore.GetStandByFeedIteratorAsync(continuationToken, requestOptions: requestOptions);
 
                 await foreach(Response responseMessage in feedIterator)
                 {
@@ -338,7 +338,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 int count = 0;
                 IAsyncEnumerable<Response> iteratorForToken =
-                    itemsCore.GetStandByFeedIterator(continuationToken: token, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
+                    itemsCore.GetStandByFeedIteratorAsync(continuationToken: token, requestOptions: new ChangeFeedRequestOptions() { StartTime = DateTime.MinValue });
                 await foreach(Response responseMessage in iteratorForToken)
                 {
                     if (!responseMessage.IsSuccessStatusCode())

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -444,7 +444,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 while(itemIds.Count > 0)
                 {
-                    await foreach (Response responseMessage in this.Container.GetItemQueryStreamIterator(
+                    await foreach (Response responseMessage in this.Container.GetItemQueryStreamResultsAsync(
                         continuationToken: lastContinuationToken,
                         requestOptions: requestOptions))
                     {
@@ -463,7 +463,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
             else
             {
-                await foreach (Response responseMessage in this.Container.GetItemQueryStreamIterator(requestOptions: requestOptions))
+                await foreach (Response responseMessage in this.Container.GetItemQueryStreamResultsAsync(requestOptions: requestOptions))
                 {
                     responseMessage.Headers.TryGetValue(Microsoft.Azure.Documents.HttpConstants.HttpHeaders.Continuation, out lastContinuationToken);
                     Collection<ToDoActivity> response = TestCommon.Serializer.Value.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.ContentStream).Data;
@@ -582,7 +582,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 List<dynamic> allItems = new List<dynamic>();
 
-                await foreach(Page<Dictionary<string, object>> response in containerSerializer.GetItemQueryIterator<Dictionary<string, object>>(
+                await foreach(Page<Dictionary<string, object>> response in containerSerializer.GetItemQueryResultsAsync<Dictionary<string, object>>(
                     queryDefinition: queryDefinition).AsPages())
                 {
                     allItems.AddRange(response.Values);
@@ -608,7 +608,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             IList<ToDoActivity> deleteList = await ToDoActivity.CreateRandomItems(this.Container, 3, randomPartitionKey: true);
             HashSet<string> itemIds = deleteList.Select(x => x.id).ToHashSet<string>();
-            await foreach (ToDoActivity toDoActivity in this.Container.GetItemQueryIterator<ToDoActivity>())
+            await foreach (ToDoActivity toDoActivity in this.Container.GetItemQueryResultsAsync<ToDoActivity>())
             {
                 if (itemIds.Contains(toDoActivity.id))
                 {
@@ -659,7 +659,7 @@ namespace Azure.Cosmos.EmulatorTests
             // }
 
             IAsyncEnumerable<Response> setIterator =
-                this.Container.GetItemQueryStreamIterator();
+                this.Container.GetItemQueryStreamResultsAsync();
             FeedIterators.Add(setIterator);
 
             QueryRequestOptions options = new QueryRequestOptions()
@@ -668,7 +668,7 @@ namespace Azure.Cosmos.EmulatorTests
                 MaxConcurrency = 1,
             };
 
-            IAsyncEnumerable<Response> queryIterator = this.Container.GetItemQueryStreamIterator(
+            IAsyncEnumerable<Response> queryIterator = this.Container.GetItemQueryStreamResultsAsync(
                     queryText: @"select * from t where t.id != """" ",
                     requestOptions: options);
 
@@ -741,7 +741,7 @@ namespace Azure.Cosmos.EmulatorTests
             do
             {
                 iterationCount++;
-                IAsyncEnumerable<Response> feedIterator = this.Container.GetItemQueryStreamIterator(
+                IAsyncEnumerable<Response> feedIterator = this.Container.GetItemQueryStreamResultsAsync(
                     sql,
                     continuationToken: lastContinuationToken,
                     requestOptions: new QueryRequestOptions()
@@ -809,7 +809,7 @@ namespace Azure.Cosmos.EmulatorTests
                 MaxConcurrency = 1,
             };
 
-            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryIterator<ToDoActivity>(
+            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
                     sql,
                     requestOptions: requestOptions).AsPages())
             {
@@ -854,7 +854,7 @@ namespace Azure.Cosmos.EmulatorTests
                     List<ToDoActivity> resultList = new List<ToDoActivity>();
                     double totalRequstCharge = 0;
 
-                    await foreach(Response iter in this.Container.GetItemQueryStreamIterator(
+                    await foreach(Response iter in this.Container.GetItemQueryStreamResultsAsync(
                         sql,
                         requestOptions: requestOptions))
                     {
@@ -902,7 +902,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
-            await foreach(Response iter in this.Container.GetItemQueryStreamIterator(sql, requestOptions: requestOptions))
+            await foreach(Response iter in this.Container.GetItemQueryStreamResultsAsync(sql, requestOptions: requestOptions))
             {
                 Assert.IsTrue(iter.IsSuccessStatusCode());
                 Assert.IsNull(iter.ReasonPhrase);
@@ -943,7 +943,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             double totalRequstCharge = 0;
             List<ToDoActivity> foundItems = new List<ToDoActivity>();
-            await foreach (Response iter in this.Container.GetItemQueryStreamIterator(
+            await foreach (Response iter in this.Container.GetItemQueryStreamResultsAsync(
                 sql,
                 requestOptions: new QueryRequestOptions()
                 {
@@ -1003,7 +1003,7 @@ namespace Azure.Cosmos.EmulatorTests
             };
             queryRequestOptions.Properties.Add(Microsoft.Azure.Documents.WFConstants.BackendHeaders.EffectivePartitionKeyString, epk);
 
-            await foreach(Page<dynamic> page in this.Container.GetItemQueryIterator<dynamic>(
+            await foreach(Page<dynamic> page in this.Container.GetItemQueryResultsAsync<dynamic>(
                     queryText: "SELECT * FROM root",
                     requestOptions: queryRequestOptions).AsPages())
             {
@@ -1088,7 +1088,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             List<ToDoActivity> resultList = new List<ToDoActivity>();
             double totalRequstCharge = 0;
-            await foreach(Response response in this.Container.GetItemQueryStreamIterator(
+            await foreach(Response response in this.Container.GetItemQueryStreamResultsAsync(
                 sql,
                 requestOptions: requestOptions))
             {
@@ -1142,7 +1142,7 @@ namespace Azure.Cosmos.EmulatorTests
                 .WithParameter("@status", toDoActivity.status);
 
             // Test max size at 1
-            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryIterator<ToDoActivity>(
+            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
                 sql,
                 requestOptions: new QueryRequestOptions()
                 {
@@ -1154,7 +1154,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
 
             // Test max size at 2
-            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryIterator<ToDoActivity>(
+            await foreach(Page<ToDoActivity> iter in this.Container.GetItemQueryResultsAsync<ToDoActivity>(
                 sql,
                 requestOptions: new QueryRequestOptions()
                 {
@@ -1177,7 +1177,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                await foreach(dynamic item in this.Container.GetItemQueryIterator<dynamic>(
+                await foreach(dynamic item in this.Container.GetItemQueryResultsAsync<dynamic>(
                     queryText: "SELECT r.id FROM root r WHERE r._ts > 0",
                     requestOptions: new QueryRequestOptions() { ResponseContinuationTokenLimitInKb = 0, MaxItemCount = 10, MaxConcurrency = 1 }))
                 {
@@ -1192,7 +1192,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                await foreach(dynamic item in this.Container.GetItemQueryIterator<dynamic>(
+                await foreach(dynamic item in this.Container.GetItemQueryResultsAsync<dynamic>(
                     queryText: "SELECT r.id FROM root r WHERE r._ts >!= 0",
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 1 }))
                 {
@@ -1298,7 +1298,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 //Quering items on fixed container with cross partition enabled.
                 QueryDefinition sql = new QueryDefinition("select * from r");
-                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryIterator<dynamic>(
+                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryResultsAsync<dynamic>(
                     sql,
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 1, MaxItemCount = 10 }).AsPages())
                 {
@@ -1306,13 +1306,13 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 //Reading all items on fixed container.
-                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryIterator<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 }).AsPages())
+                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryResultsAsync<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 }).AsPages())
                 {
                     Assert.AreEqual(3, queryResponse.Values.Count);
                 }
 
                 //Quering items on fixed container with CosmosContainerSettings.NonePartitionKeyValue.
-                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryIterator<dynamic>(
+                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryResultsAsync<dynamic>(
                     new QueryDefinition("select * from r"),
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = Cosmos.PartitionKey.None, }).AsPages())
                 {
@@ -1320,7 +1320,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 //Quering items on fixed container with non-none PK.
-                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryIterator<dynamic>(
+                await foreach(Page<dynamic> queryResponse in fixedContainer.GetItemQueryResultsAsync<dynamic>(
                     sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = new Cosmos.PartitionKey(itemWithPK.status) }).AsPages())
                 {
@@ -1385,7 +1385,7 @@ namespace Azure.Cosmos.EmulatorTests
                 // Query items on the container that have no partition key value
                 int resultsFetched = 0;
                 QueryDefinition sql = new QueryDefinition("select * from r ");
-                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryIterator<ToDoActivity>(
+                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryResultsAsync<ToDoActivity>(
                     sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 2, PartitionKey = Cosmos.PartitionKey.None, }).AsPages())
                 {
@@ -1413,7 +1413,7 @@ namespace Azure.Cosmos.EmulatorTests
                 Assert.AreEqual(ItemsToCreate, resultsFetched);
 
                 // Re-Query the items on the container with NonePartitionKeyValue
-                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryIterator<ToDoActivity>(
+                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryResultsAsync<ToDoActivity>(
                     sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = ItemsToCreate, PartitionKey = Cosmos.PartitionKey.None, }).AsPages())
                 {
@@ -1421,7 +1421,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 // Query the items with newly inserted PartitionKey
-                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryIterator<ToDoActivity>(
+                await foreach(Page<ToDoActivity> queryResponse in fixedContainer.GetItemQueryResultsAsync<ToDoActivity>(
                     sql,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = ItemsToCreate + 1, PartitionKey = new Cosmos.PartitionKey("TestPK"), }).AsPages())
                 {
@@ -1628,7 +1628,7 @@ namespace Azure.Cosmos.EmulatorTests
                 queryText = "select * from r";
             }
 
-            await foreach(Response response in container.GetItemQueryStreamIterator(queryText))
+            await foreach(Response response in container.GetItemQueryStreamResultsAsync(queryText))
             {
                 if (response.Status == 429)
                 {
@@ -1640,7 +1640,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         private static async Task ExecuteQueryAsync(CosmosContainer container, int expected)
         {
-            await foreach(Response response in container.GetItemQueryStreamIterator("select * from r"))
+            await foreach(Response response in container.GetItemQueryStreamResultsAsync("select * from r"))
             {
                 Assert.AreEqual(expected, response.Status, $"ExecuteQueryAsync substatuscode: {response.Headers.GetSubStatusCode()} ");
             }
@@ -1648,7 +1648,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         private static async Task ExecuteReadFeedAsync(CosmosContainer container, int expected)
         {
-            await foreach(Response response in container.GetItemQueryStreamIterator())
+            await foreach(Response response in container.GetItemQueryStreamResultsAsync())
             {
                 Assert.AreEqual(expected, response.Status, $"ExecuteReadFeedAsync substatuscode: {response.Headers.GetSubStatusCode()} ");
             }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosNotFoundTests.cs
@@ -53,13 +53,13 @@ namespace Azure.Cosmos.EmulatorTests
 
             await container.DeleteContainerAsync();
 
-            IAsyncEnumerable<Response> crossPartitionQueryIterator = container.GetItemQueryStreamIterator(
+            IAsyncEnumerable<Response> crossPartitionQueryIterator = container.GetItemQueryStreamResultsAsync(
                 "select * from t where true",
                 requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
             await this.VerifyQueryNotFoundResponse(crossPartitionQueryIterator);
 
-            IAsyncEnumerable<Response> queryIterator = container.GetItemQueryStreamIterator(
+            IAsyncEnumerable<Response> queryIterator = container.GetItemQueryStreamResultsAsync(
                 "select * from t where true",
                 requestOptions: new QueryRequestOptions()
                 {
@@ -69,7 +69,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             await this.VerifyQueryNotFoundResponse(queryIterator);
 
-            IAsyncEnumerable<Response> crossPartitionQueryIterator2 = container.GetItemQueryStreamIterator(
+            IAsyncEnumerable<Response> crossPartitionQueryIterator2 = container.GetItemQueryStreamResultsAsync(
                 "select * from t where true",
                 requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
@@ -116,14 +116,14 @@ namespace Azure.Cosmos.EmulatorTests
                 Stream create = TestCommon.Serializer.Value.ToStream<dynamic>(randomItem);
                 this.VerifyNotFoundResponse(await container.CreateItemStreamAsync(create, new PartitionKey(randomItem.pk)));
 
-                IAsyncEnumerable<Response> queryIterator = container.GetItemQueryStreamIterator(
+                IAsyncEnumerable<Response> queryIterator = container.GetItemQueryStreamResultsAsync(
                     "select * from t where true",
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
 
                 this.VerifyNotFoundResponse(await queryIterator.GetFirstResponse());
 
-                IAsyncEnumerable<Response> feedIterator = container.GetItemQueryStreamIterator();
+                IAsyncEnumerable<Response> feedIterator = container.GetItemQueryStreamResultsAsync();
                 this.VerifyNotFoundResponse(await feedIterator.GetFirstResponse());
 
                 dynamic randomUpsertItem = new { id = DoesNotExist, pk = DoesNotExist, status = 42 };

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CosmosReadFeedTests.cs
@@ -71,7 +71,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
 
             string lastKnownContinuationToken = null;
-            IAsyncEnumerable<Response> iter = this.Container.Database.GetContainer(this.Container.Id).GetItemQueryStreamIterator(
+            IAsyncEnumerable<Response> iter = this.Container.Database.GetContainer(this.Container.Id).GetItemQueryStreamResultsAsync(
                 continuationToken: lastKnownContinuationToken, 
                 requestOptions: requestOptions);
 
@@ -81,7 +81,7 @@ namespace Azure.Cosmos.EmulatorTests
             {
                 do
                 {
-                    iter = this.Container.Database.GetContainer(this.Container.Id).GetItemQueryStreamIterator(
+                    iter = this.Container.Database.GetContainer(this.Container.Id).GetItemQueryStreamResultsAsync(
                             continuationToken: lastKnownContinuationToken,
                             requestOptions: requestOptions);
                     await foreach (Response response in iter)
@@ -139,7 +139,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             lastKnownContinuationToken = null;
             iter = this.Container.Database.GetContainer(this.Container.Id)
-                    .GetItemQueryStreamIterator(queryDefinition: null, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
+                    .GetItemQueryStreamResultsAsync(queryDefinition: null, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
 
 
             if (useStatelessIteration)
@@ -147,7 +147,7 @@ namespace Azure.Cosmos.EmulatorTests
                 do
                 {
                     iter = this.Container.Database.GetContainer(this.Container.Id)
-                            .GetItemQueryStreamIterator(queryDefinition: null, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
+                            .GetItemQueryStreamResultsAsync(queryDefinition: null, continuationToken: lastKnownContinuationToken, requestOptions: requestOptions);
                     await foreach (Response response in iter)
                     {
                         lastKnownContinuationToken = response.Headers.GetContinuationToken();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/CrossPartitionQueryTests.cs
@@ -332,7 +332,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         private static async Task CleanUp(CosmosClient client)
         {
-            AsyncPageable<DatabaseProperties> allDatabases = client.GetDatabaseQueryIterator<DatabaseProperties>();
+            AsyncPageable<DatabaseProperties> allDatabases = client.GetDatabaseQueryResultsAsync<DatabaseProperties>();
 
             await foreach (DatabaseProperties db in allDatabases)
             {
@@ -616,7 +616,7 @@ namespace Azure.Cosmos.EmulatorTests
                 QueryRequestOptions computeRequestOptions = queryRequestOptions.Clone();
                 computeRequestOptions.ExecutionEnvironment = Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ExecutionEnvironment.Compute;
 
-                IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryIterator<T>(
+                IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryResultsAsync<T>(
                    queryText: query,
                    requestOptions: computeRequestOptions,
                    continuationToken: state).AsPages();
@@ -653,7 +653,7 @@ namespace Azure.Cosmos.EmulatorTests
             string continuationToken = null;
             do
             {
-                IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryIterator<T>(
+                IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryResultsAsync<T>(
                    queryText: query,
                    requestOptions: queryRequestOptions,
                    continuationToken: continuationToken).AsPages();
@@ -689,7 +689,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
 
             List<T> results = new List<T>();
-            IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryIterator<T>(
+            IAsyncEnumerable<Page<T>> itemQuery = container.GetItemQueryResultsAsync<T>(
                 queryText: query,
                 requestOptions: queryRequestOptions).AsPages();
 
@@ -777,7 +777,7 @@ namespace Azure.Cosmos.EmulatorTests
             await CrossPartitionQueryTests.NoOp();
             try
             {
-                AsyncPageable<Document> resultSetIterator = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> resultSetIterator = container.GetItemQueryResultsAsync<Document>(
                     @"SELECT * FROM Root r WHERE a = 1",
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 2 });
 
@@ -818,7 +818,7 @@ namespace Azure.Cosmos.EmulatorTests
                 /// '"code":"SC2001","message":"Identifier 'c' could not be resolved."'
                 string query = "SELECT c._ts, c.id, c.TicketNumber, c.PosCustomerNumber, c.CustomerId, c.CustomerUserId, c.ContactEmail, c.ContactPhone, c.StoreCode, c.StoreUid, c.PoNumber, c.OrderPlacedOn, c.OrderType, c.OrderStatus, c.Customer.UserFirstName, c.Customer.UserLastName, c.Customer.Name, c.UpdatedBy, c.UpdatedOn, c.ExpirationDate, c.TotalAmountFROM c ORDER BY c._ts";
                 List<Document> expectedValues = new List<Document>();
-                AsyncPageable<Document> resultSetIterator = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> resultSetIterator = container.GetItemQueryResultsAsync<Document>(
                     query,
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 0 });
 
@@ -911,7 +911,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                 foreach ((string, string) queryAndExpectedResult in queries)
                 {
-                    AsyncPageable<Document> resultSetIterator = container.GetItemQueryIterator<Document>(
+                    AsyncPageable<Document> resultSetIterator = container.GetItemQueryResultsAsync<Document>(
                         queryText: queryAndExpectedResult.Item1,
                         requestOptions: new QueryRequestOptions()
                         {
@@ -957,7 +957,7 @@ namespace Azure.Cosmos.EmulatorTests
             IEnumerable<Document> documents)
         {
             // Query with partition key should be done in one round trip.
-            IAsyncEnumerable<Page<dynamic>> resultSetIterator = container.GetItemQueryIterator<dynamic>(
+            IAsyncEnumerable<Page<dynamic>> resultSetIterator = container.GetItemQueryResultsAsync<dynamic>(
                 "SELECT * FROM c WHERE c.pk = 'doc5'").AsPages();
 
             await foreach(Page<dynamic> response in resultSetIterator)
@@ -967,7 +967,7 @@ namespace Azure.Cosmos.EmulatorTests
                 break;
             }            
 
-            resultSetIterator = container.GetItemQueryIterator<dynamic>(
+            resultSetIterator = container.GetItemQueryResultsAsync<dynamic>(
                "SELECT * FROM c WHERE c.pk = 'doc10'").AsPages();
 
             await foreach (Page<dynamic> response in resultSetIterator)
@@ -1131,7 +1131,7 @@ namespace Azure.Cosmos.EmulatorTests
                     break;
             }
 
-            await foreach(SpecialPropertyDocument doc in container.GetItemQueryIterator<SpecialPropertyDocument>(
+            await foreach(SpecialPropertyDocument doc in container.GetItemQueryResultsAsync<SpecialPropertyDocument>(
                 query,
                 requestOptions: new QueryRequestOptions()
                 {
@@ -1303,7 +1303,7 @@ namespace Azure.Cosmos.EmulatorTests
                 $"SELECT VALUE r.{args.PartitionKey} FROM r WHERE ARRAY_CONTAINS(@keys, r.{args.PartitionKey})").WithParameter("@keys", args.ExpectedPartitionKeyValues);
 
             HashSet<int> actualPartitionKeyValues = new HashSet<int>();
-            AsyncPageable<int> documentQuery = container.GetItemQueryIterator<int>(
+            AsyncPageable<int> documentQuery = container.GetItemQueryResultsAsync<int>(
                     queryDefinition: query,
                     requestOptions: new QueryRequestOptions() { MaxItemCount = -1, MaxConcurrency = 100 });
 
@@ -1701,7 +1701,7 @@ namespace Azure.Cosmos.EmulatorTests
                     //}
 
                     // Make sure ExecuteNextAsync works for unsupported aggregate projection
-                    AsyncPageable<dynamic> asyncPageble = container.GetItemQueryIterator<dynamic>(query, requestOptions: new QueryRequestOptions() { MaxConcurrency = 1 });
+                    AsyncPageable<dynamic> asyncPageble = container.GetItemQueryResultsAsync<dynamic>(query, requestOptions: new QueryRequestOptions() { MaxConcurrency = 1 });
                     await foreach(dynamic doc in asyncPageble)
                     {
                         break;
@@ -2422,7 +2422,7 @@ namespace Azure.Cosmos.EmulatorTests
                 string queryWithoutDistinct = string.Format(query, "");
 
                 QueryRequestOptions requestOptions = new QueryRequestOptions() { MaxItemCount = 100, MaxConcurrency = 100 };
-                AsyncPageable<JToken> documentQueryWithoutDistinct = container.GetItemQueryIterator<JToken>(
+                AsyncPageable<JToken> documentQueryWithoutDistinct = container.GetItemQueryResultsAsync<JToken>(
                         queryWithoutDistinct,
                         requestOptions: requestOptions);
 
@@ -2444,7 +2444,7 @@ namespace Azure.Cosmos.EmulatorTests
                 {
                     string queryWithDistinct = string.Format(query, "DISTINCT");
                     List<JToken> documentsFromWithDistinct = new List<JToken>();
-                    AsyncPageable<JToken> documentQueryWithDistinct = container.GetItemQueryIterator<JToken>(
+                    AsyncPageable<JToken> documentQueryWithDistinct = container.GetItemQueryResultsAsync<JToken>(
                         queryWithDistinct,
                         requestOptions: requestOptions);
                     await foreach (JToken doc in documentQueryWithDistinct)
@@ -3170,7 +3170,7 @@ namespace Azure.Cosmos.EmulatorTests
 
                                     DateTime startTime = DateTime.Now;
                                     List<Document> result = new List<Document>();
-                                    AsyncPageable<Document> query = container.GetItemQueryIterator<Document>(
+                                    AsyncPageable<Document> query = container.GetItemQueryResultsAsync<Document>(
                                         querySpec,
                                         requestOptions: feedOptions);
 
@@ -3350,7 +3350,7 @@ namespace Azure.Cosmos.EmulatorTests
                             // Max DOP needs to be 0 since the query needs to run in serial => 
                             // otherwise the parallel code will prefetch from other partitions,
                             // since the first N-1 partitions might be empty.
-                            AsyncPageable<dynamic> documentQuery = container.GetItemQueryIterator<dynamic>(
+                            AsyncPageable<dynamic> documentQuery = container.GetItemQueryResultsAsync<dynamic>(
                                     query,
                                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 0, MaxItemCount = pageSize });
 
@@ -3448,7 +3448,7 @@ namespace Azure.Cosmos.EmulatorTests
             #region BadContinuations
             try
             {
-                AsyncPageable<Document> query = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> query = container.GetItemQueryResultsAsync<Document>(
                     "SELECT * FROM t",
                     continuationToken: Guid.NewGuid().ToString(),
                     requestOptions: new QueryRequestOptions() { MaxConcurrency = 1 });
@@ -3471,7 +3471,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                AsyncPageable<Document> query = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> query = container.GetItemQueryResultsAsync<Document>(
                     "SELECT TOP 10 * FROM r",
                     continuationToken: "{'top':11}",
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 10, MaxConcurrency = -1 });
@@ -3490,7 +3490,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                AsyncPageable<Document> query = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> query = container.GetItemQueryResultsAsync<Document>(
                     "SELECT * FROM r ORDER BY r.field1",
                     continuationToken: "{'compositeToken':{'range':{'min':'05C1E9CD673398','max':'FF'}}, 'orderByItems':[{'item':2}, {'item':1}]}",
                     requestOptions: new QueryRequestOptions() { MaxItemCount = 10, MaxConcurrency = -1 });
@@ -3509,7 +3509,7 @@ namespace Azure.Cosmos.EmulatorTests
 
             try
             {
-                AsyncPageable<Document> query = container.GetItemQueryIterator<Document>(
+                AsyncPageable<Document> query = container.GetItemQueryResultsAsync<Document>(
                    "SELECT * FROM r ORDER BY r.field1, r.field2",
                    continuationToken: "{'compositeToken':{'range':{'min':'05C1E9CD673398','max':'FF'}}, 'orderByItems':[{'item':2}, {'item':1}]}",
                    requestOptions: new QueryRequestOptions() { MaxItemCount = 10, MaxConcurrency = -1 });
@@ -3527,7 +3527,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
             #endregion
 
-            IAsyncEnumerable<Page<Document>> responseWithEmptyContinuationExpected = container.GetItemQueryIterator<Document>(
+            IAsyncEnumerable<Page<Document>> responseWithEmptyContinuationExpected = container.GetItemQueryResultsAsync<Document>(
                 string.Format(CultureInfo.InvariantCulture, "SELECT TOP 1 * FROM r ORDER BY r.{0}", partitionKey),
                 requestOptions: new QueryRequestOptions() { MaxConcurrency = 10, MaxItemCount = -1 }).AsPages();
 
@@ -4354,7 +4354,7 @@ namespace Azure.Cosmos.EmulatorTests
             // Malformed continuation token
             try
             {
-                IAsyncEnumerable<Response> itemQuery = container.GetItemQueryStreamIterator(
+                IAsyncEnumerable<Response> itemQuery = container.GetItemQueryStreamResultsAsync(
                     queryText: query,
                     continuationToken: "is not the continuation token you are looking for");
                 await foreach (Response response in itemQuery)
@@ -4516,7 +4516,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         //    int totalReadCount = 0;
 
-        //    FeedIterator<dynamic> docQuery = coll.Items.GetItemQueryIterator<dynamic>(query, feedOptions);
+        //    FeedIterator<dynamic> docQuery = coll.Items.GetItemQueryResultsAsync<dynamic>(query, feedOptions);
         //        while (docQuery.HasMoreResults && (maxReadItemCount < 0 || maxReadItemCount > totalReadCount))
         //        {
         //            FeedResponse<dynamic> response = await docQuery.FetchNextSetAsync();
@@ -4649,7 +4649,7 @@ namespace Azure.Cosmos.EmulatorTests
             string query,
             QueryRequestOptions requestOptions = null)
         {
-            AsyncPageable<T> resultSetIterator = container.GetItemQueryIterator<T>(
+            AsyncPageable<T> resultSetIterator = container.GetItemQueryResultsAsync<T>(
                 query,
                 requestOptions: requestOptions);
 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/SmokeTests.cs
@@ -90,7 +90,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
 
             int count = 0;
-            await foreach(dynamic item in container.GetItemQueryIterator<dynamic>())
+            await foreach(dynamic item in container.GetItemQueryResultsAsync<dynamic>())
             {
                 count++;
             }
@@ -133,7 +133,7 @@ namespace Azure.Cosmos.EmulatorTests
             QueryRequestOptions options = new QueryRequestOptions { MaxItemCount = 1 };
 
             int smithFamilyCount = 0;
-            await foreach (Person person in container.GetItemQueryIterator<Person>("SELECT * FROM d WHERE d.LastName = 'Smith'", requestOptions: options))
+            await foreach (Person person in container.GetItemQueryResultsAsync<Person>("SELECT * FROM d WHERE d.LastName = 'Smith'", requestOptions: options))
             {
                 smithFamilyCount++;
             }
@@ -141,7 +141,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(2, smithFamilyCount);
 
             List<Person> personsList = new List<Person>();
-            await foreach (Page<Person> page in container.GetItemQueryIterator<Person>(requestOptions: options).AsPages())
+            await foreach (Page<Person> page in container.GetItemQueryResultsAsync<Person>(requestOptions: options).AsPages())
             {
                 int maxItemCount = options.MaxItemCount ?? default(int);
                 Assert.IsTrue(page.Values.Count >= 0 && page.Values.Count <= maxItemCount);
@@ -186,7 +186,7 @@ namespace Azure.Cosmos.EmulatorTests
             }
 
             List<dynamic> list = new List<dynamic>();
-            await foreach(Page<dynamic> page in container.GetItemQueryIterator<dynamic>("SELECT TOP 10 * FROM coll").AsPages())
+            await foreach(Page<dynamic> page in container.GetItemQueryResultsAsync<dynamic>("SELECT TOP 10 * FROM coll").AsPages())
             {
                 list.AddRange(page.Values);
             }
@@ -305,7 +305,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         private async Task CleanupDocumentCollection(CosmosContainer container)
         {
-            await foreach(JsonElement doc in container.GetItemQueryIterator<JsonElement>())
+            await foreach(JsonElement doc in container.GetItemQueryResultsAsync<JsonElement>())
             {
                 string id = doc.GetProperty("id").GetString();
                 await container.DeleteItemAsync<JsonElement>(id, new PartitionKey(id));

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/StoredProcedureTests.cs
@@ -199,7 +199,7 @@ namespace Azure.Cosmos.EmulatorTests
                 }
 
                 List<string> readSprocIds = new List<string>();
-                await foreach (StoredProcedureProperties storedProcedureSettingsEntry in scripts.GetStoredProcedureQueryIterator<StoredProcedureProperties>())
+                await foreach (StoredProcedureProperties storedProcedureSettingsEntry in scripts.GetStoredProcedureQueryResultsAsync<StoredProcedureProperties>())
                 {
                     readSprocIds.Add(storedProcedureSettingsEntry.Id);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -154,7 +154,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(1, createdItem.JobNumber);
 
             List<Job> result = new List<Job>();
-            await foreach(Job job in this.container.GetItemQueryIterator<Job>("select * from x where x.investigationKey = 'investigation~1'"))
+            await foreach(Job job in this.container.GetItemQueryResultsAsync<Job>("select * from x where x.investigationKey = 'investigation~1'"))
             {
                 result.Add(job);
             }
@@ -180,7 +180,7 @@ namespace Azure.Cosmos.EmulatorTests
             Assert.AreEqual(2, createdItem2.JobNumber);
 
             result.Clear();
-            await foreach (Job job in this.container.GetItemQueryIterator<Job>("select * from x where x.investigationKey = 'investigation~1'"))
+            await foreach (Job job in this.container.GetItemQueryResultsAsync<Job>("select * from x where x.investigationKey = 'investigation~1'"))
             {
                 result.Add(job);
             }
@@ -251,7 +251,7 @@ namespace Azure.Cosmos.EmulatorTests
                 TriggerProperties cosmosTrigger = await this.CreateRandomTrigger();
 
                 HashSet<string> settings = new HashSet<string>();
-                await foreach (TriggerProperties storedProcedureSettingsEntry in scripts.GetTriggerQueryIterator<TriggerProperties>())
+                await foreach (TriggerProperties storedProcedureSettingsEntry in scripts.GetTriggerQueryResultsAsync<TriggerProperties>())
                 {
                     settings.Add(storedProcedureSettingsEntry.Id);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -133,7 +133,7 @@ namespace Azure.Cosmos.EmulatorTests
                  .WithParameter("@status", "Done");
 
             HashSet<string> iterIds = new HashSet<string>();
-            await foreach(JsonElement response in this.container.GetItemQueryIterator<JsonElement>(
+            await foreach(JsonElement response in this.container.GetItemQueryResultsAsync<JsonElement>(
                  queryDefinition: sqlQuery))
             {
                 Assert.IsTrue(response.GetProperty("cost").GetInt32() > 9000);
@@ -159,7 +159,7 @@ namespace Azure.Cosmos.EmulatorTests
                 UserDefinedFunctionProperties cosmosUserDefinedFunction = await this.CreateRandomUdf();
 
                 HashSet<string> settings = new HashSet<string>();
-                await foreach (UserDefinedFunctionProperties iter in scripts.GetUserDefinedFunctionQueryIterator<UserDefinedFunctionProperties>())
+                await foreach (UserDefinedFunctionProperties iter in scripts.GetUserDefinedFunctionQueryResultsAsync<UserDefinedFunctionProperties>())
                 {
                     settings.Add(iter.Id);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/QueryOracle.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/QueryOracle.cs
@@ -82,7 +82,7 @@ namespace Azure.Cosmos.EmulatorTests
 
         private async Task ReadAllDocsAndBuildInvertedIndex()
         {
-            IAsyncEnumerable<Page<JToken>> iterator = this.container.GetItemQueryIterator<JToken>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1000 }).AsPages();
+            IAsyncEnumerable<Page<JToken>> iterator = this.container.GetItemQueryResultsAsync<JToken>(requestOptions: new QueryRequestOptions() { MaxItemCount = 1000 }).AsPages();
             await foreach (Page<JToken> page in iterator)
             {
                 Trace.TraceInformation(DateTime.Now.ToString("HH:mm:ss.ffff") + ": Indexing {0} documents", page.Values.Count);
@@ -193,7 +193,7 @@ namespace Azure.Cosmos.EmulatorTests
                                            resultCount / (double)numberOfQueries, numberOfQueries);
                 }
 
-                IAsyncEnumerable<Page<dynamic>> docQuery = this.container.GetItemQueryIterator<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize }).AsPages();
+                IAsyncEnumerable<Page<dynamic>> docQuery = this.container.GetItemQueryResultsAsync<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize }).AsPages();
                 await foreach (Page<dynamic> queryResultsPage in docQuery)
                 {
                     DateTime startTime = DateTime.Now;

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/QueryOracleUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/QueryOracleUtil.cs
@@ -634,7 +634,7 @@ namespace Azure.Cosmos.EmulatorTests
             // First we make sure that all the queries are inserted
             {
                 List<dynamic> queriedDocuments = new List<dynamic>();
-                await foreach (Page<dynamic> queryResultsPage in container.GetItemQueryIterator<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize }).AsPages())
+                await foreach (Page<dynamic> queryResultsPage in container.GetItemQueryResultsAsync<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize }).AsPages())
                 {
                     System.Diagnostics.Trace.TraceInformation("ReadFeed continuation token: {0}, SessionToken: {1}", queryResultsPage.ContinuationToken, queryResultsPage.GetRawResponse().Headers.GetSession());
                     queriedDocuments.AddRange(queryResultsPage.Values);
@@ -681,7 +681,7 @@ namespace Azure.Cosmos.EmulatorTests
                                            totalQueryLatencyAllPages.TotalMilliseconds / numberOfQueries, numberOfQueries);
                 }
 
-                await foreach (Page<dynamic> queryResultsPage in container.GetItemQueryIterator<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize, EnableScanInQuery = allowScan }).AsPages())
+                await foreach (Page<dynamic> queryResultsPage in container.GetItemQueryResultsAsync<dynamic>(requestOptions: new QueryRequestOptions() { MaxItemCount = pageSize, EnableScanInQuery = allowScan }).AsPages())
                 {
                     DateTime startTime = DateTime.Now;
                     activityIDsAllQueryPages.Add(queryResultsPage.GetRawResponse().Headers.GetActivityId());

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -195,7 +195,7 @@ namespace Azure.Cosmos.EmulatorTests
         {
             IList<Cosmos.CosmosDatabase> databases = new List<Cosmos.CosmosDatabase>();
 
-            AsyncPageable<DatabaseProperties> resultSetIterator = client.GetDatabaseQueryIterator<DatabaseProperties>(
+            AsyncPageable<DatabaseProperties> resultSetIterator = client.GetDatabaseQueryResultsAsync<DatabaseProperties>(
                 queryDefinition: null,
                 continuationToken: null,
                 requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
@@ -224,7 +224,7 @@ namespace Azure.Cosmos.EmulatorTests
         public static async Task DeleteDatabaseCollectionAsync(CosmosClient client, Cosmos.CosmosDatabase database)
         {
             //Delete them in chunks of 10.
-            AsyncPageable<ContainerProperties> resultSetIterator = database.GetContainerQueryIterator<ContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
+            AsyncPageable<ContainerProperties> resultSetIterator = database.GetContainerQueryResultsAsync<ContainerProperties>(requestOptions: new QueryRequestOptions() { MaxItemCount = 10 });
             List<Task> deleteCollectionTasks = new List<Task>(10);
             await foreach (ContainerProperties container in resultSetIterator)
             {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseContainerCosmosTests.cs
@@ -85,7 +85,7 @@ namespace Azure.Cosmos.ChangeFeed.Tests
             mockEnumerable.Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>())).Returns(new MockAsyncEnumerator<Response>(new List<Response>() { mockFeedResponse }));
 
             Mock<CosmosContainer> mockedItems = new Mock<CosmosContainer>();
-            mockedItems.Setup(i => i.GetItemQueryStreamIterator(
+            mockedItems.Setup(i => i.GetItemQueryStreamResultsAsync(
                 // To make sure the SQL Query gets correctly created
                 It.Is<string>(value => string.Equals("SELECT * FROM c WHERE STARTSWITH(c.id, '" + DocumentServiceLeaseContainerCosmosTests.leaseStoreManagerSettings.GetPartitionLeasePrefix() + "')", value)),
                 It.IsAny<string>(), 

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -621,15 +621,15 @@
     "CosmosClient": {
       "Subclasses": {},
       "Members": {
-        "Azure.AsyncPageable`1[T] GetDatabaseQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetDatabaseQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetDatabaseQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetDatabaseQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetDatabaseQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetDatabaseQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetDatabaseQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetDatabaseQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "Azure.Cosmos.CosmosContainer GetContainer(System.String, System.String)": {
           "Type": "Method",
@@ -641,17 +641,17 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.CosmosDatabase GetDatabase(System.String)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<GetDatabaseQueryStreamIterator>d__41))]": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute(typeof(Azure.Cosmos.CosmosClient+<GetDatabaseQueryStreamResultsAsync>d__41))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncIteratorStateMachineAttribute"
           ],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetDatabaseQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.AccountProperties] ReadAccountAsync()": {
           "Type": "Method",
@@ -1029,15 +1029,15 @@
     "CosmosContainer": {
       "Subclasses": {},
       "Members": {
-        "Azure.AsyncPageable`1[T] GetItemQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetItemQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetItemQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetItemQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetItemQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetItemQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetItemQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetItemQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "Azure.Cosmos.CosmosConflicts Conflicts": {
           "Type": "Property",
@@ -1059,15 +1059,15 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetItemQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "System.String get_Id()": {
           "Type": "Method",
@@ -1180,25 +1180,25 @@
     "CosmosDatabase": {
       "Subclasses": {},
       "Members": {
-        "Azure.AsyncPageable`1[T] GetContainerQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetContainerQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetContainerQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetContainerQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetContainerQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetContainerQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetContainerQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetContainerQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetUserQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetUserQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetUserQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetUserQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "Azure.Cosmos.CosmosContainer GetContainer(System.String)": {
           "Type": "Method",
@@ -1215,15 +1215,15 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.Fluent.ContainerBuilder DefineContainer(System.String, System.String)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetContainerQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "System.String get_Id()": {
           "Type": "Method",
@@ -1375,15 +1375,15 @@
     "CosmosUser": {
       "Subclasses": {},
       "Members": {
-        "Azure.AsyncPageable`1[T] GetPermissionQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetPermissionQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetPermissionQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetPermissionQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetPermissionQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetPermissionQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetPermissionQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetPermissionQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "Azure.Cosmos.CosmosPermission GetPermission(System.String)": {
           "Type": "Method",
@@ -3362,65 +3362,65 @@
     "CosmosScripts": {
       "Subclasses": {},
       "Members": {
-        "Azure.AsyncPageable`1[T] GetStoredProcedureQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetStoredProcedureQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetStoredProcedureQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetStoredProcedureQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetStoredProcedureQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetStoredProcedureQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetStoredProcedureQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetStoredProcedureQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetTriggerQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetTriggerQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetTriggerQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetTriggerQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetTriggerQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetTriggerQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetTriggerQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetTriggerQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryIterator[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryResultsAsync[T](Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryIterator[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "Azure.AsyncPageable`1[T] GetUserDefinedFunctionQueryResultsAsync[T](System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetStoredProcedureQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetTriggerQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamIterator(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamResultsAsync(Azure.Cosmos.QueryDefinition, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
+        "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamIterator(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Collections.Generic.IAsyncEnumerable`1[Azure.Response] GetUserDefinedFunctionQueryStreamResultsAsync(System.String, System.String, Azure.Cosmos.QueryRequestOptions, System.Threading.CancellationToken)"
         },
         "System.Threading.Tasks.Task`1[Azure.Cosmos.Scripts.StoredProcedureExecuteResponse`1[TOutput]] ExecuteStoredProcedureAsync[TOutput](System.String, Azure.Cosmos.PartitionKey, System.Object[], Azure.Cosmos.StoredProcedureRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",


### PR DESCRIPTION
## Description

This PR addresses the Review feedback regarding iterator naming.

All existing `GetXXXXQueryIterator` are renamed to `GetXXXXQueryResultsAsync` to convey the async nature and async enumeration capabilities.
All existing `GetXXXXQueryStreamIterator` are renamed to `GetXXXXQueryStreamResultsAsync` to convey the async nature and async enumeration capabilities.

Documentation and examples were updated to reflect the changes and correct some incorrect texts.

The `Microsoft.VisualStudio.Threading.Analyzers` analyzer is updated to support `IAsyncEnumerable` (it does not yet detect correctly `AsyncPageable` so I had to introduce local suppression messages).

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

