### PR TITLE
Query : Fix Multi- ORDER BY continuation token support with QueryExecutionInfo Response headers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducer.cs
@@ -213,6 +213,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers
         /// </summary>
         public Guid ActivityId { get; private set; }
 
+        public CosmosQueryExecutionInfo CosmosQueryExecutionInfo { get; private set; }
+
         /// <summary>
         /// Gets the current document in this producer.
         /// </summary>
@@ -272,6 +274,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers
                     isContinuationExpected: this.queryContext.IsContinuationExpected,
                     pageSize: pageSize,
                     cancellationToken: token);
+
+                this.CosmosQueryExecutionInfo = feedResponse.CosmosQueryExecutionInfo;
 
                 if ((this.testFlags != null) && this.testFlags.SimulateThrottles)
                 {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducerTree.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/ItemProducers/ItemProducerTree.cs
@@ -349,6 +349,21 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.ItemProducers
             }
         }
 
+        public CosmosQueryExecutionInfo CosmosQueryExecutionInfo
+        {
+            get
+            {
+                if (this.CurrentItemProducerTree == this)
+                {
+                    return this.Root.CosmosQueryExecutionInfo;
+                }
+                else
+                {
+                    return this.CurrentItemProducerTree.CosmosQueryExecutionInfo;
+                }
+            }
+        }
+
         /// <summary>
         /// Gets the current item from the document producer tree.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
@@ -396,11 +396,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
 
                         // Once the item matches the order by items from the continuation tokens
                         // We still need to remove all the documents that have a lower rid in the rid sort order.
-                        // If there is a tie in the sort order the documents should be in _rid order in the same direction as the first order by field.
-                        // So if it's ORDER BY c.age ASC, c.name DESC the _rids are ASC 
-                        // If ti's ORDER BY c.age DESC, c.name DESC the _rids are DESC
+                        // If there is a tie in the sort order the documents should be in _rid order in the same direction as the index (given by the backend)
                         cmp = continuationRid.Document.CompareTo(rid.Document);
-                        if (sortOrders[0] == SortOrder.Descending)
+                        if (producer.CosmosQueryExecutionInfo.ReverseRidEnabled)
                         {
                             cmp = -cmp;
                         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
@@ -400,7 +400,19 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
                         cmp = continuationRid.Document.CompareTo(rid.Document);
                         if (producer.CosmosQueryExecutionInfo.ReverseRidEnabled)
                         {
-                            cmp = -cmp;
+                            // If reverse rid is enabled on the backend then fallback to the old way of doing it.
+                            if (sortOrders[0] == SortOrder.Descending)
+                            {
+                                cmp = -cmp;
+                            }
+                        }
+                        else
+                        {
+                            // Go by the whatever order the index wants
+                            if (producer.CosmosQueryExecutionInfo.ReverseIndexScan)
+                            {
+                                cmp = -cmp;
+                            }
                         }
 
                         // We might have passed the item due to deletions and filters.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
@@ -15,9 +15,15 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             this.ReverseIndexScan = reverseIndexScan;
         }
 
+        /// <summary>
+        /// Whether or not the backend has the reverseRid feature enabled.
+        /// </summary>
         [JsonProperty("reverseRidEnabled")]
         public bool ReverseRidEnabled { get; }
 
+        /// <summary>
+        /// Indicates the direction of the index scan.
+        /// </summary>
         [JsonProperty("reverseIndexScan")]
         public bool ReverseIndexScan { get; }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
@@ -1,0 +1,24 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
+{
+    using Newtonsoft.Json;
+
+    internal sealed class CosmosQueryExecutionInfo
+    {
+        [JsonConstructor]
+        public CosmosQueryExecutionInfo(bool reverseRidEnabled, bool reverseIndexScan)
+        {
+            this.ReverseRidEnabled = reverseRidEnabled;
+            this.ReverseIndexScan = reverseIndexScan;
+        }
+
+        [JsonProperty("reverseRidEnabled")]
+        public bool ReverseRidEnabled { get; }
+
+        [JsonProperty("reverseIndexScan")]
+        public bool ReverseIndexScan { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/QueryResponseCore.cs
@@ -5,13 +5,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Linq;
     using System.Net;
-    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Query.Core.Metrics;
     using SubStatusCodes = Documents.SubStatusCodes;
 
 #if INTERNAL
@@ -37,7 +32,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             string disallowContinuationTokenMessage,
             string continuationToken,
             CosmosException cosmosException,
-            SubStatusCodes? subStatusCode)
+            SubStatusCodes? subStatusCode,
+            CosmosQueryExecutionInfo cosmosQueryExecutionInfo = default)
         {
             this.IsSuccess = isSuccess;
             this.CosmosElements = result;
@@ -49,6 +45,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             this.ContinuationToken = continuationToken;
             this.CosmosException = cosmosException;
             this.SubStatusCode = subStatusCode;
+            this.CosmosQueryExecutionInfo = cosmosQueryExecutionInfo;
         }
 
         internal IReadOnlyList<CosmosElement> CosmosElements { get; }
@@ -69,6 +66,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
 
         internal long ResponseLengthBytes { get; }
 
+        internal CosmosQueryExecutionInfo CosmosQueryExecutionInfo { get; }
+
         internal bool IsSuccess { get; }
 
         internal static QueryResponseCore CreateSuccess(
@@ -77,7 +76,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             string activityId,
             long responseLengthBytes,
             string disallowContinuationTokenMessage,
-            string continuationToken)
+            string continuationToken,
+            CosmosQueryExecutionInfo cosmosQueryExecutionInfo = default)
         {
             QueryResponseCore cosmosQueryResponse = new QueryResponseCore(
                result: result,
@@ -89,7 +89,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
                disallowContinuationTokenMessage: disallowContinuationTokenMessage,
                continuationToken: continuationToken,
                cosmosException: null,
-               subStatusCode: null);
+               subStatusCode: null,
+               cosmosQueryExecutionInfo: cosmosQueryExecutionInfo);
 
             return cosmosQueryResponse;
         }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
@@ -77,18 +77,18 @@ namespace Microsoft.Azure.Cosmos.Query
             }    
 
             return this.QueryClient.ExecuteItemQueryAsync(
-                           resourceUri: this.ResourceLink,
-                           resourceType: this.ResourceTypeEnum,
-                           operationType: this.OperationTypeEnum,
-                           clientQueryCorrelationId: this.CorrelatedActivityId,
-                           requestOptions: requestOptions,
-                           sqlQuerySpec: querySpecForInit,
-                           continuationToken: continuationToken,
-                           partitionKeyRange: partitionKeyRange,
-                           isContinuationExpected: isContinuationExpected,
-                           pageSize: pageSize,
-                           queryPageDiagnostics: this.AddQueryPageDiagnostic,
-                           cancellationToken: cancellationToken);
+                resourceUri: this.ResourceLink,
+                resourceType: this.ResourceTypeEnum,
+                operationType: this.OperationTypeEnum,
+                clientQueryCorrelationId: this.CorrelatedActivityId,
+                requestOptions: requestOptions,
+                sqlQuerySpec: querySpecForInit,
+                continuationToken: continuationToken,
+                partitionKeyRange: partitionKeyRange,
+                isContinuationExpected: isContinuationExpected,
+                pageSize: pageSize,
+                queryPageDiagnostics: this.AddQueryPageDiagnostic,
+                cancellationToken: cancellationToken);
         }
 
         internal override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(


### PR DESCRIPTION
# Internal Query : Fix ReverseRid with QueryExecutionInfo Response headers

## Description

Wires through QueryExeuctionInfo to determine when the Rids are reversed on order by resume keys. This is necessary, since comparing just the first column leads to a bug. 
