### PR TITLE
[Internal] FeedIterator: Add support to pass custom RequestEnricherFunc to FeedRangeIteratorCore

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Azure.Cosmos
         /// where the partition key range needs to be computed. 
         /// </summary>
         internal bool IsPartitionKeyRangeHandlerRequired => this.OperationType == OperationType.ReadFeed &&
-            (this.ResourceType == ResourceType.Document || this.ResourceType == ResourceType.Conflict) &&
-            this.PartitionKeyRangeId == null && this.Headers.PartitionKey == null;
+            this.ResourceType.IsPartitioned() && this.PartitionKeyRangeId == null &&
+            this.Headers.PartitionKey == null;
 
         /// <summary>
         /// Request properties Per request context available to handlers. 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
@@ -120,7 +120,65 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null);
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: null);
+            ResponseMessage response = await feedTokenIterator.ReadNextAsync();
+
+            Mock.Get(feedToken)
+                .Verify(f => f.ReplaceContinuation(It.Is<string>(ct => ct == continuation)), Times.Once);
+
+            Mock.Get(feedToken)
+                .Verify(f => f.HandleSplitAsync(It.Is<ContainerInternal>(c => c == containerCore), It.IsAny<ResponseMessage>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task ReadFeedIteratorCore_ReadNextAsync_WithEnricherFunc()
+        {
+            string continuation = "TBD";
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK);
+            responseMessage.Headers.ContinuationToken = continuation;
+            responseMessage.Headers[Documents.HttpConstants.HttpHeaders.ItemCount] = "1";
+            responseMessage.Content = new MemoryStream(Encoding.UTF8.GetBytes("{}"));
+
+            Mock<CosmosClientContext> cosmosClientContext = new Mock<CosmosClientContext>();
+            cosmosClientContext.Setup(c => c.ClientOptions).Returns(new CosmosClientOptions());
+            cosmosClientContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<Uri>(),
+                    It.Is<Documents.ResourceType>(rt => rt == Documents.ResourceType.Document),
+                    It.IsAny<Documents.OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<CosmosDiagnosticsContext>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(responseMessage));
+
+            ContainerInternal containerCore = Mock.Of<ContainerInternal>();
+            Mock.Get(containerCore)
+                .Setup(c => c.ClientContext)
+                .Returns(cosmosClientContext.Object);
+            FeedRangeInternal range = Mock.Of<FeedRangeInternal>();
+            Mock.Get(range)
+                .Setup(f => f.Accept(It.IsAny<FeedRangeRequestMessagePopulatorVisitor>()));
+            FeedRangeContinuation feedToken = Mock.Of<FeedRangeContinuation>();
+            Mock.Get(feedToken)
+               .Setup(f => f.FeedRange)
+               .Returns(range);
+            Mock.Get(feedToken)
+                .Setup(f => f.HandleSplitAsync(It.Is<ContainerInternal>(c => c == containerCore), It.IsAny<ResponseMessage>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(Documents.ShouldRetryResult.NoRetry()));
+            Mock.Get(feedToken)
+                .Setup(f => f.GetContinuation())
+                .Returns(continuation);
+            Mock.Get(feedToken)
+                .Setup(f => f.IsDone)
+                .Returns(true);
+
+            Action<RequestMessage> enricherFunc = (RequestMessage requestMessage)=> { };
+
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: enricherFunc);
             ResponseMessage response = await feedTokenIterator.ReadNextAsync();
 
             Mock.Get(feedToken)
@@ -176,7 +234,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Conflict, queryDefinition: null);
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Conflict, queryDefinition: null, requestEnricherFunc: null);
             ResponseMessage response = await feedTokenIterator.ReadNextAsync();
 
             Mock.Get(feedToken)
@@ -233,7 +291,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Conflict, queryDefinition: new QueryDefinition("select * from c"));
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Conflict, queryDefinition: new QueryDefinition("select * from c"), requestEnricherFunc: null);
             ResponseMessage response = await feedTokenIterator.ReadNextAsync();
 
             Mock.Get(feedToken)
@@ -289,7 +347,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null);
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: null);
             bool creatorCalled = false;
             Func<ResponseMessage, FeedResponse<dynamic>> creator = (ResponseMessage r) =>
             {
@@ -354,7 +412,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null);
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: null);
             ResponseMessage response = await feedTokenIterator.ReadNextAsync();
 
             Mock.Get(feedToken)
@@ -411,7 +469,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.IsDone)
                 .Returns(true);
 
-            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null);
+            FeedRangeIteratorCore feedTokenIterator = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: null);
             ResponseMessage response = await feedTokenIterator.ReadNextAsync();
 
             Mock.Get(feedToken)
@@ -507,7 +565,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 .Setup(f => f.HandleSplitAsync(It.Is<ContainerInternal>(c => c == containerCore), It.IsAny<ResponseMessage>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Documents.ShouldRetryResult.NoRetry()));
 
-            FeedRangeIteratorCore changeFeedIteratorCore = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null);
+            FeedRangeIteratorCore changeFeedIteratorCore = new FeedRangeIteratorCore(containerCore, feedToken, new QueryRequestOptions(), Documents.ResourceType.Document, queryDefinition: null, requestEnricherFunc: null);
 
             ResponseMessage response = await changeFeedIteratorCore.ReadNextAsync();
 


### PR DESCRIPTION
## [Internal] FeedIterator: Add support to pass custom RequestEnricherFunc to FeedRangeIteratorCore

1. Added support to pass a customRequestEnricher function to FeedRangeIteratorCore.
2. Modified RequestMessage class to use `ResourceType.IsPartitioned()` to set `IsPartitionKeyRangeHandlerRequired` property.

The above changes are done to use FeedRangeIteratorCore for an internal resource type, with an additional header set in the request.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
