### PR TITLE
[Internal] Encryption: Add specific encryption emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
@@ -1,0 +1,54 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Platform>AnyCPU</Platform>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>
+    <AssemblyName>Microsoft.Azure.Cosmos.Encryption.EmulatorTests</AssemblyName>
+    <IsEmulatorTest>true</IsEmulatorTest>
+    <EmulatorFlavor>master</EmulatorFlavor>
+    <DisableCopyEmulator>True</DisableCopyEmulator>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.8.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.0.8.11" />
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+  </ItemGroup>
+  
+  
+   <ItemGroup>
+    <Compile Include="..\..\..\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\Utils\ConfigurationManager.cs" Link="Utils\ConfigurationManager.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\..\..\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\settings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos.Encryption\src\Microsoft.Azure.Cosmos.Encryption.csproj" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Utils/TestCommon.cs
@@ -1,0 +1,88 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
+{
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Azure.Cosmos.Utils;
+    using Newtonsoft.Json;
+    using System;
+    using System.IO;
+    using System.Text;
+
+    internal static class TestCommon
+    {
+        internal static Stream ToStream<T>(T input)
+        {
+            string s = JsonConvert.SerializeObject(input);
+            return new MemoryStream(Encoding.UTF8.GetBytes(s));
+        }
+
+        internal static T FromStream<T>(Stream stream)
+        {
+            using (StreamReader sr = new StreamReader(stream))
+            using (JsonReader reader = new JsonTextReader(sr))
+            {
+                JsonSerializer serializer = new JsonSerializer();
+                return serializer.Deserialize<T>(reader);
+            }
+        }
+
+        internal static MemoryStream GenerateStreamFromString(string s)
+        {
+            MemoryStream stream = new MemoryStream();
+            StreamWriter writer = new StreamWriter(stream);
+            writer.Write(s);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+
+        private static (string endpoint, string authKey) GetAccountInfo()
+        {
+            string authKey = ConfigurationManager.AppSettings["MasterKey"];
+            string endpoint = ConfigurationManager.AppSettings["GatewayEndpoint"];
+
+            return (endpoint, authKey);
+        }
+
+        internal static CosmosClientBuilder GetClientBuilder(string resourceToken)
+        {
+            (string endpoint, string authKey) accountInfo = TestCommon.GetAccountInfo();
+            CosmosClientBuilder clientBuilder = new CosmosClientBuilder(
+                accountEndpoint: accountInfo.endpoint,
+                authKeyOrResourceToken: resourceToken ?? accountInfo.authKey);
+
+            return clientBuilder;
+        }
+
+        internal static CosmosClient CreateCosmosClient(Action<CosmosClientBuilder> customizeClientBuilder = null)
+        {
+            CosmosClientBuilder cosmosClientBuilder = GetClientBuilder(resourceToken: null);
+            customizeClientBuilder?.Invoke(cosmosClientBuilder);
+
+            return cosmosClientBuilder.Build();
+        }
+
+        internal static CosmosClient CreateCosmosClient(string resourceToken, Action<CosmosClientBuilder> customizeClientBuilder = null)
+        {
+            CosmosClientBuilder cosmosClientBuilder = GetClientBuilder(resourceToken);
+            customizeClientBuilder?.Invoke(cosmosClientBuilder);
+
+            return cosmosClientBuilder.Build();
+        }
+
+        internal static CosmosClient CreateCosmosClient(
+            bool useGateway)
+        {
+            CosmosClientBuilder cosmosClientBuilder = GetClientBuilder(resourceToken: null);
+            if (useGateway)
+            {
+                cosmosClientBuilder.WithConnectionModeGateway();
+            }
+
+            return cosmosClientBuilder.Build();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -13,6 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Perf
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Encryption", "Microsoft.Azure.Cosmos.Encryption\src\Microsoft.Azure.Cosmos.Encryption.csproj", "{4D0FBC91-268E-44DD-AC10-6851A69C52FB}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Encryption", "Encryption", "{B382B965-7D1B-4DE8-8007-197741C49F88}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos.Encryption.EmulatorTests", "Microsoft.Azure.Cosmos.Encryption\tests\EmulatorTests\Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj", "{D6A405BF-15E1-46D3-8C13-210BA043ADC5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Cover|Any CPU = Cover|Any CPU
@@ -83,9 +87,25 @@ Global
 		{4D0FBC91-268E-44DD-AC10-6851A69C52FB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4D0FBC91-268E-44DD-AC10-6851A69C52FB}.Release|x64.ActiveCfg = Release|Any CPU
 		{4D0FBC91-268E-44DD-AC10-6851A69C52FB}.Release|x64.Build.0 = Release|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Cover|x64.Build.0 = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4D0FBC91-268E-44DD-AC10-6851A69C52FB} = {B382B965-7D1B-4DE8-8007-197741C49F88}
+		{D6A405BF-15E1-46D3-8C13-210BA043ADC5} = {B382B965-7D1B-4DE8-8007-197741C49F88}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C6A1D820-CB03-4DE6-87D1-46EF476F0040}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -222,7 +222,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos.Encryption\src\Microsoft.Azure.Cosmos.Encryption.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.Azure.Cosmos.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ConfigurationManager.cs
@@ -14,18 +14,18 @@ namespace Microsoft.Azure.Cosmos.Utils
     /// </summary>
     internal static class ConfigurationManager
     {
-        const string GatewayEndpointSettingName = "GatewayEndpoint";
-        const string GatewayEndpointEnvironmentName = "COSMOSDBEMULATOR_ENDPOINT";
+        private const string GatewayEndpointSettingName = "GatewayEndpoint";
+        private const string GatewayEndpointEnvironmentName = "COSMOSDBEMULATOR_ENDPOINT";
 
         static ConfigurationManager()
         {
             AppSettings = new Dictionary<string, string>();
 
-            var builder = new ConfigurationBuilder()
+            IConfigurationBuilder builder = new ConfigurationBuilder()
                 .AddJsonFile($"settings.json", true, true);
 
-            var configuration = builder.Build();
-            foreach(var configurationSetting in configuration.GetSection("AppSettings").GetChildren())
+            IConfigurationRoot configuration = builder.Build();
+            foreach (IConfigurationSection configurationSetting in configuration.GetSection("AppSettings").GetChildren())
             {
                 string configurationValue = configurationSetting.Value;
                 if (string.Equals(GatewayEndpointSettingName, configurationSetting.Key))

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -70,3 +70,27 @@ jobs:
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
+
+- job:
+  displayName: Encryption EmulatorTests ${{ parameters.BuildConfiguration }}
+  timeoutInMinutes: 90
+  condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
+  pool:
+    vmImage: ${{ parameters.VmImage }}
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  - template:  emulator-setup.yml
+
+  - task: DotNetCoreCLI@2
+    displayName: Microsoft.Azure.Cosmos.Encryption.EmulatorTests
+    condition: succeeded()
+    inputs:
+      command: test
+      projects: 'Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/*.csproj'
+      arguments: ${{ parameters.Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      nugetConfigPath: NuGet.config
+      publishTestResults: true
+      testRunTitle: Microsoft.Azure.Cosmos.Encryption.EmulatorTests


### PR DESCRIPTION
# Pull Request Template

## Description

This refactors the encryption tests into it's own emulator test project. This is necessary to fix a dll conflict between the SDK project and the Encryption project. 

This might increase CI gates time as a new emulator will be required to complete the tests.

Old dependencies. 
```
- Emulator Test -> SDK project
                         -> Emulator project -> SDK nuget

```

New dependencies
```
- Emulator Test -> SDK project
- Encryption Emulator Test -> Encryption Project -> SDK via nuget
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

