### PR TITLE
ResponseFactory: Fix changefeed not modified should not throw

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
@@ -65,9 +65,6 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage cosmosResponseMessage,
             Documents.ResourceType resourceType)
         {
-            //Throw the exception
-            cosmosResponseMessage.EnsureSuccessStatusCode();
-
             QueryResponse queryResponse = cosmosResponseMessage as QueryResponse;
             if (queryResponse != null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Text;
     using System.Threading;
@@ -206,6 +207,11 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
 
             mockUserJsonSerializer.VerifyAll();
 
+            ResponseMessage changeFeedResponseMessage = this.CreateChangeFeedNotModifiedResponse();
+            FeedResponse<ToDoActivity> changeFeedResponse = cosmosResponseFactory.CreateItemFeedResponse<ToDoActivity>(changeFeedResponseMessage);
+            Assert.AreEqual(HttpStatusCode.NotModified, changeFeedResponse.StatusCode);
+            Assert.IsFalse(changeFeedResponse.Resource.Any());
+
             ResponseMessage queryResponse = this.CreateReadFeedResponse();
             mockUserJsonSerializer.Setup(x => x.FromStream<ToDoActivity>(It.IsAny<Stream>())).Callback<Stream>(input => input.Dispose()).Returns(new ToDoActivity());
             FeedResponse<ToDoActivity> queryFeedResponse = cosmosResponseFactory.CreateItemFeedResponse<ToDoActivity>(queryResponse);
@@ -347,6 +353,16 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
                     "+o4fAPfXPzw="),
                 new CosmosDiagnosticsContextCore(),
                 null);
+
+            return cosmosResponse;
+        }
+
+        private ResponseMessage CreateChangeFeedNotModifiedResponse()
+        {
+            ResponseMessage cosmosResponse = new ResponseMessage(statusCode: HttpStatusCode.NotModified)
+            {
+                Content = null
+            };
 
             return cosmosResponse;
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Preview response factory should not throw on not modified responses since it's an expected status code for changefeed. The QueryResponse and ReadFeedResponse already do the check in their factories to ensure status code so removed the unnecessary duplicate check.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update