### PR TITLE
[Internal] Serializer : Fix Moved CosmosElementSerializer outside the CosmosElement namespace.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
     using static Microsoft.Azure.Documents.RuntimeConstants;

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryResponse.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/ReadFeedResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/ReadFeedResponse.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Serializer;
 
     internal class ReadFeedResponse<T> : FeedResponse<T>
     {

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
@@ -1,13 +1,14 @@
 ﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
-namespace Microsoft.Azure.Cosmos.CosmosElements
+namespace Microsoft.Azure.Cosmos.Serializer
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using System.Runtime.InteropServices;
+    using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Documents;
 
@@ -352,8 +353,4 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             }
         }
     }
-#if INTERNAL
-#pragma warning restore SA1600 // Elements should be documented
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-#endif
 }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Scripts;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
 
     /// <summary>


### PR DESCRIPTION
# Internal Serializer : Fix Moved CosmosElementSerializer outside the CosmosElement namespace.

## Description

Moved CosmosElementSerializer outside the CosmosElement namespace, since one uses the other and that's about it. They are independent pieces of code and ownership is separate. 