### PR TITLE
Performance: Fixes Reduces AuthorizationHelper memory allocations

### DIFF
--- a/Microsoft.Azure.Cosmos/src/AuthorizationHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/AuthorizationHelper.cs
@@ -483,34 +483,32 @@ namespace Microsoft.Azure.Cosmos
             int length = stream.Write(verb.ToLowerInvariant());
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write("\n");
+            length = stream.Write("\n");
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write(resourceType.ToLowerInvariant());
+            length = stream.Write(resourceType.ToLowerInvariant());
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write("\n");
+            length = stream.Write("\n");
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write(resourceId);
+            length = stream.Write(resourceId);
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write("\n");
+            length = stream.Write("\n");
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write(xDate.ToLowerInvariant());
+            length = stream.Write(xDate.ToLowerInvariant());
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write("\n");
+            length = stream.Write("\n");
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write(xDate.Equals(string.Empty, StringComparison.OrdinalIgnoreCase) ? date.ToLowerInvariant() : string.Empty);
+            length = stream.Write(xDate.Equals(string.Empty, StringComparison.OrdinalIgnoreCase) ? date.ToLowerInvariant() : string.Empty);
             totalLength += length;
             stream = stream.Slice(length);
-            stream.Write("\n");
+            length = stream.Write("\n");
             totalLength += length;
-            stream = stream.Slice(length);
-
             return totalLength;
         }
 

--- a/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
@@ -84,8 +84,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 PathsHelper.GetResourcePath(request.ResourceType),
                 request.Method.ToString(),
                 serviceRequest.Headers,
-                AuthorizationTokenType.PrimaryMasterKey,
-                payload: out _);
+                AuthorizationTokenType.PrimaryMasterKey);
 
             serviceRequest.Headers[HttpConstants.HttpHeaders.Authorization] = authorization;
 

--- a/Microsoft.Azure.Cosmos/src/IComputeHash.cs
+++ b/Microsoft.Azure.Cosmos/src/IComputeHash.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Cosmos
 
     internal interface IComputeHash : IDisposable
     {
-        byte[] ComputeHash(MemoryStream bytesToHash);
+        byte[] ComputeHash(ArraySegment<byte> bytesToHash);
 
         SecureString Key
         {

--- a/Microsoft.Azure.Cosmos/src/ICosmosAuthorizationTokenProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/ICosmosAuthorizationTokenProvider.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.IO;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
@@ -22,7 +23,6 @@ namespace Microsoft.Azure.Cosmos
             string resourceType,
             string requestVerb,
             INameValueCollection headers,
-            AuthorizationTokenType tokenType,
-            out MemoryStream payload);
+            AuthorizationTokenType tokenType);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -92,6 +92,7 @@
 
     <!--HybridRow Dependencies-->
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.1" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/Microsoft.Azure.Cosmos/src/SecureStringHMACSHA256Helper.cs
+++ b/Microsoft.Azure.Cosmos/src/SecureStringHMACSHA256Helper.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Cosmos
         /// SHA256 HMAC of the payload, and destroy the native memory containing the decoded key.
         /// </summary>
         /// <param name="bytesToHash">payload that is hashed</param>
