### PR TITLE
CosmosOperationCanceledException: Fix handler to catch all operation cancelled exceptions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -172,10 +172,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 requestEnricher?.Invoke(request);
                 return await this.SendAsync(request, cancellationToken);
             }
-            catch (OperationCanceledException oe)
-            {
-                throw new CosmosOperationCanceledException(oe, diagnosticsContext);
-            }
             finally
             {
                 if (disposeDiagnosticContext)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -11,6 +11,7 @@
     <IsEmulatorTest>true</IsEmulatorTest>
     <EmulatorFlavor>master</EmulatorFlavor>
     <DisableCopyEmulator>True</DisableCopyEmulator>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Pull Request Template

## Description

CosmosOperationCanceledException catch logic is moved up into the inline helper. This fixes an issue where some OperationCanceledException where not getting converted because some caches and other operations do not use the request invoker. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
