### PR TITLE
[vNext] Monitoring: Add explicit headers

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -78,6 +78,7 @@ namespace Azure.Cosmos
             this.ConnectionProtocol = CosmosClientOptions.DefaultProtocol;
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
+            this.InitializeLoggedHeaderNames();
         }
 
         /// <summary>
@@ -655,6 +656,19 @@ namespace Azure.Cosmos
             {
                 throw new ArgumentException($"{settingName} requires {nameof(this.ConnectionMode)} to be set to {nameof(ConnectionMode.Direct)}");
             }
+        }
+
+        private void InitializeLoggedHeaderNames()
+        {
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.RequestCharge);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.ConsistencyLevel);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.SessionToken);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.ActivityId);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.ClientRequestId);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.ContentLength);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.Location);
+            this.Diagnostics.LoggedHeaderNames.Add(WFConstants.BackendHeaders.SubStatus);
+            this.Diagnostics.LoggedHeaderNames.Add(HttpConstants.HttpHeaders.ContentType);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -406,6 +406,25 @@ namespace Azure.Cosmos.Tests
             Assert.IsFalse(connectionPolicy.EnableEndpointDiscovery);
         }
 
+        [TestMethod]
+        public void ContainsLoggedHeaderNames()
+        {
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: Guid.NewGuid().ToString());
+
+            CosmosClientOptions cosmosClientOptions = cosmosClientBuilder.Build(new MockDocumentClient()).ClientOptions;
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.RequestCharge));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.ConsistencyLevel));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.SessionToken));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.ActivityId));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.ClientRequestId));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.ContentLength));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.Location));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(WFConstants.BackendHeaders.SubStatus));
+            Assert.IsTrue(cosmosClientOptions.Diagnostics.LoggedHeaderNames.Contains(HttpConstants.HttpHeaders.ContentType));
+        }
+
         private class TestWebProxy : IWebProxy
         {
             public ICredentials Credentials { get; set; }


### PR DESCRIPTION
## Description

Azure Core Diagnostics can automatically log headers from the Responses. But it needs the SDK to individually indicate which headers (to avoid logging private information or information you wouldn't want unless [opted-in](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/samples/Diagnostics.md#logging-redacted-headers-and-query-parameters).

Following other SDKs, this PR adds relevant headers to the Diagnostics collection in the Core SDK type:
* https://github.com/Azure/azure-sdk-for-net/blob/6944bd8761b5d89e28d3e57f8261ae49971b7459/sdk/storage/Azure.Storage.Files.DataLake/src/DataLakeClientOptions.cs#L89
* https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Blobs/src/BlobClientOptions.cs#L99

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

