### PR TITLE
Gateway Trace: Fixes a bug where the ActivityId is being set to Guid.Empty

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -107,8 +107,7 @@ namespace Microsoft.Azure.Cosmos
                 }
                 else
                 {
-                    Exception e = await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
-                    throw e;
+                    throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
                 }
             }
         }
@@ -192,7 +191,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 Stream readStream = await responseMessage.Content.ReadAsStreamAsync();
                 Error error = Documents.Resource.LoadFrom<Error>(readStream);
-                DocumentClientException dce = new DocumentClientException(
+                return new DocumentClientException(
                     error,
                     responseMessage.Headers,
                     responseMessage.StatusCode)
@@ -201,8 +200,6 @@ namespace Microsoft.Azure.Cosmos
                     ResourceAddress = resourceIdOrFullName,
                     RequestStatistics = requestStatistics
                 };
-
-                return dce;
             }
             else
             {
@@ -225,7 +222,7 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 String message = await responseMessage.Content.ReadAsStringAsync();
-                DocumentClientException dce = new DocumentClientException(
+                return new DocumentClientException(
                     message: context.ToString(),
                     innerException: null,
                     responseHeaders: responseMessage.Headers,
@@ -236,8 +233,6 @@ namespace Microsoft.Azure.Cosmos
                     ResourceAddress = resourceIdOrFullName,
                     RequestStatistics = requestStatistics
                 };
-
-                return dce;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -162,19 +162,6 @@ namespace Microsoft.Azure.Cosmos
             HttpResponseMessage responseMessage,
             IClientSideRequestStatistics requestStatistics)
         {
-            // ensure there is no local ActivityId, since in Gateway mode ActivityId
-            // should always come from message headers
-            if (responseMessage.Headers.TryGetValues(HttpConstants.HttpHeaders.ActivityId, out IEnumerable<string> activityIds) &&
-                activityIds.Count() == 1 &&
-                Guid.TryParse(activityIds.First(), out Guid responseActivityId))
-            {
-                Trace.CorrelationManager.ActivityId = responseActivityId;
-            }
-            else
-            {
-                Debug.Fail("Activity id is not valid");
-            }
-
             bool isNameBased = false;
             bool isFeed = false;
             string resourceTypeString;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -604,7 +604,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(CosmosException))]
         public async Task NegativePartitionedCreateDelete()
         {
             string containerName = Guid.NewGuid().ToString();
@@ -613,10 +612,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             partitionKeyDefinition.Paths.Add("/users");
             partitionKeyDefinition.Paths.Add("/test");
 
-            ContainerProperties settings = new ContainerProperties(containerName, partitionKeyDefinition);
-            ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
+            try
+            {
+                ContainerProperties settings = new ContainerProperties(containerName, partitionKeyDefinition);
+                ContainerResponse containerResponse = await this.cosmosDatabase.CreateContainerAsync(settings);
 
-            Assert.Fail("Multiple partition keys should have caused an exception.");
+                Assert.Fail("Multiple partition keys should have caused an exception.");
+            }
+            catch(CosmosException ce) when (ce.StatusCode == HttpStatusCode.BadRequest)
+            {
+                string message = ce.ToString();
+                Assert.IsNotNull(message);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a bug where Trace.CorrelationManager.ActivityId was getting set to Guid.Empty instead of the response Activity Id. This causes any traces to have Guid.Empty instead of the correct value.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber