### PR TITLE
[vNext] Contract: Fix Move SpatialPath to base namespace

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/IndexingPolicy.cs
@@ -7,7 +7,6 @@ namespace Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using Azure.Cosmos.Spatial;
 
     /// <summary>
     /// Represents the indexing policy configuration for a collection in the Azure Cosmos DB service.
@@ -248,8 +247,8 @@ namespace Azure.Cosmos
                     return false;
                 }
 
-                HashSet<Spatial.SpatialType> hashedSpatialTypes1 = new HashSet<Spatial.SpatialType>(spatialSpec1.SpatialTypes);
-                HashSet<Spatial.SpatialType> hashedSpatialTypes2 = new HashSet<Spatial.SpatialType>(spatialSpec2.SpatialTypes);
+                HashSet<SpatialType> hashedSpatialTypes1 = new HashSet<SpatialType>(spatialSpec1.SpatialTypes);
+                HashSet<SpatialType> hashedSpatialTypes2 = new HashSet<SpatialType>(spatialSpec2.SpatialTypes);
 
                 if (!hashedSpatialTypes1.SetEquals(hashedSpatialTypes2))
                 {
@@ -263,7 +262,7 @@ namespace Azure.Cosmos
             {
                 int hashCode = 0;
                 hashCode ^= spatialSpec.Path.GetHashCode();
-                foreach (Spatial.SpatialType spatialType in spatialSpec.SpatialTypes)
+                foreach (SpatialType spatialType in spatialSpec.SpatialTypes)
                 {
                     hashCode ^= spatialType.GetHashCode();
                 }

--- a/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialPath.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Resource/Settings/SpatialPath.cs
@@ -1,7 +1,7 @@
 ﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
-namespace Azure.Cosmos.Spatial
+namespace Azure.Cosmos
 {
     using System;
     using System.Collections.ObjectModel;

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonSpatialPathConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/Settings/TextJsonSpatialPathConverter.cs
@@ -9,7 +9,6 @@ namespace Azure.Cosmos
     using System.Globalization;
     using System.Text.Json;
     using System.Text.Json.Serialization;
-    using Azure.Cosmos.Spatial;
     using Microsoft.Azure.Documents;
 
     internal class TextJsonSpatialPathConverter : JsonConverter<SpatialPath>
@@ -59,7 +58,7 @@ namespace Azure.Cosmos
             {
                 writer.WritePropertyName(JsonEncodedStrings.Types);
                 writer.WriteStartArray();
-                foreach (Spatial.SpatialType type in path.SpatialTypes)
+                foreach (SpatialType type in path.SpatialTypes)
                 {
                     writer.WriteStringValue(type.ToString());
                 }
@@ -91,10 +90,10 @@ namespace Azure.Cosmos
             }
             else if (property.NameEquals(JsonEncodedStrings.Types.EncodedUtf8Bytes))
             {
-                path.SpatialTypes = new Collection<Spatial.SpatialType>();
+                path.SpatialTypes = new Collection<SpatialType>();
                 foreach (JsonElement item in property.Value.EnumerateArray())
                 {
-                    TextJsonSettingsHelper.TryParseEnum<Spatial.SpatialType>(item, type => path.SpatialTypes.Add(type));
+                    TextJsonSettingsHelper.TryParseEnum<SpatialType>(item, type => path.SpatialTypes.Add(type));
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/SpatialType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Enums/SpatialType.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 #if AZURECORE
-namespace Azure.Cosmos.Spatial
+namespace Azure.Cosmos
 #else
 namespace Microsoft.Azure.Cosmos
 #endif

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyEqualityComparer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.EmulatorTests/IndexingPolicyEqualityComparer.cs
@@ -7,7 +7,6 @@ namespace Azure.Cosmos.EmulatorTests
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using Azure.Cosmos.Spatial;
 
     #region EqualityComparers
     internal sealed class CompositePathEqualityComparer : IEqualityComparer<CompositePath>

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/ContractTests.cs
@@ -31,11 +31,10 @@ namespace Azure.Cosmos.Tests
         [TestMethod]
         public void ClientDllNamespaceTest()
         {
-
 #if INTERNAL
-            int expected = 6;
-#else
             int expected = 5;
+#else
+            int expected = 4;
 #endif
             ContractTests.NamespaceCountTest(typeof(CosmosClient), expected);
         }

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2134,10 +2134,10 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String)"
         },
-        "Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Azure.Cosmos.Spatial.SpatialType[])": {
+        "Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Azure.Cosmos.SpatialType[])": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Azure.Cosmos.Spatial.SpatialType[])"
+          "MethodInfo": "Azure.Cosmos.Fluent.SpatialIndexDefinition`1[T] Path(System.String, Azure.Cosmos.SpatialType[])"
         },
         "T Attach()": {
           "Type": "Method",
@@ -2296,14 +2296,14 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialPath] get_SpatialIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialPath] get_SpatialIndexes()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialPath] get_SpatialIndexes()"
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialPath] get_SpatialIndexes()"
         },
-        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialPath] SpatialIndexes": {
+        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialPath] SpatialIndexes": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
@@ -3918,12 +3918,12 @@
     "SpatialPath": {
       "Subclasses": {},
       "Members": {
-        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialType] get_SpatialTypes()": {
+        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialType] get_SpatialTypes()": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialType] get_SpatialTypes()"
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialType] get_SpatialTypes()"
         },
-        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.Spatial.SpatialType] SpatialTypes": {
+        "System.Collections.ObjectModel.Collection`1[Azure.Cosmos.SpatialType] SpatialTypes": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
@@ -3958,22 +3958,22 @@
     "SpatialType": {
       "Subclasses": {},
       "Members": {
-        "Azure.Cosmos.Spatial.SpatialType LineString": {
+        "Azure.Cosmos.SpatialType LineString": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null
         },
-        "Azure.Cosmos.Spatial.SpatialType MultiPolygon": {
+        "Azure.Cosmos.SpatialType MultiPolygon": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null
         },
-        "Azure.Cosmos.Spatial.SpatialType Point": {
+        "Azure.Cosmos.SpatialType Point": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null
         },
-        "Azure.Cosmos.Spatial.SpatialType Polygon": {
+        "Azure.Cosmos.SpatialType Polygon": {
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": null

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
@@ -31,10 +31,11 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ClientDllNamespaceTest()
         {
+
 #if INTERNAL
-            int expected = 6;
+            int expected = 7;
 #else
-            int expected = 4;
+            int expected = 5;
 #endif
             ContractTests.NamespaceCountTest(typeof(CosmosClient), expected);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Azure.Cosmos
         {
 
 #if INTERNAL
-            int expected = 7;
+            int expected = 6;
 #else
-            int expected = 5;
+            int expected = 4;
 #endif
             ContractTests.NamespaceCountTest(typeof(CosmosClient), expected);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ContractTests.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ClientDllNamespaceTest()
         {
-
 #if INTERNAL
             int expected = 6;
 #else


### PR DESCRIPTION
## Description

This PR removes Azure.Cosmos.Spatial from the public surface and moves the remaining SpatialPath and SpatialType that are used on IndexingPolicy to the base namespace.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
