### PR TITLE
[Internal] Documentation: Fixes old article Urls on public classes and APIs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
-        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-container">Set throughput on a container</seealso>
         public abstract Task<int?> ReadThroughputAsync(
             CancellationToken cancellationToken = default(CancellationToken));
 
@@ -214,11 +214,6 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The provisioned throughput for this container.
         /// </value>
-        /// <remarks>
-        /// <para>
-        /// Refer to http://azure.microsoft.com/documentation/articles/documentdb-performance-levels/ for details on provision offer throughput.
-        /// </para>
-        /// </remarks>
         /// <example>
         /// The following example shows how to get the throughput
         /// <code language="c#">
@@ -241,6 +236,8 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-container">Set throughput on a container</seealso>
         public abstract Task<ThroughputResponse> ReadThroughputAsync(
             RequestOptions requestOptions,
             CancellationToken cancellationToken = default(CancellationToken));
@@ -265,6 +262,7 @@ namespace Microsoft.Azure.Cosmos
         /// </code>
         /// </example>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-container">Set throughput on a container</seealso>
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             int throughput,
             RequestOptions requestOptions = null,
@@ -298,6 +296,7 @@ namespace Microsoft.Azure.Cosmos
         /// </example>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-container">Set throughput on a container</seealso>
         /// </remarks>
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             ThroughputProperties throughputProperties,

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -175,6 +175,7 @@ namespace Microsoft.Azure.Cosmos
         /// </example>
         /// <remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
         /// </remarks>
         public abstract Task<ThroughputResponse> ReplaceThroughputAsync(
             ThroughputProperties throughputProperties,

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ConsistencyLevel.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ConsistencyLevel.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     /// <remarks>
     /// The requested Consistency Level must match or be weaker than that provisioned for the database account.
-    /// For more information on consistency levels, please see <see>http://azure.microsoft.com/documentation/articles/documentdb-consistency-levels/"</see> Consistency Levels article.
     /// </remarks>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/consistency-levels"/>
     public enum ConsistencyLevel
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Cosmos
     /// A database may contain zero or more named containers and each container consists of zero or more JSON documents. 
     /// Being schema-free, the documents in a container do not need to share the same structure or fields. Since containers are application resources, 
     /// they can be authorized using either the master key or resource keys.
-    /// Refer to <see>http://azure.microsoft.com/documentation/articles/documentdb-resources/#collections</see> for more details on containers.
     /// </remarks>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/databases-containers-items"/>
     /// <example>
     /// The example below creates a new partitioned container with 50000 Request-per-Unit throughput.
     /// The partition key is the first level 'country' property in all the documents within this container.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/HashIndex.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/HashIndex.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The data type for which this index should be applied.
         /// </value>
-        /// <remarks>Refer to <a href="http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy">Customizing the indexing policy of a collection</a> for valid ranges of values.</remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.DataType)]
         [JsonConverter(typeof(StringEnumConverter))]
         public DataType DataType { get; set; }
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The precision for this particular index. Returns null, if not set.
         /// </value>
-        /// <remarks>Refer to <a href="http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy">Customizing the indexing policy of a collection</a> for valid ranges of values.</remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.Precision,
             NullValueHandling = NullValueHandling.Ignore)]
         public short? Precision { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.Cosmos
         /// The path to be indexed.
         /// </value>
         /// <remarks>
-        /// Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for how to specify paths.
         /// Some valid examples: /"prop"/?, /"prop"/**, /"prop"/"subprop"/?, /"prop"/[]/?
         /// </remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.Path)]
         public string Path { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexKind.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexKind.cs
@@ -5,10 +5,8 @@ namespace Microsoft.Azure.Cosmos
 {
     /// <summary>
     /// These are the indexing types available for indexing a path in the Azure Cosmos DB service.
-    /// </summary> 
-    /// <remarks>
-    /// For additional details, refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy.
-    /// </remarks>
+    /// </summary>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
     public enum IndexKind
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/RangeIndex.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/RangeIndex.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The data type for which this index should be applied.
         /// </value>
-        /// <remarks>Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for valid ranges of values.</remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.DataType)]
         [JsonConverter(typeof(StringEnumConverter))]
         public DataType DataType { get; set; }
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The precision for this particular index. Returns null, if not set.
         /// </value>
-        /// <remarks>Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for valid ranges of values.</remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.Precision,
             NullValueHandling = NullValueHandling.Ignore)]
         public short? Precision { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/SpatialIndex.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/SpatialIndex.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The data type for which this index should be applied.
         /// </value>
-        /// <remarks>Refer to http://azure.microsoft.com/documentation/articles/documentdb-indexing-policies/#ConfigPolicy for valid ranges of values.</remarks>
+        /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/index-policy"/>
         [JsonProperty(PropertyName = Constants.Properties.DataType)]
         [JsonConverter(typeof(StringEnumConverter))]
         public DataType DataType { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ThroughputProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ThroughputProperties.cs
@@ -14,8 +14,9 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     /// <remarks>
     /// It contains provisioned container throughput in measurement of request units per second in the Azure Cosmos service.
-    /// Refer to http://azure.microsoft.com/documentation/articles/documentdb-performance-levels/ for details on provision offer throughput.
     /// </remarks>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput">Set throughput on resources</seealso>
     /// <example>
     /// The example below fetch the ThroughputProperties on testContainer.
     /// <code language="c#">


### PR DESCRIPTION
We had old Azure articles URLs lingering on some of our public types and methods. Replaced them with the new format and correct urls.