### PR TITLE
Performance: Fix MemoryStream with un-accesible buffer

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedIteratorCore.cs
@@ -148,11 +148,12 @@ namespace Microsoft.Azure.Cosmos
             MemoryStream rewrittenMemoryStream;
             if (MemoryMarshal.TryGetArray(result, out ArraySegment<byte> rewrittenSegment))
             {
-                rewrittenMemoryStream = new MemoryStream(rewrittenSegment.Array, index: rewrittenSegment.Offset, count: rewrittenSegment.Count);
+                rewrittenMemoryStream = new MemoryStream(rewrittenSegment.Array, index: rewrittenSegment.Offset, count: rewrittenSegment.Count, writable: false, publiclyVisible: true);
             }
             else
             {
-                rewrittenMemoryStream = new MemoryStream(result.ToArray());
+                byte[] toArray = result.ToArray();
+                rewrittenMemoryStream = new MemoryStream(toArray, index: 0, count: toArray.Length, writable: false, publiclyVisible: true);
             }
 
             responseMessage.Content = rewrittenMemoryStream;

--- a/Microsoft.Azure.Cosmos/src/FeedRangeIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRangeIteratorCore.cs
@@ -219,11 +219,12 @@ namespace Microsoft.Azure.Cosmos
                 MemoryStream rewrittenMemoryStream;
                 if (MemoryMarshal.TryGetArray(result, out ArraySegment<byte> rewrittenSegment))
                 {
-                    rewrittenMemoryStream = new MemoryStream(rewrittenSegment.Array, index: rewrittenSegment.Offset, count: rewrittenSegment.Count);
+                    rewrittenMemoryStream = new MemoryStream(rewrittenSegment.Array, index: rewrittenSegment.Offset, count: rewrittenSegment.Count, writable: false, publiclyVisible: true);
                 }
                 else
                 {
-                    rewrittenMemoryStream = new MemoryStream(result.ToArray());
+                    byte[] toArray = result.ToArray();
+                    rewrittenMemoryStream = new MemoryStream(toArray, index: 0, count: toArray.Length, writable: false, publiclyVisible: true);
                 }
 
                 responseMessage.Content = rewrittenMemoryStream;

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Cosmos.Serializer
                 resultAsArray = new ArraySegment<byte>(result.ToArray());
             }
 
-            return new MemoryStream(resultAsArray.Array, resultAsArray.Offset, resultAsArray.Count);
+            return new MemoryStream(resultAsArray.Array, resultAsArray.Offset, resultAsArray.Count, writable: false, publiclyVisible: true);
         }
 
         internal static IEnumerable<T> GetResources<T>(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -94,6 +94,24 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.SerializerCore.ToStream(testItem), partitionKey: new Cosmos.PartitionKey(testItem.status));
             Assert.IsNotNull(response);
             Assert.IsTrue((response.Content as MemoryStream).TryGetBuffer(out _));
+            FeedIterator feedIteratorQuery = this.Container.GetItemQueryStreamIterator(queryText: "SELECT * FROM c");
+
+            while (feedIteratorQuery.HasMoreResults)
+            {
+                ResponseMessage feedResponseQuery = await feedIteratorQuery.ReadNextAsync();
+                Assert.IsTrue((feedResponseQuery.Content as MemoryStream).TryGetBuffer(out _));
+            }
+
+            FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(requestOptions: new QueryRequestOptions()
+            {
+                PartitionKey = new Cosmos.PartitionKey(testItem.status)
+            });
+
+            while (feedIterator.HasMoreResults)
+            {
+                ResponseMessage feedResponse = await feedIterator.ReadNextAsync();
+                Assert.IsTrue((feedResponse.Content as MemoryStream).TryGetBuffer(out _));
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

#1398 made the underlying transport's stream have an accessible buffer, which benefited point operations and queries while reading through to create CosmosElements.

But there were other parts in the code that was taking this underlying stream and test it for required conversion (binary to text). This code was doing a memcopy into a new MemoryStream.

This new MemoryStream did not have the buffer accessible, so it was hurting the performance while deserializing the resulting MemoryStream to the user type.

This PR makes sure these new MemoryStreams have the buffer accessible and also adds a test to verify this does not regress.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
