### PR TITLE
[Internal] Performance: Improve performance of authorization further.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
+++ b/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Collections.Concurrent;
     using System.IO;
     using System.Security;
     using System.Security.Cryptography;
@@ -14,18 +15,33 @@ namespace Microsoft.Azure.Cosmos
         private readonly String base64EncodedKey;
         private readonly byte[] keyBytes;
         private SecureString secureString;
+        private ConcurrentQueue<HMACSHA256> hmacPool;
 
         public StringHMACSHA256Hash(String base64EncodedKey)
         {
             this.base64EncodedKey = base64EncodedKey;
             this.keyBytes = Convert.FromBase64String(base64EncodedKey);
+            this.hmacPool = new ConcurrentQueue<HMACSHA256>();
         }
 
         public byte[] ComputeHash(MemoryStream bytesToHash)
         {
-            using (HMACSHA256 hmacSha256 = new HMACSHA256(this.keyBytes))
+            if (this.hmacPool.TryDequeue(out HMACSHA256 hmacSha256))
             {
-                return hmacSha256.ComputeHash(bytesToHash);
+                hmacSha256.Initialize();
+            }
+            else
+            {
+                hmacSha256 = new HMACSHA256(this.keyBytes);
+            }
+
+            try
+            {
+                return hmacSha256.ComputeHash(bytesToHash.GetBuffer(), 0, (int)bytesToHash.Length);
+            }
+            finally
+            {
+                this.hmacPool.Enqueue(hmacSha256);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
+++ b/Microsoft.Azure.Cosmos/src/StringHMACSHA256Hash.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Azure.Cosmos
                 this.secureString.Dispose();
                 this.secureString = null;
             }
+
+            while (this.hmacPool.TryDequeue(out HMACSHA256 hmacsha256))
+            {
+                hmacsha256.Dispose();
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/AuthorizationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/AuthorizationBenchmark.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Azure.Cosmos.Benchmarks
+{
+    using System.Globalization;
+    using System.IO;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+
+    [MemoryDiagnoser]
+    public class AuthorizationBenchmark
+    {
+        private readonly DictionaryNameValueCollection headers = new DictionaryNameValueCollection();
+        private readonly IComputeHash hashFunction;
+
+        public AuthorizationBenchmark()
+        {
+            this.headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture);
+            this.hashFunction = new StringHMACSHA256Hash("c29tZSByYW5kb20gc3RyaW5nIHRvIGVuY29kZQ==");
+        }
+
+        [Benchmark]
+        public void GenerateAuthorizationToken()
+        {
+            AuthorizationHelper.GenerateKeyAuthorizationSignature(
+                "GET",
+                "dbs/database/colls/collection/docs/document",
+                "docs",
+                this.headers,
+                this.hashFunction,
+                out MemoryStream _);
+        }
+
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

- Add a performance benchmark only for the Authorization layer.
- Add pooling for the HMac pool in StringHMacSha256

Here's the perf results:
1) Without the earlier change (to use Span/MemoryStream etc):
|                     Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| GenerateAuthorizationToken | 5.242 us | 0.0584 us | 0.3031 us | 0.0992 |     - |     - |   1.61 KB |

2) With the earlier change (to use Span/MemoryStream etc):
|                     Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
| GenerateAuthorizationToken | 6.465 us | 0.1005 us | 0.5239 us | 6.383 us | 0.0916 |     - |     - |   1.41 KB |

3) With the HMac Pooling:
|                     Method |     Mean |     Error |    StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------- |---------:|----------:|----------:|---------:|-------:|------:|------:|----------:|
| GenerateAuthorizationToken | 4.194 us | 0.0557 us | 0.2828 us | 4.138 us | 0.0687 |     - |     - |   1.09 KB |

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber