### PR TITLE
Performance: Fix CPU consumption with EnableTcpConnectionEndpointRediscovery

### DIFF
--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ClientOfficialVersion>3.10.1</ClientOfficialVersion>
     <ClientPreviewVersion>3.9.1</ClientPreviewVersion>
-    <DirectVersion>3.11.1</DirectVersion>
+    <DirectVersion>3.11.2</DirectVersion>
     <EncryptionVersion>1.0.0-preview4</EncryptionVersion>
     <HybridRowVersion>1.0.0-preview</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Rntbd;
     using Microsoft.Azure.Documents.Routing;
     using Newtonsoft.Json;
 
@@ -707,6 +709,16 @@ namespace Microsoft.Azure.Cosmos
                 partitionKey.Components.Count);
 
             return null;
+        }
+
+        public Task UpdateAsync(ServerKey serverKey, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateAsync(IReadOnlyList<AddressCacheToken> addressCacheTokens, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         private class ResolutionResult

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -14,12 +14,13 @@ namespace Microsoft.Azure.Cosmos.Routing
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Rntbd;
 
     /// <summary>
     /// AddressCache implementation for client SDK. Supports cross region address routing based on
     /// avaialbility and preference list.
     /// </summary>
-    internal sealed class GlobalAddressResolver : IAddressResolverExtension, IDisposable
+    internal sealed class GlobalAddressResolver : IAddressResolver, IDisposable
     {
         private const int MaxBackupReadRegions = 3;
 
@@ -35,6 +36,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         private readonly ConcurrentDictionary<Uri, EndpointCache> addressCacheByEndpoint;
         private readonly TimeSpan requestTimeout;
         private readonly ApiType apiType;
+        private readonly bool enableTcpConnectionEndpointRediscovery;
 
         public GlobalAddressResolver(
             GlobalEndpointManager endpointManager,
@@ -62,6 +64,8 @@ namespace Microsoft.Azure.Cosmos.Routing
             int maxBackupReadEndpoints =
                 !connectionPolicy.EnableReadRequestsFallback.HasValue || connectionPolicy.EnableReadRequestsFallback.Value
                 ? GlobalAddressResolver.MaxBackupReadRegions : 0;
+
+            this.enableTcpConnectionEndpointRediscovery = connectionPolicy.EnableTcpConnectionEndpointRediscovery;
 
             this.maxEndpoints = maxBackupReadEndpoints + 2; // for write and alternate write endpoint (during failover)
 
@@ -131,6 +135,21 @@ namespace Microsoft.Azure.Cosmos.Routing
             await Task.WhenAll(tasks);
         }
 
+        public async Task UpdateAsync(
+            ServerKey serverKey,
+            CancellationToken cancellationToken)
+        {
+            List<Task> tasks = new List<Task>();
+
+            foreach (KeyValuePair<Uri, EndpointCache> addressCache in this.addressCacheByEndpoint)
+            {
+                // since we don't know which address cache contains the pkRanges mapped to this node, we do a tryUpdate on all AddressCaches of all regions
+                tasks.Add(addressCache.Value.AddressCache.TryUpdateAddressAsync(serverKey, cancellationToken));
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
         /// <summary>
         /// ReplicatedResourceClient will use this API to get the direct connectivity AddressCache for given request.
         /// </summary>
@@ -164,7 +183,8 @@ namespace Microsoft.Azure.Cosmos.Routing
                         this.serviceConfigReader,
                         this.requestTimeout,
                         messageHandler: this.messageHandler,
-                        apiType: this.apiType);
+                        apiType: this.apiType,
+                        enableTcpConnectionEndpointRediscovery: this.enableTcpConnectionEndpointRediscovery);
 
                     string location = this.endpointManager.GetLocation(endpoint);
                     AddressResolver addressResolver = new AddressResolver(null, new NullRequestSigner(), location);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
@@ -81,9 +81,8 @@ namespace Microsoft.Azure.Cosmos
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
             TransportClient mockTransportClient = this.GetMockTransportClient();
             ISessionContainer sessionContainer = new SessionContainer(string.Empty);
-            var connectionStateListener = new ConnectionStateListener(null);
 
-            StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer, connectionStateListener);
+            StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer);
 
             Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
             mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(
@@ -149,7 +148,7 @@ namespace Microsoft.Azure.Cosmos
                     It.IsAny<DocumentServiceRequest>(),
                     It.IsAny<bool>(),
                     new CancellationToken()))
-                    .ReturnsAsync(new PartitionAddressInformation(addressInformation, null, null));
+                    .ReturnsAsync(new PartitionAddressInformation(addressInformation));
 
             return mockAddressCache;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
                     It.IsAny<DocumentServiceRequest>(),
                     false /*forceRefresh*/,
                     new CancellationToken()))
-                    .ReturnsAsync(new PartitionAddressInformation(addressInformation, null, null));
+                    .ReturnsAsync(new PartitionAddressInformation(addressInformation));
 
             // validate that the mock works
             PartitionAddressInformation addressInfo = mockAddressCache.Object.ResolveAsync(entity, false, new CancellationToken()).Result;
@@ -480,7 +480,7 @@ namespace Microsoft.Azure.Cosmos
                     It.IsAny<DocumentServiceRequest>(),
                     It.IsAny<bool>(),/*forceRefresh*/
                     new CancellationToken()))
