### PR TITLE
[vNext] Contract: Add CosmosClientOptions constructor for ApplicationName

### DIFF
--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -79,8 +79,11 @@ namespace Azure.Cosmos
             this.ConnectionProtocol = CosmosClientOptions.DefaultProtocol;
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
-            this.ApplicationName = applicationName;
             this.InitializeLoggedHeaderNames();
+            if (applicationName != null)
+            {
+                this.ApplicationName = applicationName;
+            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -68,9 +68,9 @@ namespace Azure.Cosmos
         /// <summary>
         /// Creates a new CosmosClientOptions
         /// </summary>
-        /// <param name="applicationName">A suffix to be added to the default user-agent for the Azure Cosmos DB service.</param>
+        /// <param name="applicationId">A suffix to be added to the default user-agent for the Azure Cosmos DB service.</param>
         public CosmosClientOptions(
-            string applicationName = null)
+            string applicationId = null)
         {
             this.UserAgentContainer = new Microsoft.Azure.Cosmos.UserAgentContainer();
             this.GatewayModeMaxConnectionLimit = ConnectionPolicy.Default.MaxConnectionLimit;
@@ -80,9 +80,9 @@ namespace Azure.Cosmos
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
             this.InitializeLoggedHeaderNames();
-            if (applicationName != null)
+            if (applicationId != null)
             {
-                this.ApplicationName = applicationName;
+                this.ApplicationName = applicationId;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -82,7 +82,7 @@ namespace Azure.Cosmos
             this.InitializeLoggedHeaderNames();
             if (applicationId != null)
             {
-                this.ApplicationName = applicationId;
+                this.ApplicationId = applicationId;
             }
         }
 
@@ -371,7 +371,7 @@ namespace Azure.Cosmos
 
         internal Collection<RequestHandler> CustomHandlers { get; }
 
-        internal string ApplicationName
+        internal string ApplicationId
         {
             get => this.UserAgentContainer.Suffix;
             set

--- a/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/CosmosClientOptions.cs
@@ -68,7 +68,9 @@ namespace Azure.Cosmos
         /// <summary>
         /// Creates a new CosmosClientOptions
         /// </summary>
-        public CosmosClientOptions()
+        /// <param name="applicationName">A suffix to be added to the default user-agent for the Azure Cosmos DB service.</param>
+        public CosmosClientOptions(
+            string applicationName = null)
         {
             this.UserAgentContainer = new Microsoft.Azure.Cosmos.UserAgentContainer();
             this.GatewayModeMaxConnectionLimit = ConnectionPolicy.Default.MaxConnectionLimit;
@@ -77,23 +79,8 @@ namespace Azure.Cosmos
             this.ConnectionProtocol = CosmosClientOptions.DefaultProtocol;
             this.ApiType = CosmosClientOptions.DefaultApiType;
             this.CustomHandlers = new Collection<RequestHandler>();
+            this.ApplicationName = applicationName;
             this.InitializeLoggedHeaderNames();
-        }
-
-        /// <summary>
-        /// Get or set user-agent suffix to include with every Azure Cosmos DB service interaction.
-        /// </summary>
-        /// <remarks>
-        /// Setting this property after sending any request won't have any effect.
-        /// </remarks>
-        public string ApplicationName
-        {
-            get => this.UserAgentContainer.Suffix;
-            set
-            {
-                this.UserAgentContainer.Suffix = value;
-                this.Diagnostics.ApplicationId = value;
-            }
         }
 
         /// <summary>
@@ -380,6 +367,16 @@ namespace Azure.Cosmos
         internal CosmosSerializer PropertiesSerializer => CosmosClientOptions.propertiesSerializer;
 
         internal Collection<RequestHandler> CustomHandlers { get; }
+
+        internal string ApplicationName
+        {
+            get => this.UserAgentContainer.Suffix;
+            set
+            {
+                this.UserAgentContainer.Suffix = value;
+                this.Diagnostics.ApplicationId = value;
+            }
+        }
 
         /// <summary>
         /// Gets or sets the connection protocol when connecting to the Azure Cosmos service.

--- a/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Fluent/CosmosClientBuilder.cs
@@ -112,14 +112,14 @@ namespace Azure.Cosmos
         /// <summary>
         /// A suffix to be added to the default user-agent for the Azure Cosmos DB service.
         /// </summary>
-        /// <param name="applicationName">A string to use as suffix in the User Agent.</param>
+        /// <param name="applicationId">A string to use as suffix in the User Agent.</param>
         /// <remarks>
         /// Setting this property after sending any request won't have any effect.
         /// </remarks>
         /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
-        public CosmosClientBuilder WithApplicationName(string applicationName)
+        public CosmosClientBuilder WithApplicationId(string applicationId)
         {
-            this.clientOptions.ApplicationName = applicationName;
+            this.clientOptions.ApplicationId = applicationId;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/JsonEncodedStrings.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/JsonEncodedStrings.cs
@@ -15,7 +15,7 @@ namespace Azure.Cosmos
         public readonly static JsonEncodedText Query = JsonEncodedText.Encode("query");
         public readonly static JsonEncodedText Parameters = JsonEncodedText.Encode("parameters");
         public readonly static JsonEncodedText CosmosSerializer = JsonEncodedText.Encode("CosmosSerializer");
-        public readonly static JsonEncodedText ApplicationName = JsonEncodedText.Encode("ApplicationName");
+        public readonly static JsonEncodedText ApplicationName = JsonEncodedText.Encode("ApplicationId");
         public readonly static JsonEncodedText GatewayModeMaxConnectionLimit = JsonEncodedText.Encode("GatewayModeMaxConnectionLimit");
         public readonly static JsonEncodedText RequestTimeout = JsonEncodedText.Encode("RequestTimeout");
         public readonly static JsonEncodedText ConnectionMode = JsonEncodedText.Encode("ConnectionMode");

--- a/Microsoft.Azure.Cosmos/azuredata/Serializer/TextJsonCosmosClientOptionsConverter.cs
+++ b/Microsoft.Azure.Cosmos/azuredata/Serializer/TextJsonCosmosClientOptionsConverter.cs
@@ -43,9 +43,9 @@ namespace Azure.Cosmos
                 writer.WriteString(JsonEncodedStrings.CosmosSerializer, cosmosSerializer.GetType().ToString());
             }
 
-            if (!string.IsNullOrEmpty(value.ApplicationName))
+            if (!string.IsNullOrEmpty(value.ApplicationId))
             {
-                writer.WriteString(JsonEncodedStrings.ApplicationName, value.ApplicationName);
+                writer.WriteString(JsonEncodedStrings.ApplicationName, value.ApplicationId);
             }
 
             if (value.GatewayModeMaxConnectionLimit > 0)

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Cosmos.Tests
             Assert.AreNotEqual(connectionMode, clientOptions.ConnectionMode);
             Assert.AreNotEqual(maxConnections, clientOptions.GatewayModeMaxConnectionLimit);
             Assert.AreNotEqual(requestTimeout, clientOptions.RequestTimeout);
-            Assert.AreNotEqual(userAgentSuffix, clientOptions.ApplicationName);
+            Assert.AreNotEqual(userAgentSuffix, clientOptions.ApplicationId);
             Assert.AreNotEqual(apiType, clientOptions.ApiType);
             Assert.IsFalse(clientOptions.AllowBulkExecution);
             Assert.AreEqual(0, clientOptions.CustomHandlers.Count);
@@ -85,7 +85,7 @@ namespace Azure.Cosmos.Tests
             cosmosClientBuilder.WithApplicationRegion(region)
                 .WithConnectionModeGateway(maxConnections, webProxy)
                 .WithRequestTimeout(requestTimeout)
-                .WithApplicationName(userAgentSuffix)
+                .WithApplicationId(userAgentSuffix)
                 .AddCustomHandlers(preProcessHandler)
                 .WithApiType(apiType)
                 .WithThrottlingRetryOptions(maxRetryWaitTime, maxRetryAttemptsOnThrottledRequests)
@@ -100,7 +100,7 @@ namespace Azure.Cosmos.Tests
             Assert.AreEqual(connectionMode, clientOptions.ConnectionMode);
             Assert.AreEqual(maxConnections, clientOptions.GatewayModeMaxConnectionLimit);
             Assert.AreEqual(requestTimeout, clientOptions.RequestTimeout);
-            Assert.AreEqual(userAgentSuffix, clientOptions.ApplicationName);
+            Assert.AreEqual(userAgentSuffix, clientOptions.ApplicationId);
             Assert.AreEqual(userAgentSuffix, clientOptions.Diagnostics.ApplicationId);
             Assert.AreEqual(preProcessHandler, clientOptions.CustomHandlers[0]);
             Assert.AreEqual(apiType, clientOptions.ApiType);
@@ -179,9 +179,9 @@ namespace Azure.Cosmos.Tests
             string expectedValue = "cosmos-netstandard-sdk/" + environmentInformation.ClientVersion;
             string userAgentSuffix = "testSuffix";
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions(userAgentSuffix);
-            Assert.AreEqual(cosmosClientOptions.ApplicationName, userAgentSuffix);
+            Assert.AreEqual(cosmosClientOptions.ApplicationId, userAgentSuffix);
             Assert.AreEqual(cosmosClientOptions.Diagnostics.ApplicationId, userAgentSuffix);
-            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
+            Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationId);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.Diagnostics.ApplicationId);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.UserAgentContainer.Suffix);
             Assert.IsTrue(cosmosClientOptions.UserAgentContainer.UserAgent.StartsWith(expectedValue));

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -177,9 +177,10 @@ namespace Azure.Cosmos.Tests
         {
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
             string expectedValue = "cosmos-netstandard-sdk/" + environmentInformation.ClientVersion;
-            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
             string userAgentSuffix = "testSuffix";
-            cosmosClientOptions.ApplicationName = userAgentSuffix;
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions(userAgentSuffix);
+            Assert.AreEqual(cosmosClientOptions.ApplicationName, userAgentSuffix);
+            Assert.AreEqual(cosmosClientOptions.Diagnostics.ApplicationId, userAgentSuffix);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.Diagnostics.ApplicationId);
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.UserAgentContainer.Suffix);

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -529,10 +529,10 @@
           "Attributes": [],
           "MethodInfo": "Azure.Cosmos.CosmosClient Build()"
         },
