### PR TITLE
[vNext] TimeToLive: Fix name of DefaultTimeToLive to DefaultTimeToLiveInSeconds

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
@@ -56,24 +56,6 @@ namespace Azure.Cosmos.Fluent
         /// <see cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </summary>
-        /// <param name="defaultTtlTimeSpan">The default Time To Live.</param>
-        /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/>
-        public T WithDefaultTimeToLiveInSeconds(TimeSpan defaultTtlTimeSpan)
-        {
-            if (defaultTtlTimeSpan == null)
-            {
-                throw new ArgumentNullException(nameof(defaultTtlTimeSpan));
-            }
-
-            this.defaultTimeToLive = (int)defaultTtlTimeSpan.TotalSeconds;
-            return (T)this;
-        }
-
-        /// <summary>
-        /// <see cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/> will be applied to all the items in the container as the default time-to-live policy.
-        /// The individual item could override the default time-to-live policy by setting its time to live.
-        /// </summary>
         /// <param name="defaulTtlInSeconds">The default Time To Live.</param>
         /// <returns>An instance of the current Fluent builder.</returns>
         /// <seealso cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/>

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/Settings/ContainerDefinition.cs
@@ -53,13 +53,13 @@ namespace Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// <see cref="CosmosContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
+        /// <see cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </summary>
         /// <param name="defaultTtlTimeSpan">The default Time To Live.</param>
         /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLive"/>
