### PR TITLE
[Internal] UserAgent: Fix ClientId generation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Reflection;
     using System.Runtime.InteropServices;
-    using System.Threading;
 
     internal sealed class EnvironmentInformation
     {
@@ -16,8 +15,8 @@ namespace Microsoft.Azure.Cosmos
         private static readonly string framework;
         private static readonly string architecture;
         private static readonly string os;
+        private static readonly object clientCountLock = new object();
         private static int clientId = 0;
-        private static SemaphoreSlim semaphoreSlim = new SemaphoreSlim(1);
 
         static EnvironmentInformation()
         {
@@ -32,8 +31,7 @@ namespace Microsoft.Azure.Cosmos
 
         public EnvironmentInformation()
         {
-            semaphoreSlim.Wait();
-            try
+            lock (EnvironmentInformation.clientCountLock)
             {
                 int newClientId = EnvironmentInformation.MaxClientId;
                 if (EnvironmentInformation.clientId <= EnvironmentInformation.MaxClientId)
@@ -42,10 +40,6 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 this.ClientId = newClientId.ToString().PadLeft(2, '0');
-            }
-            finally
-            {
-                semaphoreSlim.Release();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string[] values = serialization.Split('|');
             Assert.AreEqual($"cosmos-netstandard-sdk/{envInfo.ClientVersion}", values[0]);
             Assert.AreEqual(envInfo.DirectVersion, values[1]);
-            Assert.AreEqual(envInfo.ClientId.Length, values[2].Length);
+            Assert.AreEqual(envInfo.ClientId, values[2]);
             Assert.AreEqual(envInfo.ProcessArchitecture, values[3]);
             Assert.IsTrue(!string.IsNullOrWhiteSpace(values[4]));
             if (useMacOs)
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Cosmos.UserAgentContainer userAgentContainer = client.ClientOptions.GetConnectionPolicy().UserAgentContainer;
             string userAgentString = userAgentContainer.UserAgent;
             string clientId = userAgentString.Split('|')[2];
-            Assert.AreEqual(5, clientId.Length);
+            Assert.AreEqual(2, clientId.Length);
             return clientId;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public void ValidateUniqueClientIdHeader()
         {
+            EnvironmentInformation.ResetCounter();
             using (CosmosClient client = TestCommon.CreateCosmosClient())
             {
                 string firstClientId = this.GetClientIdFromCosmosClient(client);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/EnvironmentInformationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/EnvironmentInformationTests.cs
@@ -5,16 +5,24 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class EnvironmentInformationTests
     {
+        [TestInitialize]
+        public void Reset()
+        {
+            EnvironmentInformation.ResetCounter();
+        }
+
         [TestMethod]
         public void ClientVersionIsNotNull()
         {
-            var envInfo = new EnvironmentInformation();
+            EnvironmentInformation envInfo = new EnvironmentInformation();
             Assert.IsNotNull(envInfo.ClientVersion);
 
             Version sdkVersion = Assembly.GetAssembly(typeof(CosmosClient)).GetName().Version;
@@ -24,22 +32,57 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void ProcessArchitectureIsNotNull()
         {
-            var envInfo = new EnvironmentInformation();
+            EnvironmentInformation envInfo = new EnvironmentInformation();
             Assert.IsNotNull(envInfo.ProcessArchitecture);
         }
 
         [TestMethod]
         public void FrameworkIsNotNull()
         {
-            var envInfo = new EnvironmentInformation();
+            EnvironmentInformation envInfo = new EnvironmentInformation();
             Assert.IsNotNull(envInfo.RuntimeFramework);
         }
 
         [TestMethod]
         public void ClientIdIsNotNull()
         {
-            var envInfo = new EnvironmentInformation();
+            EnvironmentInformation envInfo = new EnvironmentInformation();
             Assert.IsNotNull(envInfo.ClientId);
+        }
+
+        [TestMethod]
+        public void ClientIdIncrementsUpToMax()
+        {
+            // Max is 10
+            const int max = 10;
+            for (int i = 0; i < max + 5; i++)
+            {
+                EnvironmentInformation envInfo = new EnvironmentInformation();
+                Assert.AreEqual(i > max ? max : i, int.Parse(envInfo.ClientId));
+            }
+        }
+
+        [TestMethod]
+        public void ClientIdIncrementsUpToMax_Concurrent()
+        {
+            const int max = 10;
+            const int tasks = max + 5;
+            List<int> expected = new List<int>(tasks);
+            for (int i = 0; i < tasks; i++)
+            {
+                expected.Add(i > max ? max : i);
+            }
+
+            List<int> results = new List<int>(tasks);
+            Parallel.For(0, tasks, (int i) =>
+            {
+                EnvironmentInformation envInfo = new EnvironmentInformation();
+                results.Add(int.Parse(envInfo.ClientId));
+            });
+
+            results.Sort();
+
+            CollectionAssert.AreEqual(expected, results);
         }
     }
 }


### PR DESCRIPTION
## Description

ClientId in the UserAgent string had a high cardinality of values. The point of it was to help identify scenarios where the user was creating multiple instances of the CosmosClient within the same process (not Singleton).

This PR changes the logic behind ClientId to have a zero based incremental value with a max bound instead of being based on the time.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

