### PR TITLE
[Internal] FeedRange: Fix ExceptionType for PKRangeId

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKeyRange.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKeyRange.cs
@@ -6,9 +6,12 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
 
     /// <summary>
     /// FeedRange that represents a Partition Key Range.
@@ -44,7 +47,18 @@ namespace Microsoft.Azure.Cosmos
 
             if (pkRange == null)
             {
-                throw new InvalidOperationException($"The PartitionKeyRangeId: \"{this.PartitionKeyRangeId}\" is not valid for the current container {containerRid} .");
+                throw CosmosExceptionFactory.Create(
+                    statusCode: HttpStatusCode.Gone,
+                    subStatusCode: (int)SubStatusCodes.PartitionKeyRangeGone,
+                    message: $"The PartitionKeyRangeId: \"{this.PartitionKeyRangeId}\" is not valid for the current container {containerRid} .",
+                    stackTrace: string.Empty,
+                    activityId: string.Empty,
+                    requestCharge: 0,
+                    retryAfter: null,
+                    headers: null,
+                    diagnosticsContext: null,
+                    error: null,
+                    innerException: null);
             }
 
             return new List<Documents.Routing.Range<string>> { pkRange.ToRange() };


### PR DESCRIPTION
This PR changes the exception type when the FeedRange for a PartitionKeyRangeId does not exist. 

Changing this to CosmosException allows it to surface in naturally through the Query pipeline, otherwise it surfaces with a InternalServerError that contains the actual error as an internal exception.

This way, the exception will be a CosmosException and will be the actual exception being thrown from the GetEffectiveRanges call.