### PR TITLE
include case-sensitive issue in the cosmos tsg

### DIFF
--- a/TroubleshootingGuides/CosmosNotFound.md
+++ b/TroubleshootingGuides/CosmosNotFound.md
@@ -88,3 +88,9 @@ The database and/or container that the item exists in has been deleted.
 #### Solution:
 1. [Restore](https://docs.microsoft.com/azure/cosmos-db/online-backup-and-restore#backup-retention-period) the parent resource or recreate the resources.
 2. Create a new resource to replace the deleted resource
+
+### 7. Container/Collection names are case-sensitive
+Container/Collection names are case-sesnsitive in Cosmos DB.
+
+#### Solution:
+Make sure to use the exact name while connecting to Cosmos DB.


### PR DESCRIPTION
## Description

Collection names are case-sensitive in cosmos db and I received the following error only to realise that the collection names are case-sensitive. Since this doc is mentioned as tsg in the error, it would be helpful to include the case-sensitivity in the tsg.

```
{Reason: (Message: {"Errors":["Resource Not Found. Learn more: https:\/\/aka.ms\/cosmosdb-tsg-not-found"]}
```
https://aka.ms/cosmosdb-tsg-not-found actually redirect to [TroubleshootingGuides/CosmosNotFound.md](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/TroubleshootingGuides/CosmosNotFound.md)
## Type of change

Please delete options that are not relevant.

- Update tsg for cosmos db
