### PR TITLE
ResponseFactory : Adds method to create ItemResponse without deserialization of ResponseMessage content

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactory.cs
@@ -28,21 +28,32 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage responseMessage);
 
         /// <summary>
-        /// Creates a FeedResponse from a response message
+        /// Creates a ItemResponse from a response message
         /// </summary>
-        /// <typeparam name="T">The user</typeparam>
+        /// <typeparam name="T">The user type of the serialized item</typeparam>
         /// <param name="responseMessage">The response message from the stream API</param>
-        /// <returns>An instance of FeedResponse<typeparamref name="T"/></returns>
+        /// <returns>An instance of ItemResponse<typeparamref name="T"/></returns>
         public abstract ItemResponse<T> CreateItemResponse<T>(
             ResponseMessage responseMessage);
 
         /// <summary>
         /// Creates a StoredProcedureExecuteResponse from a response message
         /// </summary>
-        /// <typeparam name="T">The user</typeparam>
+        /// <typeparam name="T">The user type of the serialized item</typeparam>
         /// <param name="responseMessage">The response message from the stream API</param>
-        /// <returns>An instance of FeedResponse<typeparamref name="T"/></returns>
+        /// <returns>An instance of StoredProcedureExecuteResponse<typeparamref name="T"/></returns>
         public abstract StoredProcedureExecuteResponse<T> CreateStoredProcedureExecuteResponse<T>(
             ResponseMessage responseMessage);
+
+        /// <summary>
+        /// Creates a ItemResponse from a response message and the item resource.
+        /// </summary>
+        /// <typeparam name="T">The user type of the serialized item</typeparam>
+        /// <param name="responseMessage">The response message from the stream API</param>
+        /// <param name="item">The item resource.</param>
+        /// <returns>An instance of ItemResponse<typeparamref name="T"/></returns>
+        public abstract ItemResponse<T> CreateItemResponse<T>(
+            ResponseMessage responseMessage,
+            T item);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
@@ -89,6 +89,20 @@ namespace Microsoft.Azure.Cosmos
             });
         }
 
+        public override ItemResponse<T> CreateItemResponse<T>(
+            ResponseMessage responseMessage,
+            T item)
+        {
+            return this.ProcessMessage(responseMessage, (cosmosResponseMessage) =>
+            {
+                return new ItemResponse<T>(
+                    cosmosResponseMessage.StatusCode,
+                    cosmosResponseMessage.Headers,
+                    item,
+                    cosmosResponseMessage.Diagnostics);
+            });
+        }
+
         public override ContainerResponse CreateContainerResponse(
             Container container,
             ResponseMessage responseMessage)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -168,6 +168,11 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.ItemResponse`1[T] CreateItemResponse[T](Microsoft.Azure.Cosmos.ResponseMessage)"
         },
+        "Microsoft.Azure.Cosmos.ItemResponse`1[T] CreateItemResponse[T](Microsoft.Azure.Cosmos.ResponseMessage, T)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ItemResponse`1[T] CreateItemResponse[T](Microsoft.Azure.Cosmos.ResponseMessage, T)"
+        },
         "Microsoft.Azure.Cosmos.Scripts.StoredProcedureExecuteResponse`1[T] CreateStoredProcedureExecuteResponse[T](Microsoft.Azure.Cosmos.ResponseMessage)": {
           "Type": "Method",
           "Attributes": [],


### PR DESCRIPTION
# Pull Request Template

## Description

This is needed for addressing issue #1518 ([PR](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/1832) 
We need to return ItemResponse to user with the DecryptableItem resource which we have constructed.

## Type of change

- [] New feature (non-breaking change which adds functionality)