-        public T WithDefaultTimeToLive(TimeSpan defaultTtlTimeSpan)
+        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/>
+        public T WithDefaultTimeToLiveInSeconds(TimeSpan defaultTtlTimeSpan)
         {
             if (defaultTtlTimeSpan == null)
             {
@@ -71,13 +71,13 @@ namespace Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// <see cref="CosmosContainerProperties.DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
+        /// <see cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </summary>
         /// <param name="defaulTtlInSeconds">The default Time To Live.</param>
         /// <returns>An instance of the current Fluent builder.</returns>
-        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLive"/>
-        public T WithDefaultTimeToLive(int defaulTtlInSeconds)
+        /// <seealso cref="CosmosContainerProperties.DefaultTimeToLiveInSeconds"/>
+        public T WithDefaultTimeToLiveInSeconds(int defaulTtlInSeconds)
         {
             if (defaulTtlInSeconds < -1)
             {
@@ -119,7 +119,7 @@ namespace Azure.Cosmos.Fluent
 
             if (this.defaultTimeToLive.HasValue)
             {
-                containerProperties.DefaultTimeToLive = this.defaultTimeToLive.Value;
+                containerProperties.DefaultTimeToLiveInSeconds = this.defaultTimeToLive.Value;
             }
 
             if (this.partitionKeyDefinitionVersion.HasValue)

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/CosmosContainerProperties.cs
@@ -251,30 +251,30 @@ namespace Azure.Cosmos
         /// </value>
         /// <remarks>
         /// <para>
-        /// The <see cref="DefaultTimeToLive"/> will be applied to all the items in the container as the default time-to-live policy.
+        /// The <see cref="DefaultTimeToLiveInSeconds"/> will be applied to all the items in the container as the default time-to-live policy.
         /// The individual item could override the default time-to-live policy by setting its time to live.
         /// </para>
         /// <para>
-        /// When the <see cref="DefaultTimeToLive"/> is <c>null</c>, the time-to-live will be turned off for the container.
+        /// When the <see cref="DefaultTimeToLiveInSeconds"/> is <c>null</c>, the time-to-live will be turned off for the container.
         /// It means all the items will never expire. The individual item's  time to live will be disregarded.
         /// </para>
         /// <para>
-        /// When the <see cref="DefaultTimeToLive"/> is '-1', the time-to-live will be turned on for the container.
+        /// When the <see cref="DefaultTimeToLiveInSeconds"/> is '-1', the time-to-live will be turned on for the container.
         /// By default, all the items will never expire. The individual item could be given a specific time-to-live value by setting its
         /// time to live. The item's time to live will be honored, and the expired items
         /// will be deleted in background.
         /// </para>
         /// <para>
-        /// When the <see cref="DefaultTimeToLive"/> is a nonzero positive integer, the time-to-live will be turned on for the container.
+        /// When the <see cref="DefaultTimeToLiveInSeconds"/> is a nonzero positive integer, the time-to-live will be turned on for the container.
         /// And a default time-to-live in seconds will be applied to all the items. A item will be expired after the
-        /// specified <see cref="DefaultTimeToLive"/> value in seconds since its last write time.
+        /// specified <see cref="DefaultTimeToLiveInSeconds"/> value in seconds since its last write time.
         /// </para>
         /// </remarks>
         /// <example>
         /// The example below disables time-to-live on a container.
         /// <code language="c#">
         /// <![CDATA[
-        ///     container.DefaultTimeToLive = null;
+        ///     container.DefaultTimeToLiveInSeconds = null;
         /// ]]>
         /// </code>
         /// </example>
@@ -282,7 +282,7 @@ namespace Azure.Cosmos
         /// The example below enables time-to-live on a container. By default, all the items never expire.
         /// <code language="c#">
         /// <![CDATA[
-        ///     container.DefaultTimeToLive = TimeSpan.FromDays(2);
+        ///     container.DefaultTimeToLiveInSeconds = -1;
         /// ]]>
         /// </code>
         /// </example>
@@ -291,11 +291,11 @@ namespace Azure.Cosmos
         /// since its last write time.
         /// <code language="c#">
         /// <![CDATA[
-        ///     container.DefaultTimeToLive = TimeSpan.FromSeconds(1000);
+        ///     container.DefaultTimeToLiveInSeconds = TimeSpan.FromSeconds(1000);
         /// ]]>
         /// </code>
         /// </example>
-        public int? DefaultTimeToLive { get; set; }
+        public int? DefaultTimeToLiveInSeconds { get; set; }
 
         /// <summary>
         /// The function selects the right partition key constant mapping for <see cref="PartitionKey.None"/>

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonContainerPropertiesConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonContainerPropertiesConverter.cs
@@ -71,9 +71,9 @@ namespace Azure.Cosmos
                 TextJsonConflictResolutionPolicyConverter.WritePropertyValues(writer, setting.conflictResolutionInternal, options);
             }
 
-            if (setting.DefaultTimeToLive.HasValue)
+            if (setting.DefaultTimeToLiveInSeconds.HasValue)
             {
-                writer.WriteNumber(JsonEncodedStrings.DefaultTimeToLive, setting.DefaultTimeToLive.Value);
+                writer.WriteNumber(JsonEncodedStrings.DefaultTimeToLive, setting.DefaultTimeToLiveInSeconds.Value);
             }
 
             if (setting.PartitionKey != null)
@@ -139,7 +139,7 @@ namespace Azure.Cosmos
             }
             else if (property.NameEquals(JsonEncodedStrings.DefaultTimeToLive.EncodedUtf8Bytes))
             {
-                setting.DefaultTimeToLive = property.Value.GetInt32();
+                setting.DefaultTimeToLiveInSeconds = property.Value.GetInt32();
             }
             else if (property.NameEquals(JsonEncodedStrings.PartitionKey.EncodedUtf8Bytes))
             {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -471,18 +471,18 @@ namespace Azure.Cosmos.EmulatorTests
                 string partitionKeyPath = "/users";
                 int timeToLiveInSeconds = 10;
                 CosmosContainerResponse containerResponse = await this.database.DefineContainer(containerName, partitionKeyPath)
-                    .WithDefaultTimeToLive(timeToLiveInSeconds)
+                    .WithDefaultTimeToLiveInSeconds(timeToLiveInSeconds)
                     .CreateAsync();
 
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
                 CosmosContainer container = containerResponse;
                 CosmosContainerProperties responseSettings = containerResponse;
 
-                Assert.AreEqual(timeToLiveInSeconds, responseSettings.DefaultTimeToLive);
+                Assert.AreEqual(timeToLiveInSeconds, responseSettings.DefaultTimeToLiveInSeconds);
 
                 CosmosContainerResponse readResponse = await container.ReadContainerAsync();
                 Assert.AreEqual((int)HttpStatusCode.Created, containerResponse.GetRawResponse().Status);
-                Assert.AreEqual(timeToLiveInSeconds, readResponse.Value.DefaultTimeToLive);
+                Assert.AreEqual(timeToLiveInSeconds, readResponse.Value.DefaultTimeToLiveInSeconds);
 
                 Dictionary<string, object> itemTest = new Dictionary<string, object>();
                 itemTest["id"] = Guid.NewGuid().ToString();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1980,11 +1980,6 @@
           "Attributes": [],
           "MethodInfo": "T WithDefaultTimeToLiveInSeconds(Int32)"
         },
-        "T WithDefaultTimeToLiveInSeconds(System.TimeSpan)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "T WithDefaultTimeToLiveInSeconds(System.TimeSpan)"
-        },
         "T WithPartitionKeyDefinitionVersion(Azure.Cosmos.PartitionKeyDefinitionVersion)": {
           "Type": "Method",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -1055,17 +1055,17 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Nullable`1[System.Int32] DefaultTimeToLive": {
+        "System.Nullable`1[System.Int32] DefaultTimeToLiveInSeconds": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Nullable`1[System.Int32] get_DefaultTimeToLive()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "System.Nullable`1[System.Int32] get_DefaultTimeToLiveInSeconds()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLive()"
+          "MethodInfo": "System.Nullable`1[System.Int32] get_DefaultTimeToLiveInSeconds()"
         },
         "System.String get_Id()": {
           "Type": "Method",
@@ -1102,12 +1102,12 @@
           "Attributes": [],
           "MethodInfo": "Void set_ConflictResolutionPolicy(Azure.Cosmos.ConflictResolutionPolicy)"
         },
-        "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "Void set_DefaultTimeToLiveInSeconds(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "Void set_DefaultTimeToLive(System.Nullable`1[System.Int32])"
+          "MethodInfo": "Void set_DefaultTimeToLiveInSeconds(System.Nullable`1[System.Int32])"
         },
         "Void set_Id(System.String)": {
           "Type": "Method",
@@ -1975,15 +1975,15 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.Fluent.IndexingPolicyDefinition`1[T] WithIndexingPolicy()"
         },
-        "T WithDefaultTimeToLive(Int32)": {
+        "T WithDefaultTimeToLiveInSeconds(Int32)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "T WithDefaultTimeToLive(Int32)"
+          "MethodInfo": "T WithDefaultTimeToLiveInSeconds(Int32)"
         },
-        "T WithDefaultTimeToLive(System.TimeSpan)": {
+        "T WithDefaultTimeToLiveInSeconds(System.TimeSpan)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "T WithDefaultTimeToLive(System.TimeSpan)"
+          "MethodInfo": "T WithDefaultTimeToLiveInSeconds(System.TimeSpan)"
         },
         "T WithPartitionKeyDefinitionVersion(Azure.Cosmos.PartitionKeyDefinitionVersion)": {
           "Type": "Method",

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -107,39 +107,6 @@ namespace Azure.Cosmos.Tests.Fluent
         }
 
         [TestMethod]
-        public async Task WithDefaultTimeToLiveTimeSpan()
-        {
-            Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();
-            Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
-            mockContainers
-                .Setup(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
-                    It.IsAny<int?>(),
-                    It.IsAny<RequestOptions>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(mockContainerResponse.Object);
-            mockContainers
-                .Setup(c => c.Id)
-                .Returns(Guid.NewGuid().ToString());
-
-            ContainerBuilder containerFluentDefinitionForCreate = new ContainerBuilder(
-                mockContainers.Object,
-                GetContext(),
-                containerName,
-                partitionKey);
-
-            await containerFluentDefinitionForCreate
-                .WithDefaultTimeToLiveInSeconds(timeToLive)
-                .CreateAsync();
-
-            mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
-                    It.IsAny<int?>(),
-                    It.IsAny<RequestOptions>(),
-                    It.IsAny<CancellationToken>()), Times.Once);
-        }
-
-        [TestMethod]
         public async Task WithDefaultTimeToLiveInt()
         {
             Mock<CosmosContainerResponse> mockContainerResponse = new Mock<CosmosContainerResponse>();

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Fluent/ContainerDefinitionForCreateTests.cs
@@ -113,7 +113,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -129,11 +129,11 @@ namespace Azure.Cosmos.Tests.Fluent
                 partitionKey);
 
             await containerFluentDefinitionForCreate
-                .WithDefaultTimeToLive(timeToLive)
+                .WithDefaultTimeToLiveInSeconds(timeToLive)
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);
@@ -146,7 +146,7 @@ namespace Azure.Cosmos.Tests.Fluent
             Mock<CosmosDatabase> mockContainers = new Mock<CosmosDatabase>();
             mockContainers
                 .Setup(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()))
@@ -162,11 +162,11 @@ namespace Azure.Cosmos.Tests.Fluent
                 partitionKey);
 
             await containerFluentDefinitionForCreate
-                .WithDefaultTimeToLive((int)timeToLive.TotalSeconds)
+                .WithDefaultTimeToLiveInSeconds((int)timeToLive.TotalSeconds)
                 .CreateAsync();
 
             mockContainers.Verify(c => c.CreateContainerAsync(
-                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLive.Equals((int)timeToLive.TotalSeconds)),
+                    It.Is<CosmosContainerProperties>((settings) => settings.DefaultTimeToLiveInSeconds.Equals((int)timeToLive.TotalSeconds)),
                     It.IsAny<int?>(),
                     It.IsAny<RequestOptions>(),
                     It.IsAny<CancellationToken>()), Times.Once);


### PR DESCRIPTION
This PR renames `CosmosContainerProperties.DefaultTimeToLive` to `CosmosContainerProperties.DefaultTimeToLiveInSeconds` and also `Fluent.ContainerDefinition.WithDefaultTimeToLive()` to `Fluent.ContainerDefinition.WithDefaultTimeToLiveInSeconds()`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Closes #1494