-        public byte[] ComputeHash(MemoryStream bytesToHash)
+        public byte[] ComputeHash(ArraySegment<byte> bytesToHash)
         {
             IntPtr hashHandle = IntPtr.Zero;
 
@@ -95,15 +95,15 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        private void AddData(IntPtr hashHandle, MemoryStream dataStream)
+        private void AddData(IntPtr hashHandle, ArraySegment<byte> dataStream)
         {
-            byte[] data = dataStream.GetBuffer();
+            byte[] data = dataStream.Array;
             GCHandle h = GCHandle.Alloc(data, GCHandleType.Pinned);
             try
             {
                 int status = NativeMethods.BCryptHashData(hashHandle,
                     h.AddrOfPinnedObject(),
-                    (uint)data.Length,
+                    (uint)dataStream.Count,
                     0);
                 if (status != 0)
                 {

--- a/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
+++ b/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos
             this.hmacPool = new ConcurrentQueue<HMACSHA256>();
         }
 
-        public byte[] ComputeHash(MemoryStream bytesToHash)
+        public byte[] ComputeHash(ArraySegment<byte> bytesToHash)
         {
             if (this.hmacPool.TryDequeue(out HMACSHA256 hmacSha256))
             {
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos
 
             try
             {
-                return hmacSha256.ComputeHash(bytesToHash.GetBuffer(), 0, (int)bytesToHash.Length);
+                return hmacSha256.ComputeHash(bytesToHash.Array, 0, (int)bytesToHash.Count);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
+++ b/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Collections.Concurrent;
     using System.IO;
     using System.Security;
     using System.Security.Cryptography;
@@ -14,18 +15,33 @@ namespace Microsoft.Azure.Cosmos
         private readonly String base64EncodedKey;
         private readonly byte[] keyBytes;
         private SecureString secureString;
+        private ConcurrentQueue<HMACSHA256> hmacPool;
 
         public StringHMACSHA256Hash(String base64EncodedKey)
         {
             this.base64EncodedKey = base64EncodedKey;
             this.keyBytes = Convert.FromBase64String(base64EncodedKey);
+            this.hmacPool = new ConcurrentQueue<HMACSHA256>();
         }
 
         public byte[] ComputeHash(MemoryStream bytesToHash)
         {
-            using (HMACSHA256 hmacSha256 = new HMACSHA256(this.keyBytes))
+            if (this.hmacPool.TryDequeue(out HMACSHA256 hmacSha256))
             {
-                return hmacSha256.ComputeHash(bytesToHash);
+                hmacSha256.Initialize();
+            }
+            else
+            {
+                hmacSha256 = new HMACSHA256(this.keyBytes);
+            }
+
+            try
+            {
+                return hmacSha256.ComputeHash(bytesToHash.GetBuffer(), 0, (int)bytesToHash.Length);
+            }
+            finally
+            {
+                this.hmacPool.Enqueue(hmacSha256);
             }
         }
 
@@ -41,6 +57,11 @@ namespace Microsoft.Azure.Cosmos
 
         public void Dispose()
         {
+            while (this.hmacPool.TryDequeue(out HMACSHA256 hmacsha256))
+            {
+                hmacsha256.Dispose();
+            }
+
             if (this.secureString != null)
             {
                 this.secureString.Dispose();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
@@ -41,12 +41,9 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             string resourceId,
             string resourceType)
         {
-            MemoryStream payload;
+            AuthorizationHelper.ArrayOwner payload;
             AuthorizationHelper.GenerateKeyAuthorizationSignature(verb, resourceId, resourceType, this.testHeaders, this.authKeyHashFunction, out payload);
-
-#pragma warning disable CS0642 // Possible mistaken empty statement
-            using (payload) ;
-#pragma warning restore CS0642 // Possible mistaken empty statement
+            payload.Dispose();
         }
 
         public static string GenerateRandomKey()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             AuthorizationHelper.GenerateKeyAuthorizationSignature(verb, resourceId, resourceType, this.testHeaders, this.authKeyHashFunction, out payload);
 
 #pragma warning disable CS0642 // Possible mistaken empty statement
-            //using (payload) ;
+            using (payload) ;
 #pragma warning restore CS0642 // Possible mistaken empty statement
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
@@ -1,0 +1,52 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Performance.Tests
+{
+    using System;
+    using System.Globalization;
+    using System.IO;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+
+    [Config(typeof(SdkBenchmarkConfiguration))]
+    public class MasterKeyAuthorizationBenchmark
+    {
+        private IComputeHash authKeyHashFunction;
+        private INameValueCollection testHeaders;
+
+        public MasterKeyAuthorizationBenchmark()
+        {
+            this.authKeyHashFunction = new StringHMACSHA256Hash("C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
+            Headers headers = new Headers();
+            headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture);
+
+            this.testHeaders = headers.CosmosMessageHeaders;
+        }
+
+        [Benchmark]
+        public void CreateSignatureGeneration()
+        {
+            this.TestSignature("POST", "dbs/testdb/colls/testcollection/dbs", "dbs");
+        }
+
+        [Benchmark]
+        public void ReadSignatureGeneration()
+        {
+            this.TestSignature("GET", "dbs/testdb/colls/testcollection/dbs/item1", "dbs");
+        }
+
+        private void TestSignature(string verb,
+            string resourceId,
+            string resourceType)
+        {
+            MemoryStream payload;
+            AuthorizationHelper.GenerateKeyAuthorizationSignature(verb, resourceId, resourceType, this.testHeaders, this.authKeyHashFunction, out payload);
+
+#pragma warning disable CS0642 // Possible mistaken empty statement
+            //using (payload) ;
+#pragma warning restore CS0642 // Possible mistaken empty statement
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
         public MasterKeyAuthorizationBenchmark()
         {
-            this.authKeyHashFunction = new StringHMACSHA256Hash(MasterKeyAuthorizationBenchmark.GenerateRandomKey());
+            this.authKeyHashFunction = new StringHMACSHA256Hash(MockDocumentClient.GenerateRandomKey());
             Headers headers = new Headers();
             headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture);
 
@@ -44,17 +44,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             AuthorizationHelper.ArrayOwner payload;
             AuthorizationHelper.GenerateKeyAuthorizationSignature(verb, resourceId, resourceType, this.testHeaders, this.authKeyHashFunction, out payload);
             payload.Dispose();
-        }
-
-        public static string GenerateRandomKey()
-        {
-            int keyLength = 64;
-            byte[] randomEntries = new byte[keyLength];
-
-            Random r = new Random((int)DateTime.Now.Ticks);
-            r.NextBytes(randomEntries);
-
-            return Convert.ToBase64String(randomEntries);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MasterKeyAuthorizationBenchmark.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
         public MasterKeyAuthorizationBenchmark()
         {
-            this.authKeyHashFunction = new StringHMACSHA256Hash("C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
+            this.authKeyHashFunction = new StringHMACSHA256Hash(MasterKeyAuthorizationBenchmark.GenerateRandomKey());
             Headers headers = new Headers();
             headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture);
 
@@ -47,6 +47,17 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 #pragma warning disable CS0642 // Possible mistaken empty statement
             using (payload) ;
 #pragma warning restore CS0642 // Possible mistaken empty statement
+        }
+
+        public static string GenerateRandomKey()
+        {
+            int keyLength = 64;
+            byte[] randomEntries = new byte[keyLength];
+
+            Random r = new Random((int)DateTime.Now.Ticks);
+            r.NextBytes(randomEntries);
+
+            return Convert.ToBase64String(randomEntries);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MockedItemBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/MockedItemBenchmark.cs
@@ -16,8 +16,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
         OfTCustom = 2,
     }
 
-    [MemoryDiagnoser]
-    [Config(typeof(ItemBenchmarkConfig))]
+    [Config(typeof(SdkBenchmarkConfiguration))]
     public class MockedItemBenchmark : IItemBenchmark
     {
         public static readonly IItemBenchmark[] IterParameters = new IItemBenchmark[]
@@ -88,19 +87,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
         public async Task UpsertItem()
         {
             await this.CurrentBenchmark.UpsertItem();
-        }
-
-        private class ItemBenchmarkConfig : ManualConfig
-        {
-            public ItemBenchmarkConfig()
-            {
-                this.Add(StatisticColumn.Q3);
-                this.Add(StatisticColumn.P80);
-                this.Add(StatisticColumn.P85);
-                this.Add(StatisticColumn.P90);
-                this.Add(StatisticColumn.P95);
-                this.Add(StatisticColumn.P100);
-            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/SdkBenchmarkConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/SdkBenchmarkConfiguration.cs
@@ -1,0 +1,33 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Performance.Tests
+{
+    using System.Linq;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Diagnosers;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Exporters.Csv;
+    using BenchmarkDotNet.Validators;
+
+    public class SdkBenchmarkConfiguration : ManualConfig
+    {
+        public SdkBenchmarkConfiguration()
+        {
+            this.Add(JitOptimizationsValidator.DontFailOnError);
+            this.Add(DefaultConfig.Instance.GetLoggers().ToArray());
+            this.Add(StatisticColumn.Q3);
+            this.Add(StatisticColumn.P80);
+            this.Add(StatisticColumn.P85);
+            this.Add(StatisticColumn.P90);
+            this.Add(StatisticColumn.P95);
+            this.Add(StatisticColumn.P100);
+            this.Add(new IDiagnoser[] { MemoryDiagnoser.Default, ThreadingDiagnoser.Default });
+            this.Add(StatisticColumn.OperationsPerSecond);
+            this.Add(MarkdownExporter.Default);
+            this.Add(CsvExporter.Default);
+            this.Add(DefaultConfig.Instance.GetColumnProviders().ToArray());
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -92,14 +92,17 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             string resourceType,
             string requestVerb,
             INameValueCollection headers,
-            AuthorizationTokenType tokenType,
-            out MemoryStream payload) // unused, use token based upon what is passed in constructor 
+            AuthorizationTokenType tokenType) // unused, use token based upon what is passed in constructor 
         {
             // this is masterkey authZ
             headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture);
 
-            return AuthorizationHelper.GenerateKeyAuthorizationSignature(
-                    requestVerb, resourceAddress, resourceType, headers, this.authKeyHashFunction, out payload);
+            string authorization = AuthorizationHelper.GenerateKeyAuthorizationSignature(
+                    requestVerb, resourceAddress, resourceType, headers, this.authKeyHashFunction, out AuthorizationHelper.ArrayOwner payload);
+            using (payload)
+            {
+                return authorization;
+            }
         }
 
         private void Init()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
         public MockDocumentClient()
             : base(new Uri("http://localhost"), null)
         {
-            this.authKeyHashFunction = new StringHMACSHA256Hash("C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
+            this.authKeyHashFunction = new StringHMACSHA256Hash(MasterKeyAuthorizationBenchmark.GenerateRandomKey());
 
             this.Init();
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
         public MockDocumentClient()
             : base(new Uri("http://localhost"), null)
         {
-            this.authKeyHashFunction = new StringHMACSHA256Hash(MasterKeyAuthorizationBenchmark.GenerateRandomKey());
+            this.authKeyHashFunction = new StringHMACSHA256Hash(MockDocumentClient.GenerateRandomKey());
 
             this.Init();
         }
@@ -74,6 +74,17 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
         }
 
         public override Documents.ConsistencyLevel ConsistencyLevel => Documents.ConsistencyLevel.Session;
+
+        public static string GenerateRandomKey()
+        {
+            int keyLength = 64;
+            byte[] randomEntries = new byte[keyLength];
+
+            Random r = new Random((int)DateTime.Now.Ticks);
+            r.NextBytes(randomEntries);
+
+            return Convert.ToBase64String(randomEntries);
+        }
 
         internal override IRetryPolicyFactory ResetSessionTokenRetryPolicy => new RetryPolicy(this.globalEndpointManager.Object, new ConnectionPolicy());
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/EndToEnd.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/EndToEnd.cs
@@ -53,6 +53,8 @@
             TextStream,
         }
 
+        private readonly string accountEndpoint = string.Empty; // insert your endpoint here.
+        private readonly string accountKey = string.Empty; // insert your key here.
         private readonly CosmosClient client;
         private readonly Container container;
 
@@ -61,9 +63,14 @@
         /// </summary>
         public EndToEnd()
         {
+            if (string.IsNullOrEmpty(this.accountEndpoint) && string.IsNullOrEmpty(this.accountKey))
+            {
+                return;
+            }
+
             CosmosClientBuilder clientBuilder = new CosmosClientBuilder(
-                accountEndpoint: "<YOUR ENDPOINT>",
-                authKeyOrResourceToken: "<YOUR KEY>");
+                accountEndpoint: this.accountEndpoint,
+                authKeyOrResourceToken: this.accountKey);
 
             this.client = clientBuilder.Build();
             Database db = this.client.CreateDatabaseIfNotExistsAsync("BenchmarkDB").Result;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Cosmos.Contracts
             string csprojFile = "Microsoft.Azure.Cosmos.csproj";
             Dictionary<string, string> projDependencies = DirectContractTests.GetPackageReferencies(csprojFile);
             Dictionary<string, string> baselineDependencies = JsonConvert.DeserializeObject< Dictionary<string, string>>(
-                "{\"System.Numerics.Vectors\":\"4.5.0\",\"Newtonsoft.Json\":\"10.0.2\",\"System.Configuration.ConfigurationManager\":\"4.5.0\",\"System.Memory\":\"4.5.1\",\"System.Runtime.CompilerServices.Unsafe\":\"4.5.1\",\"System.Threading.Tasks.Extensions\":\"4.5.1\",\"System.ValueTuple\":\"4.5.0\"}");
+                "{\"System.Numerics.Vectors\":\"4.5.0\",\"Newtonsoft.Json\":\"10.0.2\",\"System.Configuration.ConfigurationManager\":\"4.5.0\",\"System.Memory\":\"4.5.1\",\"System.Buffers\":\"4.5.1\",\"System.Runtime.CompilerServices.Unsafe\":\"4.5.1\",\"System.Threading.Tasks.Extensions\":\"4.5.1\",\"System.ValueTuple\":\"4.5.0\"}");
 
             Assert.AreEqual(projDependencies.Count, baselineDependencies.Count);
             foreach(KeyValuePair<string, string> projectDependency in projDependencies)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -149,10 +149,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             string resourceType,
             string requestVerb,
             INameValueCollection headers,
-            AuthorizationTokenType tokenType,
-            out MemoryStream payload) /* unused, use token based upon what is passed in constructor */
+            AuthorizationTokenType tokenType) /* unused, use token based upon what is passed in constructor */
         {
-            payload = null;
             return null;
         }
 


### PR DESCRIPTION
Including exclusive auth performance micro benchmark.
Changes includes: 

1. Caching the HMACSHA256
2. Contract adjusted to avoid leaking bytes out

After the changes
RPS: 2-3% UP
Latency: 3-6% UP
GEN0: 30% DOWN
Allocations: 28% DOWN

|                    Method |     Mean |     Error |    StdDev |       Q3 |      P80 |      P85 |      P90 |      P95 |     P100 |      Op/s |  Gen 0 | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|-------:|----------:|
| CreateSignatureGeneration | 3.579 us | 0.0336 us | 0.0280 us | 3.603 us | 3.605 us | 3.612 us | 3.612 us | 3.614 us | 3.618 us | 279,387.0 | 0.0458 |     896 B |
|   ReadSignatureGeneration | 3.542 us | 0.0490 us | 0.0458 us | 3.576 us | 3.577 us | 3.580 us | 3.598 us | 3.617 us | 3.633 us | 282,301.5 | 0.0458 |     904 B |

Before changes:
Branch with-out Auth changes & perf benchmark: **users/kirankk/auth_baseline**
**NOTE**: Please change the target to netcoreapp3.1 

| OS | Allocations %Change | GC %Change | RPs %Change |
|---------------- |---------:|----------:|----------:|
| WINDOWS | ~174B Less | 11% Less GC | 7-9% less|
| LINUX | ~174B Less | 10% Less GC | 13-15% less | 

Also the latency is higher with the new optimization.

- [ ] Is high latency and less RPS results of high CPU work? 
- [ ] If so if it worth trading for allocations?

>   Op/s/Rps           : Operation per second
>   Gen 0                : GC Generation 0 collects per 1000 operations
>   Gen 1                : GC Generation 1 collects per 1000 operations
>   Gen 2                : GC Generation 2 collects per 1000 operations
>   Allocated            : Allocated memory per single operation (managed only, inclusive, 1KB = 1024B)

BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19041
Intel Core i7-8650U CPU 1.90GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.302
  [Host]     : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  DefaultJob : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT


|                    Method |     Mean |     Error |    StdDev |   Median |       Q3 |      P80 |      P85 |      P90 |      P95 |     P100 |      Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|-------:|------:|------:|----------:|
| CreateSignatureGeneration | 4.627 us | 0.2003 us | 0.5683 us | 4.338 us | 4.835 us | 5.073 us | 5.226 us | 5.402 us | 6.054 us | 6.398 us | 216,126.1 | 0.3815 |     - |     - |   1.57 KB |
|   ReadSignatureGeneration | 4.428 us | 0.0907 us | 0.2276 us | 4.361 us | 4.516 us | 4.559 us | 4.652 us | 4.811 us | 4.956 us | 5.058 us | 225,846.0 | 0.3891 |     - |     - |    1.6 KB |

|                    Method |     Mean |     Error |    StdDev |   Median |       Q3 |      P80 |      P85 |      P90 |      P95 |     P100 |      Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|-------:|------:|------:|----------:|
| CreateSignatureGeneration | 4.967 us | 0.0997 us | 0.2610 us | 4.884 us | 5.122 us | 5.157 us | 5.240 us | 5.336 us | 5.488 us | 5.765 us | 201,334.0 | 0.3433 |     - |     - |   1.41 KB |
|   ReadSignatureGeneration | 4.847 us | 0.0940 us | 0.1045 us | 4.851 us | 4.927 us | 4.930 us | 4.940 us | 4.962 us | 5.004 us | 5.036 us | 206,299.5 | 0.3433 |     - |     - |   1.43 KB |


BenchmarkDotNet=v0.12.0, OS=ubuntu 18.04
Intel Xeon Platinum 8171M CPU 2.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.301
  [Host]     : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  DefaultJob : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

|                    Method |     Mean |     Error |    StdDev |       Q3 |      P80 |      P85 |      P90 |      P95 |     P100 |      Op/s | Completed Work Items | Lock Contentions |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|---------------------:|-----------------:|-------:|------:|------:|----------:|
| CreateSignatureGeneration | 5.302 us | 0.0665 us | 0.0555 us | 5.344 us | 5.345 us | 5.353 us | 5.371 us | 5.396 us | 5.425 us | 188,590.9 |               0.0000 |                - | 0.0763 |     - |     - |   1.48 KB |
|   ReadSignatureGeneration | 5.369 us | 0.0743 us | 0.0695 us | 5.412 us | 5.420 us | 5.445 us | 5.462 us | 5.479 us | 5.499 us | 186,251.0 |               0.0000 |                - | 0.0763 |     - |     - |   1.48 KB |


|                    Method |     Mean |     Error |    StdDev |       Q3 |      P80 |      P85 |      P90 |      P95 |     P100 |      Op/s | Completed Work Items | Lock Contentions |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|---------:|----------:|---------------------:|-----------------:|-------:|------:|------:|----------:|
| CreateSignatureGeneration | 6.078 us | 0.0925 us | 0.0772 us | 6.145 us | 6.148 us | 6.159 us | 6.165 us | 6.169 us | 6.172 us | 164,537.6 |               0.0000 |                - | 0.0687 |     - |     - |    1.3 KB |
|   ReadSignatureGeneration | 6.317 us | 0.0777 us | 0.0726 us | 6.371 us | 6.375 us | 6.388 us | 6.396 us | 6.420 us | 6.465 us | 158,313.6 |               0.0000 |                - | 0.0687 |     - |     - |   1.33 KB |