### PR TITLE
Internal Routing : Refactor Try APIs to return a TryCatch or bool 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -22,9 +22,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             string itemId)
         {
             using (ResponseMessage responseMessage = await container.ReadItemStreamAsync(
-                    itemId,
-                    partitionKey)
-                    .ConfigureAwait(false))
+                itemId,
+                partitionKey).ConfigureAwait(false))
             {
                 responseMessage.EnsureSuccessStatusCode();
                 return CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(responseMessage.Content);
@@ -46,7 +45,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                         return null;
                     }
 
-                    return new ItemResponse<T>(response.StatusCode, response.Headers, CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(response.Content), response.Diagnostics);
+                    return new ItemResponse<T>(
+                        response.StatusCode,
+                        response.Headers,
+                        CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(response.Content),
+                        response.Diagnostics);
                 }
             }
         }
@@ -60,10 +63,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
         {
             using (Stream itemStream = CosmosContainerExtensions.DefaultJsonSerializer.ToStream<T>(item))
             {
-                using (ResponseMessage response = await container.ReplaceItemStreamAsync(itemStream, itemId, partitionKey, itemRequestOptions).ConfigureAwait(false))
+                using (ResponseMessage response = await container.ReplaceItemStreamAsync(
+                    itemStream,
+                    itemId,
+                    partitionKey,
+                    itemRequestOptions).ConfigureAwait(false))
                 {
                     response.EnsureSuccessStatusCode();
-                    return new ItemResponse<T>(response.StatusCode, response.Headers, CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(response.Content), response.Diagnostics);
+                    return new ItemResponse<T>(
+                        response.StatusCode,
+                        response.Headers,
+                        CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(response.Content),
+                        response.Diagnostics);
                 }
             }
         }
@@ -74,7 +85,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             string itemId,
             ItemRequestOptions cosmosItemRequestOptions = null)
         {
-            using (ResponseMessage response = await container.DeleteItemStreamAsync(itemId, partitionKey, cosmosItemRequestOptions).ConfigureAwait(false))
+            using (ResponseMessage response = await container.DeleteItemStreamAsync(
+                itemId,
+                partitionKey,
+                cosmosItemRequestOptions).ConfigureAwait(false))
             {
                 return response.IsSuccessStatusCode;
             }
@@ -86,9 +100,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             string itemId)
         {
             ResponseMessage response = await container.ReadItemStreamAsync(
-                        itemId,
-                        partitionKey)
-                        .ConfigureAwait(false);
+                itemId,
+                partitionKey).ConfigureAwait(false);
 
             return response.IsSuccessStatusCode;
         }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
     using System.Collections;
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosBinary.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosBinary.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 {
     using System;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosBoolean.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosBoolean.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 {
     using System;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
     using System.Text;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
     [Newtonsoft.Json.JsonConverter(typeof(CosmosElementJsonConverter))]
 #if INTERNAL

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosGuid.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosGuid.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 {
     using System;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosNull.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosNull.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 {
     using System;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosNumber.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosNumber.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 {
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosString.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosString.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
     using System;
     using Microsoft.Azure.Cosmos.Core.Utf8;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
 #if INTERNAL
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
@@ -1182,13 +1183,13 @@ namespace Microsoft.Azure.Cosmos
                     AuthorizationTokenType.PrimaryMasterKey))
             {
                 ContainerProperties resolvedCollection = await collectionCache.ResolveCollectionAsync(request, CancellationToken.None);
-                IReadOnlyList<PartitionKeyRange> ranges = await this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
-                resolvedCollection.ResourceId,
-                new Range<string>(
-                    PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
-                    PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
-                    true,
-                    false));
+                TryCatch<IReadOnlyList<PartitionKeyRange>> tryGetOverlappingRangesAsync = await this.partitionKeyRangeCache.TryGetOverlappingRangesAsync(
+                    resolvedCollection.ResourceId,
+                    new Range<string>(
+                        PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                        PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
+                        true,
+                        false));
 
                 // In Gateway mode, AddressCache is null
                 if (this.AddressResolver != null)

--- a/Microsoft.Azure.Cosmos/src/FeedRange/FeedRangeContinuation.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/FeedRangeContinuation.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
     /// <summary>
     /// Represents the continuation for an operation using FeedRange.

--- a/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangeEPK.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangeEPK.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Routing;
 
     /// <summary>
@@ -45,8 +46,13 @@ namespace Microsoft.Azure.Cosmos
             Documents.PartitionKeyDefinition partitionKeyDefinition,
             CancellationToken cancellationToken)
         {
-            IReadOnlyList<Documents.PartitionKeyRange> partitionKeyRanges = await routingMapProvider.TryGetOverlappingRangesAsync(containerRid, this.Range, forceRefresh: false);
-            return partitionKeyRanges.Select(partitionKeyRange => partitionKeyRange.Id);
+            TryCatch<IReadOnlyList<Documents.PartitionKeyRange>> tryGetOverlappingRangesAsync = await routingMapProvider.TryGetOverlappingRangesAsync(
+                containerRid,
+                this.Range,
+                forceRefresh: false);
+            tryGetOverlappingRangesAsync.ThrowIfFailed();
+
+            return tryGetOverlappingRangesAsync.Result.Select(partitionKeyRange => partitionKeyRange.Id);
         }
 
         public override void Accept(FeedRangeVisitor visitor)

--- a/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKey.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Routing;
 
     /// <summary>
@@ -40,8 +41,12 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken)
         {
             string effectivePartitionKeyString = this.PartitionKey.InternalKey.GetEffectivePartitionKeyString(partitionKeyDefinition);
-            Documents.PartitionKeyRange range = await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(containerRid, effectivePartitionKeyString);
-            return new List<string>() { range.Id };
+            TryCatch<Documents.PartitionKeyRange> tryGetRangeByEffectivePartitionKeyAsync = await routingMapProvider.TryGetRangeByEffectivePartitionKeyAsync(
+                containerRid,
+                effectivePartitionKeyString);
+            tryGetRangeByEffectivePartitionKeyAsync.ThrowIfFailed();
+
+            return new List<string>() { tryGetRangeByEffectivePartitionKeyAsync.Result.Id };
         }
 
         public override void Accept(FeedRangeVisitor visitor)

--- a/Microsoft.Azure.Cosmos/src/FeedRangeIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRangeIteratorCore.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Json.Interop;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Documents;
 

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBWriter.cs
@@ -196,7 +196,6 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
                             throw new ArgumentOutOfRangeException($"Unknown {nameof(JsonToken)}: {jsonTextReader.TokenType}.");
                     }
                 }
-                
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Cosmos.Json
     using System.Linq;
     using System.Reflection;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
 
     internal static class JsonSerializer
     {

--- a/Microsoft.Azure.Cosmos/src/Monads/Either.cs
+++ b/Microsoft.Azure.Cosmos/src/Monads/Either.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Monads
+namespace Microsoft.Azure.Cosmos.Monads
 {
     using System;
 

--- a/Microsoft.Azure.Cosmos/src/Monads/ExceptionWithStackTraceException.cs
+++ b/Microsoft.Azure.Cosmos/src/Monads/ExceptionWithStackTraceException.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Monads
+namespace Microsoft.Azure.Cosmos.Monads
 {
     using System;
     using System.Diagnostics;

--- a/Microsoft.Azure.Cosmos/src/Monads/TryCatch.cs
+++ b/Microsoft.Azure.Cosmos/src/Monads/TryCatch.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Monads
+namespace Microsoft.Azure.Cosmos.Monads
 {
     using System;
     using System.Threading.Tasks;

--- a/Microsoft.Azure.Cosmos/src/Monads/TryCatch{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/Monads/TryCatch{TResult}.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Monads
+namespace Microsoft.Azure.Cosmos.Monads
 {
     using System;
     using System.Diagnostics;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ContinuationTokens/CompositeContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ContinuationTokens/CompositeContinuationToken.cs
@@ -6,9 +6,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ContinuationTokens/OrderByContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ContinuationTokens/OrderByContinuationToken.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens
     using System.Linq;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Client.cs
@@ -8,11 +8,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggregators;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class AggregateDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.Compute.cs
@@ -5,13 +5,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggregators;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class AggregateDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/AggregateDocumentQueryExecutionComponent.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggregators;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Execution component that is able to aggregate local aggregates from multiple continuations and partitions.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/AverageAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/AverageAggregator.cs
@@ -8,8 +8,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global weighted average from the local weighted average of multiple partitions and continuations.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/CountAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/CountAggregator.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global count from the local counts from multiple partitions and continuations.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/MinMaxAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/MinMaxAggregator.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global min/max from the local min/max of multiple partitions and continuations.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SingleGroupAggregator.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
     using System.Linq;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Aggregates all the projections for a single grouping.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Aggregate/Aggregators/SumAggregator.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggrega
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Concrete implementation of IAggregator that can take the global sum from the local sum of multiple partitions and continuations.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Client.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.Compute.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class DistinctDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctDocumentQueryExecutionComponent.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Newtonsoft.Json;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.OrderedDistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.OrderedDistinctMap.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
 {
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Partial wrapper

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.UnorderedDistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.UnorderedDistinctMap.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Partial wrapper

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/Distinct/DistinctMap.cs
@@ -6,9 +6,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Base class for all types of DistinctMaps.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Client.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class GroupByDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.Compute.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class GroupByDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/GroupBy/GroupByDocumentQueryExecutionComponent.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.GroupBy
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate.Aggregators;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     /// <summary>
     /// Query execution component that groups groupings across continuations and pages.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.Client.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.Compute.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Documents;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/SkipDocumentQueryExecutionComponent.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     internal abstract partial class SkipDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.Client.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.Compute.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     internal abstract partial class TakeDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionComponent/SkipTake/TakeDocumentQueryExecutionComponent.cs
@@ -6,8 +6,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
 
     internal abstract partial class TakeDocumentQueryExecutionComponent : DocumentQueryExecutionComponentBase
     {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosCrossPartitionQueryExecutionContext.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Collections;
     using Microsoft.Azure.Cosmos.Query.Core.ComparableTask;
@@ -19,7 +20,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.Parallel;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using PartitionKeyRange = Documents.PartitionKeyRange;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/CosmosQueryExecutionContextFactory.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Distinct;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/LazyCosmosQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/LazyCosmosQueryExecutionContext.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
@@ -11,12 +11,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using PartitionKeyRange = Documents.PartitionKeyRange;
     using ResourceId = Documents.ResourceId;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/Parallel/CosmosParallelItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/Parallel/CosmosParallelItemQueryExecutionContext.Resume.cs
@@ -10,11 +10,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.Parallel
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using PartitionKeyRange = Documents.PartitionKeyRange;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/PipelinedDocumentQueryExecutionContext.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.Aggregate;
@@ -18,7 +19,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.Parallel;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Documents.Collections;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -10,8 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Query.Core.Metrics;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
 
     internal abstract class CosmosQueryClient
@@ -30,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
         /// <param name="range">This method will return all ranges which overlap this range.</param>
         /// <param name="forceRefresh">Whether forcefully refreshing the routing map is necessary</param>
         /// <returns>List of effective partition key ranges for a collection or null if collection doesn't exist.</returns>
-        internal abstract Task<IReadOnlyList<Documents.PartitionKeyRange>> TryGetOverlappingRangesAsync(
+        internal abstract Task<TryCatch<IReadOnlyList<Documents.PartitionKeyRange>>> TryGetOverlappingRangesAsync(
             string collectionResourceId,
             Documents.Routing.Range<string> range,
             bool forceRefresh = false);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
     using System.Runtime.InteropServices;
     using System.Text;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Routing;
     using Newtonsoft.Json;
     using PartitionKeyDefinition = Documents.PartitionKeyDefinition;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanHandler.cs
@@ -9,8 +9,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using PartitionKeyDefinition = Documents.PartitionKeyDefinition;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using OperationType = Documents.OperationType;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryResponseFactory.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
     using System;
     using System.Diagnostics;
     using System.Runtime.CompilerServices;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Documents;

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextFactory.cs
@@ -189,8 +189,8 @@ namespace Microsoft.Azure.Cosmos.Query
                  (DocumentQueryExecutionContextFactory.IsTopOrderByQuery(partitionedQueryExecutionInfo) ||
                   DocumentQueryExecutionContextFactory.IsAggregateQuery(partitionedQueryExecutionInfo) ||
                   DocumentQueryExecutionContextFactory.IsOffsetLimitQuery(partitionedQueryExecutionInfo) ||
-                  DocumentQueryExecutionContextFactory.IsParallelQuery(feedOptions)) ||
-                  !string.IsNullOrEmpty(feedOptions.PartitionKeyRangeId)) ||
+                  DocumentQueryExecutionContextFactory.IsParallelQuery(feedOptions))) ||
+                  !string.IsNullOrEmpty(feedOptions.PartitionKeyRangeId) ||
                   // Even if it's single partition query we create a specialized context to aggregate the aggregates and distinct of distinct.
                   DocumentQueryExecutionContextFactory.IsAggregateQueryWithoutContinuation(
                       partitionedQueryExecutionInfo,
@@ -206,14 +206,15 @@ namespace Microsoft.Azure.Cosmos.Query
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
         {
             return resourceTypeEnum.IsPartitioned()
-                && (feedOptions.PartitionKey == null && feedOptions.EnableCrossPartitionQuery)
+                && (feedOptions.PartitionKey == null)
+                && feedOptions.EnableCrossPartitionQuery
                 && (partitionKeyDefinition.Paths.Count > 0)
                 && !(partitionedQueryExecutionInfo.QueryRanges.Count == 1 && partitionedQueryExecutionInfo.QueryRanges[0].IsSingleValue);
         }
 
         private static bool IsParallelQuery(FeedOptions feedOptions)
         {
-            return (feedOptions.MaxDegreeOfParallelism != 0);
+            return feedOptions.MaxDegreeOfParallelism != 0;
         }
 
         private static bool IsTopOrderByQuery(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
@@ -225,7 +226,7 @@ namespace Microsoft.Azure.Cosmos.Query
         private static bool IsAggregateQuery(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
         {
             return (partitionedQueryExecutionInfo.QueryInfo != null)
-                && (partitionedQueryExecutionInfo.QueryInfo.HasAggregates);
+                && partitionedQueryExecutionInfo.QueryInfo.HasAggregates;
         }
 
         private static bool IsAggregateQueryWithoutContinuation(PartitionedQueryExecutionInfo partitionedQueryExecutionInfo, bool isContinuationExpected)

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -10,10 +10,10 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Documents;
@@ -560,14 +560,13 @@ namespace Microsoft.Azure.Cosmos
         {
             Routing.PartitionKeyRangeCache pkRangeCache = await this.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
             string containerRid = await this.GetRIDAsync(cancellationToken);
-            IReadOnlyList<Documents.PartitionKeyRange> allRanges = await pkRangeCache.TryGetOverlappingRangesAsync(
-                        containerRid,
-                        new Documents.Routing.Range<string>(
-                            Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
-                            Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
-                            isMinInclusive: true,
-                            isMaxInclusive: false),
-                        true);
+            IReadOnlyList<Documents.PartitionKeyRange> allRanges = await pkRangeCache.GetOverlappingRangesAsync(
+                containerRid,
+                new Documents.Routing.Range<string>(
+                    Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                    Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
+                    isMinInclusive: true,
+                    isMaxInclusive: false));
 
             return allRanges.Select(e => StandByFeedContinuationToken.CreateForRange(containerRid, e.MinInclusive, e.MaxExclusive));
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -213,14 +213,13 @@ namespace Microsoft.Azure.Cosmos
         {
             PartitionKeyRangeCache partitionKeyRangeCache = await this.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
             string containerRId = await this.GetRIDAsync(cancellationToken);
-            IReadOnlyList<PartitionKeyRange> partitionKeyRanges = await partitionKeyRangeCache.TryGetOverlappingRangesAsync(
-                        containerRId,
-                        new Range<string>(
-                            PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
-                            PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
-                            isMinInclusive: true,
-                            isMaxInclusive: false),
-                        forceRefresh: true);
+            IReadOnlyList<PartitionKeyRange> partitionKeyRanges = await partitionKeyRangeCache.GetOverlappingRangesAsync(
+                containerRId,
+                new Range<string>(
+                    PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                    PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
+                    isMinInclusive: true,
+                    isMaxInclusive: false));
             List<FeedRangeEPK> feedTokens = new List<FeedRangeEPK>(partitionKeyRanges.Count);
             foreach (PartitionKeyRange partitionKeyRange in partitionKeyRanges)
             {
@@ -402,11 +401,11 @@ namespace Microsoft.Azure.Cosmos
                 .ContinueWith(partitionKeyRangeCachetask =>
                 {
                     PartitionKeyRangeCache partitionKeyRangeCache = partitionKeyRangeCachetask.Result;
-                    return partitionKeyRangeCache.TryLookupAsync(
-                            collectionRID,
-                            null,
-                            null,
-                            cancellationToken);
+                    return partitionKeyRangeCache.LookupAsync(
+                        collectionRID,
+                        previousValue: null,
+                        request: null,
+                        cancellationToken);
                 })
                 .Unwrap();
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/ChangeFeedIteratorCore.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Documents;
 
@@ -232,10 +232,9 @@ namespace Microsoft.Azure.Cosmos
                 }
                 else
                 {
-                    IReadOnlyList<PartitionKeyRange> pkRanges = await partitionKeyRangeCache.TryGetOverlappingRangesAsync(
-                            collectionRid: this.lazyContainerRid.Result.Result,
-                            range: (this.FeedRangeInternal as FeedRangeEPK).Range,
-                            forceRefresh: false);
+                    IReadOnlyList<PartitionKeyRange> pkRanges = await partitionKeyRangeCache.GetOverlappingRangesAsync(
+                        collectionRid: this.lazyContainerRid.Result.Result,
+                        range: (this.FeedRangeInternal as FeedRangeEPK).Range);
                     ranges = pkRanges.Select(pkRange => pkRange.ToRange()).ToList();
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/StandByFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/QueryResponses/StandByFeedIteratorCore.cs
@@ -99,7 +99,10 @@ namespace Microsoft.Azure.Cosmos
             {
                 PartitionKeyRangeCache pkRangeCache = await this.clientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
                 this.containerRid = await this.container.GetRIDAsync(cancellationToken);
-                this.compositeContinuationToken = await StandByFeedContinuationToken.CreateAsync(this.containerRid, this.continuationToken, pkRangeCache.TryGetOverlappingRangesAsync);
+                this.compositeContinuationToken = await StandByFeedContinuationToken.CreateAsync(
+                    this.containerRid,
+                    this.continuationToken,
+                    pkRangeCache.TryGetOverlappingRangesAsync);
             }
 
             (CompositeContinuationToken currentRangeToken, string rangeId) = await this.compositeContinuationToken.GetCurrentTokenAsync();
@@ -138,7 +141,7 @@ namespace Microsoft.Azure.Cosmos
             if (partitionSplit)
             {
                 // Forcing stale refresh of Partition Key Ranges Cache
-                await this.compositeContinuationToken.GetCurrentTokenAsync(forceRefresh: true);
+                await this.compositeContinuationToken.GetCurrentTokenAsync();
                 return true;
             }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/IAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IAddressCache.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Common
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Documents;
 
     internal interface IAddressCache
@@ -23,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Common
         /// <param name="forceRefreshPartitionAddresses">Whether addresses need to be refreshed as previously resolved addresses were determined to be outdated.</param>
         /// <param name="cancellationToken">Instance of <see cref="CancellationToken"/>.</param>
         /// <returns>Physical addresses.</returns>
-        Task<PartitionAddressInformation> TryGetAddressesAsync(
+        Task<TryCatch<PartitionAddressInformation>> TryGetAddressesAsync(
             DocumentServiceRequest request,
             PartitionKeyRangeIdentity partitionKeyRangeIdentity,
             ServiceIdentity serviceIdentity,

--- a/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
@@ -5,12 +5,13 @@ namespace Microsoft.Azure.Cosmos.Common
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
 
     internal interface ICollectionRoutingMapCache
     {
-        Task<CollectionRoutingMap> TryLookupAsync(
+        Task<TryCatch<CollectionRoutingMap>> TryLookupAsync(
             string collectionRid,
             CollectionRoutingMap previousValue,
             DocumentServiceRequest request,

--- a/Microsoft.Azure.Cosmos/src/Routing/IRoutingMapProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IRoutingMapProvider.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
 
@@ -21,8 +22,22 @@ namespace Microsoft.Azure.Cosmos.Routing
         /// <param name="range">This method will return all ranges which overlap this range.</param>
         /// <param name="forceRefresh">Whether forcefully refreshing the routing map is necessary</param>
         /// <returns>List of effective partition key ranges for a collection or null if collection doesn't exist.</returns>
-        Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(string collectionResourceId, Range<string> range, bool forceRefresh = false);
+        Task<TryCatch<IReadOnlyList<PartitionKeyRange>>> TryGetOverlappingRangesAsync(
+            string collectionResourceId,
+            Range<string> range,
+            bool forceRefresh = false);
 
-        Task<PartitionKeyRange> TryGetPartitionKeyRangeByIdAsync(string collectionResourceId, string partitionKeyRangeId, bool forceRefresh = false);
+        Task<IReadOnlyList<PartitionKeyRange>> GetOverlappingRangesAsync(
+            string collectionResourceId,
+            Range<string> range);
+
+        Task<TryCatch<PartitionKeyRange>> TryGetPartitionKeyRangeByIdAsync(
+            string collectionResourceId,
+            string partitionKeyRangeId,
+            bool forceRefresh = false);
+
+        Task<PartitionKeyRange> GetPartitionKeyRangeByIdAsync(
+            string collectionResourceId,
+            string partitionKeyRangeId);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
@@ -144,7 +145,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     }
                     else
                     {
-                        if(!createdDocuments)
+                        if (!createdDocuments)
                         {
                             await this.CreateRandomItems(this.Container, expectedDocuments, randomPartitionKey: true);
                             createdDocuments = true;
@@ -364,7 +365,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Task.WhenAll(tasks);
 
             int documentsRead = 0;
-            foreach(Task<int> task in tasks)
+            foreach (Task<int> task in tasks)
             {
                 documentsRead += task.Result;
             }
@@ -454,7 +455,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         this.HasCalledForceRefresh = true;
                     }
 
-                    return Task.FromResult(filteredRanges);
+                    return Task.FromResult(TryCatch<IReadOnlyList<Documents.PartitionKeyRange>>.FromResult(filteredRanges));
                 }).Result;
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1070,7 +1070,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 // Get all the partition key ranges to verify there is more than one partition
                 IRoutingMapProvider routingMapProvider = await this.cosmosClient.DocumentClient.GetPartitionKeyRangeCacheAsync();
-                IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(
+                IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.GetOverlappingRangesAsync(
                     containerResponse.Resource.ResourceId,
                     new Documents.Routing.Range<string>("00", "FF", isMaxInclusive: true, isMinInclusive: true));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosQueryClientCoreTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosQueryClientCoreTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -51,21 +52,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(containerProperties.ResourceId);
             Assert.IsNotNull(containerProperties.EffectivePartitionKeyString);
 
-            IReadOnlyList<Documents.PartitionKeyRange> pkRange = await this.queryClientCore.TryGetOverlappingRangesAsync(
+            TryCatch<IReadOnlyList<Documents.PartitionKeyRange>> tryGetPkRange = await this.queryClientCore.TryGetOverlappingRangesAsync(
                 collectionResourceId: containerProperties.ResourceId,
                 range: new Documents.Routing.Range<string>("AA", "AB", true, false),
                 forceRefresh: false);
 
-            Assert.IsNotNull(pkRange);
-            Assert.AreEqual(1, pkRange.Count);
+            Assert.IsTrue(tryGetPkRange.Succeeded);
+            Assert.AreEqual(1, tryGetPkRange.Result.Count);
 
-            IReadOnlyList<Documents.PartitionKeyRange> pkRangeAll = await this.queryClientCore.TryGetOverlappingRangesAsync(
+            TryCatch<IReadOnlyList<Documents.PartitionKeyRange>> tryGetPkRangeAll = await this.queryClientCore.TryGetOverlappingRangesAsync(
                 collectionResourceId: containerProperties.ResourceId,
                 range: new Documents.Routing.Range<string>("00", "FF", true, false),
                 forceRefresh: false);
 
-            Assert.IsNotNull(pkRangeAll);
-            Assert.IsTrue(pkRangeAll.Count > 1);
+            Assert.IsTrue(tryGetPkRangeAll.Succeeded);
+            Assert.IsTrue(tryGetPkRangeAll.Result.Count > 1);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task Startup()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true);
+            DocumentClient client = TestCommon.CreateClient(true);
             await TestCommon.DeleteAllDatabasesAsync();
         }
 
@@ -42,23 +42,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public void ValidatePageSizeHttps()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidatePageSize(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Https);
+            this.ValidatePageSize(client);
         }
 
         [TestMethod]
         public void ValidatePageSizeRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidatePageSize(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidatePageSize(client);
         }
 
         [TestMethod]
         public void ValidatePageSizeGatway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidatePageSize(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidatePageSize(client);
         }
 
         private void ValidatePageSize(DocumentClient client)
@@ -69,12 +69,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDatabaseFeedRequest(client, headers);
+                this.ReadDatabaseFeedRequest(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
@@ -83,12 +83,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadFeedScript(client, headers);
+                this.ReadFeedScript(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
@@ -98,12 +98,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDatabaseFeedRequest(client, headers);
+                this.ReadDatabaseFeedRequest(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
@@ -112,59 +112,59 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadFeedScript(client, headers);
+                this.ReadFeedScript(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
             // Valid page size
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.PageSize, "20");
-            var response = ReadDatabaseFeedRequest(client, headers);
+            DocumentServiceResponse response = this.ReadDatabaseFeedRequest(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.OK);
 
             headers = new DictionaryNameValueCollection();
             headers.Add("pageSize", "20");
-            var result = ReadFeedScript(client, headers);
+            StoredProcedureResponse<string> result = this.ReadFeedScript(client, headers);
             Assert.IsTrue(result.StatusCode == HttpStatusCode.OK);
 
             // dynamic page size
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.PageSize, "-1");
-            response = ReadDatabaseFeedRequest(client, headers);
+            response = this.ReadDatabaseFeedRequest(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.OK);
 
             headers = new DictionaryNameValueCollection();
             headers.Add("pageSize", "-1");
-            result = ReadFeedScript(client, headers);
+            result = this.ReadFeedScript(client, headers);
             Assert.IsTrue(result.StatusCode == HttpStatusCode.OK);
         }
 
         [TestMethod]
         public void ValidateConsistencyLevelGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateCosistencyLevel(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateCosistencyLevel(client);
         }
 
         [TestMethod]
         public void ValidateConsistencyLevelRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateCosistencyLevel(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidateCosistencyLevel(client);
         }
 
         [TestMethod]
         public void ValidateConsistencyLevelHttps()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidateCosistencyLevel(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Https);
+            this.ValidateCosistencyLevel(client);
         }
 
         private void ValidateCosistencyLevel(DocumentClient client)
@@ -184,43 +184,43 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDocumentFeedRequest(client, collection.ResourceId, headers);
+                this.ReadDocumentFeedRequest(client, collection.ResourceId, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "invalid status code");
             }
 
             // Supported value
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ConsistencyLevel, ConsistencyLevel.Eventual.ToString());
-            var response = ReadDocumentFeedRequest(client, collection.ResourceId, headers);
+            DocumentServiceResponse response = this.ReadDocumentFeedRequest(client, collection.ResourceId, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.OK, "Invalid status code");
         }
 
         [TestMethod]
         public void ValidateIndexingDirectiveGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateIndexingDirective(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateIndexingDirective(client);
         }
 
         [TestMethod]
         public void ValidateIndexingDirectiveRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateIndexingDirective(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidateIndexingDirective(client);
         }
 
         [TestMethod]
         public void ValidateIndexingDirectiveHttps()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidateIndexingDirective(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Https);
+            this.ValidateIndexingDirective(client);
         }
 
         private void ValidateIndexingDirective(DocumentClient client)
@@ -232,12 +232,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                CreateDocumentRequest(client, headers);
+                this.CreateDocumentRequest(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
@@ -246,48 +246,48 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                CreateDocumentScript(client, headers);
+                this.CreateDocumentScript(client, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
             // Valid Indexing Directive
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.IndexingDirective, IndexingDirective.Exclude.ToString());
-            var response = CreateDocumentRequest(client, headers);
+            DocumentServiceResponse response = this.CreateDocumentRequest(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.Created);
 
             headers = new DictionaryNameValueCollection();
             headers.Add("indexAction", "\"exclude\"");
-            var result = CreateDocumentScript(client, headers);
+            StoredProcedureResponse<string> result = this.CreateDocumentScript(client, headers);
             Assert.IsTrue(result.StatusCode == HttpStatusCode.OK, "Invalid status code");
         }
 
         [TestMethod]
         public void ValidateEnableScanInQueryGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateEnableScanInQuery(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateEnableScanInQuery(client);
         }
 
         [TestMethod]
         public void ValidateEnableScanInQueryRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateEnableScanInQuery(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidateEnableScanInQuery(client);
         }
 
         [TestMethod]
         public void ValidateEnableScanInQueryHttps()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidateEnableScanInQuery(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Https);
+            this.ValidateEnableScanInQuery(client);
         }
 
         private void ValidateEnableScanInQuery(DocumentClient client, bool isHttps = false)
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                var response = ReadDatabaseFeedRequest(client, headers);
+                DocumentServiceResponse response = this.ReadDatabaseFeedRequest(client, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -311,22 +311,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
             // Valid boolean
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableScanInQuery, "true");
-            var response2 = ReadDatabaseFeedRequest(client, headers);
+            DocumentServiceResponse response2 = this.ReadDatabaseFeedRequest(client, headers);
             Assert.IsTrue(response2.StatusCode == HttpStatusCode.OK, "Invalid status code");
         }
 
         [TestMethod]
         public void ValidateEnableLowPrecisionOrderByGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateEnableLowPrecisionOrderBy(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateEnableLowPrecisionOrderBy(client);
         }
 
         private void ValidateEnableLowPrecisionOrderBy(DocumentClient client, bool isHttps = false)
@@ -335,10 +335,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             INameValueCollection headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy, "Not a boolean");
 
-            var document = CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
+            Document document = this.CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
             try
             {
-                var response = ReadDocumentRequest(client, document, headers);
+                DocumentServiceResponse response = this.ReadDocumentRequest(client, document, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -351,38 +351,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
             // Valid boolean
-            document = CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
+            document = this.CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy, "true");
-            var response2 = ReadDocumentRequest(client, document, headers);
+            DocumentServiceResponse response2 = this.ReadDocumentRequest(client, document, headers);
             Assert.IsTrue(response2.StatusCode == HttpStatusCode.OK, "Invalid status code");
         }
 
         [TestMethod]
         public void ValidateEmitVerboseTracesInQueryGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateEmitVerboseTracesInQuery(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateEmitVerboseTracesInQuery(client);
         }
 
         [TestMethod]
         public void ValidateEmitVerboseTracesInQueryRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateEmitVerboseTracesInQuery(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidateEmitVerboseTracesInQuery(client);
         }
 
         [TestMethod]
         public void ValidateEmitVerboseTracesInQueryHttps()
         {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidateEmitVerboseTracesInQuery(client, true);
+            DocumentClient client = TestCommon.CreateClient(false, Protocol.Https);
+            this.ValidateEmitVerboseTracesInQuery(client, true);
         }
 
         private void ValidateEmitVerboseTracesInQuery(DocumentClient client, bool isHttps = false)
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                var response = ReadDatabaseFeedRequest(client, headers);
+                DocumentServiceResponse response = this.ReadDatabaseFeedRequest(client, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -406,38 +406,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.BadRequest, "Invalid status code");
             }
 
             // Valid boolean
             headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EmitVerboseTracesInQuery, "true");
-            var response2 = ReadDatabaseFeedRequest(client, headers);
+            DocumentServiceResponse response2 = this.ReadDatabaseFeedRequest(client, headers);
             Assert.IsTrue(response2.StatusCode == HttpStatusCode.OK, "Invalid status code");
         }
 
         [TestMethod]
         public void ValidateIfNonMatchGateway()
         {
-            var client = TestCommon.CreateClient(true);
-            ValidateIfNonMatch(client);
+            DocumentClient client = TestCommon.CreateClient(true);
+            this.ValidateIfNonMatch(client);
 
         }
         [TestMethod]
         public void ValidateIfNonMatchHttps()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidateIfNonMatch(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Https);
+            this.ValidateIfNonMatch(client);
         }
 
         [TestMethod]
         public void ValidateIfNonMatchRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateIfNonMatch(client);
+            DocumentClient client = TestCommon.CreateClient(true, Protocol.Tcp);
+            this.ValidateIfNonMatch(client);
         }
 
         [TestMethod]
@@ -447,10 +447,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 DocumentClient client = TestCommon.CreateClient(true);
-                var db = client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
+                Database db = client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
                 PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/pk" }), Kind = PartitionKind.Hash };
-                var coll = client.CreateDocumentCollectionAsync(db.SelfLink, new DocumentCollection() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition }).Result.Resource;
-                var doc = client.CreateDocumentAsync(coll.SelfLink, new Document()).Result.Resource;
+                DocumentCollection coll = client.CreateDocumentCollectionAsync(db.SelfLink, new DocumentCollection() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition }).Result.Resource;
+                Document doc = client.CreateDocumentAsync(coll.SelfLink, new Document()).Result.Resource;
                 client = TestCommon.CreateClient(true);
                 doc = client.CreateDocumentAsync(coll.SelfLink, new Document()).Result.Resource;
                 HttpConstants.Versions.CurrentVersion = "2015-01-01";
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
                 catch (AggregateException exception)
                 {
-                    var dce = exception.InnerException as DocumentClientException;
+                    DocumentClientException dce = exception.InnerException as DocumentClientException;
                     if (dce != null)
                     {
                         Assert.AreEqual(dce.StatusCode, HttpStatusCode.BadRequest);
@@ -508,22 +508,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ValidateCollectionIndexProgressHeadersGateway()
         {
-            var client = TestCommon.CreateCosmosClient(true);
-            await ValidateCollectionIndexProgressHeaders(client);
+            CosmosClient client = TestCommon.CreateCosmosClient(true);
+            await this.ValidateCollectionIndexProgressHeaders(client);
         }
 
         [TestMethod]
         public async Task ValidateCollectionIndexProgressHeadersHttps()
         {
-            var client = TestCommon.CreateCosmosClient(false);
-            await ValidateCollectionIndexProgressHeaders(client);
+            CosmosClient client = TestCommon.CreateCosmosClient(false);
+            await this.ValidateCollectionIndexProgressHeaders(client);
         }
 
         [TestMethod]
         public async Task ValidateCollectionIndexProgressHeadersRntbd()
         {
-            var client = TestCommon.CreateCosmosClient(false);
-            await ValidateCollectionIndexProgressHeaders(client);
+            CosmosClient client = TestCommon.CreateCosmosClient(false);
+            await this.ValidateCollectionIndexProgressHeaders(client);
         }
 
         private async Task ValidateCollectionIndexProgressHeaders(CosmosClient client)
@@ -533,20 +533,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
-                var lazyCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
+                ContainerProperties lazyCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
                 lazyCollection.IndexingPolicy.IndexingMode = Cosmos.IndexingMode.Lazy;
                 Container lazyContainer = await db.CreateContainerAsync(lazyCollection);
 
-                var consistentCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
+                ContainerProperties consistentCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
                 consistentCollection.IndexingPolicy.IndexingMode = Cosmos.IndexingMode.Consistent;
                 Container consistentContainer = await db.CreateContainerAsync(consistentCollection);
 
-                var noneIndexCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
+                ContainerProperties noneIndexCollection = new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition };
                 noneIndexCollection.IndexingPolicy.Automatic = false;
                 noneIndexCollection.IndexingPolicy.IndexingMode = Cosmos.IndexingMode.None;
                 Container noneIndexContainer = await db.CreateContainerAsync(noneIndexCollection);
 
-                var doc = new Document() { Id = Guid.NewGuid().ToString() };
+                Document doc = new Document() { Id = Guid.NewGuid().ToString() };
                 await lazyContainer.CreateItemAsync<Document>(doc);
                 await consistentContainer.CreateItemAsync<Document>(doc);
                 await noneIndexContainer.CreateItemAsync<Document>(doc);
@@ -588,22 +588,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private void ValidateIfNonMatch(DocumentClient client)
         {
             // Valid if-match
-            var document = CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
-            var headers = new DictionaryNameValueCollection();
+            Document document = this.CreateDocumentRequest(client, new DictionaryNameValueCollection()).GetResource<Document>();
+            DictionaryNameValueCollection headers = new DictionaryNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.IfNoneMatch, document.ETag);
-            var response = ReadDocumentRequest(client, document, headers);
+            DocumentServiceResponse response = this.ReadDocumentRequest(client, document, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.NotModified, "Invalid status code");
 
             // validateInvalidIfMatch
             AccessCondition condition = new AccessCondition() { Type = AccessConditionType.IfMatch, Condition = "invalid etag" };
             try
             {
-                var replacedDoc = client.ReplaceDocumentAsync(document.SelfLink, document, new RequestOptions() { AccessCondition = condition }).Result.Resource;
+                Document replacedDoc = client.ReplaceDocumentAsync(document.SelfLink, document, new RequestOptions() { AccessCondition = condition }).Result.Resource;
                 Assert.Fail("should not reach here");
             }
             catch (Exception ex)
             {
-                var innerException = ex.InnerException as DocumentClientException;
+                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.IsTrue(innerException.StatusCode == HttpStatusCode.PreconditionFailed, "Invalid status code");
             }
         }
@@ -618,25 +618,25 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 true,
                 false);
             IRoutingMapProvider routingMapProvider = client.GetPartitionKeyRangeCacheAsync().Result;
