### PR TITLE
[Internal] Tests: Fixes emulator test that are broken from new emulator

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1366,7 +1366,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException ex)
             {
                 Assert.AreEqual(HttpStatusCode.BadRequest, ex.StatusCode);
-                Assert.IsTrue(ex.Message.Contains("One of the specified inputs is invalid"));
+                Assert.IsTrue(ex.Message.Contains("Add Operation only support adding a leaf node of an existing node(array or object), no path found beyond: 'nonExistentParent'"), ex.Message);
             }
 
             // precondition failure - 412 response

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -3366,12 +3366,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 document, requestOptions:
                 new ItemRequestOptions { IndexingDirective = Cosmos.IndexingDirective.Exclude });
 
-            Logger.LogLine("Querying Document to ensure if document is not indexed");
+            Logger.LogLine("Querying Document to ensure that document is indexed");
             FeedIterator<Document> queriedDocuments = collection.GetItemQueryIterator<Document>(
                 queryText: @"select * from root r where r.StringField=""222""",
                 requestOptions: new QueryRequestOptions { MaxConcurrency = 1 });
 
-            Assert.AreEqual(0, await this.GetCountFromIterator(queriedDocuments));
+            Assert.AreEqual(1, await this.GetCountFromIterator(queriedDocuments));
 
             Logger.LogLine("Replace document to include in index");
             retrievedDocument = await collection.ReplaceItemAsync(id: documentName, item: (Document)retrievedDocument, requestOptions: new ItemRequestOptions { IndexingDirective = Cosmos.IndexingDirective.Include });
@@ -3386,16 +3386,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Logger.LogLine("Replace document to not include in index");
             retrievedDocument = await collection.ReplaceItemAsync(id: documentName, item: (Document)retrievedDocument, requestOptions: new ItemRequestOptions { IndexingDirective = Cosmos.IndexingDirective.Exclude });
 
-            Logger.LogLine("Querying Document to ensure if document is not indexed");
+            Logger.LogLine("Querying Document to ensure that document is indexed");
             queriedDocuments = collection.GetItemQueryIterator<Document>(queryText: @"select * from root r where r.StringField=""222""", requestOptions: new QueryRequestOptions { MaxConcurrency = 1 });
-            Assert.AreEqual(0, await this.GetCountFromIterator(queriedDocuments));
+            Assert.AreEqual(1, await this.GetCountFromIterator(queriedDocuments));
 
             Logger.LogLine("Replace document to not include in index");
             retrievedDocument = await collection.ReplaceItemAsync(id: documentName, item: (Document)retrievedDocument, requestOptions: new ItemRequestOptions { IndexingDirective = Cosmos.IndexingDirective.Exclude });
 
-            Logger.LogLine("Querying Document to ensure if document is not indexed");
+            Logger.LogLine("Querying Document to ensure that document is indexed");
             queriedDocuments = collection.GetItemQueryIterator<Document>(queryText: @"select * from root r where r.StringField=""222""", requestOptions: new QueryRequestOptions { MaxConcurrency = 1 });
-            Assert.AreEqual(0, await this.GetCountFromIterator(queriedDocuments));
+            Assert.AreEqual(1, await this.GetCountFromIterator(queriedDocuments));
 
             Logger.LogLine("Delete document");
             await collection.DeleteItemAsync<Document>(partitionKey: new Cosmos.PartitionKey(documentName), id: documentName);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -660,7 +660,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(docReplaced.NumericField, 3333);
 
                 // query for changed string value
-                Assert.AreEqual(0, this.client.CreateDocumentQuery(collection.SelfLink, @"select * from root r where r.StringField=""3333""", new FeedOptions { EnableCrossPartitionQuery = true }).AsEnumerable().Count());
+                Assert.AreEqual(1, this.client.CreateDocumentQuery(collection.SelfLink, @"select * from root r where r.StringField=""3333""", new FeedOptions { EnableCrossPartitionQuery = true }).AsEnumerable().Count());
 
                 requestHeaders.Remove("x-ms-indexing-directive");
                 requestHeaders.Add("x-ms-indexing-directive", "include");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -610,7 +610,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.client.Create<Document>(collection.GetIdOrFullName(), documentDefinition, requestHeaders);
 
                 IEnumerable<Document> queriedDocuments = this.client.CreateDocumentQuery<Document>(collection.GetLink(), @"select * from root r where r.StringField = ""222""", new FeedOptions { EnableCrossPartitionQuery = true });
-                Assert.AreEqual(0, queriedDocuments.Count());
+                Assert.AreEqual(1, queriedDocuments.Count());
             }
             catch (DocumentClientException e)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is fixing the following tests that are broken from the new emulator. 

Cosmos DB master PR that made the change: https://msdata.visualstudio.com/DefaultCollection/CosmosDB/_git/CosmosDB/pullrequest/368488

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber