### PR TITLE
Query: Fix memory leak by making FeedIterator IDisposable

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ComparableTask/ComparableTaskScheduler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ComparableTask/ComparableTaskScheduler.cs
@@ -45,29 +45,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ComparableTask
 
         public int MaximumConcurrencyLevel { get; private set; }
 
-        public int CurrentRunningTaskCount
-        {
-            get
-            {
-                return this.MaximumConcurrencyLevel - Math.Max(0, this.canRunTaskSemaphoreSlim.CurrentCount);
-            }
-        }
+        public int CurrentRunningTaskCount => this.MaximumConcurrencyLevel - Math.Max(0, this.canRunTaskSemaphoreSlim.CurrentCount);
 
-        public bool IsStopped
-        {
-            get
-            {
-                return this.isStopped;
-            }
-        }
+        public bool IsStopped => this.isStopped;
 
-        private CancellationToken CancellationToken
-        {
-            get
-            {
-                return this.tokenSource.Token;
-            }
-        }
+        private CancellationToken CancellationToken => this.tokenSource.Token;
 
         public void IncreaseMaximumConcurrencyLevel(int delta)
         {
@@ -83,6 +65,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ComparableTask
         public void Dispose()
         {
             this.Stop();
+
+            this.canRunTaskSemaphoreSlim.Dispose();
+            this.tokenSource.Dispose();
         }
 
         public void Stop()

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -200,5 +200,11 @@ namespace Microsoft.Azure.Cosmos.Query
         {
             return this.cosmosQueryExecutionContext.GetCosmosElementContinuationToken();
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.cosmosQueryExecutionContext.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIterator.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -33,8 +34,10 @@ namespace Microsoft.Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    public abstract class FeedIterator
+    public abstract class FeedIterator : IDisposable
     {
+        private bool disposedValue;
+
         /// <summary>
         /// Tells if there is more results that need to be retrieved from the service
         /// </summary>
@@ -92,5 +95,29 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         public abstract Task<ResponseMessage> ReadNextAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the FeedIterator and optionally
+        /// releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // Default implementation does not need to clean anything up
+            if (!this.disposedValue)
+            {
+                this.disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the FeedIterator and optionally
+        /// releases the managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            this.Dispose(disposing: true);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorCore.cs
@@ -156,5 +156,11 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage response = await this.feedIterator.ReadNextAsync(cancellationToken);
             return this.responseCreator(response);
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.feedIterator.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Json;
 
     internal sealed class FeedIteratorInlineCore : FeedIteratorInternal
     {
@@ -44,41 +43,11 @@ namespace Microsoft.Azure.Cosmos
         {
             return TaskHelper.RunInlineIfNeededAsync(() => this.feedIteratorInternal.ReadNextAsync(cancellationToken));
         }
-    }
 
-    internal sealed class FeedIteratorInlineCore<T> : FeedIteratorInternal<T>
-    {
-        private readonly FeedIteratorInternal<T> feedIteratorInternal;
-
-        internal FeedIteratorInlineCore(
-            FeedIterator<T> feedIterator)
+        protected override void Dispose(bool disposing)
         {
-            if (feedIterator is FeedIteratorInternal<T> feedIteratorInternal)
-            {
-                this.feedIteratorInternal = feedIteratorInternal;
-            }
-            else
-            {
-                throw new ArgumentNullException(nameof(feedIterator));
-            }
-        }
-
-        internal FeedIteratorInlineCore(
-            FeedIteratorInternal<T> feedIteratorInternal)
-        {
-            this.feedIteratorInternal = feedIteratorInternal ?? throw new ArgumentNullException(nameof(feedIteratorInternal));
-        }
-
-        public override bool HasMoreResults => this.feedIteratorInternal.HasMoreResults;
-
-        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
-        {
-            return TaskHelper.RunInlineIfNeededAsync(() => this.feedIteratorInternal.ReadNextAsync(cancellationToken));
-        }
-
-        public override CosmosElement GetCosmosElementContinuationToken()
-        {
-            return this.feedIteratorInternal.GetCosmosElementContinuationToken();
+            this.feedIteratorInternal.Dispose();
+            base.Dispose(disposing);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Azure.Cosmos
         internal FeedIteratorInlineCore(
             FeedIterator feedIterator)
         {
-            if (feedIterator is FeedIteratorInternal feedIteratorInternal)
-            {
-                this.feedIteratorInternal = feedIteratorInternal;
-            }
-            else
+            if (!(feedIterator is FeedIteratorInternal feedIteratorInternal))
             {
                 throw new ArgumentNullException(nameof(feedIterator));
             }
+
+            this.feedIteratorInternal = feedIteratorInternal;
         }
 
         internal FeedIteratorInlineCore(

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore{T}.cs
@@ -1,0 +1,53 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+
+    internal sealed class FeedIteratorInlineCore<T> : FeedIteratorInternal<T>
+    {
+        private readonly FeedIteratorInternal<T> feedIteratorInternal;
+
+        internal FeedIteratorInlineCore(
+            FeedIterator<T> feedIterator)
+        {
+            if (feedIterator is FeedIteratorInternal<T> feedIteratorInternal)
+            {
+                this.feedIteratorInternal = feedIteratorInternal;
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(feedIterator));
+            }
+        }
+
+        internal FeedIteratorInlineCore(
+            FeedIteratorInternal<T> feedIteratorInternal)
+        {
+            this.feedIteratorInternal = feedIteratorInternal ?? throw new ArgumentNullException(nameof(feedIteratorInternal));
+        }
+
+        public override bool HasMoreResults => this.feedIteratorInternal.HasMoreResults;
+
+        public override Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default)
+        {
+            return TaskHelper.RunInlineIfNeededAsync(() => this.feedIteratorInternal.ReadNextAsync(cancellationToken));
+        }
+
+        public override CosmosElement GetCosmosElementContinuationToken()
+        {
+            return this.feedIteratorInternal.GetCosmosElementContinuationToken();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.feedIteratorInternal.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorInlineCore{T}.cs
@@ -16,14 +16,12 @@ namespace Microsoft.Azure.Cosmos
         internal FeedIteratorInlineCore(
             FeedIterator<T> feedIterator)
         {
-            if (feedIterator is FeedIteratorInternal<T> feedIteratorInternal)
-            {
-                this.feedIteratorInternal = feedIteratorInternal;
-            }
-            else
+            if (!(feedIterator is FeedIteratorInternal<T> feedIteratorInternal))
             {
                 throw new ArgumentNullException(nameof(feedIterator));
             }
+
+            this.feedIteratorInternal = feedIteratorInternal;
         }
 
         internal FeedIteratorInlineCore(

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIterator{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIterator{T}.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -29,8 +30,10 @@ namespace Microsoft.Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    public abstract class FeedIterator<T>
+    public abstract class FeedIterator<T> : IDisposable
     {
+        private bool disposedValue;
+
         /// <summary>
         /// Tells if there is more results that need to be retrieved from the service
         /// </summary>
@@ -80,5 +83,29 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         public abstract Task<FeedResponse<T>> ReadNextAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the FeedIterator and optionally
+        /// releases the managed resources.
+        /// </summary>
+        /// <param name="disposing">true to release both managed and unmanaged resources; false to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            // Default implementation does not need to clean anything up
+            if (!this.disposedValue)
+            {
+                this.disposedValue = true;
+            }
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by the FeedIterator and optionally
+        /// releases the managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            this.Dispose(disposing: true);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosPermissionTests.cs
@@ -341,15 +341,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //delete resource with PermissionMode.All
             using (CosmosClient tokenCosmosClient = TestCommon.CreateCosmosClient(clientOptions: null, resourceToken: permission.Token))
             {
-                FeedIterator<dynamic> feed = tokenCosmosClient
+                using (FeedIterator<dynamic> feed = tokenCosmosClient
                     .GetDatabase(this.cosmosDatabase.Id)
                     .GetContainer(containerId)
-                    .GetItemQueryIterator<dynamic>(new QueryDefinition("select * from t"));
-
-                while (feed.HasMoreResults)
+                    .GetItemQueryIterator<dynamic>(new QueryDefinition("select * from t")))
                 {
-                    FeedResponse<dynamic> response = await feed.ReadNextAsync();
-                    Assert.IsNotNull(response);
+                    while (feed.HasMoreResults)
+                    {
+                        FeedResponse<dynamic> response = await feed.ReadNextAsync();
+                        Assert.IsNotNull(response);
+                    }
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -164,16 +164,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         //swallow
                     }
-                    
+
                     // read databaseCollection feed.
-                    FeedIterator<dynamic> itemIterator = container.GetItemQueryIterator<dynamic>(queryDefinition: null);
-                    int count = 0;
-                    while (itemIterator.HasMoreResults)
+                    using (FeedIterator<dynamic> itemIterator = container.GetItemQueryIterator<dynamic>(queryDefinition: null))
                     {
-                        FeedResponse<dynamic> items = await itemIterator.ReadNextAsync();
-                        count += items.Count();
+                        int count = 0;
+                        while (itemIterator.HasMoreResults)
+                        {
+                            FeedResponse<dynamic> items = await itemIterator.ReadNextAsync();
+                            count += items.Count();
+                        }
+                        Assert.AreEqual(3, count);
                     }
-                    Assert.AreEqual(3, count);
 
                     // query documents 
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/PartitioningQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/PartitioningQueryTests.cs
@@ -137,19 +137,21 @@
             async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {
                 // Query with partition key should be done in one round trip.
-                FeedIterator<dynamic> resultSetIterator = container.GetItemQueryIterator<dynamic>(
-                    "SELECT * FROM c WHERE c.pk = 'doc5'");
+                using (FeedIterator<dynamic> resultSetIterator = container.GetItemQueryIterator<dynamic>(
+                    "SELECT * FROM c WHERE c.pk = 'doc5'"))
+                {
+                    FeedResponse<dynamic> response = await resultSetIterator.ReadNextAsync();
+                    Assert.AreEqual(1, response.Count());
+                    Assert.IsNull(response.ContinuationToken);
+                }
 
-                FeedResponse<dynamic> response = await resultSetIterator.ReadNextAsync();
-                Assert.AreEqual(1, response.Count());
-                Assert.IsNull(response.ContinuationToken);
-
-                resultSetIterator = container.GetItemQueryIterator<dynamic>(
-                   "SELECT * FROM c WHERE c.pk = 'doc10'");
-
-                response = await resultSetIterator.ReadNextAsync();
-                Assert.AreEqual(0, response.Count());
-                Assert.IsNull(response.ContinuationToken);
+                using (FeedIterator<dynamic> resultSetIterator = container.GetItemQueryIterator<dynamic>(
+                       "SELECT * FROM c WHERE c.pk = 'doc10'"))
+                {
+                    FeedResponse<dynamic> response = await resultSetIterator.ReadNextAsync();
+                    Assert.AreEqual(0, response.Count());
+                    Assert.IsNull(response.ContinuationToken);
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
@@ -309,15 +309,16 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
         private static async Task CleanUp(CosmosClient client)
         {
-            FeedIterator<DatabaseProperties> allDatabases = client.GetDatabaseQueryIterator<DatabaseProperties>();
-
-            while (allDatabases.HasMoreResults)
+            using (FeedIterator<DatabaseProperties> allDatabases = client.GetDatabaseQueryIterator<DatabaseProperties>())
             {
-                foreach (DatabaseProperties db in await allDatabases.ReadNextAsync())
+                while (allDatabases.HasMoreResults)
                 {
-                    await client.GetDatabase(db.Id).DeleteAsync();
+                    foreach (DatabaseProperties db in await allDatabases.ReadNextAsync())
+                    {
+                        await client.GetDatabase(db.Id).DeleteAsync();
+                    }
                 }
-            }
+            } 
         }
 
         internal async Task RunWithApiVersion(string apiVersion, Func<Task> function)
@@ -513,13 +514,16 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             }
             catch (Exception ex) when (ex.GetType() != typeof(AssertFailedException))
             {
-                while (ex.InnerException != null) ex = ex.InnerException;
+                while (ex.InnerException != null)
+                {
+                    ex = ex.InnerException;
+                }
 
                 ExceptionDispatchInfo.Capture(ex).Throw();
             }
         }
 
-        static ConnectionMode GetTargetConnectionMode(ConnectionModes connectionMode)
+        private static ConnectionMode GetTargetConnectionMode(ConnectionModes connectionMode)
         {
             ConnectionMode targetConnectionMode;
             switch (connectionMode)
@@ -583,39 +587,38 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 computeRequestOptions.ExecutionEnvironment = Cosmos.Query.Core.ExecutionContext.ExecutionEnvironment.Compute;
                 computeRequestOptions.CosmosElementContinuationToken = continuationToken;
 
-                FeedIteratorInternal<T> itemQuery = (FeedIteratorInternal<T>)container.GetItemQueryIterator<T>(
+                using (FeedIteratorInternal<T> itemQuery = (FeedIteratorInternal<T>)container.GetItemQueryIterator<T>(
                    queryText: query,
-                   requestOptions: computeRequestOptions);
-                try
+                   requestOptions: computeRequestOptions))
                 {
-                    FeedResponse<T> cosmosQueryResponse = await itemQuery.ReadNextAsync();
-                    if (queryRequestOptions.MaxItemCount.HasValue)
+                    try
                     {
-                        Assert.IsTrue(
-                            cosmosQueryResponse.Count <= queryRequestOptions.MaxItemCount.Value,
-                            "Max Item Count is not being honored");
-                    }
+                        FeedResponse<T> cosmosQueryResponse = await itemQuery.ReadNextAsync();
+                        if (queryRequestOptions.MaxItemCount.HasValue)
+                        {
+                            Assert.IsTrue(
+                                cosmosQueryResponse.Count <= queryRequestOptions.MaxItemCount.Value,
+                                "Max Item Count is not being honored");
+                        }
 
-                    resultsFromCosmosElementContinuationToken.AddRange(cosmosQueryResponse);
+                        resultsFromCosmosElementContinuationToken.AddRange(cosmosQueryResponse);
 
-                    // Force a rewrite of the continuation token, so that we test the case where we roundtrip it over the wire.
-                    // There was a bug where resuming from double.NaN lead to an exception,
-                    // since we parsed the type assuming it was always a double and not a string.
-                    CosmosElement originalContinuationToken = itemQuery.GetCosmosElementContinuationToken();
-                    if(originalContinuationToken != null)
-                    {
-                        continuationToken = CosmosElement.Parse(originalContinuationToken.ToString());
+                        // Force a rewrite of the continuation token, so that we test the case where we roundtrip it over the wire.
+                        // There was a bug where resuming from double.NaN lead to an exception,
+                        // since we parsed the type assuming it was always a double and not a string.
+                        CosmosElement originalContinuationToken = itemQuery.GetCosmosElementContinuationToken();
+                        if (originalContinuationToken != null)
+                        {
+                            continuationToken = CosmosElement.Parse(originalContinuationToken.ToString());
+                        }
+                        else
+                        {
+                            continuationToken = null;
+                        }
                     }
-                    else
+                    catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
                     {
-                        continuationToken = null;
                     }
-                }
-                catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
-                {
-                    itemQuery = (FeedIteratorInternal<T>)container.GetItemQueryIterator<T>(
-                            queryText: query,
-                            requestOptions: queryRequestOptions);
                 }
             } while (continuationToken != null);
 
@@ -641,29 +644,37 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                    requestOptions: queryRequestOptions,
                    continuationToken: continuationToken);
 
-                while (true)
+                try
                 {
-                    try
+                    while (true)
                     {
-                        FeedResponse<T> cosmosQueryResponse = await itemQuery.ReadNextAsync();
-                        if (queryRequestOptions.MaxItemCount.HasValue)
+                        try
                         {
-                            Assert.IsTrue(
-                                cosmosQueryResponse.Count <= queryRequestOptions.MaxItemCount.Value,
-                                "Max Item Count is not being honored");
-                        }
+                            FeedResponse<T> cosmosQueryResponse = await itemQuery.ReadNextAsync();
+                            if (queryRequestOptions.MaxItemCount.HasValue)
+                            {
+                                Assert.IsTrue(
+                                    cosmosQueryResponse.Count <= queryRequestOptions.MaxItemCount.Value,
+                                    "Max Item Count is not being honored");
+                            }
 
-                        resultsFromContinuationToken.AddRange(cosmosQueryResponse);
-                        continuationToken = cosmosQueryResponse.ContinuationToken;
-                        break;
+                            resultsFromContinuationToken.AddRange(cosmosQueryResponse);
+                            continuationToken = cosmosQueryResponse.ContinuationToken;
+                            break;
+                        }
+                        catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
+                        {
+                            itemQuery.Dispose();
+                            itemQuery = container.GetItemQueryIterator<T>(
+                                queryText: query,
+                                requestOptions: queryRequestOptions,
+                                continuationToken: continuationToken);
+                        }
                     }
-                    catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
-                    {
-                        itemQuery = container.GetItemQueryIterator<T>(
-                            queryText: query,
-                            requestOptions: queryRequestOptions,
-                            continuationToken: continuationToken);
-                    }
+                }
+                finally
+                {
+                    itemQuery.Dispose();
                 }
             } while (continuationToken != null);
 
@@ -684,44 +695,51 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             FeedIterator<T> itemQuery = container.GetItemQueryIterator<T>(
                 queryText: query,
                 requestOptions: queryRequestOptions);
-
-            string continuationTokenForRetries = null;
-            while (itemQuery.HasMoreResults)
+            try
             {
-                try
+                string continuationTokenForRetries = null;
+                while (itemQuery.HasMoreResults)
                 {
-                    FeedResponse<T> page = await itemQuery.ReadNextAsync();
-                    results.AddRange(page);
-
-                    if (queryRequestOptions.MaxItemCount.HasValue)
-                    {
-                        Assert.IsTrue(
-                            page.Count <= queryRequestOptions.MaxItemCount.Value,
-                            "Max Item Count is not being honored");
-                    }
-
                     try
                     {
-                        continuationTokenForRetries = page.ContinuationToken;
-                    }
-                    catch (Exception)
-                    {
-                        // Grabbing a continuation token is not supported on all queries.
-                    }
-                }
-                catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
-                {
-                    itemQuery = container.GetItemQueryIterator<T>(
-                        queryText: query,
-                        requestOptions: queryRequestOptions,
-                        continuationToken: continuationTokenForRetries);
+                        FeedResponse<T> page = await itemQuery.ReadNextAsync();
+                        results.AddRange(page);
 
-                    if (continuationTokenForRetries == null)
+                        if (queryRequestOptions.MaxItemCount.HasValue)
+                        {
+                            Assert.IsTrue(
+                                page.Count <= queryRequestOptions.MaxItemCount.Value,
+                                "Max Item Count is not being honored");
+                        }
+
+                        try
+                        {
+                            continuationTokenForRetries = page.ContinuationToken;
+                        }
+                        catch (Exception)
+                        {
+                            // Grabbing a continuation token is not supported on all queries.
+                        }
+                    }
+                    catch (CosmosException cosmosException) when (cosmosException.StatusCode == (HttpStatusCode)429)
                     {
-                        // The query failed and we don't have a save point, so just restart the whole thing.
-                        results = new List<T>();
+                        itemQuery.Dispose();
+                        itemQuery = container.GetItemQueryIterator<T>(
+                            queryText: query,
+                            requestOptions: queryRequestOptions,
+                            continuationToken: continuationTokenForRetries);
+
+                        if (continuationTokenForRetries == null)
+                        {
+                            // The query failed and we don't have a save point, so just restart the whole thing.
+                            results = new List<T>();
+                        }
                     }
                 }
+            }
+            finally
+            {
+                itemQuery.Dispose();
             }
 
             return results;
@@ -821,14 +839,15 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             string query,
             QueryRequestOptions requestOptions = null)
         {
-            FeedIterator<T> resultSetIterator = container.GetItemQueryIterator<T>(
-                query,
-                requestOptions: requestOptions);
-
             List<T> items = new List<T>();
-            while (resultSetIterator.HasMoreResults)
+            using (FeedIterator<T> resultSetIterator = container.GetItemQueryIterator<T>(
+                query,
+                requestOptions: requestOptions))
             {
-                items.AddRange(await resultSetIterator.ReadNextAsync());
+                while (resultSetIterator.HasMoreResults)
+                {
+                    items.AddRange(await resultSetIterator.ReadNextAsync());
+                }
             }
 
             return items;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -79,25 +79,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 inputDocuments,
                 ImplementationAsync);
 
-            //WeakReference weakReferenceFeedIterator;
-            //{
-            //    using (FeedIterator<JObject> feedIterator = container.GetItemQueryIterator<JObject>(
-            //        "SELECT * FROM c",
-            //        null,
-            //        new QueryRequestOptions
-            //        {
-            //            MaxItemCount = 1000,
-            //        }))
-            //    {
-            //        weakReferenceFeedIterator = new WeakReference(feedIterator, true);
-            //        FeedResponse<JObject> response = await feedIterator.ReadNextAsync();
-            //        foreach (JObject jObject in response)
-            //        {
-            //            Assert.IsNotNull(jObject);
-            //        }
-            //    }
-            //}
-
             async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {
                 List<WeakReference> weakReferences = await CreateWeakReferenceToFeedIterator(container);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -109,10 +109,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     }))
             {
                 weakReferences.Add(new WeakReference(feedIterator, true));
-                FeedResponse<JObject> response = await feedIterator.ReadNextAsync();
-                foreach (JObject jObject in response)
+                while (feedIterator.HasMoreResults)
                 {
-                    Assert.IsNotNull(jObject);
+                    FeedResponse<JObject> response = await feedIterator.ReadNextAsync();
+                    foreach (JObject jObject in response)
+                    {
+                        Assert.IsNotNull(jObject);
+                    }
                 }
             }
 
@@ -126,19 +129,22 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     }))
             {
                 weakReferences.Add(new WeakReference(feedIterator, true));
-                using (ResponseMessage response = await feedIterator.ReadNextAsync())
+                while (feedIterator.HasMoreResults)
                 {
-                    Assert.IsNotNull(response.Content);
+                    using (ResponseMessage response = await feedIterator.ReadNextAsync())
+                    {
+                        Assert.IsNotNull(response.Content);
+                    }
                 }
             }
 