-            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.TryGetOverlappingRangesAsync(collectionId, fullRange).Result;
+            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.GetOverlappingRangesAsync(collectionId, fullRange).Result;
             request.RouteTo(new PartitionKeyRangeIdentity(collectionId, ranges.First().Id));
 
-            var response = client.ReadFeedAsync(request, null).Result;
+            DocumentServiceResponse response = client.ReadFeedAsync(request, null).Result;
             return response;
         }
 
         private DocumentServiceResponse ReadDatabaseFeedRequest(DocumentClient client, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.ReadFeed, null, ResourceType.Database, AuthorizationTokenType.PrimaryMasterKey, headers);
-            var response = client.ReadFeedAsync(request, null).Result;
+            DocumentServiceResponse response = client.ReadFeedAsync(request, null).Result;
             return response;
         }
 
         private StoredProcedureResponse<string> ReadFeedScript(DocumentClient client, INameValueCollection headers)
         {
             var headersIterator = headers.AllKeys().SelectMany(headers.GetValues, (k, v) => new { key = k, value = v });
-            var scriptOptions = "{";
-            var headerIndex = 0;
+            string scriptOptions = "{";
+            int headerIndex = 0;
             foreach (var header in headersIterator)
             {
                 if (headerIndex != 0)
@@ -650,7 +650,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             scriptOptions += "}";
 
-            var script = @"function() {
+            string script = @"function() {
                 var client = getContext().getCollection();
                 function callback(err, docFeed, responseOptions) {
                     if(err) throw 'Error while reading documents';
@@ -666,11 +666,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
                 }).Result;
-            var sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
-            var createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
+            StoredProcedure sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
+            StoredProcedure createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
             RequestOptions requestOptions = new RequestOptions();
             requestOptions.PartitionKey = new PartitionKey("test");
-            var result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
+            StoredProcedureResponse<string> result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
             return result;
         }
 
