### PR TITLE
Transport: Fix HttpClientFactory on GatewayAccountReader

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6909,7 +6909,22 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task InitializeGatewayConfigurationReaderAsync()
         {
-            GatewayAccountReader accountReader = new GatewayAccountReader(
+            GatewayAccountReader accountReader = null;
+
+            if (this.ConnectionPolicy.HttpClientFactory != null)
+            {
+                new GatewayAccountReader(
+                    this.ServiceEndpoint,
+                    this.authKeyHashFunction,
+                    this.hasAuthKeyResourceToken,
+                    this.authKeyResourceToken,
+                    this.ConnectionPolicy,
+                    this.ApiType,
+                    this.ConnectionPolicy.HttpClientFactory);
+            }
+            else
+            {
+                new GatewayAccountReader(
                     this.ServiceEndpoint,
                     this.authKeyHashFunction,
                     this.hasAuthKeyResourceToken,
@@ -6917,6 +6932,7 @@ namespace Microsoft.Azure.Cosmos
                     this.ConnectionPolicy,
                     this.ApiType,
                     this.httpMessageHandler);
+            }
 
             this.accountServiceConfiguration = new CosmosAccountServiceConfiguration(accountReader.InitializeReaderAsync);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAccountReaderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAccountReaderTests.cs
@@ -1,0 +1,88 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Net.Http;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Microsoft.Azure.Documents;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System.Net;
+
+    /// <summary>
+    /// Tests for <see cref="GatewayAccountReader"/>.
+    /// </summary>
+    [TestClass]
+    public class GatewayAccountReaderTests
+    {
+        [TestMethod]
+        public void GatewayAccountReader_HttpClientFactory()
+        {
+            HttpClient staticHttpClient = new HttpClient();
+
+            Mock<Func<HttpClient>> mockFactory = new Mock<Func<HttpClient>>();
+            mockFactory.Setup(f => f()).Returns(staticHttpClient);
+
+            GatewayAccountReader accountReader = new GatewayAccountReader(
+                new Uri("https://localhost"),
+                Mock.Of<IComputeHash>(),
+                false,
+                null,
+                new ConnectionPolicy(),
+                ApiType.None,
+                mockFactory.Object);
+
+            Mock.Get(mockFactory.Object)
+                .Verify(f => f(), Times.Once);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void GatewayAccountReader_HttpClientFactory_IfNull()
+        {
+            HttpClient staticHttpClient = null;
+
+            Mock<Func<HttpClient>> mockFactory = new Mock<Func<HttpClient>>();
+            mockFactory.Setup(f => f()).Returns(staticHttpClient);
+
+            GatewayAccountReader accountReader = new GatewayAccountReader(
+                new Uri("https://localhost"),
+                Mock.Of<IComputeHash>(),
+                false,
+                null,
+                new ConnectionPolicy(),
+                ApiType.None,
+                mockFactory.Object);
+        }
+
+        [TestMethod]
+        public async Task GatewayAccountReader_MessageHandler()
+        {
+            HttpMessageHandler messageHandler = new CustomMessageHandler();
+
+            GatewayAccountReader accountReader = new GatewayAccountReader(
+                new Uri("https://localhost"),
+                Mock.Of<IComputeHash>(),
+                false,
+                null,
+                new ConnectionPolicy(),
+                ApiType.None,
+                messageHandler: messageHandler);
+
+            DocumentClientException exception = await Assert.ThrowsExceptionAsync<DocumentClientException>(() => accountReader.InitializeReaderAsync());
+            Assert.AreEqual(HttpStatusCode.NotFound, exception.StatusCode);
+        }
+
+        public class CustomMessageHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { RequestMessage = request, Content = new StringContent("Notfound") });
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

#1429 added support for HttpClientFactory inside the gateway connection mode, but the `DocumentClient` was maintaining another `HttpClient` to be used for reading the account details (AccountProperties).

If the user was trying to use a custom HttpClientFactory to use a single HttpClient instance, it was not reaching the `GatewayAccountReader`.

This PR wires the factory for the `GatewayAccountReader` too and adds tests to verify new and previous scenarios since we had no tests for this class.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
