### PR TITLE
Internal ChangeFeed : Fixed GetFeedRange call for logical partition keys

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedRange/Continuations/FeedRangeCompositeContinuation.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/Continuations/FeedRangeCompositeContinuation.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override FeedRange GetFeedRange()
         {
-            if (this.FeedRange is FeedRangePartitionKeyRange)
+            if (!(this.FeedRange is FeedRangeEpk))
             {
                 return this.FeedRange;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -165,7 +165,11 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             ChangeFeedIteratorCore feedIterator = itemsCore.GetChangeFeedStreamIterator(
                 ChangeFeedStartFrom.Beginning(
                     FeedRange.FromPartitionKey(
-                        new PartitionKey(pkToRead)))) as ChangeFeedIteratorCore;
+                        new PartitionKey(pkToRead))),
+                new ChangeFeedRequestOptions()
+                {
+                    PageSizeHint = 1,
+                }) as ChangeFeedIteratorCore;
             string continuation = null;
             while (feedIterator.HasMoreResults)
             {
@@ -245,7 +249,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
             ContainerInternal itemsCore = this.Container;
             FeedIterator<ToDoActivity> feedIterator = itemsCore.GetChangeFeedIterator<ToDoActivity>(
-                ChangeFeedStartFrom.Beginning(new FeedRangePartitionKey(new PartitionKey(pkToRead))));
+                ChangeFeedStartFrom.Beginning(
+                    new FeedRangePartitionKey(
+                        new PartitionKey(pkToRead))),
+                new ChangeFeedRequestOptions()
+                {
+                    PageSizeHint = 1,
+                });
             string continuation = null;
             while (feedIterator.HasMoreResults)
             {


### PR DESCRIPTION
# Internal ChangeFeed : Fixed GetFeedRange call for logical partition keys

## Description

FeedRangeCompositeContinuationToken.GetFeedRange() was returning the EPK range for a logical partition after the first continuation. Currently the backend does not honor this, so it just returns documents from the whole physical partition. The fix is to return the logical partition, which will set the header correctly. None of the tests caught this, since they use a max page size / no continuations.