@@ -684,19 +684,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
                 }).Result;
-            var document = new Document() { Id = Guid.NewGuid().ToString() };
+            Document document = new Document() { Id = Guid.NewGuid().ToString() };
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.Create, collection.SelfLink, document, ResourceType.Document, AuthorizationTokenType.Invalid, headers, SerializationFormattingPolicy.None);
             PartitionKey partitionKey = new PartitionKey(document.Id);
             request.Headers.Set(HttpConstants.HttpHeaders.PartitionKey, partitionKey.InternalKey.ToJsonString());
-            var response = client.CreateAsync(request, null).Result;
+            DocumentServiceResponse response = client.CreateAsync(request, null).Result;
             return response;
         }
 
         private StoredProcedureResponse<string> CreateDocumentScript(DocumentClient client, INameValueCollection headers)
         {
             var headersIterator = headers.AllKeys().SelectMany(headers.GetValues, (k, v) => new { key = k, value = v });
-            var scriptOptions = "{";
-            var headerIndex = 0;
+            string scriptOptions = "{";
+            int headerIndex = 0;
             foreach (var header in headersIterator)
             {
                 if (headerIndex != 0)
@@ -709,9 +709,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             scriptOptions += "}";
-            var guid = Guid.NewGuid().ToString();
+            string guid = Guid.NewGuid().ToString();
 
-            var script = @" function() {
+            string script = @" function() {
                 var client = getContext().getCollection();                
                 client.createDocument(client.getSelfLink(), { id: ""TestDoc"" }," + scriptOptions + @", function(err, docCreated, options) { 
                    if(err) throw new Error('Error while creating document: ' + err.message); 
@@ -728,19 +728,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
                 }).Result;
-            var sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
-            var createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
+            StoredProcedure sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
+            StoredProcedure createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
             RequestOptions requestOptions = new RequestOptions();
             requestOptions.PartitionKey = new PartitionKey("TestDoc");
-            var result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
+            StoredProcedureResponse<string> result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
             return result;
         }
 
         private DocumentServiceResponse ReadDocumentRequest(DocumentClient client, Document doc, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.Read, ResourceType.Document, doc.SelfLink, AuthorizationTokenType.PrimaryMasterKey, headers);
-            request.Headers.Set(HttpConstants.HttpHeaders.PartitionKey, (new PartitionKey(doc.Id)).InternalKey.ToJsonString());
-            var retrievedDocResponse = client.ReadAsync(request, null).Result;
+            request.Headers.Set(HttpConstants.HttpHeaders.PartitionKey, new PartitionKey(doc.Id).InternalKey.ToJsonString());
+            DocumentServiceResponse retrievedDocResponse = client.ReadAsync(request, null).Result;
             return retrievedDocResponse;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             CosmosClient client = TestCommon.CreateCosmosClient(true);
 
-            await SmokeTestForNameAPI(client);
+            await this.SmokeTestForNameAPI(client);
         }
 
 #if DIRECT_MODE
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             try
             {
-                await SmokeTestForNameAPI(client);
+                await this.SmokeTestForNameAPI(client);
             }
             catch (AggregateException e)
             {
@@ -472,11 +472,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             QueryRequestOptions options = new QueryRequestOptions() { MaxConcurrency = 1, MaxItemCount = 1 };
             string sqlQueryText = @"select * from root r where r.title = ""My Book""";
             FeedIterator<LinqGeneralBaselineTests.Book> cosmosResultSet = collection.GetItemQueryIterator<LinqGeneralBaselineTests.Book>(queryText: sqlQueryText, requestOptions: options);
-            Assert.AreEqual(0, await GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
+            Assert.AreEqual(0, await this.GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
 
             sqlQueryText = @"select * from root r where r.title = ""My new Book""";
             cosmosResultSet = collection.GetItemQueryIterator<LinqGeneralBaselineTests.Book>(queryText: sqlQueryText, requestOptions: options);
-            Assert.AreEqual(1, await GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
+            Assert.AreEqual(1, await this.GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
 
             myDocument.Title = "My old Book";
             // Testing the ReplaceDocumentAsync API with Document SelfLink as the parameter
@@ -484,7 +484,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             sqlQueryText = @"select * from root r where r.title = ""My old Book""";
             cosmosResultSet = collection.GetItemQueryIterator<LinqGeneralBaselineTests.Book>(queryText: sqlQueryText, requestOptions: options);
-            Assert.AreEqual(1, await GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
+            Assert.AreEqual(1, await this.GetCountFromIterator(cosmosResultSet), "Query Count doesnt match");
         }
 
         [TestMethod]
@@ -656,12 +656,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 IList<Container> containers = await this.CreateContainerssAsync(database,
                     collectionsCount - 1);
 
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToSameName, null, CallAPIForStaleCacheTest.Document);
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToSameName, null, CallAPIForStaleCacheTest.DocumentCollection);
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToDifferentName, containers[0], CallAPIForStaleCacheTest.Document);
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToDifferentName, containers[1], CallAPIForStaleCacheTest.DocumentCollection);
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.Bindable, containers[2], CallAPIForStaleCacheTest.Document);
-                await UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.Bindable, containers[3], CallAPIForStaleCacheTest.DocumentCollection);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToSameName, null, CallAPIForStaleCacheTest.Document);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToSameName, null, CallAPIForStaleCacheTest.DocumentCollection);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToDifferentName, containers[0], CallAPIForStaleCacheTest.Document);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.BoundToDifferentName, containers[1], CallAPIForStaleCacheTest.DocumentCollection);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.Bindable, containers[2], CallAPIForStaleCacheTest.Document);
+                await this.UsingSameFabircServiceTestAsync(database, FabircServiceReuseType.Bindable, containers[3], CallAPIForStaleCacheTest.DocumentCollection);
             }
             finally
             {
@@ -1457,7 +1457,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                false);
 
             PartitionKeyRangeCache routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
