### PR TITLE
FeedRange: Fix split handling for readfeed split

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeContinuationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeContinuationTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
     using Microsoft.Azure.Cosmos.Query.Core.ContinuationTokens;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using Newtonsoft.Json;
 
     [TestClass]
     public class FeedRangeContinuationTests
@@ -149,6 +150,55 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
 
             // New third token
             Assert.AreEqual(compositeContinuationTokens[0].Token, continuationTokens[2].Token);
+            Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[1].MinInclusive, continuationTokens[2].Range.Min);
+            Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[1].MaxExclusive, continuationTokens[2].Range.Max);
+        }
+
+        [TestMethod]
+        public async Task FeedRangeCompositeContinuation_HandleSplits_ReadFeed()
+        {
+            List<CompositeContinuationToken> compositeContinuationTokens = new List<CompositeContinuationToken>()
+            {
+                FeedRangeContinuationTests.BuildTokenForRange("A", "C", JsonConvert.SerializeObject(new CompositeContinuationToken() { Token = "token1", Range = new Documents.Routing.Range<string>("A", "C", true, false) })),
+                FeedRangeContinuationTests.BuildTokenForRange("C", "F", JsonConvert.SerializeObject(new CompositeContinuationToken() { Token = "token2", Range = new Documents.Routing.Range<string>("C", "F", true, false) })),
+            };
+
+            FeedRangeCompositeContinuation feedRangeCompositeContinuation = new FeedRangeCompositeContinuation(Guid.NewGuid().ToString(), Mock.Of<FeedRangeInternal>(), JsonConvert.DeserializeObject<List<CompositeContinuationToken>>(JsonConvert.SerializeObject(compositeContinuationTokens)));
+
+            MultiRangeMockDocumentClient documentClient = new MultiRangeMockDocumentClient();
+
+            Mock<CosmosClientContext> cosmosClientContext = new Mock<CosmosClientContext>();
+            cosmosClientContext.Setup(c => c.ClientOptions).Returns(new CosmosClientOptions());
+            cosmosClientContext.Setup(c => c.DocumentClient).Returns(documentClient);
+
+            Mock<ContainerInternal> containerCore = new Mock<ContainerInternal>();
+            containerCore
+                .Setup(c => c.ClientContext).Returns(cosmosClientContext.Object);
+
+            Assert.AreEqual(2, feedRangeCompositeContinuation.CompositeContinuationTokens.Count);
+
+            ResponseMessage split = new ResponseMessage(HttpStatusCode.Gone);
+            split.Headers.SubStatusCode = Documents.SubStatusCodes.PartitionKeyRangeGone;
+            Assert.IsTrue((await feedRangeCompositeContinuation.HandleSplitAsync(containerCore.Object, split, default(CancellationToken))).ShouldRetry);
+
+            // verify token state
+            // Split should have updated initial and created a new token at the end
+            Assert.AreEqual(3, feedRangeCompositeContinuation.CompositeContinuationTokens.Count);
+            CompositeContinuationToken[] continuationTokens = feedRangeCompositeContinuation.CompositeContinuationTokens.ToArray();
+            // First token is split
+            Assert.AreEqual(JsonConvert.DeserializeObject<CompositeContinuationToken>(compositeContinuationTokens[0].Token).Range.Min, JsonConvert.DeserializeObject<CompositeContinuationToken>(continuationTokens[0].Token).Range.Min);
+            Assert.AreEqual(JsonConvert.DeserializeObject<CompositeContinuationToken>(compositeContinuationTokens[0].Token).Token, JsonConvert.DeserializeObject<CompositeContinuationToken>(continuationTokens[0].Token).Token);
+            Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[0].MinInclusive, continuationTokens[0].Range.Min);
+            Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[0].MaxExclusive, continuationTokens[0].Range.Max);
+
+            // Second token remains the same
+            Assert.AreEqual(compositeContinuationTokens[1].Token, continuationTokens[1].Token);
+            Assert.AreEqual(compositeContinuationTokens[1].Range.Min, continuationTokens[1].Range.Min);
+            Assert.AreEqual(compositeContinuationTokens[1].Range.Max, continuationTokens[1].Range.Max);
+
+            // New third token
+            Assert.AreEqual(JsonConvert.DeserializeObject<CompositeContinuationToken>(compositeContinuationTokens[0].Token).Range.Max, JsonConvert.DeserializeObject<CompositeContinuationToken>(continuationTokens[2].Token).Range.Max);
+            Assert.AreEqual(JsonConvert.DeserializeObject<CompositeContinuationToken>(compositeContinuationTokens[0].Token).Token, JsonConvert.DeserializeObject<CompositeContinuationToken>(continuationTokens[2].Token).Token);
             Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[1].MinInclusive, continuationTokens[2].Range.Min);
             Assert.AreEqual(documentClient.AvailablePartitionKeyRanges[1].MaxExclusive, continuationTokens[2].Range.Max);
         }


### PR DESCRIPTION
## Description

ReadFeed operations go through the `PartitionKeyRangeHandler` to resolve and the continuation token gets wrapped into a `CompositeContinuationToken`: https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs#L132

This wrapping only affects Document ReadFeeds because Change Feed does not use CT (but rather ETag).

`FeedRangeContinuation` handles splits by creating a list of CompositeContinuationTokens for the child partitions and copying the parent's continuation to them.

For ReadFeed the problem is that if we just simply copy the token to the children, the Token has the original range that got processed by the PartitionKeyRangeHandler and when the next request happens and it sends the parent's CT, the PartitionKeyRangeHandler will try and honor the CT's Range instead of the FeedRange: https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Handler/PartitionKeyRangeHandler.cs#L94

### Example

Start point:
FeedRangeContinuation A
Continuation = [ {min:_, max:FF, token: null} ]

After first response:
FeedRangeContinuation A
Continuation = [ {min:_, max:FF, token: "{ min: "_", max: "FF", token:"something"}"} ] <-- this is the format from PartitionKeyRangeHandler

Split happens:
If we blindly copy the Continuation to the children we land in:
FeedRangeContinuation B
Continuation = [
    {min:_, max:AA, token: "{ min: "_", max: "FF", token:"something"}"},
    {min:AA, max:FF, token: "{ min: "_", max: "FF", token:"something"}"}
  ] 

And then it gets sent through the PartitionKeyRangeHandler, it generates duplicity.

This PR fixes the Split detection by understanding when the format used is a composite CT (only on ReadFeed, not Change Feed), and it correctly adapts the result:

Split happens:
FeedRangeContinuation B
Continuation = [
    {min:_, max:AA, token: "{ min: "_", max: "AA", token:"something"}"},
    {min:AA, max:FF, token: "{ min: "AA", max: "FF", token:"something"}"}
  ] 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)