### PR TITLE
LINQ : Add UDF Translation Support 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/UserDefinedFunctionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/UserDefinedFunctionProvider.cs
@@ -10,13 +10,13 @@ namespace Microsoft.Azure.Cosmos.Linq
     /// <summary>
     /// Helper class to invoke User Defined Functions via Linq queries in the Azure Cosmos DB service.
     /// </summary>
-    internal static class UserDefinedFunctionProvider
+    public static class UserDefinedFunctionProvider
     {
         /// <summary>
         /// Helper method to invoke User Defined Functions via Linq queries in the Azure Cosmos DB service.
         /// </summary>
-        /// <param name="udfName">the UserDefinedFunction name</param>
-        /// <param name="arguments">the arguments of the UserDefinedFunction</param>
+        /// <param name="udfName">The UserDefinedFunction name</param>
+        /// <param name="arguments">The arguments of the UserDefinedFunction</param>
         /// <remarks>
         /// This is a stub helper method for use within LINQ expressions. Cannot be called directly. 
         /// Refer to https://docs.microsoft.com/azure/cosmos-db/sql-query-linq-to-sql for more details about the LINQ provider.
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// </code>
         /// </example>
         /// <seealso cref="UserDefinedFunctionProperties"/>
+        /// <returns>Placeholder for the udf result.</returns>
         public static object Invoke(string udfName, params object[] arguments)
         {
             throw new Exception(string.Format(CultureInfo.CurrentCulture, ClientResources.InvalidCallToUserDefinedFunctionProvider));

--- a/Microsoft.Azure.Cosmos/src/Linq/UserDefinedFunctionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/UserDefinedFunctionProvider.cs
@@ -25,20 +25,41 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// <example> 
         /// <code language="c#">
         /// <![CDATA[
-        ///  await client.CreateUserDefinedFunctionAsync(collectionLink, new UserDefinedFunction { Id = "calculateTax", Body = @"function(amt) { return amt * 0.05; }" });
-        ///  var queryable = client.CreateDocumentQuery<Book>(collectionLink).Select(b => UserDefinedFunctionProvider.Invoke("calculateTax", b.Price));
-        ///  
+        /// StoredProcedureResponse storedProcedureResponse = await client
+        ///     .GetContainer("database", "container")
+        ///     .Scripts
+        ///     .CreateStoredProcedureAsync(
+        ///         new StoredProcedureProperties()
+        ///         {
+        ///             Id = "toLowerCase",
+        ///             Body = @"function(s) { return s.ToLowerCase(); }",
+        ///         });
+        ///         
         /// // Equivalent to SELECT * FROM books b WHERE udf.toLowerCase(b.title) = 'war and peace'" 
-        /// await client.CreateUserDefinedFunctionAsync(collectionLink, new UserDefinedFunction { Id = "toLowerCase", Body = @"function(s) { return s.ToLowerCase(); }" });
-        /// queryable = client.CreateDocumentQuery<Book>(collectionLink).Where(b => UserDefinedFunctionProvider.Invoke("toLowerCase", b.Title) == "war and peace");
+        /// IQueryable<Book> queryable = client
+        ///     .GetContainer("database", "container")
+        ///     .GetItemLinqQueryable<Book>()
+        ///     .Where(b => UserDefinedFunctionProvider.Invoke("toLowerCase", b.Title) == "war and peace");
+        ///
+        /// FeedIterator<Book> bookIterator = queryable.ToFeedIterator();
+        /// while (feedIterator.HasMoreResults)
+        /// {
+        ///     FeedResponse<Book> responseMessage = await feedIterator.ReadNextAsync();
+        ///     DoSomethingWithResponse(responseMessage);
+        /// }
         /// ]]>
         /// </code>
         /// </example>
         /// <seealso cref="UserDefinedFunctionProperties"/>
         /// <returns>Placeholder for the udf result.</returns>
+#pragma warning disable IDE0060 // Remove unused parameter
         public static object Invoke(string udfName, params object[] arguments)
+#pragma warning restore IDE0060 // Remove unused parameter
         {
-            throw new Exception(string.Format(CultureInfo.CurrentCulture, ClientResources.InvalidCallToUserDefinedFunctionProvider));
+            throw new NotSupportedException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ClientResources.InvalidCallToUserDefinedFunctionProvider));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
@@ -828,7 +828,6 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
         }
 
         [TestMethod]
