### PR TITLE
[Internal] Codeowners: Fix order to ensure correct required reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,8 @@ Microsoft.Azure.Cosmos/src/Linq @khdang @j82w @sboshra @kirankumarkolli @bchong9
 Microsoft.Azure.Cosmos/src/Spatial @lalithamv @sboshra @kirankumarkolli @j82w
 Microsoft.Azure.Cosmos/tests @khdang @sboshra @bchong95 @kirankumarkolli @j82w @ealsur @FabianMeiswinkel @kirillg
 Microsoft.Azure.Cosmos.Samples @khdang @sboshra @bchong95 @kirankumarkolli @j82w @ealsur @FabianMeiswinkel @kirillg
-Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json @kirillg @kirankumarkolli
+
+# Order is important; the last matching pattern takes the most precedence
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts @kirillg @kirankumarkolli @j82w @ealsur @FabianMeiswinkel
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kirillg @kirankumarkolli @j82w @ealsur @FabianMeiswinkel
+Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json @kirillg @kirankumarkolli


### PR DESCRIPTION
# Pull Request Template

## Description

The order of the code owner files matters. This changes the order to ensure the proper owners are required.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



