### PR TITLE
[vNext] Logging: Fix NotImplementedException while using ConsoleLogger

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Handler/RequestMessage.cs
@@ -243,10 +243,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <inheritdoc />
-        protected override IEnumerable<HttpHeader> EnumerateHeaders()
-        {
-            throw new NotImplementedException();
-        }
+        protected override IEnumerable<HttpHeader> EnumerateHeaders() => this.CosmosHeaders.GetHttpHeaders();
 
         private static Dictionary<string, object> CreateDictionary()
         {

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Diagnostics/DiagnosticsScopeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/Diagnostics/DiagnosticsScopeTests.cs
@@ -1,7 +1,9 @@
 ﻿namespace Azure.Cosmos.Tests
 {
     using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
     using System.Threading.Tasks;
+    using Azure.Core.Diagnostics;
     using Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Documents;
@@ -30,6 +32,22 @@
                 new KeyValuePair<string, string>(DiagnosticProperty.Container, "dbs/test/colls/test"),
                 new KeyValuePair<string, string>(DiagnosticProperty.ResourceType, ResourceType.Document.ToString()),
                 new KeyValuePair<string, string>(DiagnosticProperty.OperationType, OperationType.Create.ToString()));
+        }
+
+        [TestMethod]
+        public async Task VerifyConsoleLogger()
+        {
+            AzureEventSourceListener.CreateConsoleLogger(EventLevel.Informational);
+
+            CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+
+            TestHandler testHandler = new TestHandler((request, cancellationToken) =>
+            {
+                return TestHandler.ReturnSuccess(new MockDiagnostics());
+            });
+
+            client.RequestHandler.InnerHandler = testHandler;
+            await client.GetContainer("test", "test").CreateItemAsync(new Dictionary<string, object> { { "id", "test" } });
         }
 
         private class MockDiagnostics : CosmosDiagnostics


### PR DESCRIPTION
## Description

`AzureEventSourceListener` console logger calls the `EnumerateHeaders` on the Request and Response on the Core pipeline.

Response had the method implemented, but Request did not.

This PR adds the correct implementation call on Request to avoid the exception on the logger.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1592