### PR TITLE
[Internal] Build infrastructure: Fix default .editorconfig 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,8 @@ indent_style = space
 indent_size = 4
 tab_width = 4
 trim_trailing_whitespace = true
+insert_final_newline = true
+charset = utf-8-bom
 
 ############################### 
 # .NET Coding Conventions     # 
@@ -27,6 +29,10 @@ dotnet_style_qualification_for_field = true:error
 dotnet_style_qualification_for_property = true:error 
 dotnet_style_qualification_for_method = true:error 
 dotnet_style_qualification_for_event = true:error
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_member_access = false:error
 
 # New line preferences 
 csharp_new_line_before_open_brace = all 
@@ -45,13 +51,17 @@ dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:err
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:error 
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary:error 
 
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:error
+dotnet_style_readonly_field = true:error
+
 # Expression-level preferences 
 dotnet_style_prefer_auto_properties = true:error 
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error 
 
 # CSharp code style settings:
-csharp_style_var_for_built_in_types = false:error
-csharp_style_var_when_type_is_apparent = false:error
+csharp_style_var_for_built_in_types = true:error
+csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_elsewhere = false:error
 
 # Patern matching


### PR DESCRIPTION
My personal preferences - I don't care whether you change any of the value s- as long as tools enforce consistency I don't want to spend any time discussing preferences - I am aware that taste is hugely different here. I care that all the settings I modified have some enforcement in .editorconfig to recuce time we all waste discussion prettiness on CRs :-)
