### PR TITLE
Internal Query : Fix Made ExecutionInfo optional 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExecutionContext/OrderBy/CosmosOrderByItemQueryExecutionContext.Resume.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.OrderBy
                         // We still need to remove all the documents that have a lower rid in the rid sort order.
                         // If there is a tie in the sort order the documents should be in _rid order in the same direction as the index (given by the backend)
                         cmp = continuationRid.Document.CompareTo(rid.Document);
-                        if (producer.CosmosQueryExecutionInfo.ReverseRidEnabled)
+                        if ((producer.CosmosQueryExecutionInfo == null) || producer.CosmosQueryExecutionInfo.ReverseRidEnabled)
                         {
                             // If reverse rid is enabled on the backend then fallback to the old way of doing it.
                             if (sortOrders[0] == SortOrder.Descending)


### PR DESCRIPTION
# Internal Query : Fix Made ExecutionInfo optional 

## Description

It's possible that execution info is null (maybe in the future we stop returning it). 

