### PR TITLE
[Internal] Tests: Fixes contract update tool

### DIFF
--- a/UpdateContracts.ps1
+++ b/UpdateContracts.ps1
@@ -5,7 +5,7 @@
 #Run the Cosmos DB SDK GA contract tests
 $projResult = dotnet test '.\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\Microsoft.Azure.Cosmos.Tests.csproj' --filter "TestCategory=UpdateContract" --configuration Release
 
-$updatedContractFile = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.0\Contracts\DotNetSDKAPIChanges.json"
+$updatedContractFile = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.1\Contracts\DotNetSDKAPIChanges.json"
 if(!(Test-Path -Path $updatedContractFile)){
     Write-Error ("The contract file did not get updated with the build. Please fix the test to output the contract file: " + $updatedContractFile)
 }else{
@@ -13,7 +13,7 @@ if(!(Test-Path -Path $updatedContractFile)){
     Write-Output ("Updated contract " + $updatedContractFile)
 }
 
-$updatedContractFolder = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.0\BaselineTest\TestOutput\*"
+$updatedContractFolder = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.1\BaselineTest\TestOutput\*"
 if(!(Test-Path -Path $updatedContractFolder)){
     Write-Error ("The contract file did not get updated with the build. Please fix the test to output the contract file: " + $updatedContractFile)
 }else{
@@ -24,7 +24,7 @@ if(!(Test-Path -Path $updatedContractFolder)){
 #Run the Cosmos DB SDK Preview contract tests
 $projResult = dotnet test '.\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\Microsoft.Azure.Cosmos.Tests.csproj' --filter "TestCategory=UpdateContract" --configuration Release -p:IsPreview=true
 
-$updatedContractFile = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.0\Contracts\DotNetPreviewSDKAPIChanges.json"
+$updatedContractFile = ".\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests\bin\Release\netcoreapp2.1\Contracts\DotNetPreviewSDKAPIChanges.json"
 if(!(Test-Path -Path $updatedContractFile)){
     Write-Error ("The contract file did not get updated with the preview build. Please fix the test to output the contract file: " + $updatedContractFile)
 }else{
@@ -35,7 +35,7 @@ if(!(Test-Path -Path $updatedContractFile)){
 #Run the Encryption SDK contract tests
 $projResult = dotnet test '.\Microsoft.Azure.Cosmos.Encryption\tests\Microsoft.Azure.Cosmos.Encryption.Tests\Microsoft.Azure.Cosmos.Encryption.Tests.csproj' --filter "TestCategory=UpdateContract" --configuration Release
 
-$updatedContractFile = ".\Microsoft.Azure.Cosmos.Encryption\tests\Microsoft.Azure.Cosmos.Encryption.Tests\bin\Release\netcoreapp2.0\Contracts\DotNetSDKEncryptionAPIChanges.json"
+$updatedContractFile = ".\Microsoft.Azure.Cosmos.Encryption\tests\Microsoft.Azure.Cosmos.Encryption.Tests\bin\Release\netcoreapp2.1\Contracts\DotNetSDKEncryptionAPIChanges.json"
 if(!(Test-Path -Path $updatedContractFile)){
     Write-Error ("The contract file did not get updated with the build. Please fix the test to output the contract file: " + $updatedContractFile)
 }else{


### PR DESCRIPTION
The PS1 command file used to update public contract was targeting `netcoreapp2.0` but our test projects were moved to `netcoreapp2.1`.