-            // Test draining typed iterator
+            // Test single page typed iterator
             using (FeedIterator<JObject> feedIterator = container.GetItemQueryIterator<JObject>(
                     queryText: "SELECT * FROM c",
                     continuationToken: null,
                     requestOptions: new QueryRequestOptions
                     {
-                        MaxItemCount = 1000,
+                        MaxItemCount = 10,
                     }))
             {
                 weakReferences.Add(new WeakReference(feedIterator, true));
@@ -149,13 +155,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 }
             }
 
-            // Test draining stream iterator
+            // Test single page stream iterator
             using (FeedIterator feedIterator = container.GetItemQueryStreamIterator(
                     queryText: "SELECT * FROM c",
                     continuationToken: null,
                     requestOptions: new QueryRequestOptions
                     {
-                        MaxItemCount = 1000,
+                        MaxItemCount = 10,
                     }))
             {
                 weakReferences.Add(new WeakReference(feedIterator, true));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SkipTakeQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SkipTakeQueryTests.cs
@@ -63,26 +63,28 @@
                                 // Max DOP needs to be 0 since the query needs to run in serial => 
                                 // otherwise the parallel code will prefetch from other partitions,
                                 // since the first N-1 partitions might be empty.
-                                FeedIterator<dynamic> documentQuery = container.GetItemQueryIterator<dynamic>(
+                                using (FeedIterator<dynamic> documentQuery = container.GetItemQueryIterator<dynamic>(
                                         query,
-                                        requestOptions: new QueryRequestOptions() { MaxConcurrency = 0, MaxItemCount = pageSize });
-
-                                //QueryMetrics aggregatedQueryMetrics = QueryMetrics.Zero;
-                                int numberOfDocuments = 0;
-                                while (documentQuery.HasMoreResults)
+                                        requestOptions: new QueryRequestOptions() { MaxConcurrency = 0, MaxItemCount = pageSize }))
                                 {
-                                    FeedResponse<dynamic> cosmosQueryResponse = await documentQuery.ReadNextAsync();
+                                    //QueryMetrics aggregatedQueryMetrics = QueryMetrics.Zero;
+                                    int numberOfDocuments = 0;
+                                    while (documentQuery.HasMoreResults)
+                                    {
+                                        FeedResponse<dynamic> cosmosQueryResponse = await documentQuery.ReadNextAsync();
 
-                                    numberOfDocuments += cosmosQueryResponse.Count();
-                                    //foreach (QueryMetrics queryMetrics in cosmosQueryResponse.QueryMetrics.Values)
-                                    //{
-                                    //    aggregatedQueryMetrics += queryMetrics;
-                                    //}
+                                        numberOfDocuments += cosmosQueryResponse.Count();
+                                        //foreach (QueryMetrics queryMetrics in cosmosQueryResponse.QueryMetrics.Values)
+                                        //{
+                                        //    aggregatedQueryMetrics += queryMetrics;
+                                        //}
+                                    }
+
+                                    Assert.IsTrue(
+                                        numberOfDocuments <= topCount,
+                                        $"Received {numberOfDocuments} documents with query: {query} and pageSize: {pageSize}");
                                 }
 
-                                Assert.IsTrue(
-                                    numberOfDocuments <= topCount,
-                                    $"Received {numberOfDocuments} documents with query: {query} and pageSize: {pageSize}");
                                 //if (!useDistinct)
                                 //{
                                 //    Assert.IsTrue(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
@@ -205,14 +205,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 await container.CreateItemAsync<Person>(new Person() { Id = id + Guid.NewGuid().ToString(), FirstName = "James", LastName = "Smith" });
             }
 
