### PR TITLE
[vNext] Monitoring: Add Diagnostics.ApplicationId when ApplicationName is set

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -89,7 +89,11 @@ namespace Azure.Cosmos
         public string ApplicationName
         {
             get => this.UserAgentContainer.Suffix;
-            set => this.UserAgentContainer.Suffix = value;
+            set
+            {
+                this.UserAgentContainer.Suffix = value;
+                this.Diagnostics.ApplicationId = value;
+            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -102,6 +102,7 @@ namespace Azure.Cosmos.Tests
             Assert.AreEqual(maxConnections, clientOptions.GatewayModeMaxConnectionLimit);
             Assert.AreEqual(requestTimeout, clientOptions.RequestTimeout);
             Assert.AreEqual(userAgentSuffix, clientOptions.ApplicationName);
+            Assert.AreEqual(userAgentSuffix, clientOptions.Diagnostics.ApplicationId);
             Assert.AreEqual(preProcessHandler, clientOptions.CustomHandlers[0]);
             Assert.AreEqual(apiType, clientOptions.ApiType);
             Assert.AreEqual(maxRetryAttemptsOnThrottledRequests, clientOptions.MaxRetryAttemptsOnRateLimitedRequests);
@@ -181,6 +182,7 @@ namespace Azure.Cosmos.Tests
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.Diagnostics.ApplicationId);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.UserAgentContainer.Suffix);
             Assert.IsTrue(cosmosClientOptions.UserAgentContainer.UserAgent.StartsWith(expectedValue));
             Assert.IsTrue(cosmosClientOptions.UserAgentContainer.UserAgent.EndsWith(userAgentSuffix));


### PR DESCRIPTION
## Description

Azure Core Diagnostics has an ApplicationId property to add an application identifier to the collected logs. This maps to your ApplicationName property.

This PR makes it so if the user changes the `ApplicationName`, the `Diagnostics.ApplicationId` is also set to the same value.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1054