-            Assert.AreNotEqual(sessionToken1.Split(':')[0], (await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange)).First().Id);
+            Assert.AreNotEqual(sessionToken1.Split(':')[0], (await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange)).First().Id);
 
             Assert.AreEqual(2, client.CreateDocumentQuery("/dbs/db1/colls/coll1", "SELECT * FROM c WHERE c.field1 IN (1, 2)", new FeedOptions { EnableCrossPartitionQuery = true }).AsEnumerable().Count());
 
@@ -1515,7 +1515,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                false);
 
             PartitionKeyRangeCache routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
-            Assert.AreNotEqual(sessionToken1.Split(':')[0], (await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange)).First().Id);
+            Assert.AreNotEqual(sessionToken1.Split(':')[0], (await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange)).First().Id);
 
             Assert.AreEqual(2, client.CreateDocumentQuery("/dbs/db1/colls/coll1", "SELECT * FROM c WHERE c.field1 IN (1, 2)", new FeedOptions { EnableCrossPartitionQuery = true }).AsEnumerable().Count());
 
@@ -1548,10 +1548,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             document1.SetPropertyValue("field1", 1);
             await client.CreateDocumentAsync("/dbs/db1/colls/coll1", document1);
 
-            var query = client.CreateDocumentQuery("/dbs/db1/colls/coll1", "SELECT * FROM c", new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery();
+            IDocumentQuery<dynamic> query = client.CreateDocumentQuery("/dbs/db1/colls/coll1", "SELECT * FROM c", new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery();
             await query.ExecuteNextAsync();
             await query.ExecuteNextAsync();
-            var result = await query.ExecuteNextAsync();
+            DocumentFeedResponse<dynamic> result = await query.ExecuteNextAsync();
             Assert.AreEqual("2", result.SessionToken.Split(':')[0], result.SessionToken);
 
             DocumentClient otherClient = TestCommon.CreateClient(false);
@@ -1948,7 +1948,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 for (int i = 0; i < numberOfCollectionsPerDatabase; ++i)
                 {
-                    containers.Add(await AsyncRetryRateLimiting(() => database.CreateContainerAsync(new ContainerProperties { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition })));
+                    containers.Add(await this.AsyncRetryRateLimiting(() => database.CreateContainerAsync(new ContainerProperties { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition })));
                 }
             }
             return containers;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -98,15 +98,15 @@
             ContainerProperties containerSettings = await container.ReadContainerAsync();
             foreach (CosmosObject document in documents)
             {
-                IReadOnlyList<PartitionKeyRange> targetRanges = await routingMapProvider.TryGetOverlappingRangesAsync(
-                containerSettings.ResourceId,
-                Range<string>.GetPointRange(
-                    PartitionKeyInternal.FromObjectArray(
-                        new object[]
-                        {
-                            Number64.ToLong((document[partitionKey] as CosmosNumber).Value)
-                        },
-                        true).GetEffectivePartitionKeyString(containerSettings.PartitionKey)));
+                IReadOnlyList<PartitionKeyRange> targetRanges = await routingMapProvider.GetOverlappingRangesAsync(
+                    containerSettings.ResourceId,
+                    Range<string>.GetPointRange(
+                        PartitionKeyInternal.FromObjectArray(
+                            new object[]
+                            {
+                                Number64.ToLong((document[partitionKey] as CosmosNumber).Value)
+                            },
+                            true).GetEffectivePartitionKeyString(containerSettings.PartitionKey)));
                 Debug.Assert(targetRanges.Count == 1);
                 idToRangeMinKeyMap.Add(((CosmosString)document["id"]).Value, targetRanges[0].MinInclusive);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IRoutingMapProvider routingMapProvider = await this.Client.DocumentClient.GetPartitionKeyRangeCacheAsync();
             Assert.IsNotNull(routingMapProvider);
 
-            IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(container.ResourceId, fullRange);
+            IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.GetOverlappingRangesAsync(container.ResourceId, fullRange);
             return ranges;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -933,7 +933,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
             IReadOnlyList<PartitionKeyRange> ranges =
-                await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange);
+                await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange);
             Assert.IsTrue(ranges.Count() > 1);
 
             Document document = new Document { Id = "id1" };
