### PR TITLE
[Internal] Diagnostics: Fix bug causing flaky test

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosClientSideRequestStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosClientSideRequestStatistics.cs
@@ -18,11 +18,12 @@ namespace Microsoft.Azure.Cosmos
     {
         public const string DefaultToStringMessage = "Please see CosmosDiagnostics";
         private readonly object lockObject = new object();
-        private readonly long firstStartRequestTimestamp;
+        private readonly long clientSideRequestStatisticsCreateTime;
 
-        private long lastStartRequestTimestamp;
-        private long cumulativeEstimatedDelayDueToRateLimitingInStopwatchTicks;
-        private bool received429ResponseSinceLastStartRequest;
+        private long? firstStartRequestTimestamp;
+        private long? lastStartRequestTimestamp;
+        private long cumulativeEstimatedDelayDueToRateLimitingInStopwatchTicks = 0;
+        private bool received429ResponseSinceLastStartRequest = false;
 
         public CosmosClientSideRequestStatistics(CosmosDiagnosticsContext diagnosticsContext = null)
         {
@@ -34,9 +35,7 @@ namespace Microsoft.Azure.Cosmos
             this.RegionsContacted = new HashSet<Uri>();
             this.DiagnosticsContext = diagnosticsContext ?? new CosmosDiagnosticsContextCore();
             this.DiagnosticsContext.AddDiagnosticsInternal(this);
-
-            this.firstStartRequestTimestamp = Stopwatch.GetTimestamp();
-            this.lastStartRequestTimestamp = this.firstStartRequestTimestamp;
+            this.clientSideRequestStatisticsCreateTime = Stopwatch.GetTimestamp();
         }
 
         private DateTime RequestStartTimeUtc { get; }
@@ -72,7 +71,19 @@ namespace Microsoft.Azure.Cosmos
 
         public TimeSpan EstimatedClientDelayFromRateLimiting => TimeSpan.FromSeconds(this.cumulativeEstimatedDelayDueToRateLimitingInStopwatchTicks / (double)Stopwatch.Frequency);
 
-        public TimeSpan EstimatedClientDelayFromAllCauses => TimeSpan.FromSeconds((this.lastStartRequestTimestamp - this.firstStartRequestTimestamp) / (double)Stopwatch.Frequency);
+        public TimeSpan EstimatedClientDelayFromAllCauses
+        {
+            get
+            {
+                if (!this.lastStartRequestTimestamp.HasValue || !this.firstStartRequestTimestamp.HasValue)
+                {
+                    return TimeSpan.Zero;
+                }
+
+                long clientDelayInTicks = this.lastStartRequestTimestamp.Value - this.firstStartRequestTimestamp.Value;
+                return TimeSpan.FromSeconds(clientDelayInTicks / (double)Stopwatch.Frequency);
+            }
+        }
 
         public void RecordRequest(DocumentServiceRequest request)
         {
@@ -81,8 +92,15 @@ namespace Microsoft.Azure.Cosmos
                 long timestamp = Stopwatch.GetTimestamp();
                 if (this.received429ResponseSinceLastStartRequest)
                 {
-                    this.cumulativeEstimatedDelayDueToRateLimitingInStopwatchTicks += timestamp - this.lastStartRequestTimestamp;
+                    long lastTimestamp = this.lastStartRequestTimestamp ?? this.clientSideRequestStatisticsCreateTime;
+                    this.cumulativeEstimatedDelayDueToRateLimitingInStopwatchTicks += timestamp - lastTimestamp;
                 }
+
+                if (!this.firstStartRequestTimestamp.HasValue)
+                {
+                    this.firstStartRequestTimestamp = timestamp;
+                }
+
                 this.lastStartRequestTimestamp = timestamp;
                 this.received429ResponseSinceLastStartRequest = false;
             }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosClientSideRequestStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosClientSideRequestStatistics.cs
@@ -80,8 +80,9 @@ namespace Microsoft.Azure.Cosmos
                     return TimeSpan.Zero;
                 }
 
-                long clientDelayInTicks = this.lastStartRequestTimestamp.Value - this.firstStartRequestTimestamp.Value;
-                return TimeSpan.FromSeconds(clientDelayInTicks / (double)Stopwatch.Frequency);
+                // Stopwatch ticks are not equivalent to DateTime ticks
+                long clientDelayInStopWatchTicks = this.lastStartRequestTimestamp.Value - this.firstStartRequestTimestamp.Value;
+                return TimeSpan.FromSeconds(clientDelayInStopWatchTicks / (double)Stopwatch.Frequency);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
+    using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.TransportClientHelper;
 
     [TestClass]
     public class CosmosDiagnosticsTests : BaseCosmosClientHelper
@@ -126,6 +127,67 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     Assert.IsFalse(string.IsNullOrEmpty(diagnosics));
                     Assert.IsTrue(exception.Contains(diagnosics));
