### PR TITLE
Internal QueryParser: Adds Validations for parser.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Parser/QueryParser.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Parser/QueryParser.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Parser
             }
 
             sqlQuery = monadicParse.Result;
-            return false;
+            return true;
         }
 
         public static SqlQuery Parse(string text)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Parser/sql.g4
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Parser/sql.g4
@@ -1,0 +1,224 @@
+﻿grammar sql;
+
+program
+	: sql_query EOF
+	;
+
+sql_query : select_clause from_clause? where_clause? group_by_clause? order_by_clause? offset_limit_clause? ;
+
+/*--------------------------------------------------------------------------------*/
+/* SELECT */
+/*--------------------------------------------------------------------------------*/
+select_clause : K_SELECT K_DISTINCT? top_spec? selection ;
+top_spec : K_TOP NUMERIC_LITERAL;
+selection
+	: select_star_spec
+	| select_value_spec 
+	| select_list_spec
+	;
+select_star_spec : '*' ;
+select_value_spec : K_VALUE scalar_expression ;
+select_list_spec : select_item ( ',' select_item )* ;
+select_item : scalar_expression (K_AS IDENTIFIER)? ;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* FROM */
+/*--------------------------------------------------------------------------------*/
+from_clause : K_FROM collection_expression ;
+collection_expression
+	: collection (K_AS IDENTIFIER)? #AliasedCollectionExpression
+	| IDENTIFIER K_IN collection #ArrayIteratorCollectionExpression 
+	| collection_expression K_JOIN collection_expression #JoinCollectionExpression
+	;
+collection
+	: IDENTIFIER path_expression?  #InputPathCollection
+	| '(' sql_query ')' #SubqueryCollection
+	;
+path_expression
+	: path_expression'.'IDENTIFIER #IdentifierPathExpression
+	| path_expression'[' NUMERIC_LITERAL ']' #NumberPathExpression
+	| path_expression'[' STRING_LITERAL ']' #StringPathExpression
+	| /*epsilon*/ #EpsilonPathExpression
+	;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* WHERE */
+/*--------------------------------------------------------------------------------*/
+where_clause : K_WHERE scalar_expression ;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* GROUP BY */
+/*--------------------------------------------------------------------------------*/
+group_by_clause : K_GROUP K_BY scalar_expression_list ;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* ORDER BY */
+/*--------------------------------------------------------------------------------*/
+order_by_clause : K_ORDER K_BY order_by_items ;
+order_by_items : order_by_item (',' order_by_item)* ;
+order_by_item : scalar_expression sort_order? ;
+sort_order
+	: K_ASC
+	| K_DESC
+	;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* OFFSET LIMIT */
+/*--------------------------------------------------------------------------------*/
+offset_limit_clause : K_OFFSET offset_count K_LIMIT limit_count;
+offset_count : NUMERIC_LITERAL;
+limit_count : NUMERIC_LITERAL;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* SCALAR EXPRESSIONs */
+/*--------------------------------------------------------------------------------*/
+scalar_expression
+	: '[' scalar_expression_list? ']' #ArrayCreateScalarExpression
+	| K_ARRAY '(' sql_query ')' #ArrayScalarExpression
+	| scalar_expression K_NOT? K_BETWEEN scalar_expression K_AND scalar_expression #BetweenScalarExpression
+	| scalar_expression binary_operator scalar_expression #BinaryScalarExpression
+	| scalar_expression '??' scalar_expression #CoalesceScalarExpression
+	| scalar_expression '?' scalar_expression ':' scalar_expression #ConditionalScalarExpression
+	| K_EXISTS '(' sql_query ')' #ExistsScalarExpression
+	| (K_UDF '.')? IDENTIFIER '(' scalar_expression_list? ')' #FunctionCallScalarExpression
+	| scalar_expression K_NOT? K_IN '(' scalar_expression_list ')' #InScalarExpression
+	| literal #LiteralScalarExpression
+	| scalar_expression '[' scalar_expression ']' #MemberIndexerScalarExpression
+	| '{' object_propertty_list? '}' #ObjectCreateScalarExpression
+	| IDENTIFIER #PropertyRefScalarExpressionBase
+	| scalar_expression '.' IDENTIFIER #PropertyRefScalarExpressionRecursive
+	| '(' sql_query ')' #SubqueryScalarExpression
+	| unary_operator scalar_expression #UnaryScalarExpression
+	;
+scalar_expression_list : scalar_expression ( ',' scalar_expression )* ;
+binary_operator
+	: '+' 
+	| K_AND 
+	| '&' 
+	| '|' 
+	| '^' 
+	| '/' 
+	| '=' 
+	| '>' 
+	| '>=' 
+	| '<' 
+	| '<=' 
+	| '%' 
+	| '*' 
+	| '!=' 
+	| K_OR 
+	| '||' 
+	| '-'
+	;
+unary_operator
+	: '-' 
+	| '+' 
+	| '~' 
+	| K_NOT
+	;
+object_propertty_list : object_property (',' object_property)* ;
+
+object_property : STRING_LITERAL ':' scalar_expression ;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* KEYWORDS */
+/*--------------------------------------------------------------------------------*/
+K_AND : A N D;
+K_ARRAY : A R R A Y;
+K_AS : A S;
+K_ASC : A S C;
+K_BETWEEN : B E T W E E N;
+K_BY : B Y;
+K_DESC : D E S C;
+K_DISTINCT : D I S T I N C T;
+K_EXISTS : E X I S T S;
+K_FALSE : 'false';
+K_FROM : F R O M;
+K_GROUP : G R O U P;
+K_IN : I N ;
+K_JOIN : J O I N;
+K_LIMIT : L I M I T;
+K_NOT : N O T;
+K_NULL : 'null';
+K_OFFSET : O F F S E T;
+K_OR : O R;
+K_ORDER : O R D E R;
+K_SELECT : S E L E C T;
+K_TOP : T O P;
+K_TRUE : 'true';
+K_UDF : U D F;
+K_UNDEFINED : 'undefined';
+K_VALUE : V A L U E;
+K_WHERE : W H E R E;
+/*--------------------------------------------------------------------------------*/
+
+WS
+   : [ \r\n\t] + -> skip
+   ;
+
+/*--------------------------------------------------------------------------------*/
+/* LITERALS */
+/*--------------------------------------------------------------------------------*/
+literal
+	: STRING_LITERAL
+	| NUMERIC_LITERAL
+	| K_TRUE
+	| K_FALSE
+	| K_NULL
+	| K_UNDEFINED
+	;
+
+NUMERIC_LITERAL
+	: ( '+' | '-' )? DIGIT+ ( '.' DIGIT* )? ( E [-+]? DIGIT+ )?
+	| ( '+' | '-' )? '.' DIGIT+ ( E [-+]? DIGIT+ )?
+	;
+
+STRING_LITERAL
+	: ('\'' | '"') ( ~'\'' | '\'\'' )* ('\'' | '"')
+	;
+
+IDENTIFIER
+	:
+	| [a-zA-Z_][a-zA-Z_]*DIGIT*
+	;
+/*--------------------------------------------------------------------------------*/
+
+/*--------------------------------------------------------------------------------*/
+/* FRAGMENTS */
+/*--------------------------------------------------------------------------------*/
+fragment DIGIT : [0-9];
+
+fragment A : [aA];
+fragment B : [bB];
+fragment C : [cC];
+fragment D : [dD];
+fragment E : [eE];
+fragment F : [fF];
+fragment G : [gG];
+fragment H : [hH];
+fragment I : [iI];
+fragment J : [jJ];
+fragment K : [kK];
+fragment L : [lL];
+fragment M : [mM];
+fragment N : [nN];
+fragment O : [oO];
+fragment P : [pP];
+fragment Q : [qQ];
+fragment R : [rR];
+fragment S : [sS];
+fragment T : [tT];
+fragment U : [uU];
+fragment V : [vV];
+fragment W : [wW];
+fragment X : [xX];
+fragment Y : [yY];
+fragment Z : [zZ];
+/*--------------------------------------------------------------------------------*/

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/Visitors/SqlObjectEqualityVisitor.cs
@@ -910,7 +910,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects.Visitors
 
             foreach ((SqlObject firstItem, SqlObject secondItem) in itemPairs)
             {
-                if (firstItem.Accept(SqlObjectEqualityVisitor.Singleton, secondItem))
+                if (!firstItem.Accept(SqlObjectEqualityVisitor.Singleton, secondItem))
                 {
                     return false;
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/FromClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/FromClauseTests.cs
@@ -1,0 +1,61 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Linq;
+
+    [TestClass]
+    public class FromClauseTests : ParserTests
+    {
+        private static readonly string baseInputPathExpression = "c";
+        private static readonly string recursiveInputPathExpression = "c.age";
+        private static readonly string numberPathExpression = "c.arr[5]";
+        private static readonly string stringPathExpression = "c.blah['asdf']";
+        private static readonly string[] pathExpressions = new string[]
+        {
+            baseInputPathExpression,
+            recursiveInputPathExpression,
+            numberPathExpression,
+            stringPathExpression,
+        };
+
+        private static readonly string[] inputPathCollections = pathExpressions;
+        private static readonly string subqueryCollection = "(SELECT * FROM c)";
+        private static readonly string[] collections = new string[]
+        {
+            subqueryCollection,
+        }.Concat(inputPathCollections).ToArray();
+
+        [TestMethod]
+        public void AliasedCollection()
+        {
+            foreach (string collection in collections)
+            {
+                foreach (bool useAlias in new bool[] { false, true })
+                {
+                    FromClauseTests.ValidateFromClause($"FROM {collection} {(useAlias ? "AS asdf" : string.Empty)}");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ArrayIteratorCollection()
+        {
+            foreach (string collection in collections)
+            {
+                FromClauseTests.ValidateFromClause($"FROM item IN {collection}");
+            }
+        }
+
+        [TestMethod]
+        public void JoinCollection()
+        {
+            FromClauseTests.ValidateFromClause($"FROM c JOIN d in c.children");
+        }
+
+        private static void ValidateFromClause(string fromClause)
+        {
+            string query = $"SELECT * {fromClause}";
+            ParserTests.Validate(query);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/GroupByClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/GroupByClauseTests.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class GroupByClauseTests : ParserTests
+    {
+        [TestMethod]
+        public void SingleGroupBy()
+        {
+            GroupByClauseTests.ValidateGroupBy("GROUP BY 1");
+            GroupByClauseTests.InvalidateGroupBy("GROUP BY ");
+            GroupByClauseTests.InvalidateGroupBy("GROUPBY 1");
+        }
+
+        [TestMethod]
+        public void MultiGroupBy()
+        {
+            GroupByClauseTests.ValidateGroupBy("GROUP BY 1, 2, 3");
+            GroupByClauseTests.ValidateGroupBy("GROUP BY 1, 2");
+            GroupByClauseTests.InvalidateGroupBy("GROUP BY 1,");
+        }
+
+        private static void ValidateGroupBy(string groupByClause)
+        {
+            string query = $"SELECT * {groupByClause}";
+            ParserTests.Validate(query);
+        }
+
+        private static void InvalidateGroupBy(string groupByClause)
+        {
+            string query = $"SELECT * {groupByClause}";
+            ParserTests.Invalidate(query);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/OffsetLimitClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/OffsetLimitClauseTests.cs
@@ -1,0 +1,30 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class OffsetLimitClauseTests : ParserTests
+    {
+        [TestMethod]
+        public void OffsetLimit()
+        {
+            OffsetLimitClauseTests.ValidateOffsetLimit("OFFSET 10 LIMIT 10");
+
+            OffsetLimitClauseTests.InvalidateOffsetLimit("OFFSET 'asdf' LIMIT 10");
+            OffsetLimitClauseTests.InvalidateOffsetLimit("OFFSET 10 ");
+            OffsetLimitClauseTests.InvalidateOffsetLimit("LIMIT 10 ");
+        }
+
+        private static void ValidateOffsetLimit(string offsetLimitClause)
+        {
+            string query = $"SELECT * {offsetLimitClause}";
+            ParserTests.Validate(query);
+        }
+
+        private static void InvalidateOffsetLimit(string offsetLimitClause)
+        {
+            string query = $"SELECT * {offsetLimitClause}";
+            ParserTests.Invalidate(query);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/OrderByClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/OrderByClauseTests.cs
@@ -1,0 +1,38 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class OrderByClauseTests : ParserTests
+    {
+        [TestMethod]
+        public void SingleOrderBy()
+        {
+            //OrderByClauseTests.ValidateOrderBy("ORDER BY 1");
+            //OrderByClauseTests.ValidateOrderBy("ORDER BY 1 asc");
+            //OrderByClauseTests.ValidateOrderBy("ORDER BY 1 DESC");
+            OrderByClauseTests.InvalidateOrderBy("ORDERBY 1");
+        }
+
+        [TestMethod]
+        public void MultiOrderBy()
+        {
+            OrderByClauseTests.ValidateOrderBy("ORDER BY 1, 2, 3");
+            OrderByClauseTests.ValidateOrderBy("ORDER BY 1, 2 DESC, 3");
+            OrderByClauseTests.ValidateOrderBy("ORDER BY 1 ASC, 2 DESC, 3 ASC");
+            OrderByClauseTests.InvalidateOrderBy("ORDER BY 1 ASC,");
+        }
+
+        private static void ValidateOrderBy(string orderByClause)
+        {
+            string query = $"SELECT * {orderByClause}";
+            ParserTests.Validate(query);
+        }
+
+        private static void InvalidateOrderBy(string orderByClause)
+        {
+            string query = $"SELECT * {orderByClause}";
+            ParserTests.Invalidate(query);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/ParserTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/ParserTests.cs
@@ -1,0 +1,46 @@
+namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.Azure.Cosmos.Query.Core.Parser;
+    using Microsoft.Azure.Cosmos.SqlObjects;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public abstract class ParserTests
+    {
+        protected static void Validate(string query)
+        {
+            Assert.IsNotNull(query);
+
+            if (!QueryParser.TryParse(query, out SqlQuery parsedQuery))
+            {
+                Assert.Fail($"Failed to parse query: {query}");
+            }
+
+            string normalizedQuery = NormalizeText(query);
+            string normalizedToString = NormalizeText(parsedQuery.ToString());
+            Assert.AreEqual(normalizedQuery, normalizedToString);
+        }
+
+        protected static void Invalidate(string query)
+        {
+            Assert.IsNotNull(query);
+
+            Assert.IsFalse(
+                QueryParser.TryParse(query, out _),
+                $"Expected failure to parse query: {query}");
+        }
+
+        private static string NormalizeText(string text)
+        {
+            return text
+                .ToLower()
+                .Replace("(", string.Empty)
+                .Replace(")", string.Empty)
+                .Replace("asc", string.Empty)
+                .Replace("desc", string.Empty)
+                .Replace("'", "\"")
+                .Replace(" ", string.Empty)
+                .Replace("+", string.Empty);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/ScalarExpressionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/ScalarExpressionTests.cs
@@ -1,0 +1,307 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ScalarExpressionTests : ParserTests
+    {
+        [TestMethod]
+        [DataRow("[]", DisplayName = "Empty Array")]
+        [DataRow("[1]", DisplayName = "Single Item Array")]
+        [DataRow("[1, 2, 3]", DisplayName = "Multi Item Array")]
+        public void ArrayCreateScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("[", DisplayName = "No closing brace")]
+        [DataRow("]", DisplayName = "No opening brace")]
+        [DataRow("[1,]", DisplayName = "trailing delimiter")]
+        [DataRow("[,]", DisplayName = "delimiter no items")]
+        public void ArrayCreateScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("ARRAY(SELECT *)", DisplayName = "Basic")]
+        public void ArrayScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("ARRAY(SELECT *", DisplayName = "No closing parens")]
+        [DataRow("ARRAY(123)", DisplayName = "not a subquery")]
+        //[DataRow("ARAY(123)", DisplayName = "Wrong token")] -> becomes function call
+        public void ArrayScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 BETWEEN 15 AND 1337", DisplayName = "Regular Betweeen")]
+        [DataRow("42 NOT BETWEEN 15 AND 1337", DisplayName = "NOT Betweeen")]
+        public void BetweenScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 15 AND 1337", DisplayName = "Missing Betweeen")]
+        [DataRow("42 NOT 15 AND 1337", DisplayName = "NOT + Missing between")]
+        [DataRow("42 BETWEEN 15 AND ", DisplayName = "Missing end range")]
+        [DataRow("42 BETWEEN AND 1337", DisplayName = "missing start range")]
+        [DataRow("BETWEEN 15 AND 1337", DisplayName = "missing needle")]
+        public void BetweenScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 + 1337", DisplayName = "Plus")]
+        [DataRow("42 AND 1337", DisplayName = "AND")]
+        [DataRow("42 & 1337", DisplayName = "Bitwise AND")]
+        [DataRow("42 | 1337", DisplayName = "Bitwise OR")]
+        [DataRow("42 ^ 1337", DisplayName = "Bitwise XOR")]
+        [DataRow("42 / 1337", DisplayName = "Division")]
+        [DataRow("42 = 1337", DisplayName = "Equals")]
+        [DataRow("42 > 1337", DisplayName = "Greater Than")]
+        [DataRow("42 >= 1337", DisplayName = "Greater Than Or Equal To")]
+        [DataRow("42 < 1337", DisplayName = "Less Than")]
+        [DataRow("42 <= 1337", DisplayName = "Less Than Or Equal To")]
+        [DataRow("42 % 1337", DisplayName = "Mod")]
+        [DataRow("42 * 1337", DisplayName = "Multiplication")]
+        [DataRow("42 != 1337", DisplayName = "Not Equals")]
+        [DataRow("42 OR 1337", DisplayName = "OR")]
+        [DataRow("42 || 1337", DisplayName = "String Concat")]
+        [DataRow("42 - 1337", DisplayName = "Minus")]
+        public void BinaryScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 +", DisplayName = "Missing Right")]
+        [DataRow("AND 1337", DisplayName = "Missing Left")]
+        [DataRow("42 # 1337", DisplayName = "Unknown Operator")]
+        public void BinaryScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 ?? 1337")]
+        public void CoalesceScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 ??", DisplayName = "Missing Right")]
+        [DataRow("?? 1337", DisplayName = "Missing Left")]
+        public void CoalesceScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 ? 123 : 1337", DisplayName = "Basic")]
+        public void ConditionalScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow(" ? 123 : 1337", DisplayName = "Missing Condition")]
+        [DataRow("42 ?  : 1337", DisplayName = "Missing if true")]
+        [DataRow("42 ? 123 : ", DisplayName = "Missing if false")]
+        public void ConditionalScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("EXISTS(SELECT *)", DisplayName = "Basic")]
+        [DataRow("ExIsTS(SELECT *)", DisplayName = "case insensitive")]
+        public void ExistsScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("EXISTS(SELECT *", DisplayName = "No closing parens")]
+        [DataRow("EXISTS(123)", DisplayName = "not a subquery")]
+        //[DataRow("EXITS(123)", DisplayName = "Wrong token")] -> becomes function call
+        public void ExistsScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("ABS(-123)", DisplayName = "Basic")]
+        [DataRow("PI()", DisplayName = "No Arguments")]
+        [DataRow("STARTSWITH('asdf', 'as')", DisplayName = "multiple arguments")]
+        [DataRow("udf.my_udf(-123)", DisplayName = "udf")]
+        public void FunctionCallScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("ABS(-123", DisplayName = "missing brace")]
+        [DataRow("*@#$('asdf')", DisplayName = "invalid identifier")]
+        [DataRow("ABS('asdf',)", DisplayName = "trailing delimiter")]
+        [DataRow("ABS(,)", DisplayName = "delimiter but no arguments")]
+        public void FunctionCallScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 IN(42)", DisplayName = "Basic")]
+        [DataRow("42 IN ('asdf', 'as')", DisplayName = "multiple arguments")]
+        [DataRow("42 NOT IN (42)", DisplayName = "NOT IN")]
+        public void InScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42 IN()", DisplayName = "Empty List")]
+        [DataRow("42 IN (-123", DisplayName = "missing brace")]
+        [DataRow("42 IN ('asdf',)", DisplayName = "trailing delimiter")]
+        [DataRow("42 IN (,)", DisplayName = "delimiter but no arguments")]
+        [DataRow("IN (-123", DisplayName = "missing needle")]
+        [DataRow("42 IN ", DisplayName = "missing haystack")]
+        [DataRow("42 inn (123)", DisplayName = "mispelled keyword")]
+        public void InScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("42", DisplayName = "Integer")]
+        [DataRow("1337.42", DisplayName = "Double")]
+        [DataRow("-1337.42", DisplayName = "Negative Number")]
+        //[DataRow("1E2", DisplayName = "E notation")] E notation doesn't round trip with AST.
+        [DataRow("\"hello\"", DisplayName = "string with double quotes")]
+        [DataRow("'hello'", DisplayName = "string with single quotes")]
+        [DataRow("true", DisplayName = "true")]
+        [DataRow("false", DisplayName = "false")]
+        [DataRow("null", DisplayName = "null")]
+        [DataRow("undefined", DisplayName = "undefined")]
+        public void LiteralScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("-0.E", DisplayName = "Invalid Number")]
+        [DataRow("\"hello", DisplayName = "string missing quote")]
+        public void LiteralScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("c.arr[2]", DisplayName = "Basic")]
+        [DataRow("c.arr[2 + 2]", DisplayName = "Basic")]
+        public void MemberIndexerScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("c.array[]", DisplayName = "missing indexer expression")]
+        public void MemberIndexerScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("{}", DisplayName = "Empty Object")]
+        [DataRow("{ 'prop' : 42 }", DisplayName = "Single Property")]
+        [DataRow("{ 'prop1' : 42, 'prop2' : 1337 }", DisplayName = "MultipleProperty")]
+        public void ObjectCreateScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("{", DisplayName = "Missing Close Brace")]
+        [DataRow("{ 'prop' : 42, }", DisplayName = "trailing delimiter")]
+        [DataRow("{ , }", DisplayName = "delimiter but no properties")]
+        [DataRow("{ 23 : 42, }", DisplayName = "non string property name")]
+        public void ObjectCreateScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("c", DisplayName = "root")]
+        [DataRow("c.arr", DisplayName = "Basic")]
+        [DataRow("c.arr[2]", DisplayName = "ArrayIndex")]
+        [DataRow("c.arr['asdf']", DisplayName = "StringIndex")]
+        public void PropertyRefScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("c.2", DisplayName = "number with dot notation")]
+        public void PropertyRefScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("(SELECT *)", DisplayName = "basic")]
+        public void SubqueryScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("(SELECT *", DisplayName = "missing right parens")]
+        [DataRow("SELECT *)", DisplayName = "missing left parens")]
+        [DataRow("SELECT *", DisplayName = "missing both parens")]
+        [DataRow("(2)", DisplayName = "not a subquery")]
+        public void SubqueryScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("-42", DisplayName = "negative")]
+        [DataRow("+42", DisplayName = "positive")]
+        [DataRow("~42", DisplayName = "bitwise not")]
+        [DataRow("NOT 42", DisplayName = "not")]
+        public void UnaryScalarExpressionPositive(string scalarExpression)
+        {
+            ScalarExpressionTests.ValidateScalarExpression(scalarExpression);
+        }
+
+        [TestMethod]
+        [DataRow("$42", DisplayName = "unknown operator")]
+        public void UnaryScalarExpressionNegative(string scalarExpression)
+        {
+            ScalarExpressionTests.InvalidateScalarExpression(scalarExpression);
+        }
+
+        private static void ValidateScalarExpression(string scalarExpression)
+        {
+            Assert.IsNotNull(scalarExpression);
+            string query = $"SELECT VALUE {scalarExpression}";
+            ScalarExpressionTests.Validate(query);
+        }
+
+        private static void InvalidateScalarExpression(string scalarExpression)
+        {
+            Assert.IsNotNull(scalarExpression);
+            string query = $"SELECT VALUE {scalarExpression}";
+            ScalarExpressionTests.Invalidate(query);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/SelectClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/SelectClauseTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class SelectClauseTests : ParserTests
+    {
+        [TestMethod]
+        public void SelectStar()
+        {
+            ParserTests.Validate("SELECT *");
+            ParserTests.Invalidate("SELECT");
+        }
+
+        [TestMethod]
+        public void SelectList()
+        {
+            ParserTests.Validate("SELECT 1, 2, 3");
+            ParserTests.Validate("SELECT 1 AS asdf, 2, 3 AS asdf2");
+            ParserTests.Invalidate("SELECT 1,");
+        }
+
+        [TestMethod]
+        public void SelectValue()
+        {
+            ParserTests.Validate("SELECT VALUE 1");
+            ParserTests.Invalidate("SELECT VALUE 1, 2");
+            ParserTests.Invalidate("SELECTVALUE 1");
+        }
+
+        [TestMethod]
+        public void Distinct()
+        {
+            ParserTests.Validate("SELECT DISTINCT *");
+        }
+
+        [TestMethod]
+        public void Top()
+        {
+            ParserTests.Validate("SELECT TOP 5 *");
+            ParserTests.Invalidate("SELECT TOP 'asdf' *");
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/WhereClauseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Parser/WhereClauseTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query.Parser
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class WhereClauseTests : ParserTests
+    {
+        [TestMethod]
+        public void WhereClause()
+        {
+            WhereClauseTests.ValidateWhere("WHERE true");
+            WhereClauseTests.InvalidateWhere("WHERE true, true");
+        }
+
+        private static void ValidateWhere(string whereClause)
+        {
+            string query = $"SELECT * {whereClause}";
+            WhereClauseTests.Validate(query);
+        }
+
+        private static void InvalidateWhere(string whereClause)
+        {
+            string query = $"SELECT * {whereClause}";
+            WhereClauseTests.Invalidate(query);
+        }
+    }
+}


### PR DESCRIPTION
# Internal QueryParser: Adds Validations for parser

## Description

Adds unit test for the parser. This is ported from:

https://github.com/bchong95/CosmosSQLANTLR/tree/master/CosmosSqlAntlr/Tests

Mainly so that when we take updates on the auto generated parser we can be confident that there are no regressions. 