### PR TITLE
CosmosClient: Add check for empty keys

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -194,12 +194,12 @@ namespace Microsoft.Azure.Cosmos
             string authKeyOrResourceToken,
             CosmosClientOptions clientOptions = null)
         {
-            if (accountEndpoint == null)
+            if (string.IsNullOrEmpty(accountEndpoint))
             {
                 throw new ArgumentNullException(nameof(accountEndpoint));
             }
 
-            if (authKeyOrResourceToken == null)
+            if (string.IsNullOrEmpty(authKeyOrResourceToken))
             {
                 throw new ArgumentNullException(nameof(authKeyOrResourceToken));
             }
@@ -222,12 +222,12 @@ namespace Microsoft.Azure.Cosmos
             CosmosClientOptions cosmosClientOptions,
             DocumentClient documentClient)
         {
-            if (accountEndpoint == null)
+            if (string.IsNullOrEmpty(accountEndpoint))
             {
                 throw new ArgumentNullException(nameof(accountEndpoint));
             }
 
-            if (authKeyOrResourceToken == null)
+            if (string.IsNullOrEmpty(authKeyOrResourceToken))
             {
                 throw new ArgumentNullException(nameof(authKeyOrResourceToken));
             }

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -54,12 +54,12 @@ namespace Microsoft.Azure.Cosmos.Fluent
             string accountEndpoint,
             string authKeyOrResourceToken)
         {
-            if (accountEndpoint == null)
+            if (string.IsNullOrEmpty(accountEndpoint))
             {
                 throw new ArgumentNullException(nameof(CosmosClientBuilder.accountEndpoint));
             }
 
-            if (authKeyOrResourceToken == null)
+            if (string.IsNullOrEmpty(authKeyOrResourceToken))
             {
                 throw new ArgumentNullException(nameof(authKeyOrResourceToken));
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -51,6 +52,42 @@ namespace Microsoft.Azure.Cosmos.Tests
                 }
                 catch (ObjectDisposedException) { }
             }
+        }
+
+        [DataTestMethod]
+        [DataRow(null, "425Mcv8CXQqzRNCgFNjIhT424GK99CKJvASowTnq15Vt8LeahXTcN5wt3342vQ==")]
+        [DataRow(AccountEndpoint, null)]
+        [DataRow("", "425Mcv8CXQqzRNCgFNjIhT424GK99CKJvASowTnq15Vt8LeahXTcN5wt3342vQ==")]
+        [DataRow(AccountEndpoint, "")]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void InvalidEndpointAndKey(string endpoint, string key)
+        {
+            new CosmosClient(endpoint, key);
+        }
+
+        [DataTestMethod]
+        [DataRow(null, "425Mcv8CXQqzRNCgFNjIhT424GK99CKJvASowTnq15Vt8LeahXTcN5wt3342vQ==")]
+        [DataRow(AccountEndpoint, null)]
+        [DataRow("", "425Mcv8CXQqzRNCgFNjIhT424GK99CKJvASowTnq15Vt8LeahXTcN5wt3342vQ==")]
+        [DataRow(AccountEndpoint, "")]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void Builder_InvalidEndpointAndKey(string endpoint, string key)
+        {
+            new CosmosClientBuilder(endpoint, key);
+        }
+
+        [TestMethod]
+        public void InvalidConnectionString()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new CosmosClient(""));
+            Assert.ThrowsException<ArgumentNullException>(() => new CosmosClient(null));
+        }
+
+        [TestMethod]
+        public void Builder_InvalidConnectionString()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new CosmosClientBuilder(""));
+            Assert.ThrowsException<ArgumentNullException>(() => new CosmosClientBuilder(null));
         }
     }
 }


### PR DESCRIPTION
## Description

Currently we check for `null` parameters on the `CosmosClient` and `CosmosClientBuilder` constructor. But if customers are reading the key (for example) from a configuration source (like KeyVault) where the value stored there is an empty string, this leads to a support case for a 401 - Not Authorized.

401 investigations are not easy, and from past experience, this is an easy fix that can rule out one of the most common scenarios.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
