### PR TITLE
[Internal] Unit tests: Adds tests to verify request options are not sealed

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/CosmosVirtualUnitTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/CosmosVirtualUnitTest.cs
@@ -51,6 +51,31 @@ namespace Microsoft.Azure.Cosmos.Tests.Contracts
         }
 
         [TestMethod]
+        public void VerifyAllRequestOptionsCanBeExtended()
+        {
+            // The following classes are public, but not meant to be mocked.
+            HashSet<string> nonMockableClasses = new HashSet<string>()
+            {
+#if PREVIEW
+                nameof(ChangeFeedRequestOptions)
+#endif
+            };
+
+            // All request options should not be sealed to allow compute to extend them.
+            IEnumerable<Type> sealedRequestOptions = from t in Assembly.GetAssembly(typeof(CosmosClient)).GetTypes()
+                where
+                    t.IsClass &&
+                    t.Namespace == "Microsoft.Azure.Cosmos" &&
+                    t.IsPublic &&
+                    !nonMockableClasses.Contains(t.Name) &&
+                    t.Name.EndsWith("RequestOptions") &&
+                    t.IsSealed
+                select t;
+
+            Assert.IsFalse(sealedRequestOptions.Any(), $"RequestOptions should not be sealed: {string.Join(";", "sealedRequestOptions")}");
+        }
+
+        [TestMethod]
         public void VerifyAllPublicClassesCanBeMocked()
         {
             // The following classes are public, but not meant to be mocked.


### PR DESCRIPTION
# Pull Request Template

## Description

Adding unit test to verify request options are not sealed to allow compute and other teams to extend them.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber