### PR TITLE
[Internal] Performance: Add TimerWheel implementation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
@@ -6,6 +6,22 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
 
+    /// <summary>
+    /// TimerWheel is a Simple TimerWheel implementation that uses a single System.Threading.Timer to maintain a wheel.
+    /// Creation of the wheel requires the resolution of each wheel's bucket and the amount of buckets, which define which its MaxInterval.
+    /// Timed-based tasks can use <see cref="TimerWheel.CreateTimer(TimeSpan)"/> to obtain a new timer.
+    /// Starting the timer through <see cref="TimerWheelTimer.StartTimerAsync()"/> returns a Task that can be awaited and will complete on time expiration.
+    /// </summary>
+    /// <example>
+    /// <code language="c#">
+    /// <![CDATA[
+    /// TimerWheel wheel = TimerWheel.CreateTimerWheel(resolution: TimeSpan.FromMilliseconds(50), buckets: 20);
+    /// TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(100));
+    /// await timer.StartTimerAsync();
+    /// ]]>
+    /// </code>
+    /// </example>
+#nullable enable
     internal abstract class TimerWheel : IDisposable
     {
         public abstract void Dispose();
@@ -13,8 +29,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns a <see cref="TimerWheelTimer"/> that can be used and started.
         /// </summary>
-        /// <param name="timeoutInMs">A timeout in milliseconds</param>
-        public abstract TimerWheelTimer GetTimer(int timeoutInMs);
+        /// <param name="timeout">The timeout</param>
+        public abstract TimerWheelTimer CreateTimer(TimeSpan timeout);
 
         public abstract void SubscribeForTimeouts(TimerWheelTimer timer);
 
@@ -22,15 +38,15 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a new <see cref="TimerWheel"/> which is a simple timer wheel implementation
         /// </summary>
         /// <remarks>
-        /// The <paramref name="resolutionInMs"/> defines the minimum supported timeout and <paramref name="buckets"/> times <paramref name="resolutionInMs"/> define the maximum supported timeout.
+        /// The <paramref name="resolution"/> defines the minimum supported timeout and <paramref name="buckets"/> times <paramref name="resolution"/> define the maximum supported timeout.
         /// </remarks>
-        /// <param name="resolutionInMs">Amount of milliseconds per wheel slice.</param>
+        /// <param name="resolution">Amount of time for each wheel step.</param>
         /// <param name="buckets">Amount of slices in the wheel</param>
         public static TimerWheel CreateTimerWheel(
-            int resolutionInMs,
+            TimeSpan resolution,
             int buckets)
         {
-            return new Timers.TimerWheelCore(resolutionInMs, buckets);   
+            return new Timers.TimerWheelCore(resolution, buckets);   
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
@@ -10,10 +10,22 @@ namespace Microsoft.Azure.Cosmos
     {
         public abstract void Dispose();
 
+        /// <summary>
+        /// Returns a <see cref="TimerWheelTimer"/> that can be used and started.
+        /// </summary>
+        /// <param name="timeoutInMs">A timeout in milliseconds</param>
         public abstract TimerWheelTimer GetTimer(int timeoutInMs);
 
         public abstract void SubscribeForTimeouts(TimerWheelTimer timer);
 
+        /// <summary>
+        /// Creates a new <see cref="TimerWheel"/> which is a simple timer wheel implementation
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="resolutionInMs"/> defines the minimum supported timeout and <paramref name="buckets"/> times <paramref name="resolutionInMs"/> define the maximum supported timeout.
+        /// </remarks>
+        /// <param name="resolutionInMs">Amount of milliseconds per wheel slice.</param>
+        /// <param name="buckets">Amount of slices in the wheel</param>
         public static TimerWheel CreateTimerWheel(
             int resolutionInMs,
             int buckets)

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheel.cs
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    internal abstract class TimerWheel : IDisposable
+    {
+        public abstract void Dispose();
+
+        public abstract TimerWheelTimer GetTimer(int timeoutInMs);
+
+        public abstract void SubscribeForTimeouts(TimerWheelTimer timer);
+
+        public static TimerWheel CreateTimerWheel(
+            int resolutionInMs,
+            int buckets)
+        {
+            return new Timers.TimerWheelCore(resolutionInMs, buckets);   
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelCore.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelCore.cs
@@ -1,0 +1,195 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Timers
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Threading;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+
+    internal class TimerWheelCore : TimerWheel, IDisposable
+    {
+        private readonly ConcurrentDictionary<int, ConcurrentQueue<TimerWheelTimer>> timers;
+        private readonly int resolutionInTicks;
+        private readonly int resolutionInMs;
+        private readonly int buckets;        
+        private readonly Timer timer;
+        private readonly object subscriptionLock;
+        private readonly object timerConcurrencyLock;
+        private bool isDisposed = false;
+        private bool isRunning = false;
+        private int expirationIndex = 0;
+
+        internal TimerWheelCore(
+            int resolutionInMs,
+            int buckets)
+        {
+            if (resolutionInMs <= 20)
+            {
+                throw new ArgumentOutOfRangeException(nameof(resolutionInMs), "Value is too low, machine resolution less than 20 ms has unexpected results https://docs.microsoft.com/dotnet/api/system.threading.timer");
+            }
+
+            if (buckets <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(buckets));
+            }
+
+            this.resolutionInMs = resolutionInMs;
+            this.resolutionInTicks = (int)TimeSpan.FromMilliseconds(resolutionInMs).Ticks;
+            this.buckets = buckets;
+            this.timers = new ConcurrentDictionary<int, ConcurrentQueue<TimerWheelTimer>>();
+            this.subscriptionLock = new object();
+            this.timerConcurrencyLock = new object();
+            this.timer = new Timer(this.OnTimer, state: null, this.resolutionInMs, this.resolutionInMs);
+        }
+
+        /// <summary>
+        /// Used only for unit tests.
+        /// </summary>
+        internal TimerWheelCore(
+            int resolutionInMs,
+            int buckets,
+            Timer timer)
+            : this(resolutionInMs, buckets)
+        {
+            this.timer.Dispose();
+            this.timer = timer;
+        }
+
+        public override void Dispose()
+        {
+            if (this.isDisposed)
+            {
+                return;
+            }
+
+            this.DisposeAllTimers();
+
+            this.isDisposed = true;
+        }
+
+        public override TimerWheelTimer GetTimer(int timeoutInMs)
+        {
+            this.ThrowIfDisposed();
+            if (timeoutInMs < this.resolutionInMs)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutInMs), $"TimerWheel configured with {this.resolutionInMs} resolution, cannot use a smaller timeout of {timeoutInMs}.");
+            }
+
+            if (timeoutInMs % this.resolutionInMs != 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutInMs), $"TimerWheel configured with {this.resolutionInMs} resolution, cannot use a different resolution of {timeoutInMs}.");
+            }
+
+            if (timeoutInMs > this.resolutionInMs * this.buckets)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutInMs), $"TimerWheel configured with {this.resolutionInMs * this.buckets} max, cannot use a larger timeout of {timeoutInMs}.");
+            }
+
+            return new TimerWheelTimerCore(TimeSpan.FromMilliseconds(timeoutInMs), this);
+        }
+
+        public override void SubscribeForTimeouts(TimerWheelTimer timer)
+        {
+            this.ThrowIfDisposed();
+            long timerTimeoutInTicks = timer.Timeout.Ticks;
+            int bucket = (int)timerTimeoutInTicks / this.resolutionInTicks;
+            lock (this.subscriptionLock)
+            {
+                int index = this.GetIndexForTimeout(bucket);
+                ConcurrentQueue<TimerWheelTimer> timerQueue;
+                if (this.timers.TryGetValue(index, out timerQueue))
+                {
+                    timerQueue.Enqueue(timer);
+                }
+                else
+                {
+                    timerQueue = this.timers.GetOrAdd(index,
+                        arg =>
+                        {
+                            return new ConcurrentQueue<TimerWheelTimer>();
+                        });
+                    timerQueue.Enqueue(timer);
+                }
+            }
+        }
+
+        public void OnTimer(Object stateInfo)
+        {
+            lock (this.timerConcurrencyLock)
+            {
+                if (!this.isRunning)
+                {
+                    this.isRunning = true;
+                }
+                else
+                {
+                    return;
+                }
+            }
+
+            try
+            {
+                if (this.timers.TryGetValue(this.expirationIndex, out ConcurrentQueue<TimerWheelTimer> timerQueue))
+                {
+                    while (timerQueue.TryDequeue(out TimerWheelTimer timer))
+                    {
+                        timer.FireTimeout();
+                    }
+                }
+
+                if (++this.expirationIndex == this.buckets)
+                {
+                    this.expirationIndex = 0;
+                }
+            }
+            catch (Exception ex)
+            {
+                DefaultTrace.TraceWarning($"TimerWheel: OnTimer error : {ex.Message}\n, stack: {ex.StackTrace}");
+            }
+            finally
+            {
+                lock (this.timerConcurrencyLock)
+                {
+                    this.isRunning = false;
+                }
+            }
+        }
+
+        private int GetIndexForTimeout(int bucket)
+        {
+            int index = bucket + this.expirationIndex;
+            if (index > this.buckets)
+            {
+                index -= this.buckets;
+            }
+
+            return index - 1; // zero based
+        }
+
+        private void DisposeAllTimers()
+        {
+            foreach (KeyValuePair<int, ConcurrentQueue<TimerWheelTimer>> kv in this.timers)
+            {
+                ConcurrentQueue<TimerWheelTimer> pooledTimerQueue = kv.Value;
+                while (pooledTimerQueue.TryDequeue(out TimerWheelTimer timer))
+                {
+                    timer.CancelTimer();
+                }
+            }
+
+            this.timer?.Dispose();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (this.isDisposed)
+            {
+                throw new ObjectDisposedException("TimerWheel is disposed.");
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimer.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimer.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Threading.Tasks;
 
+#nullable enable
     internal abstract class TimerWheelTimer
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimer.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimer.cs
@@ -1,0 +1,32 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Threading.Tasks;
+
+    internal abstract class TimerWheelTimer
+    {
+        /// <summary>
+        /// Timeout of the timer.
+        /// </summary>
+        public abstract TimeSpan Timeout { get; }
+
+        /// <summary>
+        /// Starts the timer based on the Timeout configuration.
+        /// </summary>
+        public abstract Task StartTimerAsync();
+
+        /// <summary>
+        /// Cancels the timer.
+        /// </summary>
+        public abstract bool CancelTimer();
+
+        /// <summary>
+        /// Fire the associated timeout callback.
+        /// </summary>
+        public abstract bool FireTimeout();
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimerCore.cs
@@ -1,0 +1,60 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Timers
+{
+    using System;
+    using System.Threading.Tasks;
+
+    internal sealed class TimerWheelTimerCore : TimerWheelTimer
+    {
+        private readonly TaskCompletionSource<object> taskCompletionSource;
+        private readonly Object memberLock;
+        private readonly TimerWheel timerWheel;
+        private bool timerStarted = false;
+
+        internal TimerWheelTimerCore(
+            TimeSpan timeoutPeriod, 
+            TimerWheel timerWheel)
+        {
+            if (timeoutPeriod.Ticks == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(timeoutPeriod));
+            }
+
+            this.timerWheel = timerWheel ?? throw new ArgumentNullException(nameof(timerWheel));
+            this.Timeout = timeoutPeriod;
+            this.taskCompletionSource = new TaskCompletionSource<object>();
+            this.memberLock = new Object();
+        }
+
+        public override TimeSpan Timeout { get; }
+
+        public override Task StartTimerAsync()
+        {
+            lock (this.memberLock)
+            {
+                if (this.timerStarted)
+                {
+                    // use only once enforcement
+                    throw new InvalidOperationException("Timer Already Started");
+                }
+
+                this.timerWheel.SubscribeForTimeouts(this);
+                this.timerStarted = true;
+                return this.taskCompletionSource.Task;
+            }
+        }
+
+        public override bool CancelTimer()
+        {
+            return this.taskCompletionSource.TrySetCanceled();
+        }
+
+        public override bool FireTimeout()
+        {
+            return this.taskCompletionSource.TrySetResult(null);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/TimerWheel/TimerWheelTimerCore.cs
@@ -7,8 +7,10 @@ namespace Microsoft.Azure.Cosmos.Timers
     using System;
     using System.Threading.Tasks;
 
+#nullable enable
     internal sealed class TimerWheelTimerCore : TimerWheelTimer
     {
+        private static object completedObject = new object();
         private readonly TaskCompletionSource<object> taskCompletionSource;
         private readonly Object memberLock;
         private readonly TimerWheel timerWheel;
@@ -54,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Timers
 
         public override bool FireTimeout()
         {
-            return this.taskCompletionSource.TrySetResult(null);
+            return this.taskCompletionSource.TrySetResult(TimerWheelTimerCore.completedObject);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/TimerBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/TimerBenchmark.cs
@@ -20,18 +20,18 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
         public TimerWheelBenchmark()
         {
             this.timeouts = TimerUtilities.GenerateTimeoutList(10000, 10000, 1000);
-            this.mainWheel = TimerWheel.CreateTimerWheel(1000, 10);
+            this.mainWheel = TimerWheel.CreateTimerWheel(TimeSpan.FromMilliseconds(1000), 10);
             this.timerPool = new TimerPool(1);
         }
 
         [Benchmark]
         public async Task TenK_WithTimerWheel()
         {
-            TimerWheel wheel = TimerWheel.CreateTimerWheel(1000, 10);
+            TimerWheel wheel = TimerWheel.CreateTimerWheel(TimeSpan.FromMilliseconds(1000), 10);
             List<Task> timers = new List<Task>(this.timeouts.Count);
             for (int i = 0; i < this.timeouts.Count; i++)
             {
-                TimerWheelTimer timer = wheel.GetTimer(this.timeouts[i]);
+                TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(this.timeouts[i]));
                 timers.Add(timer.StartTimerAsync());
             }
 
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
         [Benchmark]
         public async Task One_WithTimerWheel()
         {
-            TimerWheelTimer timer = this.mainWheel.GetTimer(1000);
+            TimerWheelTimer timer = this.mainWheel.CreateTimer(TimeSpan.FromMilliseconds(1000));
             await timer.StartTimerAsync();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/TimerBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/TimerBenchmark.cs
@@ -1,0 +1,101 @@
+﻿// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.Azure.Documents;
+
+    [MemoryDiagnoser]
+    public class TimerWheelBenchmark
+    {
+        private readonly TimerPool timerPool;
+        private readonly TimerWheel mainWheel;
+        private readonly IReadOnlyList<int> timeouts;
+        public TimerWheelBenchmark()
+        {
+            this.timeouts = TimerUtilities.GenerateTimeoutList(10000, 10000, 1000);
+            this.mainWheel = TimerWheel.CreateTimerWheel(1000, 10);
+            this.timerPool = new TimerPool(1);
+        }
+
+        [Benchmark]
+        public async Task TenK_WithTimerWheel()
+        {
+            TimerWheel wheel = TimerWheel.CreateTimerWheel(1000, 10);
+            List<Task> timers = new List<Task>(this.timeouts.Count);
+            for (int i = 0; i < this.timeouts.Count; i++)
+            {
+                TimerWheelTimer timer = wheel.GetTimer(this.timeouts[i]);
+                timers.Add(timer.StartTimerAsync());
+            }
+
+            await Task.WhenAll(timers);
+            wheel.Dispose();
+        }
+
+        [Benchmark]
+        public async Task TenK_WithPooledTimer()
+        {
+            TimerPool timerPool = new TimerPool(1);
+            List<Task> timers = new List<Task>(this.timeouts.Count);
+            for (int i = 0; i < this.timeouts.Count; i++)
+            {
+                PooledTimer timer = timerPool.GetPooledTimer(this.timeouts[i] / 1000);
+                timers.Add(timer.StartTimerAsync());
+            }
+
+            await Task.WhenAll(timers);
+            timerPool.Dispose();
+        }
+
+        [Benchmark]
+        public async Task One_WithTimerWheel()
+        {
+            TimerWheelTimer timer = this.mainWheel.GetTimer(1000);
+            await timer.StartTimerAsync();
+        }
+
+        [Benchmark]
+        public async Task One_WithPooledTimer()
+        {
+            PooledTimer timer = this.timerPool.GetPooledTimer(1);
+            await timer.StartTimerAsync();
+        }
+
+        public void DoNothing(Object state) { }
+
+        public class WorkerWithTimer : IDisposable
+        {
+            private readonly TaskCompletionSource<object> taskCompletionSource;
+            private readonly int timeout;
+            private Timer timer;
+            public WorkerWithTimer(int timeout)
+            {
+                this.timeout = timeout;
+                this.taskCompletionSource = new TaskCompletionSource<object>();
+            }
+
+            public Task StartTimerAsync()
+            {
+                this.timer = new Timer(this.OnTimer, null, this.timeout, this.timeout);
+                return this.taskCompletionSource.Task;
+            }
+
+            public void OnTimer(Object stateInfo)
+            {
+                this.taskCompletionSource.TrySetResult(null);
+            }
+
+            public void Dispose()
+            {
+                this.timer.Dispose();
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/TimerWheel/Utils.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/TimerWheel/Utils.cs
@@ -1,0 +1,47 @@
+// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal static class TimerUtilities
+    {
+        private static Random random = new Random();
+        public static IReadOnlyList<int> GenerateTimeoutList(
+            int count,
+            int maxTimeoutValue,
+            int resolution)
+        {
+            IReadOnlyList<int> possibleValues = TimerUtilities.GeneratePossibleValuesList(maxTimeoutValue, resolution);
+            List<int> timeouts = new List<int>(count);
+            for (int i = 0; i < count; i++)
+            {
+                timeouts.Add(possibleValues[TimerUtilities.random.Next(0, possibleValues.Count)]);
+            }
+            return timeouts;
+        }
+
+        private static IReadOnlyList<int> GeneratePossibleValuesList(
+            int maxTimeoutValue,
+            int resolution)
+        {
+            int possibleValuesCount = maxTimeoutValue / resolution;
+            List<int> possibleValues = new List<int>(possibleValuesCount);
+            for (int i = 0; i < possibleValuesCount; i++)
+            {
+                int value = (i + 1) * resolution;
+                if (value > maxTimeoutValue)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                possibleValues.Add(value);
+            }
+
+            return possibleValues;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
@@ -1,0 +1,160 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Timers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TimerWheelCoreTests
+    {
+        [TestMethod]
+        public void CreatesTimerWheel()
+        {
+            Assert.IsNotNull(TimerWheel.CreateTimerWheel(50, 1));
+        }
+
+        [DataTestMethod]
+        [DataRow(0,1)]
+        [DataRow(-1,1)]
+        [DataRow(50,0)]
+        [DataRow(50,-1)]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void InvalidConstructor(int resolutionInMs, int buckets)
+        {
+            new TimerWheelCore(resolutionInMs, buckets);
+        }
+
+        [TestMethod]
+        public void CreatesTimer()
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 10);
+            TimerWheelTimer timer = wheel.GetTimer(90);
+            Assert.IsNotNull(timer);
+        }
+
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(-1)]
+        [DataRow(1)]
+        [DataRow(35)]
+        [DataRow(330)]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void InvalidTimeout(int timeout)
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 10);
+            wheel.GetTimer(timeout);
+        }
+
+        [TestMethod]
+        public void IndexMovesAsTimerPasses()
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 3, timer: null); // deactivate timer to fire manually
+            TimerWheelTimer timer = wheel.GetTimer(90);
+            Task timerTask = timer.StartTimerAsync();
+            wheel.OnTimer(null);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, timerTask.Status);
+            wheel.OnTimer(null);
+            Assert.AreEqual(TaskStatus.WaitingForActivation, timerTask.Status);
+            TimerWheelTimer secondTimer = wheel.GetTimer(60);
+            Task secondTimerTask = secondTimer.StartTimerAsync();
+            wheel.OnTimer(null);
+            Assert.AreEqual(TaskStatus.RanToCompletion, timerTask.Status);
+            wheel.OnTimer(null);
+            Assert.AreEqual(TaskStatus.RanToCompletion, secondTimerTask.Status);
+        }
+
+        [TestMethod]
+        public void DisposedCannotCreateTimers()
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 3);
+            TimerWheelTimer timer = wheel.GetTimer(90);
+            Assert.IsNotNull(timer);
+            wheel.Dispose();
+            Assert.ThrowsException<ObjectDisposedException>(() => wheel.GetTimer(90));
+        }
+
+        [TestMethod]
+        public void DisposedCannotStartTimers()
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 3);
+            TimerWheelTimer timer = wheel.GetTimer(90);
+            Assert.IsNotNull(timer);
+            wheel.Dispose();
+            Assert.ThrowsException<ObjectDisposedException>(() => timer.StartTimerAsync());
+        }
+
+        [TestMethod]
+        public void DisposeCancelsTimers()
+        {
+            TimerWheelCore wheel = new TimerWheelCore(30, 3);
+            TimerWheelTimer timer = wheel.GetTimer(90);
+            Task timerTask = timer.StartTimerAsync();
+            wheel.Dispose();
+            Assert.AreEqual(TaskStatus.Canceled, timerTask.Status);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public async Task TimeoutFires()
+        {
+            const int timerTimeout = 200;
+            const int resolution = 50;
+            TimerWheelCore wheel = new TimerWheelCore(resolution, 10); // 10 buckets of 50 ms go up to 500ms
+            TimerWheelTimer timer = wheel.GetTimer(timerTimeout);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            await timer.StartTimerAsync();
+            stopwatch.Stop();
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution && stopwatch.ElapsedMilliseconds <= timerTimeout + resolution);
+        }
+
+        [TestMethod]
+        [Timeout(1000)]
+        public async Task TimeoutFires_SameTimeout()
+        {
+            const int timerTimeout = 200;
+            const int resolution = 50;
+            TimerWheelCore wheel = new TimerWheelCore(resolution, 10); // 10 buckets of 50 ms go up to 500ms
+            TimerWheelTimer timer = wheel.GetTimer(timerTimeout);
+            TimerWheelTimer timer2 = wheel.GetTimer(timerTimeout);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            await Task.WhenAll(timer.StartTimerAsync(), timer2.StartTimerAsync());
+            stopwatch.Stop();
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution && stopwatch.ElapsedMilliseconds <= timerTimeout + resolution);
+        }
+
+        [TestMethod]
+        [Timeout(2000)]
+        public async Task MultipleTimeouts()
+        {
+            const int timerTimeout = 100;
+            const int buckets = 20;
+            const int resolution = 50;
+            TimerWheelCore wheel = new TimerWheelCore(resolution, buckets); // 20 buckets of 50 ms go up to 1000ms
+            List<Task<(int, long)>> tasks = new List<Task<(int, long)>>();
+            for (int i = 0; i < 10; i++)
+            {
+                int estimatedTimeout = (i + 1) * timerTimeout;
+                TimerWheelTimer timer = wheel.GetTimer(estimatedTimeout);
+                tasks.Add(Task.Run(async () => {
+                    Stopwatch stopwatch = Stopwatch.StartNew();
+                    await timer.StartTimerAsync();
+                    stopwatch.Stop();
+                    return (estimatedTimeout,stopwatch.ElapsedMilliseconds);
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+            foreach (Task<(int, long)> task in tasks)
+            {
+                Assert.IsTrue(task.Result.Item2 >= task.Result.Item1  - resolution && task.Result.Item2 <= task.Result.Item1 + resolution, $"Timer configured with {task.Result.Item1} took {task.Result.Item2} to fire.");
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelTimerCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelTimerCoreTests.cs
@@ -1,0 +1,86 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Timers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class TimerWheelTimerCoreTests
+    {
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void TimeSpanZero()
+        {
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.Zero, Mock.Of<TimerWheel>());
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void NullTimerWheel()
+        {
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.FromMilliseconds(1), null);
+        }
+
+        [TestMethod]
+        public void TimeoutMatchesInput()
+        {
+            TimeSpan timeout = TimeSpan.FromMilliseconds(1);
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(timeout, Mock.Of<TimerWheel>());
+            Assert.AreEqual(timeout, timer.Timeout);
+        }
+
+        [TestMethod]
+        public void SubscribesToWheel()
+        {
+            Mock<TimerWheel> mockedWheel = new Mock<TimerWheel>();
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.FromMilliseconds(10), mockedWheel.Object);
+            Task task = timer.StartTimerAsync();
+            Mock.Get(mockedWheel.Object)
+                .Verify(w => w.SubscribeForTimeouts(It.Is<TimerWheelTimer>(t => t == timer)), Times.Once);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public async Task CannotStartTwice()
+        {
+            Mock<TimerWheel> mockedWheel = new Mock<TimerWheel>();
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.FromMilliseconds(10), mockedWheel.Object);
+            List<Task> tasks = new List<Task>()
+            {
+                timer.StartTimerAsync(),
+                timer.StartTimerAsync()
+            };
+
+            await Task.WhenAll(tasks);
+        }
+
+        [TestMethod]
+        public void FireTimeout()
+        {
+            Mock<TimerWheel> mockedWheel = new Mock<TimerWheel>();
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.FromMilliseconds(10), mockedWheel.Object);
+            Task task = timer.StartTimerAsync();
+            Assert.AreEqual(TaskStatus.WaitingForActivation, task.Status);
+            timer.FireTimeout();
+            Assert.AreEqual(TaskStatus.RanToCompletion, task.Status);
+        }
+
+        [TestMethod]
+        public void Cancel()
+        {
+            Mock<TimerWheel> mockedWheel = new Mock<TimerWheel>();
+            TimerWheelTimerCore timer = new TimerWheelTimerCore(TimeSpan.FromMilliseconds(10), mockedWheel.Object);
+            Task task = timer.StartTimerAsync();
+            Assert.AreEqual(TaskStatus.WaitingForActivation, task.Status);
+            timer.CancelTimer();
+            Assert.AreEqual(TaskStatus.Canceled, task.Status);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR adds a [Simple Timer Wheel](https://blog.acolyer.org/2015/11/23/hashed-and-hierarchical-timing-wheels/) implementation that can be used to host and manage multiple tasks that have independent timeout intervals and reduce memory allocations versus using independent `System.Threading.Timer` instances.

### Usage

Creation of the wheel requires the *resolution* of each wheel's bucket and the amount of *buckets*, which define which is the *MaxInterval*.

```csharp
TimerWheel wheel = TimerWheel.CreateTimerWheel(resolutionInMs: 50, buckets: 20);
```

Once a wheel is created, new timers can be requested by specifying the *timeout in milliseconds* for that particular timer. Then, a call to `StartTimerAsync` will return a `Task` that resolves once the timeout is up:

```csharp
TimerWheelTimer timer = wheel.CreateTimer(timeoutInMs:50);
await timer.StartTimerAsync();
```

### Disposal

The `TimerWheel` instance is disposable and should be disposed after it has been used or the parent's scope is disposed.

### Performance

Performance comparison version using independent timers per task show a reduction of allocations of ~50%, both in single operations and also in bigger operations (creating 10K timed tasks):

![image](https://user-images.githubusercontent.com/1633401/84322685-3e466b80-ab2a-11ea-93b3-790a142318f0.png)

The PR includes unit tests and benchmark tests.

## Goal

The goal for this implementation is to replace the `PooledTimer` used currently in Bulk which has a minimum of 1 second granularity. This implementation has a minimum supported granularity of 20ms.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
