### PR TITLE
Documentation: Fix Database and ContainerProperties code comments

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.Cosmos
         /// The example below enables time-to-live on a container. By default, all the items never expire.
         /// <code language="c#">
         /// <![CDATA[
-        ///     container.DefaultTimeToLive = (int)TimeSpan.FromDays(2).TotalSeconds;
+        ///     container.DefaultTimeToLive = -1;
         /// ]]>
         /// </code>
         /// </example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/DatabaseProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/DatabaseProperties.cs
@@ -14,48 +14,19 @@ namespace Microsoft.Azure.Cosmos
     /// <remarks>
     /// Each Azure Cosmos DB database account can have zero or more databases. A database in Azure Cosmos DB is a logical container for 
     /// document collections and users.
-    /// Refer to <see>http://azure.microsoft.com/documentation/articles/documentdb-resources/#databases</see> for more details on databases.
+    /// Refer to <see>https://docs.microsoft.com/azure/cosmos-db/databases-containers-items#databases</see> for more details on databases.
     /// </remarks>
     /// <example>
     /// The example below creates a new Database with an Id property of 'MyDatabase'.
     /// <code language="c#">
     /// <![CDATA[ 
-    /// using (DocumentClient client = new DocumentClient(new Uri("service endpoint"), "auth key"))
+    /// using (CosmosClient client = new CosmosClient("connection string"))
     /// {
-    ///     Database db = await client.CreateDatabaseAsync(new Database { Id = "MyDatabase" });
+    ///     CosmosDatabase db = await client.CreateDatabaseAsync(new Database { Id = "MyDatabase" });
     /// }
     /// ]]>
     /// </code>
     /// </example>
-    /// <example> 
-    /// The example below creates a collection within this database with OfferThroughput set to 10000.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// DocumentCollection coll = await client.CreateDocumentCollectionAsync(db.SelfLink,
-    ///     new DocumentCollection { Id = "MyCollection" }, 
-    ///     10000);
-    /// ]]>
-    /// </code>
-    /// </example>
-    /// <example>
-    /// The example below queries for a Database by Id to retrieve the SelfLink.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// using Microsoft.Azure.Cosmos.Linq;
-    /// Database database = client.CreateDatabaseQuery().Where(d => d.Id == "MyDatabase").AsEnumerable().FirstOrDefault();
-    /// string databaseLink = database.SelfLink;
-    /// ]]>
-    /// </code>
-    /// </example>    
-    /// <example>
-    /// The example below deletes the database using its SelfLink property.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// await client.DeleteDatabaseAsync(db.SelfLink);
-    /// ]]>
-    /// </code>
-    /// </example>
-    /// <seealso cref="ContainerProperties"/>
     public class DatabaseProperties
     {
         private string id;


### PR DESCRIPTION
## Description

This PR fixes some old broken examples from DatabaseProperties and also fixes the DefaultTimeToLive example (-1 is used to set the TTL on but items not expiring).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update