### PR TITLE
[Internal] Query: Add equality comparer for QueryDefinition

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlParameter.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlParameter.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.Query.Core
 {
+    using System;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core
     /// Unlike in relation SQL databases, they don't have types associated with them.
     /// </remarks>
     [DataContract]
-    internal sealed class SqlParameter
+    internal sealed class SqlParameter : IEquatable<SqlParameter>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SqlParameter"/> class for the Azure Cosmos DB service.
@@ -60,5 +61,40 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// <remarks>The value gets serialized and passed in as JSON to the document query.</remarks>
         [DataMember(Name = "value")]
         public object Value { get; set; }
+
+        /// <summary>
+        /// Checking for equality between two Sql parameter objects.
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns>True if objects are equal, false otherwise.</returns>
+        public bool Equals(SqlParameter other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Object.ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.Name == other.Name && this.Value == other.Value;
+        }
+
+        /// <summary>
+        /// Simple implementation of hash code for SqlParameter class.
+        /// </summary>
+        /// <returns>Integer representing the hash code.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                hash = (hash * 233) + (this.Name == null ? 0 : this.Name.GetHashCode());
+                hash = (hash * 233) + (this.Value == null ? 0 : this.Value.GetHashCode());
+                return hash;
+            }
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using Microsoft.Azure.Cosmos.Query.Core;
 
     /// <summary>