-            FeedIterator<dynamic> query =
-                container.GetItemQueryIterator<dynamic>("SELECT TOP 10 * FROM coll");
             List<dynamic> list = new List<dynamic>();
-            while (query.HasMoreResults)
+            using (FeedIterator<dynamic> query =
+                container.GetItemQueryIterator<dynamic>("SELECT TOP 10 * FROM coll"))
             {
-                list.AddRange(await query.ReadNextAsync());
+                while (query.HasMoreResults)
+                {
+                    list.AddRange(await query.ReadNextAsync());
+                }
             }
-            
+
             await this.CleanupDocumentCollection(container);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -129,18 +129,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
              "SELECT t.id, t.status, t.cost, udf.calculateTax(t.cost) as total FROM toDoActivity t where t.cost > @expensive and t.status = @status")
                  .WithParameter("@expensive", 9000)
                  .WithParameter("@status", "Done");
-            
-             FeedIterator<dynamic> feedIterator = this.container.GetItemQueryIterator<dynamic>(
-                 queryDefinition: sqlQuery);
-
             HashSet<string> iterIds = new HashSet<string>();
-            while (feedIterator.HasMoreResults)
+            using (FeedIterator<dynamic> feedIterator = this.container.GetItemQueryIterator<dynamic>(
+                 queryDefinition: sqlQuery))
             {
-                foreach (var response in await feedIterator.ReadNextAsync())
+                while (feedIterator.HasMoreResults)
                 {
-                    Assert.IsTrue(response.cost > 9000);
-                    Assert.AreEqual(response.cost * .05, response.total);
-                    iterIds.Add(response.id.Value);
+                    foreach (dynamic response in await feedIterator.ReadNextAsync())
+                    {
+                        Assert.IsTrue(response.cost > 9000);
+                        Assert.AreEqual(response.cost * .05, response.total);
+                        iterIds.Add(response.id.Value);
+                    }
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -2574,6 +2574,11 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ResponseMessage] ReadNextAsync(System.Threading.CancellationToken)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
         }
       },
       "NestedTypes": {}
@@ -2595,6 +2600,11 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.FeedResponse`1[T]] ReadNextAsync(System.Threading.CancellationToken)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose()"
         }
       },
       "NestedTypes": {}


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds IDisposable to the FeedIterators to fix a memory leak caused by the query logic buffering pages in the background. The FeedIterators have default implementation to avoid breaking any users that are extending the base abstract class.

**NOTE: BREAKING CHANGE**
Any users that have a static analysis tool checking for IDisposable will be broken when upgrade to this version.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Put closes #1607

## Assignee

Please add yourself as the assignee

## Projects

Please add relevant projects so this issue can be properly tracked.