-        [TestCategory("Ignore")]
         public void TestUDFs()
         {
             // The UDFs invokation are not supported on the client side.
@@ -837,27 +836,29 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             IOrderedQueryable<DataObject> query = testContainer.GetItemLinqQueryable<DataObject>(allowSynchronousQueryExecution : true);
             Func<bool, IQueryable<DataObject>> getQuery = useQuery => useQuery ? query : data.AsQueryable();
 
-            List<LinqTestInput> inputs = new List<LinqTestInput>();
-            inputs.Add(new LinqTestInput("No param", b => getQuery(b).Select(f => UserDefinedFunctionProvider.Invoke("NoParameterUDF"))));
-            inputs.Add(new LinqTestInput("Single param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDF", doc.NumericField))));
-            inputs.Add(new LinqTestInput("Single param w/ array", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", doc.ArrayField))));
-            inputs.Add(new LinqTestInput("Multi param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDF", doc.NumericField, doc.StringField, doc.Point))));
-            inputs.Add(new LinqTestInput("Multi param w/ array", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDWithArrayF", doc.ArrayField, doc.NumericField, doc.Point))));
-            inputs.Add(new LinqTestInput("ArrayCount", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", doc.ArrayField) > 2)));
-            inputs.Add(new LinqTestInput("ArrayCount && SomeBooleanUDF", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", doc.ArrayField) > 2 && (bool)UserDefinedFunctionProvider.Invoke("SomeBooleanUDF"))));
-            inputs.Add(new LinqTestInput("expression", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("SingleParameterUDF", doc.NumericField) + 2 == 4)));
-            // UDF with constant parameters
-            inputs.Add(new LinqTestInput("Single constant param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDF", 1))));
-            inputs.Add(new LinqTestInput("Single constant int array param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", new int[] { 1, 2, 3 }))));
-            inputs.Add(new LinqTestInput("Single constant string array param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", new string[] { "1", "2" }))));
-            inputs.Add(new LinqTestInput("Multi constant params", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDF", 1, "str", true))));
-            inputs.Add(new LinqTestInput("Multi constant array params", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDWithArrayF", new int[] { 1, 2, 3 }, 1, "str"))));
-            inputs.Add(new LinqTestInput("ArrayCount with constant param", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", new int[] { 1, 2, 3 }) > 2)));
-            // regression (different type parameters including objects)
-            inputs.Add(new LinqTestInput("different type parameters including objects", b => getQuery(b).Where(doc => (bool)UserDefinedFunctionProvider.Invoke("MultiParamterUDF2", doc.Point, "str", 1))));
-            // errors
-            inputs.Add(new LinqTestInput("Null udf name", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke(null))));
-            inputs.Add(new LinqTestInput("Empty udf name", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke(""))));
+            List<LinqTestInput> inputs = new List<LinqTestInput>
+            {
+                new LinqTestInput("No param", b => getQuery(b).Select(f => UserDefinedFunctionProvider.Invoke("NoParameterUDF"))),
+                new LinqTestInput("Single param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDF", doc.NumericField))),
+                new LinqTestInput("Single param w/ array", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", doc.ArrayField))),
+                new LinqTestInput("Multi param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDF", doc.NumericField, doc.StringField, doc.Point))),
+                new LinqTestInput("Multi param w/ array", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDWithArrayF", doc.ArrayField, doc.NumericField, doc.Point))),
+                new LinqTestInput("ArrayCount", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", doc.ArrayField) > 2)),
+                new LinqTestInput("ArrayCount && SomeBooleanUDF", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", doc.ArrayField) > 2 && (bool)UserDefinedFunctionProvider.Invoke("SomeBooleanUDF"))),
+                new LinqTestInput("expression", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("SingleParameterUDF", doc.NumericField) + 2 == 4)),
+                // UDF with constant parameters
+                new LinqTestInput("Single constant param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDF", 1))),
+                new LinqTestInput("Single constant int array param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", new int[] { 1, 2, 3 }))),
+                new LinqTestInput("Single constant string array param", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("SingleParameterUDFWithArray", new string[] { "1", "2" }))),
+                new LinqTestInput("Multi constant params", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDF", 1, "str", true))),
+                new LinqTestInput("Multi constant array params", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("MultiParamterUDWithArrayF", new int[] { 1, 2, 3 }, 1, "str"))),
+                new LinqTestInput("ArrayCount with constant param", b => getQuery(b).Where(doc => (int)UserDefinedFunctionProvider.Invoke("ArrayCount", new int[] { 1, 2, 3 }) > 2)),
+                // regression (different type parameters including objects)
+                new LinqTestInput("different type parameters including objects", b => getQuery(b).Where(doc => (bool)UserDefinedFunctionProvider.Invoke("MultiParamterUDF2", doc.Point, "str", 1))),
+                // errors
+                new LinqTestInput("Null udf name", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke(null))),
+                new LinqTestInput("Empty udf name", b => getQuery(b).Select(doc => UserDefinedFunctionProvider.Invoke("")))
+            };
             this.ExecuteTestSuite(inputs);
         }
 


### PR DESCRIPTION
# LINQ : Add UDF Translation Support 

## Description

Turns on UDF translation support for LINQ. The API looks like this:

```
IQueryable<Book> queryable = client
    .GetContainer("database", "container")
    .GetItemLinqQueryable<Book>()
    .Where(b => UserDefinedFunctionProvider.Invoke("toLowerCase", b.Title) == "war and peace");
	
FeedIterator<Book> bookIterator = queryable.ToFeedIterator();
while (feedIterator.HasMoreResults)
{
    FeedResponse<Book> responseMessage = await feedIterator.ReadNextAsync();
    DoSomethingWithResponse(responseMessage);
}
```

The PR mainly makes `UserDefinedFunctionProvider` a public type and turns on the LINQ UDF translation tests.