### PR TITLE
[Internal] Samples: Adds HttpClientFactory usage samples

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/BulkExecutorMigration/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/BulkExecutorMigration/Program.cs
@@ -304,8 +304,7 @@
                 }
 
                 AggregateException innerExceptions = itemResponse.Exception.Flatten();
-                CosmosException cosmosException = innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) as CosmosException;
-                if (cosmosException != null)
+                if (innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
                 {
                     return new OperationResponse<T>()
                     {

--- a/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UserManagement", "UserManag
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BulkExecutorMigration", "BulkExecutorMigration\BulkExecutorMigration.csproj", "{DC8D7000-8291-4E75-B12F-DD2D38586467}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HttpClientFactory", "HttpClientFactory\HttpClientFactory.csproj", "{D4CFD5B2-67A8-4383-947F-FAADD998043E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{DC8D7000-8291-4E75-B12F-DD2D38586467}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DC8D7000-8291-4E75-B12F-DD2D38586467}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DC8D7000-8291-4E75-B12F-DD2D38586467}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4CFD5B2-67A8-4383-947F-FAADD998043E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4CFD5B2-67A8-4383-947F-FAADD998043E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4CFD5B2-67A8-4383-947F-FAADD998043E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4CFD5B2-67A8-4383-947F-FAADD998043E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/HttpClientFactory.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/HttpClientFactory.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\AppSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
@@ -67,7 +67,7 @@
         /// <summary>
         /// In scenarios where connection to the Emulator requires disabled SSL verification due to multiple environments.
         /// </summary>
-        private static void ConnectToEmulatorWithSSLDisabled(
+        private static void ConnectToEmulatorWithSslDisabled(
             string endpoint,
             string authKey)
         {
@@ -121,7 +121,7 @@
         /// </summary>
         /// <see href="https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests"/>
         /// <see href="https://docs.microsoft.com/aspnet/core/fundamentals/http-requests"/>
-        private static void UseNETCoreIHttpClientFactory(
+        private static void UseNetCoreIHttpClientFactory(
             string endpoint,
             string authKey)
         {
@@ -207,4 +207,3 @@
         }
     }
 }
-

--- a/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
@@ -43,8 +43,8 @@
                     throw new ArgumentException("Please specify a valid AuthorizationKey in the appSettings.json");
                 }
 
-                Program.ConnectToEmulatorWithSSLDisabled(endpoint, authKey);
-                Program.UseNETCoreIHttpClientFactory(endpoint, authKey);
+                Program.ConnectToEmulatorWithSslDisabled(endpoint, authKey);
+                Program.UseNetCoreIHttpClientFactory(endpoint, authKey);
                 Program.ShareHttpHandlers(endpoint, authKey);
             }
             catch (CosmosException cre)
@@ -192,6 +192,7 @@
             // Maintain a single instance of the SocketsHttpHandler for the lifetime of the application
             SocketsHttpHandler socketsHttpHandler = new SocketsHttpHandler();
             socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMinutes(10); // Customize this value based on desired DNS refresh timer
+            socketsHttpHandler.MaxConnectionsPerServer = 20; // Customize the maximum number of allowed connections
 
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
             {

--- a/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/Program.cs
@@ -1,0 +1,210 @@
+﻿namespace Cosmos.Samples.Shared
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    // ----------------------------------------------------------------------------------------------------------
+    // Prerequisites - 
+    // 
+    // 1. An Azure Cosmos account - 
+    //    https://docs.microsoft.com/azure/cosmos-db/create-cosmosdb-resources-portal
+    //
+    // 2. Microsoft.Azure.Cosmos NuGet package - 
+    //    http://www.nuget.org/packages/Microsoft.Azure.Cosmos/ 
+    // ----------------------------------------------------------------------------------------------------------
+    // Sample - demonstrates usage scenarios for HttpClientFactory
+    // ----------------------------------------------------------------------------------------------------------
+
+    public class Program
+    {
+        // <Main>
+        public static async Task Main(string[] args)
+        {
+            try
+            {
+                IConfigurationRoot configuration = new ConfigurationBuilder()
+                    .AddJsonFile("appSettings.json")
+                    .Build();
+
+                string endpoint = configuration["EndPointUrl"];
+                if (string.IsNullOrEmpty(endpoint))
+                {
+                    throw new ArgumentNullException("Please specify a valid endpoint in the appSettings.json");
+                }
+
+                string authKey = configuration["AuthorizationKey"];
+                if (string.IsNullOrEmpty(authKey) || string.Equals(authKey, "Super secret key"))
+                {
+                    throw new ArgumentException("Please specify a valid AuthorizationKey in the appSettings.json");
+                }
+
+                Program.ConnectToEmulatorWithSSLDisabled(endpoint, authKey);
+                Program.UseNETCoreIHttpClientFactory(endpoint, authKey);
+                Program.ShareHttpHandlers(endpoint, authKey);
+            }
+            catch (CosmosException cre)
+            {
+                Console.WriteLine(cre.ToString());
+            }
+            catch (Exception e)
+            {
+                Exception baseException = e.GetBaseException();
+                Console.WriteLine("Error: {0}, Message: {1}", e.Message, baseException.Message);
+            }
+            finally
+            {
+                Console.WriteLine("End of demo, press any key to exit.");
+                Console.ReadKey();
+            }
+        }
+        // </Main>
+
+        /// <summary>
+        /// In scenarios where connection to the Emulator requires disabled SSL verification due to multiple environments.
+        /// </summary>
+        private static void ConnectToEmulatorWithSSLDisabled(
+            string endpoint,
+            string authKey)
+        {
+            // For applications running in NET Standard 2.0 compatible frameworks
+            {
+                // <DisableSSLNETStandard20>
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                {
+                    HttpClientFactory = () =>
+                    {
+                        HttpMessageHandler httpMessageHandler = new HttpClientHandler()
+                        {
+                            ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true
+                        };
+
+                        return new HttpClient(httpMessageHandler);
+                    },
+                    ConnectionMode = ConnectionMode.Gateway
+                };
+
+
+                CosmosClient client = new CosmosClient(endpoint, authKey, cosmosClientOptions);
+                // </DisableSSLNETStandard20>
+            }
+
+            // For applications running in NET Standard 2.1+ compatible frameworks
+            {
+                // <DisableSSLNETStandard21>
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                {
+                    HttpClientFactory = () =>
+                    {
+                        HttpMessageHandler httpMessageHandler = new HttpClientHandler()
+                        {
+                            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                        };
+
+                        return new HttpClient(httpMessageHandler);
+                    },
+                    ConnectionMode = ConnectionMode.Gateway
+                };
+
+
+                CosmosClient client = new CosmosClient(endpoint, authKey, cosmosClientOptions);
+                // </DisableSSLNETStandard21>
+            }
+        }
+
+        /// <summary>
+        /// When running NET Core / ASP.NET Core applications, you can leverage IHttpClientFactory to reuse and share HttpClients across your entire NET Core / ASP.NET Core application.
+        /// </summary>
+        /// <see href="https://docs.microsoft.com/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests"/>
+        /// <see href="https://docs.microsoft.com/aspnet/core/fundamentals/http-requests"/>
+        private static void UseNETCoreIHttpClientFactory(
+            string endpoint,
+            string authKey)
+        {
+            // Console applications can use IHttpClientFactory by using the HostBuilder
+            // https://docs.microsoft.com/aspnet/core/fundamentals/http-requests?view=aspnetcore-2.1#use-ihttpclientfactory-in-a-console-app-2
+            {
+                // <IHttpClientFactoryConsole>
+                IHostBuilder builder = new HostBuilder()
+                    .ConfigureServices((hostContext, services) =>
+                    {
+                        services.AddHttpClient();
+                    }).UseConsoleLifetime();
+
+                IHost host = builder.Build();
+
+                using (IServiceScope serviceScope = host.Services.CreateScope())
+                {
+                    IServiceProvider serviceProvider = serviceScope.ServiceProvider;
+
+                    IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+                    CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                    {
+                        HttpClientFactory = httpClientFactory.CreateClient
+                    };
+
+
+                    CosmosClient client = new CosmosClient(endpoint, authKey, cosmosClientOptions);
+                }
+
+                // </IHttpClientFactoryConsole>
+            }
+
+            //ASP.NET Core applications get it from the Dependency Injection container.
+            {
+                // <IHttpClientFactoryASPNETCore>
+                void ConfigureServices(IServiceCollection services)
+                {
+                    services.AddHttpClient();
+                    services.AddSingleton<CosmosClient>(serviceProvider =>
+                    {
+                        IHttpClientFactory httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();
+
+                        CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                        {
+                            HttpClientFactory = httpClientFactory.CreateClient
+                        };
+
+
+                        return new CosmosClient(endpoint, authKey, cosmosClientOptions);
+                    });
+
+                    //... other service registration
+                }
+                // </IHttpClientFactoryASPNETCore>
+            }
+        }
+
+        /// <summary>
+        /// When IHttpClientFactory is not available or not needed, the right way is to share HttpHandlers.
+        /// </summary>
+        /// <see href="https://docs.microsoft.com/aspnet/core/fundamentals/http-requests?view=aspnetcore-3.1#alternatives-to-ihttpclientfactory"/>
+        private static void ShareHttpHandlers(
+            string endpoint,
+            string authKey)
+        {
+            // <ReusingHandler>
+            // Maintain a single instance of the SocketsHttpHandler for the lifetime of the application
+            SocketsHttpHandler socketsHttpHandler = new SocketsHttpHandler();
+            socketsHttpHandler.PooledConnectionLifetime = TimeSpan.FromMinutes(10); // Customize this value based on desired DNS refresh timer
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                HttpClientFactory = () => new HttpClient(socketsHttpHandler, disposeHandler: false)
+            };
+
+
+            CosmosClient client = new CosmosClient(endpoint, authKey, cosmosClientOptions);
+
+            HttpClient anotherHttpClient = new HttpClient(socketsHttpHandler, disposeHandler: false);
+            //... use the other client for another operations
+            // </ReusingHandler>
+        }
+    }
+}
+


### PR DESCRIPTION
## Description

This PR adds a new Samples project focused on `CosmosClientOptions.HttpClientFactory` and its use cases:

* Disabling SSL validation for Emulator scenarios
* Leveraging NET Core IHttpClientFactory for ASP.NET and console applications
* Reusing HTTP connections when IHttpClientFactory is not available