@@ -997,7 +997,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
             IReadOnlyList<PartitionKeyRange> ranges =
-                await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange);
+                await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange);
             Assert.IsTrue(ranges.Count() > 1);
 
             DateTime startTime = DateTime.Now;
@@ -1049,7 +1049,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
             IReadOnlyList<PartitionKeyRange> ranges =
-                await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange);
+                await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange);
             Assert.IsTrue(ranges.Count > 1);
 
             // Query Number 1, that failed before
@@ -1227,7 +1227,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
             IReadOnlyList<PartitionKeyRange> ranges =
-                await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange);
+                await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange);
             Assert.AreEqual(5, ranges.Count);
 
             // Query Number 1
@@ -1386,7 +1386,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync();
             IReadOnlyList<PartitionKeyRange> ranges =
-                await routingMapProvider.TryGetOverlappingRangesAsync(coll.ResourceId, fullRange);
+                await routingMapProvider.GetOverlappingRangesAsync(coll.ResourceId, fullRange);
             Assert.AreEqual(5, ranges.Count);
 
             FeedOptions feedOptions = new FeedOptions

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ClientCollectionCache collectionCache = client.GetCollectionCacheAsync().Result;
             ContainerProperties collection = collectionCache.ResolveCollectionAsync(request, CancellationToken.None).Result;
             IRoutingMapProvider routingMapProvider = client.GetPartitionKeyRangeCacheAsync().Result;
