### PR TITLE
[Internal] Benchmark: Adds Few more benchmark related changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ClientOfficialVersion>3.11.0</ClientOfficialVersion>
+    <ClientPreviewVersion>3.11.0</ClientPreviewVersion>
+    <DirectVersion>3.11.2</DirectVersion>
+    <EncryptionVersion>1.0.0-preview4</EncryptionVersion>
+    <HybridRowVersion>1.0.0-preview</HybridRowVersion>
+    <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
+	<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
+  </PropertyGroup>
+  <Import Project="$(AboveDirBuildProps)" Condition=" '$(AboveDirBuildProps)' != '' " />
+</Project>

--- a/Microsoft.Azure.Cosmos.Encryption/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos.Encryption/Directory.Build.props
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\Microsoft.Azure.Cosmos\Directory.Build.props" />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>

--- a/Microsoft.Azure.Cosmos.Samples/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos.Samples/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
@@ -26,11 +26,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(ProjectRef)' == 'True' ">
-    <!-- UNCOMMENTING BELOW and REMOVING ABOVE condition above will enable run with latest V3 sources
-    
-    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="*" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="1.0.0-preview" />
-    -->
     <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(OSSProjectRef)' == 'True' ">
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" />
   </ItemGroup>
 </Project>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -18,7 +18,7 @@ dotnet run CosmosBenchmark.csproj -p:OSSProjectRef=True -e {ACCOUNT_ENDPOINT} -k
 
 For PerfRuns with reports (INTERNAL)
 ```
-dotnet run -c Release -- -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY} --publishresults --resultspartitionkeyvalue "runs-summary"  --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 200000 -w ReadStreamExistsV3 --pl 300 
+dotnet run -c Release  -p:OSSProjectRef=True -- -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY} --publishresults --resultspartitionkeyvalue "runs-summary"  --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 200000 -w ReadStreamExistsV3 --pl 300 
 ```
 
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -12,7 +12,8 @@ dotnet run CosmosBenchmark.csproj -e "https://localhost:8081" -k "C2y6yDjf5/R+ob
 
 To target Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj
 ```
-dotnet run CosmosBenchmark.csproj -p:OSSProjectRef=True -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
+export OSSProjectRef=True
+dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
 ```
 
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -16,6 +16,12 @@ dotnet run CosmosBenchmark.csproj -p:OSSProjectRef=True -e {ACCOUNT_ENDPOINT} -k
 ```
 
 
+For PerfRuns with reports (INTERNAL)
+```
+dotnet run -c Release -- -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY} --publishresults --resultspartitionkeyvalue "runs-summary"  --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 200000 -w ReadStreamExistsV3 --pl 300 
+```
+
+
 ![image](https://user-images.githubusercontent.com/6880899/61565403-8e41bd00-aa96-11e9-9996-b7fc77c3aed3.png)
 
 ## Usage

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -10,6 +10,12 @@ Dry tun targeting emulator will look like below
 dotnet run CosmosBenchmark.csproj -e "https://localhost:8081" -k "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
 ```
 