+                    DiagnosticValidator.ValidatePointOperationDiagnostics(ce.DiagnosticsContext);
+                }
+            }
+        }
+
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public async Task PointOperationThrottledDiagnostic(bool disableDiagnostics)
+        {
+            string errorMessage = "Mock throttle exception" + Guid.NewGuid().ToString();
+            Guid exceptionActivityId = Guid.NewGuid();
+            // Set a small retry count to reduce test time
+            CosmosClient throttleClient = TestCommon.CreateCosmosClient(builder =>
+                builder.WithThrottlingRetryOptions(TimeSpan.FromSeconds(5), 5)
+                .WithTransportClientHandlerFactory(transportClient => new TransportClientWrapper(
+                       transportClient,
+                       (uri, resourceOperation, request) => TransportClientHelper.ReturnThrottledStoreResponseOnItemOperation(
+                            uri,
+                            resourceOperation,
+                            request,
+                            exceptionActivityId,
+                            errorMessage)))
+                );
+
+            ItemRequestOptions requestOptions = new ItemRequestOptions();
+            if (disableDiagnostics)
+            {
+                requestOptions.DiagnosticContextFactory = () => EmptyCosmosDiagnosticsContext.Singleton;
+            };
+
+            Container containerWithThrottleException = throttleClient.GetContainer(
+                this.database.Id,
+                this.Container.Id);
+
+            //Checking point operation diagnostics on typed operations
+            ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+            try
+            {
+                ItemResponse<ToDoActivity> createResponse = await containerWithThrottleException.CreateItemAsync<ToDoActivity>(
+                  item: testItem,
+                  requestOptions: requestOptions);
+                Assert.Fail("Should have thrown a request timeout exception");
+            }
+            catch (CosmosException ce) when ((int)ce.StatusCode == (int)Documents.StatusCodes.TooManyRequests)
+            {
+                string exception = ce.ToString();
+                Assert.IsNotNull(exception);
+                Assert.IsTrue(exception.Contains(exceptionActivityId.ToString()));
+                Assert.IsTrue(exception.Contains(errorMessage));
+
+                string diagnosics = ce.Diagnostics.ToString();
+                if (disableDiagnostics)
+                {
+                    Assert.IsTrue(string.IsNullOrEmpty(diagnosics));
+                }
+                else
+                {
+                    Assert.IsFalse(string.IsNullOrEmpty(diagnosics));
+                    Assert.IsTrue(exception.Contains(diagnosics));
+                    DiagnosticValidator.ValidatePointOperationDiagnostics(ce.DiagnosticsContext);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
@@ -194,7 +194,8 @@ namespace Microsoft.Azure.Cosmos
 
             Assert.IsNotNull(stats.RequestUri);
             Assert.IsNotNull(stats.RequestCharge);
-            if (stats.StatusCode != HttpStatusCode.RequestEntityTooLarge)
+            if (stats.StatusCode != HttpStatusCode.RequestEntityTooLarge &&
+                stats.StatusCode != HttpStatusCode.RequestTimeout)
             {
                 Assert.IsTrue(stats.RequestCharge > 0);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 headers.Add(HttpConstants.HttpHeaders.ActivityId, activityId.ToString());
                 headers.Add(WFConstants.BackendHeaders.SubStatus, ((int)SubStatusCodes.WriteForbidden).ToString(CultureInfo.InvariantCulture));
                 headers.Add(HttpConstants.HttpHeaders.RetryAfterInMilliseconds, TimeSpan.FromMilliseconds(100).TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
-                headers.Add(HttpConstants.HttpHeaders.RequestCharge, ((double)429).ToString(CultureInfo.InvariantCulture));
+                headers.Add(HttpConstants.HttpHeaders.RequestCharge, ((double)9001).ToString(CultureInfo.InvariantCulture));
 
                 StoreResponse storeResponse = new StoreResponse()
                 {
@@ -121,6 +121,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 DictionaryNameValueCollection headers = new DictionaryNameValueCollection();
                 headers.Add(HttpConstants.HttpHeaders.ActivityId, activityId.ToString());
                 headers.Add(WFConstants.BackendHeaders.SubStatus, ((int)SubStatusCodes.WriteForbidden).ToString(CultureInfo.InvariantCulture));
+                headers.Add(HttpConstants.HttpHeaders.RequestCharge, ((double)9001).ToString(CultureInfo.InvariantCulture));
 
                 ForbiddenException forbiddenException = new ForbiddenException(
                     errorMessage,


### PR DESCRIPTION
# Pull Request Template

## Description

The firstStartRequestTimestamp was getting set to the CosmosClientSideRequestStatistics creation time, and not the actual first request start time. This would cause the EstimatedClientDelayFromAllCauses to show a small value when it should be 0 since there was no failures.

Bug introduced in https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1570 which has not been released.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.