-        "Azure.Cosmos.CosmosClientBuilder WithApplicationName(System.String)": {
+        "Azure.Cosmos.CosmosClientBuilder WithApplicationId(System.String)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Azure.Cosmos.CosmosClientBuilder WithApplicationName(System.String)"
+          "MethodInfo": "Azure.Cosmos.CosmosClientBuilder WithApplicationId(System.String)"
         },
         "Azure.Cosmos.CosmosClientBuilder WithApplicationRegion(System.String)": {
           "Type": "Method",

--- a/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Azure.Cosmos/Azure.Cosmos.Tests/DotNetSDKAPI.json
@@ -733,20 +733,10 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "System.String ApplicationName": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": null
-        },
         "System.String ApplicationRegion": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": null
-        },
-        "System.String get_ApplicationName()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.String get_ApplicationName()"
         },
         "System.String get_ApplicationRegion()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -767,15 +757,10 @@
           "Attributes": [],
           "MethodInfo": null
         },
-        "Void .ctor()": {
+        "Void .ctor(System.String)": {
           "Type": "Constructor",
           "Attributes": [],
-          "MethodInfo": "Void .ctor()"
-        },
-        "Void set_ApplicationName(System.String)": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void set_ApplicationName(System.String)"
+          "MethodInfo": "Void .ctor(System.String)"
         },
         "Void set_ApplicationRegion(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",


### PR DESCRIPTION
## Description

Following API review feedback, this PR removes the `CosmosClientOptions.ApplicationName` property that competes with `ClientOptions.Diagnostics.ApplicationId`.

Since ApplicationName is a fairly common setting, it is promoted to the `CosmosClientOptions` constructor instead, as proposed during review:

`CosmosClientOptions options = new CosmosClientOptions(applicatioId: "MyApp");`

Internally it will set the Cosmos DB user-agent suffix and also the Azure.Core Diagnostics.ApplicationId.

## Type of change

- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