+To target Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj
+```
+dotnet run CosmosBenchmark.csproj -p:OSSProjectRef=True -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
+```
+
+
 ![image](https://user-images.githubusercontent.com/6880899/61565403-8e41bd00-aa96-11e9-9996-b7fc77c3aed3.png)
 
 ## Usage

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -19,7 +19,13 @@ dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
 
 For PerfRuns with reports (INTERNAL)
 ```
-dotnet run -c Release  -p:OSSProjectRef=True -- -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY} --publishresults --resultspartitionkeyvalue "runs-summary"  --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 200000 -w ReadStreamExistsV3 --pl 300 
+export OSSProjectRef=True
+export ACCOUNT_ENDPOINT=<ENDPOINT
+export ACCOUNT_KEY=<KEY>
+export RESULTS_PK="runs-summary" #For test runs use different one
+export PL=300
+
+dotnet run -c Release  -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --publishresults --resultspartitionkeyvalue $RESULTS_PK -commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 500000 -w ReadStreamExistsV3 --pl $PL 
 ```
 
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Looped benchmrak run
+# $1: BenchmarkName
+# $2: IterationCount
+loopedBenchmarkRun() {
+    echo
+    echo ========$1==========
+    echo
+
+    for ((i=0; i < $2; i++))
+    do
+        echo ========ITER: $i ==========
+        dotnet run -c Release  -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --publishresults --resultspartitionkeyvalue $RESULTS_PK -commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 500000 -w ReadStreamExistsV3 --pl $PL 
+    done
+}
+
+if [ -z "$ACCOUNT_ENDPOINT" ]
+then
+    echo "Missing ACCOUNT_ENDPOINT"
+    exit -1
+fi
+
+if [ -z "$ACCOUNT_KEY" ]
+then
+    echo "Missing ACCOUNT_KEY"
+    exit -1
+fi
+
+if [ -z "$RESULTS_PK" ]
+then
+    echo "Missing RESULTS_PK"
+    exit -1
+fi
+
+if [ -Z "$PL" ]
+then
+    echo "Missing PL"
+    exit -1
+fi
+
+for BENCHMARK_NAME in InsertV3 ReadFeedStreamV3 ReadNotExistsV3 ReadStreamExistsV3 ReadTExistsV3
+do
+    loopedBenchmarkRun $BENCHMARK_NAME 5
+done
+

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
@@ -11,7 +11,10 @@ loopedBenchmarkRun() {
     for ((i=0; i < $2; i++))
     do
         echo ========ITER: $i ==========
-        dotnet run -c Release  -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --publishresults --resultspartitionkeyvalue $RESULTS_PK -commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 500000 -w ReadStreamExistsV3 --pl $PL 
+        echo SLEEPING for 60s
+        sleep 60
+
+        dotnet run -c Release  -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --publishresults --resultspartitionkeyvalue $RESULTS_PK --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 500000 -w ReadStreamExistsV3 --pl $PL 
     done
 }
 
@@ -33,14 +36,20 @@ then
     exit -1
 fi
 
-if [ -Z "$PL" ]
+if [ -z "$PL" ]
 then
     echo "Missing PL"
     exit -1
 fi
 
+if [ -z "$BENCH_MARK_ITER_COUNT" ]
+then
+    echo "BENCH_MARK_ITER_COUNT not set, setting to default 5"
+    BENCH_MARK_ITER_COUNT=5
+fi
+
 for BENCHMARK_NAME in InsertV3 ReadFeedStreamV3 ReadNotExistsV3 ReadStreamExistsV3 ReadTExistsV3
 do
-    loopedBenchmarkRun $BENCHMARK_NAME 5
+    loopedBenchmarkRun $BENCHMARK_NAME $BENCH_MARK_ITER_COUNT
 done
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Directory.Build.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+</Project>

--- a/Microsoft.Azure.Cosmos/Directory.Build.props
+++ b/Microsoft.Azure.Cosmos/Directory.Build.props
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <ClientOfficialVersion>3.11.0</ClientOfficialVersion>
-    <ClientPreviewVersion>3.11.0</ClientPreviewVersion>
-    <DirectVersion>3.11.2</DirectVersion>
-    <EncryptionVersion>1.0.0-preview4</EncryptionVersion>
-    <HybridRowVersion>1.0.0-preview</HybridRowVersion>
-    <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
-	<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
-  </PropertyGroup>
-  <Import Project="$(AboveDirBuildProps)" Condition=" '$(AboveDirBuildProps)' != '' " />
+    <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 </Project>


### PR DESCRIPTION
- Directory.Build.props moved upto the root for all of source availability
- No touch benchmark execution support (including targetting current branch), related README changes
- Linux bash script used internally for running tests