@@ -13,7 +14,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     public class QueryDefinition
     {
-        internal Dictionary<string, SqlParameter> SqlParameters { get; }
+        private Dictionary<string, SqlParameter> SqlParameters { get; }
 
         /// <summary>
         /// Create a <see cref="QueryDefinition"/>
@@ -92,6 +93,17 @@ namespace Microsoft.Azure.Cosmos
         internal SqlQuerySpec ToSqlQuerySpec()
         {
             return new SqlQuerySpec(this.QueryText, new SqlParameterCollection(this.SqlParameters.Values));
+        }
+
+        /// <summary>
+        /// Gets the sql parameters for the class
+        /// </summary>
+        internal ReadOnlyDictionary<string, SqlParameter> Parameters
+        {
+            get
+            {
+                return new ReadOnlyDictionary<string, SqlParameter>(this.SqlParameters);
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Defines a Cosmos SQL query
     /// </summary>
-    public class QueryDefinition
+    public class QueryDefinition : IEquatable<QueryDefinition>
     {
         private Dictionary<string, SqlParameter> SqlParameters { get; }
 
@@ -87,6 +87,58 @@ namespace Microsoft.Azure.Cosmos
 
             this.SqlParameters[name] = new SqlParameter(name, value);
             return this;
+        }
+
+        /// <summary>
+        /// Checks for equality of two QueryDefinitions ignoring order of sqlParameters
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns>Boolean representing the equality</returns>
+        public bool Equals(QueryDefinition other)
+        {
+            if (this.QueryText != other.QueryText)
+            {
+                return false;
+            }
+
+            if (this.SqlParameters.Count != other.SqlParameters.Count)
+            {
+                return false;
+            }
+
+            foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
+            {
+                if (!other.SqlParameters.TryGetValue(queryParameter.Key, out SqlParameter value) ||
+                    !value.Name.Equals(queryParameter.Value.Name) ||
+                    (value.Value != null && !value.Value.Equals(queryParameter.Value.Value)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Caculates a hashcode of QueryDefinition, ignoring order of sqlParameters.
+        /// </summary>
+        /// <returns>Hash code of the object.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = 17;
+                foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
+                {
+                    int kvpHashCode = 23 + (queryParameter.Value.Name.GetHashCode() * 233) + queryParameter.Value.Value.GetHashCode();
+
+                    // xor is associative so we generate the same hash code if order of parameters is different
+                    hashCode ^= kvpHashCode;
+                }
+
+                hashCode = (hashCode * 233) + this.QueryText.GetHashCode();
+                return hashCode;
+            }
         }
 
         internal SqlQuerySpec ToSqlQuerySpec()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -90,7 +90,9 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Checks for equality of two QueryDefinitions ignoring order of sqlParameters
+        /// Checks for equality of two QueryDefinitions. Two queries are considered equal if
+        /// 1. They are the same object in memory
+        /// 2. Their query text is exactly the same AND they provide the same parameter values.
         /// </summary>
         /// <param name="other"></param>
         /// <returns>Boolean representing the equality</returns>

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Defines a Cosmos SQL query
     /// </summary>
-    public class QueryDefinition : IEquatable<QueryDefinition>
+    public class QueryDefinition
     {
-        private Dictionary<string, SqlParameter> SqlParameters { get; }
+        internal Dictionary<string, SqlParameter> SqlParameters { get; }
 
         /// <summary>
         /// Create a <see cref="QueryDefinition"/>
@@ -87,80 +87,6 @@ namespace Microsoft.Azure.Cosmos
 
             this.SqlParameters[name] = new SqlParameter(name, value);
             return this;
-        }
-
-        /// <summary>
-        /// Checks for equality of two QueryDefinitions. Two queries are considered equal if
-        /// 1. They are the same object in memory
-        /// 2. Their query text is exactly the same AND they provide the same parameter values.
-        /// Following are NOT Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.B= @param2 AND c.A=@param1 , param1=val1, param2=val2)
-        /// Following are Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param2=val2, param1=val1)
-        /// </summary>
-        /// <param name="other"></param>
-        /// <returns>Boolean representing the equality</returns>
-        public bool Equals(QueryDefinition other)
-        {
-            if (Object.ReferenceEquals(other, this))
-            {
-                return true;
-            }
-
-            if (other is null)
-            {
-                return false;
-            }
-
-            if (this.SqlParameters.Count != other.SqlParameters.Count)
-            {
-                return false;
-            }
-
-            if (!string.Equals(this.QueryText, other.QueryText, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return ParameterEquals(this.SqlParameters, other.SqlParameters);
-        }
-
-        /// <summary>
-        /// Caculates a hashcode of QueryDefinition, ignoring order of sqlParameters.
-        /// </summary>
-        /// <returns>Hash code of the object.</returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                int hashCode = 23;
-                foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
-                {
-                    // xor is associative so we generate the same hash code if order of parameters is different
-                    hashCode ^= queryParameter.Value.GetHashCode();
-                }
-
-                hashCode = (hashCode * 16777619) + this.QueryText.GetHashCode();
-                return hashCode;
-            }
-        }
-
-        private static bool ParameterEquals(Dictionary<string, SqlParameter> parameters, Dictionary<string, SqlParameter> otherParameters)
-        {
-            if (parameters.Count != otherParameters.Count)
-            {
-                return false;
-            }
-
-            foreach (KeyValuePair<string, SqlParameter> queryParameter in parameters)
-            {
-                if (!otherParameters.TryGetValue(queryParameter.Key, out SqlParameter value) ||
-                    !value.Name.Equals(queryParameter.Value.Name) ||
-                    (value.Value != null && !value.Value.Equals(queryParameter.Value.Value)))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
 
         internal SqlQuerySpec ToSqlQuerySpec()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -98,11 +98,11 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the sql parameters for the class
         /// </summary>
-        internal ReadOnlyDictionary<string, SqlParameter> Parameters
+        internal IReadOnlyDictionary<string, SqlParameter> Parameters
         {
             get
             {
-                return new ReadOnlyDictionary<string, SqlParameter>(this.SqlParameters);
+                return this.SqlParameters;
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -93,6 +93,8 @@ namespace Microsoft.Azure.Cosmos
         /// Checks for equality of two QueryDefinitions. Two queries are considered equal if
         /// 1. They are the same object in memory
         /// 2. Their query text is exactly the same AND they provide the same parameter values.
+        /// Following are NOT Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.B= @param2 AND c.A=@param1 , param1=val1, param2=val2)
+        /// Following are Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param2=val2, param1=val1)
         /// </summary>
         /// <param name="other"></param>
         /// <returns>Boolean representing the equality</returns>

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -96,29 +96,27 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>Boolean representing the equality</returns>
         public bool Equals(QueryDefinition other)
         {
-            if (other == null ||
-                this.SqlParameters.Count != other.SqlParameters.Count ||
-                !string.Equals(this.QueryText, other.QueryText, StringComparison.Ordinal))
-            {
-                return false;
-            }
-
             if (Object.ReferenceEquals(other, this))
             {
                 return true;
             }
 
-            foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
+            if (other is null)
             {
-                if (!other.SqlParameters.TryGetValue(queryParameter.Key, out SqlParameter value) ||
-                    !value.Name.Equals(queryParameter.Value.Name) ||
-                    (value.Value != null && !value.Value.Equals(queryParameter.Value.Value)))
-                {
-                    return false;
-                }
+                return false;
             }
 
-            return true;
+            if (this.SqlParameters.Count != other.SqlParameters.Count)
+            {
+                return false;
+            }
+
+            if (!string.Equals(this.QueryText, other.QueryText, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return ParameterEquals(this.SqlParameters, other.SqlParameters);
         }
 
         /// <summary>
@@ -139,6 +137,26 @@ namespace Microsoft.Azure.Cosmos
                 hashCode = (hashCode * 16777619) + this.QueryText.GetHashCode();
                 return hashCode;
             }
+        }
+
+        private static bool ParameterEquals(Dictionary<string, SqlParameter> parameters, Dictionary<string, SqlParameter> otherParameters)
+        {
+            if (parameters.Count != otherParameters.Count)
+            {
+                return false;
+            }
+
+            foreach (KeyValuePair<string, SqlParameter> queryParameter in parameters)
+            {
+                if (!otherParameters.TryGetValue(queryParameter.Key, out SqlParameter value) ||
+                    !value.Name.Equals(queryParameter.Value.Name) ||
+                    (value.Value != null && !value.Value.Equals(queryParameter.Value.Value)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         internal SqlQuerySpec ToSqlQuerySpec()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -96,14 +96,16 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>Boolean representing the equality</returns>
         public bool Equals(QueryDefinition other)
         {
-            if (this.QueryText != other.QueryText)
+            if (other == null ||
+                this.SqlParameters.Count != other.SqlParameters.Count ||
+                !string.Equals(this.QueryText, other.QueryText, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            if (this.SqlParameters.Count != other.SqlParameters.Count)
+            if (Object.ReferenceEquals(other, this))
             {
-                return false;
+                return true;
             }
 
             foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
@@ -127,16 +129,14 @@ namespace Microsoft.Azure.Cosmos
         {
             unchecked
             {
-                int hashCode = 17;
+                int hashCode = 23;
                 foreach (KeyValuePair<string, SqlParameter> queryParameter in this.SqlParameters)
                 {
-                    int kvpHashCode = 23 + (queryParameter.Value.Name.GetHashCode() * 233) + queryParameter.Value.Value.GetHashCode();
-
                     // xor is associative so we generate the same hash code if order of parameters is different
-                    hashCode ^= kvpHashCode;
+                    hashCode ^= queryParameter.Value.GetHashCode();
                 }
 
-                hashCode = (hashCode * 233) + this.QueryText.GetHashCode();
+                hashCode = (hashCode * 16777619) + this.QueryText.GetHashCode();
                 return hashCode;
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using Microsoft.Azure.Cosmos.Query.Core;
 
     /// <summary>
@@ -82,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="parameters"></param>
         /// <param name="otherParameters"></param>
         /// <returns>True if parameters have the same values.</returns>
-        private static bool ParameterEquals(ReadOnlyDictionary<string, SqlParameter> parameters, ReadOnlyDictionary<string, SqlParameter> otherParameters)
+        private static bool ParameterEquals(IReadOnlyDictionary<string, SqlParameter> parameters, IReadOnlyDictionary<string, SqlParameter> otherParameters)
         {
             if (parameters.Count != otherParameters.Count)
             {

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Query.Core;
+
+    /// <summary>
+    /// Custom comparer class to check equality for query definition. This class does not check for
+    /// logical equivalence.
+    /// </summary>
+    internal sealed class QueryDefinitionEqualityComparer : IEqualityComparer<QueryDefinition>
+    {
+        public static readonly QueryDefinitionEqualityComparer Instance = new QueryDefinitionEqualityComparer();
+
+        private QueryDefinitionEqualityComparer()
+        {
+        }
+
+        /// <summary>
+        /// Checks for equality of two QueryDefinitions. Two queries are considered equal if
+        /// 1. They are the same object in memory
+        /// 2. Their query text is exactly the same AND they provide the same parameter values.
+        /// Following are NOT Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.B= @param2 AND c.A=@param1 , param1=val1, param2=val2)
+        /// Following are Equal: (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param1=val1, param2=val2), (SELECT * FROM c WHERE c.A= @param1 AND c.B=@param2 , param2=val2, param1=val1)
+        /// </summary>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <returns>Boolean representing the equality</returns>
+        public bool Equals(QueryDefinition x, QueryDefinition y)
+        {
+            if (Object.ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x is null || y is null)
+            {
+                return false;
+            }
+
+            if (x.SqlParameters.Count != y.SqlParameters.Count)
+            {
+                return false;
+            }
+
+            if (!string.Equals(x.QueryText, y.QueryText, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return ParameterEquals(x.SqlParameters, y.SqlParameters);
+        }
+
+        /// <summary>
+        /// Caculates a hashcode of QueryDefinition, ignoring order of sqlParameters.
+        /// </summary>
+        /// <returns>Hash code of the object.</returns>
+        public int GetHashCode(QueryDefinition queryDefinition)
+        {
+            unchecked
+            {
+                int hashCode = 23;
+                foreach (KeyValuePair<string, SqlParameter> queryParameter in queryDefinition.SqlParameters)
+                {
+                    // xor is associative so we generate the same hash code if order of parameters is different
+                    hashCode ^= queryParameter.Value.GetHashCode();
+                }
+
+                hashCode = (hashCode * 16777619) + queryDefinition.QueryText.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Checks if two sets of parameters have the same values.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <param name="otherParameters"></param>
+        /// <returns>True if parameters have the same values.</returns>
+        private static bool ParameterEquals(Dictionary<string, SqlParameter> parameters, Dictionary<string, SqlParameter> otherParameters)
+        {
+            if (parameters.Count != otherParameters.Count)
+            {
+                return false;
+            }
+
+            foreach (KeyValuePair<string, SqlParameter> queryParameter in parameters)
+            {
+                if (!otherParameters.TryGetValue(queryParameter.Key, out SqlParameter value) ||
+                    !value.Name.Equals(queryParameter.Value.Name) ||
+                    (value.Value != null && !value.Value.Equals(queryParameter.Value.Value)))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinitionEqualityComparer.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using Microsoft.Azure.Cosmos.Query.Core;
 
     /// <summary>
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.Cosmos
                 return false;
             }
 
-            if (x.SqlParameters.Count != y.SqlParameters.Count)
+            if (x.Parameters.Count != y.Parameters.Count)
             {
                 return false;
             }
@@ -52,7 +53,7 @@ namespace Microsoft.Azure.Cosmos
                 return false;
             }
 
-            return ParameterEquals(x.SqlParameters, y.SqlParameters);
+            return ParameterEquals(x.Parameters, y.Parameters);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
             unchecked
             {
                 int hashCode = 23;
-                foreach (KeyValuePair<string, SqlParameter> queryParameter in queryDefinition.SqlParameters)
+                foreach (KeyValuePair<string, SqlParameter> queryParameter in queryDefinition.Parameters)
                 {
                     // xor is associative so we generate the same hash code if order of parameters is different
                     hashCode ^= queryParameter.Value.GetHashCode();
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="parameters"></param>
         /// <param name="otherParameters"></param>
         /// <returns>True if parameters have the same values.</returns>
-        private static bool ParameterEquals(Dictionary<string, SqlParameter> parameters, Dictionary<string, SqlParameter> otherParameters)
+        private static bool ParameterEquals(ReadOnlyDictionary<string, SqlParameter> parameters, ReadOnlyDictionary<string, SqlParameter> otherParameters)
         {
             if (parameters.Count != otherParameters.Count)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -4152,6 +4152,16 @@
     "QueryDefinition": {
       "Subclasses": {},
       "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.QueryDefinition)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.QueryDefinition)"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode()"
+        },
         "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)": {
           "Type": "Method",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -4152,16 +4152,6 @@
     "QueryDefinition": {
       "Subclasses": {},
       "Members": {
-        "Boolean Equals(Microsoft.Azure.Cosmos.QueryDefinition)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.QueryDefinition)"
-        },
-        "Int32 GetHashCode()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Int32 GetHashCode()"
-        },
         "Microsoft.Azure.Cosmos.QueryDefinition WithParameter(System.String, System.Object)": {
           "Type": "Method",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionComparerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionComparerUnitTests.cs
@@ -1,0 +1,63 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class QueryDefinitionComparerUnitTests
+    {
+     
+        [TestMethod]
+        public void ValidateHashWithSameParameter()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+
+            int hashCode = QueryDefinitionEqualityComparer.Instance.GetHashCode(sqlQueryDefinition);
+
+            // Reverse the order
+            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+
+            Assert.AreEqual(hashCode, QueryDefinitionEqualityComparer.Instance.GetHashCode(sqlQueryDefinition));
+        }
+
+        [TestMethod]
+        public void ValidateHashWithNullValue()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", null);
+
+            int hashCode = QueryDefinitionEqualityComparer.Instance.GetHashCode(sqlQueryDefinition);
+
+            // Reverse the order
+            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", null);
+
+            Assert.AreEqual(hashCode, QueryDefinitionEqualityComparer.Instance.GetHashCode(sqlQueryDefinition));
+        }
+
+        [TestMethod]
+        public void ValidateEqualsWithParameters()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+
+            // Reverse the order
+            QueryDefinition sqlQueryDefinition2 = new QueryDefinition("select * from s where s.Account = 1234");
+
+            Assert.IsFalse(QueryDefinitionEqualityComparer.Instance.Equals(sqlQueryDefinition, sqlQueryDefinition2));
+
+            sqlQueryDefinition2.WithParameter("@name", "ABC");
+            sqlQueryDefinition2.WithParameter("@account", "12345");
+
+            Assert.IsTrue(QueryDefinitionEqualityComparer.Instance.Equals(sqlQueryDefinition, sqlQueryDefinition2));
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Linq;
-    using System.Net.Http;
-    using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -66,57 +64,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
             sqlQueryDefinition.WithParameter(null, null);
-        }
-
-
-        [TestMethod]
-        public void ValidateHashWithSameParameter()
-        {
-            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
-            sqlQueryDefinition.WithParameter("@account", "12345");
-            sqlQueryDefinition.WithParameter("@name", "ABC");
-
-            int hashCode = sqlQueryDefinition.GetHashCode();
-
-            // Reverse the order
-            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
-            sqlQueryDefinition.WithParameter("@name", "ABC");
-            sqlQueryDefinition.WithParameter("@account", "12345");
-
-            Assert.AreEqual(hashCode, sqlQueryDefinition.GetHashCode());
-        }
-
-        [TestMethod]
-        public void ValidateHashWithNullValue()
-        {
-            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
-            sqlQueryDefinition.WithParameter("@account", null);
-
-            int hashCode = sqlQueryDefinition.GetHashCode();
-
-            // Reverse the order
-            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
-            sqlQueryDefinition.WithParameter("@account", null);
-
-            Assert.AreEqual(hashCode, sqlQueryDefinition.GetHashCode());
-        }
-
-        [TestMethod]
-        public void ValidateEqualsWithParameters()
-        {
-            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
-            sqlQueryDefinition.WithParameter("@account", "12345");
-            sqlQueryDefinition.WithParameter("@name", "ABC");
-
-            // Reverse the order
-            QueryDefinition sqlQueryDefinition2 = new QueryDefinition("select * from s where s.Account = 1234");
-
-            Assert.IsFalse(sqlQueryDefinition.Equals(sqlQueryDefinition2));
-
-            sqlQueryDefinition2.WithParameter("@name", "ABC");
-            sqlQueryDefinition2.WithParameter("@account", "12345");
-
-            Assert.IsTrue(sqlQueryDefinition.Equals(sqlQueryDefinition2));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/QueryDefinitionUnitTests.cs
@@ -67,5 +67,56 @@ namespace Microsoft.Azure.Cosmos.Tests
             QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
             sqlQueryDefinition.WithParameter(null, null);
         }
+
+
+        [TestMethod]
+        public void ValidateHashWithSameParameter()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+
+            int hashCode = sqlQueryDefinition.GetHashCode();
+
+            // Reverse the order
+            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+
+            Assert.AreEqual(hashCode, sqlQueryDefinition.GetHashCode());
+        }
+
+        [TestMethod]
+        public void ValidateHashWithNullValue()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", null);
+
+            int hashCode = sqlQueryDefinition.GetHashCode();
+
+            // Reverse the order
+            sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", null);
+
+            Assert.AreEqual(hashCode, sqlQueryDefinition.GetHashCode());
+        }
+
+        [TestMethod]
+        public void ValidateEqualsWithParameters()
+        {
+            QueryDefinition sqlQueryDefinition = new QueryDefinition("select * from s where s.Account = 1234");
+            sqlQueryDefinition.WithParameter("@account", "12345");
+            sqlQueryDefinition.WithParameter("@name", "ABC");
+
+            // Reverse the order
+            QueryDefinition sqlQueryDefinition2 = new QueryDefinition("select * from s where s.Account = 1234");
+
+            Assert.IsFalse(sqlQueryDefinition.Equals(sqlQueryDefinition2));
+
+            sqlQueryDefinition2.WithParameter("@name", "ABC");
+            sqlQueryDefinition2.WithParameter("@account", "12345");
+
+            Assert.IsTrue(sqlQueryDefinition.Equals(sqlQueryDefinition2));
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Equality comparer for internal use in compute. We need access to the QueryDefinition parameters to compare for their equality.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.