-            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.TryGetOverlappingRangesAsync(
+            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.GetOverlappingRangesAsync(
                 collection.ResourceId,
                 Range<string>.GetPointRange(PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey)).Result;
             request.RouteTo(new PartitionKeyRangeIdentity(collection.ResourceId, ranges.Single().Id));
@@ -1162,7 +1162,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     ClientCollectionCache collectionCache = client.GetCollectionCacheAsync().Result;
                     ContainerProperties collection = collectionCache.ResolveCollectionAsync(request, CancellationToken.None).Result;
                     IRoutingMapProvider routingMapProvider = client.GetPartitionKeyRangeCacheAsync().Result;
-                    IReadOnlyList<PartitionKeyRange> overlappingRanges = routingMapProvider.TryGetOverlappingRangesAsync(
+                    IReadOnlyList<PartitionKeyRange> overlappingRanges = routingMapProvider.GetOverlappingRangesAsync(
                         collection.ResourceId,
                         Range<string>.GetPointRange(PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey)).Result;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
     using Microsoft.Azure.Documents.Client;
     using Microsoft.Azure.Documents.Collections;
     using Moq;
+    using Microsoft.Azure.Cosmos.Monads;
 
     internal class MockDocumentClient : DocumentClient, IAuthorizationTokenProvider
     {
@@ -73,27 +74,25 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
         private void Init()
         {
             this.collectionCache = new Mock<ClientCollectionCache>(null, new ServerStoreModel(null), null, null);
-            this.collectionCache.Setup
-                    (m =>
-                        m.ResolveCollectionAsync(
-                        It.IsAny<DocumentServiceRequest>(),
-                        It.IsAny<CancellationToken>()
-                    )
-                ).Returns(Task.FromResult(ContainerProperties.CreateWithResourceId("test")));
+            this.collectionCache
+                .Setup(m =>
+                    m.ResolveCollectionAsync(
+                    It.IsAny<DocumentServiceRequest>(),
+                    It.IsAny<CancellationToken>()
+                ))
+                .Returns(Task.FromResult(ContainerProperties.CreateWithResourceId("test")));
 
             this.partitionKeyRangeCache = new Mock<PartitionKeyRangeCache>(null, null, null);
-            this.partitionKeyRangeCache.Setup(
-                        m => m.TryLookupAsync(
-                            It.IsAny<string>(),
-                            It.IsAny<CollectionRoutingMap>(),
-                            It.IsAny<DocumentServiceRequest>(),
-                            It.IsAny<CancellationToken>()
-                        )
-                ).Returns(Task.FromResult<CollectionRoutingMap>(null));
-
+            this.partitionKeyRangeCache
+                .Setup(m => m.TryLookupAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CollectionRoutingMap>(),
+                    It.IsAny<DocumentServiceRequest>(),
+                    It.IsAny<CancellationToken>()
+                ))
+                .Returns(Task.FromResult<TryCatch<CollectionRoutingMap>>(TryCatch<CollectionRoutingMap>.FromException(new NotFoundException())));
 
             this.globalEndpointManager = new Mock<GlobalEndpointManager>(this, new ConnectionPolicy());
-
             this.InitStoreModels();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionComponent.SkipTake;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/DeserializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/DeserializerTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationResumeLogicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationResumeLogicTests.cs
@@ -5,7 +5,7 @@
     using System.Linq;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/CompositeContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/CompositeContinuationTokenTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Cosmos.Query
 {
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Newtonsoft.Json;
     using VisualStudio.TestTools.UnitTesting;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
     using VisualStudio.TestTools.UnitTesting;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/PipelineContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/PipelineContinuationTokenTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Xml;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Test.BaselineTest;
     using VisualStudio.TestTools.UnitTesting;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryFactory.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/MockQueryFactory.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
@@ -109,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     bool isFailureResponse = itemsInPage.Length == 1 && itemsInPage[0] < 0;
                     if (isFailureResponse)
                     {
-                        if(itemsInPage[0] == MockPartitionResponse.MessageWithToManyRequestFailure)
+                        if (itemsInPage[0] == MockPartitionResponse.MessageWithToManyRequestFailure)
                         {
                             queryResponse = QueryResponseMessageFactory.CreateFailureToManyRequestResponse();
                         }
@@ -172,7 +173,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                             x.TryGetOverlappingRangesAsync(
                                 containerRid,
                                 It.Is<Documents.Routing.Range<string>>(inputRange => inputRange.Equals(partitionKeyRange.ToRange())),
-                                true)).Returns(Task.FromResult(partitionAndMessages.GetPartitionKeyRangeOfSplit()));
+                                true)).Returns(Task.FromResult(TryCatch<IReadOnlyList<PartitionKeyRange>>.FromResult(partitionAndMessages.GetPartitionKeyRangeOfSplit())));
 
                     mockQueryClient.Setup(x =>
                      x.ExecuteItemQueryAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPipelineMockTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPipelineMockTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.Parallel;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Documents;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseFactoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryResponseFactoryTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using System.Runtime.CompilerServices;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using VisualStudio.TestTools.UnitTesting;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/TryCatchTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/TryCatchTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
             Exception exception = tryCatch.Exception;
             Assert.IsNotNull(exception.StackTrace);
             // exception.ToString() >>
-            //Microsoft.Azure.Cosmos.Query.Core.Monads.ExceptionWithStackTraceException: TryCatch resulted in an exception. --->System.Exception: Exception of type 'System.Exception' was thrown.
+            //Microsoft.Azure.Cosmos.Monads.ExceptionWithStackTraceException: TryCatch resulted in an exception. --->System.Exception: Exception of type 'System.Exception' was thrown.
             //   at Microsoft.Azure.Cosmos.Tests.Query.TryCatchTests.MethodWhereExceptionWasThrown() in C:\azure - cosmos - dotnet - v3\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\Query\TryCatchTests.cs:line 43
             //   at Microsoft.Azure.Cosmos.Tests.Query.TryCatchTests.MethodWhereExceptionWasCaught() in C:\azure - cosmos - dotnet - v3\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\Query\TryCatchTests.cs:line 30
             //         -- - End of inner exception stack trace-- -

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Query;
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.Azure.Cosmos.Routing;
@@ -36,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 documentClient = new MockDocumentClient();
             }
-            
+
             CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
             if (customizeClientBuilder != null)
             {
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             string dbName = "myDb",
             string containerName = "myContainer")
         {
-            Uri link = new Uri($"/dbs/{dbName}/colls/{containerName}" , UriKind.Relative);
+            Uri link = new Uri($"/dbs/{dbName}/colls/{containerName}", UriKind.Relative);
             Mock<ContainerInternal> mockContainer = new Mock<ContainerInternal>();
             mockContainer.Setup(x => x.LinkUri).Returns(link);
             return mockContainer;
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<Range<string>>(),
                 It.IsAny<List<CompositeContinuationToken>>(),
                 It.IsAny<RntbdConstants.RntdbEnumerationDirection>()
-            )).Returns(Task.FromResult(new ResolvedRangeInfo(new PartitionKeyRange { Id = partitionRangeKeyId }, new List<CompositeContinuationToken>())));
+            )).Returns(Task.FromResult(TryCatch<ResolvedRangeInfo>.FromResult(new ResolvedRangeInfo(new PartitionKeyRange { Id = partitionRangeKeyId }, new List<CompositeContinuationToken>()))));
             partitionRoutingHelperMock.Setup(m => m.TryAddPartitionKeyRangeToContinuationTokenAsync(
                 It.IsAny<INameValueCollection>(),
                 It.IsAny<List<Range<string>>>(),

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Monads;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
@@ -215,7 +216,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                             It.IsAny<DocumentServiceRequest>(),
                             It.IsAny<CancellationToken>()
                         )
-                ).Returns(Task.FromResult<CollectionRoutingMap>(null));
+                ).Returns(Task.FromResult(TryCatch<CollectionRoutingMap>.FromException(new NotFoundException())));
             this.partitionKeyRangeCache.Setup(
                         m => m.TryGetOverlappingRangesAsync(
                             It.IsAny<string>(),
@@ -224,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         )
                 ).Returns((string collectionRid, Documents.Routing.Range<string> range, bool forceRefresh) =>
                 {
-                    return Task.FromResult<IReadOnlyList<PartitionKeyRange>>(this.ResolveOverlapingPartitionKeyRanges(collectionRid, range, forceRefresh));
+                    return Task.FromResult(TryCatch<IReadOnlyList<PartitionKeyRange>>.FromResult(this.ResolveOverlapingPartitionKeyRanges(collectionRid, range, forceRefresh)));
                 });
 
             this.globalEndpointManager = new Mock<GlobalEndpointManager>(this, new ConnectionPolicy());


### PR DESCRIPTION
# Internal Routing : Refactor Try APIs to return a TryCatch or bool 

## Description

Refactors the Try APIs in routing to return either a bool or a TryCatch. This avoids NRE and is a much stronger contract than randomly returning null in places. 

