### PR TITLE
ClientEncryption: Fix dependency to latest SDK preview in Encryption package

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     streamPayload = await EncryptionProcessor.EncryptAsync(
                         streamPayload,
                         this.encryptor,
-                        encryptionItemRequestOptions.EncryptionOption,
+                        encryptionItemRequestOptions.EncryptionOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     streamPayload = await EncryptionProcessor.EncryptAsync(
                         streamPayload,
                         this.encryptor,
-                        encryptionItemRequestOptions.EncryptionOption,
+                        encryptionItemRequestOptions.EncryptionOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -373,7 +373,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     streamPayload = await EncryptionProcessor.EncryptAsync(
                         streamPayload,
                         this.encryptor,
-                        encryptionItemRequestOptions.EncryptionOption,
+                        encryptionItemRequestOptions.EncryptionOptions,
                         diagnosticsContext,
                         cancellationToken);
 

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionItemRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionItemRequestOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// <summary>
         /// Options to be provided for encryption of data.
         /// </summary>
-        public EncryptionOptions EncryptionOption { get; set; }
+        public EncryptionOptions EncryptionOptions { get; set; }
 
         /// <summary>
         /// Delegate method that will be invoked (if configured) in case of decryption failure.

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatchItemRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatchItemRequestOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// <summary>
         /// Options to be provided for encryption of data.
         /// </summary>
-        public EncryptionOptions EncryptionOption { get; set; }
+        public EncryptionOptions EncryptionOptions { get; set; }
 
         /// <summary>
         /// Delegate method that will be invoked (if configured) in case of decryption failure.

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.0-preview2" />  
+     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.9.0-preview3" />  
   </ItemGroup>
 
   <PropertyGroup>

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -7,10 +7,7 @@
     <IsPreview>true</IsPreview>
     
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
-    <VersionSuffix Condition=" '$(IsNightly)' == 'true' ">nightly-$(CurrentDate)</VersionSuffix>
-    <VersionSuffix Condition=" '$(IsPreview)' == 'true' ">preview</VersionSuffix>
-    <Version Condition=" '$(VersionSuffix)' == '' ">$(EncryptionPreviewVersion)</Version>
-    <Version Condition=" '$(VersionSuffix)' != '' ">$(EncryptionPreviewVersion)-$(VersionSuffix)</Version>
+    <Version>$(EncryptionVersion)</Version>
     <Company>Microsoft Corporation</Company>
     <Authors>Microsoft</Authors>
     <Description>This library provides an implementation for client-side encryption for Azure Cosmos's SQL API. For more information, refer to https://aka.ms/CosmosClientEncryption</Description>

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/EncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/EncryptionTests.cs
@@ -946,7 +946,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
         {
             return new EncryptionItemRequestOptions
             {
-                EncryptionOption = EncryptionTests.GetEncryptionOptions(dekId, pathsToEncrypt),
+                EncryptionOptions = EncryptionTests.GetEncryptionOptions(dekId, pathsToEncrypt),
                 IfMatchEtag = ifMatchEtag
             };
         }
@@ -958,7 +958,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
         {
             return new EncryptionTransactionalBatchItemRequestOptions
             {
-                EncryptionOption = EncryptionTests.GetEncryptionOptions(dekId, pathsToEncrypt),
+                EncryptionOptions = EncryptionTests.GetEncryptionOptions(dekId, pathsToEncrypt),
                 IfMatchEtag = ifMatchEtag
             };
         }

--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -4,7 +4,7 @@
     <ClientOfficialVersion>3.8.0</ClientOfficialVersion>
     <ClientPreviewVersion>3.9.0</ClientPreviewVersion>
     <DirectVersion>3.9.0</DirectVersion>
-    <EncryptionPreviewVersion>1.0.0</EncryptionPreviewVersion>
+    <EncryptionPreviewVersion>1.1.0</EncryptionPreviewVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
   </PropertyGroup>

--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -4,7 +4,7 @@
     <ClientOfficialVersion>3.8.0</ClientOfficialVersion>
     <ClientPreviewVersion>3.9.0</ClientPreviewVersion>
     <DirectVersion>3.9.0</DirectVersion>
-    <EncryptionPreviewVersion>1.1.0</EncryptionPreviewVersion>
+    <EncryptionVersion>1.0.0-preview2</EncryptionVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Make Encryption project depend on latest released version of preview SDK and bump its version. 
Rename EncryptionOption to EncryptionOptions as the conflict with the base classes have been removed.

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
While breaking, Encryption is in private preview and the change is expected.
