### PR TITLE
PartitionRoutingHelper: Fix ReadFeed ArgumentNullException due to container cache miss

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             if (routingMap == null)
             {
-                DefaultTrace.TraceInformation(string.Format("Routing Map Null for collection: {0} for range: {1}, forceRefresh:{2}", collectionRid, range.ToString(), forceRefresh));
+                DefaultTrace.TraceWarning(string.Format("Routing Map Null for collection: {0} for range: {1}, forceRefresh:{2}", collectionRid, range.ToString(), forceRefresh));
                 return null;
             }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
@@ -228,9 +229,9 @@ namespace Microsoft.Azure.Cosmos.Routing
             if (!rangeFromContinuationToken.Equals(targetPartitionKeyRange.ToRange()))
             {
                 // Cannot find target range. Either collection was resolved incorrectly or the range was split
-                List<PartitionKeyRange> replacedRanges = (await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, rangeFromContinuationToken, true)).ToList();
+                IReadOnlyList<PartitionKeyRange> replacedRanges = await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, rangeFromContinuationToken, true);
 
-                if (replacedRanges == null || replacedRanges.Count < 1)
+                if (replacedRanges == null || !replacedRanges.Any())
                 {
                     return new ResolvedRangeInfo(null, null);
                 }
@@ -244,7 +245,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                 if (direction == RntdbEnumerationDirection.Reverse)
                 {
-                    replacedRanges.Reverse();
+                    replacedRanges = new ReadOnlyCollection<PartitionKeyRange>(replacedRanges.Reverse().ToList());
                 }
 
                 List<CompositeContinuationToken> continuationTokensToBePersisted = null;

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 // Cannot find target range. Either collection was resolved incorrectly or the range was split
                 IReadOnlyList<PartitionKeyRange> replacedRanges = await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, rangeFromContinuationToken, true);
 
-                if (replacedRanges == null || !replacedRanges.Any())
+                if (replacedRanges == null || replacedRanges.Count < 1)
                 {
                     return new ResolvedRangeInfo(null, null);
                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -229,7 +229,10 @@ namespace Microsoft.Azure.Cosmos.Routing
             if (!rangeFromContinuationToken.Equals(targetPartitionKeyRange.ToRange()))
             {
                 // Cannot find target range. Either collection was resolved incorrectly or the range was split
-                IReadOnlyList<PartitionKeyRange> replacedRanges = await routingMapProvider.TryGetOverlappingRangesAsync(collectionRid, rangeFromContinuationToken, true);
+                IReadOnlyList<PartitionKeyRange> replacedRanges = await routingMapProvider.TryGetOverlappingRangesAsync(
+                        collectionResourceId: collectionRid,
+                        range: rangeFromContinuationToken,
+                        forceRefresh: true);
 
                 if (replacedRanges == null || replacedRanges.Count < 1)
                 {


### PR DESCRIPTION
ReadFeed with container cache misss will lead to NRE (from LINIQ). 

Fix: 
1. Return expected payload so-that callers can retry (force-refresh)
2. Avoid unnecessary array materializations (in simple paths, except reverse)
3. Info log turned to warning for observability