-                    .ReturnsAsync(new PartitionAddressInformation(addressInformation, null, null));
+                    .ReturnsAsync(new PartitionAddressInformation(addressInformation));
 
             return mockAddressCache;
         }
@@ -520,10 +520,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Tuple<Uri, AddressCacheToken> primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
 
             // check if the address return from Address Selector matches the original address info
-            Assert.IsTrue(primaryAddress.Item1.Equals(addressInformation[0].PhysicalUri));
+            Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
 
             // get mock transport client that returns a sequence of responses to simulate upgrade
             TransportClient mockTransportClient = this.GetMockTransportClientDuringUpgrade(addressInformation);
@@ -542,14 +542,11 @@ namespace Microsoft.Azure.Cosmos
             // create a real session container - we don't need session for this test anyway
             ISessionContainer sessionContainer = new SessionContainer(string.Empty);
 
-            ConnectionStateListener connectionStateListener = new ConnectionStateListener(null);
-
             // create store reader with mock transport client, real address selector (that has mock address cache), and real session container
             StoreReader storeReader =
                 new StoreReader(mockTransportClient,
                     addressSelector,
-                    sessionContainer,
-                    connectionStateListener);
+                    sessionContainer);
 
             // reads always go to read quorum (2) replicas
             int replicaCountToRead = 2;
@@ -606,15 +603,13 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Tuple<Uri, AddressCacheToken> primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
 
             // check if the address return from Address Selector matches the original address info
-            Assert.IsTrue(primaryAddress.Item1.Equals(addressInformation[0].PhysicalUri));
+            Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
 
             // create a real session container - we don't need session for this test anyway
             ISessionContainer sessionContainer = new SessionContainer(string.Empty);
-
-            ConnectionStateListener connectionStateListener = new ConnectionStateListener(null);
 
             Mock<IServiceConfigurationReader> mockServiceConfigReader = new Mock<IServiceConfigurationReader>();
 
@@ -626,14 +621,14 @@ namespace Microsoft.Azure.Cosmos
             for (int i = 0; i < addressInformation.Length; i++)
             {
                 TransportClient mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, false, false, false);
-                StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer, connectionStateListener);
-                ConsistencyWriter consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, connectionStateListener, false);
+                StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer);
+                ConsistencyWriter consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 StoreResponse response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
                 Assert.AreEqual(100, response.LSN);
 
                 //globalCommittedLsn never catches up in this case
                 mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, true, false, false);
-                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, connectionStateListener, false);
+                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 try
                 {
                     response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
@@ -644,17 +639,17 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, false, true, false);
-                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, connectionStateListener, false);
+                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
                 Assert.AreEqual(100, response.LSN);
 
                 mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, false, true, true);
-                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, connectionStateListener, false);
+                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
                 Assert.AreEqual(100, response.LSN);
 
                 mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, false, false, true);
-                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, connectionStateListener, false);
+                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
                 Assert.AreEqual(100, response.LSN);
             }
@@ -700,10 +695,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Tuple<Uri, AddressCacheToken> primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
 
             // check if the address return from Address Selector matches the original address info
-            Assert.IsTrue(primaryAddress.Item1.Equals(addressInformation[0].PhysicalUri));
+            Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
 
             // Quorum Met scenario
             {
@@ -713,14 +708,11 @@ namespace Microsoft.Azure.Cosmos
                 // create a real session container - we don't need session for this test anyway
                 ISessionContainer sessionContainer = new SessionContainer(string.Empty);
 
-                ConnectionStateListener connectionStateListener = new ConnectionStateListener(null);
-
                 // create store reader with mock transport client, real address selector (that has mock address cache), and real session container
                 StoreReader storeReader =
                     new StoreReader(mockTransportClient,
                         addressSelector,
-                        sessionContainer,
-                        connectionStateListener);
+                        sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
                 mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(
@@ -758,14 +750,11 @@ namespace Microsoft.Azure.Cosmos
                 // create a real session container - we don't need session for this test anyway
                 ISessionContainer sessionContainer = new SessionContainer(string.Empty);
 
-                ConnectionStateListener connectionStateListener = new ConnectionStateListener(null);
-
                 // create store reader with mock transport client, real address selector (that has mock address cache), and real session container
                 StoreReader storeReader =
                     new StoreReader(mockTransportClient,
                         addressSelector,
-                        sessionContainer,
-                        connectionStateListener);
+                        sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
                 mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(
@@ -812,14 +801,11 @@ namespace Microsoft.Azure.Cosmos
                 // create a real session container - we don't need session for this test anyway
                 ISessionContainer sessionContainer = new SessionContainer(string.Empty);
 
-                ConnectionStateListener connectionStateListener = new ConnectionStateListener(null);
-
                 // create store reader with mock transport client, real address selector (that has mock address cache), and real session container
                 StoreReader storeReader =
                 new StoreReader(mockTransportClient,
                     addressSelector,
-                    sessionContainer,
-                    connectionStateListener);
+                    sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
                 mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(


### PR DESCRIPTION
## Description

This PR resolves a CPU consumption issue while using `CosmosClientOptions.EnableTcpConnectionEndpointRediscovery` that could cause higher CPU than intended.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
