### PR TITLE
Client Encryption : Adds support to make usage of default DEK cache optional

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/CosmosEncryptor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/CosmosEncryptor.cs
@@ -33,11 +33,13 @@ namespace Microsoft.Azure.Cosmos.Encryption
             byte[] cipherText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
             DataEncryptionKey dek = await this.DataEncryptionKeyProvider.FetchDataEncryptionKeyAsync(
                 dataEncryptionKeyId,
                 encryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
 
             if (dek == null)
@@ -53,11 +55,13 @@ namespace Microsoft.Azure.Cosmos.Encryption
             byte[] plainText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
             DataEncryptionKey dek = await this.DataEncryptionKeyProvider.FetchDataEncryptionKeyAsync(
                 dataEncryptionKeyId,
                 encryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
 
             if (dek == null)

--- a/Microsoft.Azure.Cosmos.Encryption/src/DataEncryptionKeyProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/DataEncryptionKeyProvider.cs
@@ -18,11 +18,13 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// </summary>
         /// <param name="id">Identifier of the data encryption key.</param>
         /// <param name="encryptionAlgorithm">Encryption algorithm that the retrieved key will be used with.</param>
+        /// <param name="requestOptions">The options for the request.</param>
         /// <param name="cancellationToken">Token for request cancellation.</param>
         /// <returns>Data encryption key bytes.</returns>
         public abstract Task<DataEncryptionKey> FetchDataEncryptionKeyAsync(
             string id,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/DekCache.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/DekCache.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             }
 
             InMemoryRawDek inMemoryRawDek = await this.RawDekCache.GetAsync(
-                dekProperties.SelfLink,
+                dekProperties.Id,
                 null,
                 () => unwrapper(dekProperties, requestOptions, diagnosticsContext, cancellationToken),
                 cancellationToken);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             if (inMemoryRawDek.RawDekExpiry <= DateTime.UtcNow)
             {
                 inMemoryRawDek = await this.RawDekCache.GetAsync(
-                   dekProperties.SelfLink,
+                   dekProperties.Id,
                    null,
                    () => unwrapper(dekProperties, requestOptions, diagnosticsContext, cancellationToken),
                    cancellationToken,

--- a/Microsoft.Azure.Cosmos.Encryption/src/DekCache.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/DekCache.cs
@@ -12,13 +12,16 @@ namespace Microsoft.Azure.Cosmos.Encryption
     internal class DekCache
     {
         private readonly TimeSpan dekPropertiesTimeToLive;
+        private readonly bool isUnwrappedDekCached;
 
         // Internal for unit testing
         internal AsyncCache<string, CachedDekProperties> DekPropertiesCache { get; } = new AsyncCache<string, CachedDekProperties>();
 
         internal AsyncCache<string, InMemoryRawDek> RawDekCache { get; } = new AsyncCache<string, InMemoryRawDek>();
 
-        public DekCache(TimeSpan? dekPropertiesTimeToLive = null)
+        public DekCache(
+            bool cacheUnwrappedDek,
+            TimeSpan? dekPropertiesTimeToLive = null)
         {
             if (dekPropertiesTimeToLive.HasValue)
             {
@@ -28,6 +31,8 @@ namespace Microsoft.Azure.Cosmos.Encryption
             {
                 this.dekPropertiesTimeToLive = TimeSpan.FromMinutes(30);
             }
+
+            this.isUnwrappedDekCached = cacheUnwrappedDek;
         }
 
         public async Task<DataEncryptionKeyProperties> GetOrAddDekPropertiesAsync(
@@ -37,10 +42,10 @@ namespace Microsoft.Azure.Cosmos.Encryption
             CancellationToken cancellationToken)
         {
             CachedDekProperties cachedDekProperties = await this.DekPropertiesCache.GetAsync(
-                    dekId,
-                    null,
-                    () => this.FetchAsync(dekId, fetcher, diagnosticsContext, cancellationToken),
-                    cancellationToken);
+                dekId,
+                null,
+                () => this.FetchAsync(dekId, fetcher, diagnosticsContext, cancellationToken),
+                cancellationToken);
 
             if (cachedDekProperties.ServerPropertiesExpiryUtc <= DateTime.UtcNow)
             {
@@ -57,22 +62,32 @@ namespace Microsoft.Azure.Cosmos.Encryption
 
         public async Task<InMemoryRawDek> GetOrAddRawDekAsync(
             DataEncryptionKeyProperties dekProperties,
-            Func<DataEncryptionKeyProperties, CosmosDiagnosticsContext, CancellationToken, Task<InMemoryRawDek>> unwrapper,
+            Func<DataEncryptionKeyProperties, RequestOptions, CosmosDiagnosticsContext, CancellationToken, Task<InMemoryRawDek>> unwrapper,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
+            if (!this.isUnwrappedDekCached)
+            {
+                return await unwrapper(
+                    dekProperties,
+                    requestOptions,
+                    diagnosticsContext,
+                    cancellationToken);
+            }
+
             InMemoryRawDek inMemoryRawDek = await this.RawDekCache.GetAsync(
-                   dekProperties.SelfLink,
-                   null,
-                   () => unwrapper(dekProperties, diagnosticsContext, cancellationToken),
-                   cancellationToken);
+                dekProperties.SelfLink,
+                null,
+                () => unwrapper(dekProperties, requestOptions, diagnosticsContext, cancellationToken),
+                cancellationToken);
 
             if (inMemoryRawDek.RawDekExpiry <= DateTime.UtcNow)
             {
                 inMemoryRawDek = await this.RawDekCache.GetAsync(
                    dekProperties.SelfLink,
                    null,
-                   () => unwrapper(dekProperties, diagnosticsContext, cancellationToken),
+                   () => unwrapper(dekProperties, requestOptions, diagnosticsContext, cancellationToken),
                    cancellationToken,
                    forceRefresh: true);
             }
@@ -88,13 +103,17 @@ namespace Microsoft.Azure.Cosmos.Encryption
 
         public void SetRawDek(string dekId, InMemoryRawDek inMemoryRawDek)
         {
-            this.RawDekCache.Set(dekId, inMemoryRawDek);
+            if (this.isUnwrappedDekCached)
+            {
+                this.RawDekCache.Set(dekId, inMemoryRawDek);
+            }
         }
 
         public async Task RemoveAsync(string dekId)
         {
             CachedDekProperties cachedDekProperties = await this.DekPropertiesCache.RemoveAsync(dekId);
-            if (cachedDekProperties != null)
+            if (cachedDekProperties != null &&
+                this.isUnwrappedDekCached)
             {
                 this.RawDekCache.Remove(dekId);
             }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -105,6 +105,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.Encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -117,6 +118,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     responseMessage.Content = await this.DecryptResponseAsync(
                         responseMessage.Content,
                         encryptionItemRequestOptions.DecryptionResultHandler,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -199,6 +201,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 responseMessage.Content = await this.DecryptResponseAsync(
                     responseMessage.Content,
                     decryptionErroHandler,
+                    requestOptions,
                     diagnosticsContext,
                     cancellationToken);
 
@@ -285,6 +288,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.Encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -298,6 +302,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     responseMessage.Content = await this.DecryptResponseAsync(
                         responseMessage.Content,
                         encryptionItemRequestOptions.DecryptionResultHandler,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -380,6 +385,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.Encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -392,6 +398,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     responseMessage.Content = await this.DecryptResponseAsync(
                         responseMessage.Content,
                         encryptionItemRequestOptions.DecryptionResultHandler,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 
@@ -570,6 +577,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     continuationToken,
                     requestOptions),
                 this.Encryptor,
+                requestOptions,
                 decryptionResultHandler);
         }
 
@@ -594,6 +602,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     continuationToken,
                     requestOptions),
                 this.Encryptor,
+                requestOptions,
                 decryptionResultHandler);
         }
 
@@ -644,6 +653,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     continuationToken,
                     changeFeedRequestOptions),
                 this.Encryptor,
+                changeFeedRequestOptions,
                 decryptionResultHandler);
         }
 
@@ -666,6 +676,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     feedRange,
                     changeFeedRequestOptions),
                 this.Encryptor,
+                changeFeedRequestOptions,
                 decryptionResultHandler);
         }
 
@@ -688,6 +699,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     partitionKey,
                     changeFeedRequestOptions),
                 this.Encryptor,
+                changeFeedRequestOptions,
                 decryptionResultHandler);
         }
 
@@ -754,6 +766,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     continuationToken,
                     requestOptions),
                 this.Encryptor,
+                requestOptions,
                 decryptionResultHandler);
         }
 
@@ -775,6 +788,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         private async Task<Stream> DecryptResponseAsync(
             Stream input,
             Action<DecryptionResult> decryptionResultHandler,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
@@ -788,6 +802,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 return await EncryptionProcessor.DecryptAsync(
                     input,
                     this.Encryptor,
+                    requestOptions,
                     diagnosticsContext,
                     cancellationToken);
             }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainerExtensions.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             return new EncryptionFeedIterator(
                 query.ToStreamIterator(),
                 encryptionContainer.Encryptor,
+                queryRequestOptions,
                 decryptionResultHandler);
         }
     }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionFeedIterator.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionFeedIterator.cs
@@ -16,14 +16,17 @@ namespace Microsoft.Azure.Cosmos.Encryption
         private readonly FeedIterator feedIterator;
         private readonly Encryptor encryptor;
         private readonly Action<DecryptionResult> decryptionResultHandler;
+        private readonly RequestOptions requestOptions;
 
         public EncryptionFeedIterator(
             FeedIterator feedIterator,
             Encryptor encryptor,
+            RequestOptions requestOptions = null,
             Action<DecryptionResult> decryptionResultHandler = null)
         {
             this.feedIterator = feedIterator;
             this.encryptor = encryptor;
+            this.requestOptions = requestOptions;
             this.decryptionResultHandler = decryptionResultHandler;
         }
 
@@ -76,6 +79,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     JObject decryptedDocument = await EncryptionProcessor.DecryptAsync(
                         document,
                         this.encryptor,
+                        this.requestOptions,
                         diagnosticsContext,
                         cancellationToken);
 

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionKeyWrapProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionKeyWrapProvider.cs
@@ -25,17 +25,27 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// </summary>
         /// <param name="key">Data encryption key that needs to be wrapped.</param>
         /// <param name="metadata">Metadata for the wrap provider that should be used to wrap / unwrap the key.</param>
+        /// <param name="requestOptions">The options for the request.</param>
         /// <param name="cancellationToken">Cancellation token allowing for cancellation of this operation.</param>
         /// <returns>Awaitable wrapped (i.e. encrypted) version of data encryption key passed in possibly with updated metadata.</returns>
-        public abstract Task<EncryptionKeyWrapResult> WrapKeyAsync(byte[] key, EncryptionKeyWrapMetadata metadata, CancellationToken cancellationToken);
+        public abstract Task<EncryptionKeyWrapResult> WrapKeyAsync(
+            byte[] key,
+            EncryptionKeyWrapMetadata metadata,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken);
 
         /// <summary>
         /// Unwraps (i.e. decrypts) the provided wrapped data encryption key.
         /// </summary>
         /// <param name="wrappedKey">Wrapped form of data encryption key that needs to be unwrapped.</param>
         /// <param name="metadata">Metadata for the wrap provider that should be used to wrap / unwrap the key.</param>
+        /// <param name="requestOptions">The options for the request.</param>
         /// <param name="cancellationToken">Cancellation token allowing for cancellation of this operation.</param>
         /// <returns>Awaitable unwrapped (i.e. unencrypted) version of data encryption key passed in and how long the raw data encryption key can be cached on the client.</returns>
-        public abstract Task<EncryptionKeyUnwrapResult> UnwrapKeyAsync(byte[] wrappedKey, EncryptionKeyWrapMetadata metadata, CancellationToken cancellationToken);
+        public abstract Task<EncryptionKeyUnwrapResult> UnwrapKeyAsync(
+            byte[] wrappedKey,
+            EncryptionKeyWrapMetadata metadata,
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionProcessor.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             Stream input,
             Encryptor encryptor,
             EncryptionOptions encryptionOptions,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
@@ -104,6 +105,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 plainText,
                 encryptionOptions.DataEncryptionKeyId,
                 encryptionOptions.EncryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
 
             if (cipherText == null)
@@ -130,6 +132,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         public static async Task<Stream> DecryptAsync(
             Stream input,
             Encryptor encryptor,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
@@ -163,6 +166,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             JObject plainTextJObj = await EncryptionProcessor.DecryptContentAsync(
                 encryptionProperties,
                 encryptor,
+                requestOptions,
                 diagnosticsContext,
                 cancellationToken);
 
@@ -179,6 +183,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         public static async Task<JObject> DecryptAsync(
             JObject document,
             Encryptor encryptor,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
@@ -196,6 +201,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             JObject plainTextJObj = await EncryptionProcessor.DecryptContentAsync(
                 encryptionProperties,
                 encryptor,
+                requestOptions,
                 diagnosticsContext,
                 cancellationToken);
 
@@ -212,6 +218,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         private static async Task<JObject> DecryptContentAsync(
             EncryptionProperties encryptionProperties,
             Encryptor encryptor,
+            RequestOptions requestOptions,
             CosmosDiagnosticsContext diagnosticsContext,
             CancellationToken cancellationToken)
         {
@@ -224,6 +231,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 encryptionProperties.EncryptedData,
                 encryptionProperties.DataEncryptionKeyId,
                 encryptionProperties.EncryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
 
             if (plainText == null)

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken: default).Result;
                 }
@@ -133,6 +134,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken: default).Result;
                 }
@@ -180,6 +182,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         streamPayload,
                         this.encryptor,
                         encryptionItemRequestOptions.EncryptionOptions,
+                        requestOptions,
                         diagnosticsContext,
                         cancellationToken: default).Result;
                 }
@@ -211,6 +214,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                             result.ResourceStream = await EncryptionProcessor.DecryptAsync(
                                 result.ResourceStream,
                                 this.encryptor,
+                                requestOptions: null,
                                 diagnosticsContext,
                                 cancellationToken);
                         }

--- a/Microsoft.Azure.Cosmos.Encryption/src/Encryptor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Encryptor.cs
@@ -19,12 +19,14 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// <param name="plainText">Plain text.</param>
         /// <param name="dataEncryptionKeyId">Identifier of the data encryption key.</param>
         /// <param name="encryptionAlgorithm">Identifier for the encryption algorithm.</param>
+        /// <param name="requestOptions">The options for the request.</param>
         /// <param name="cancellationToken">Token for cancellation.</param>
         /// <returns>Cipher text.</returns>
         public abstract Task<byte[]> EncryptAsync(
             byte[] plainText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -33,12 +35,14 @@ namespace Microsoft.Azure.Cosmos.Encryption
         /// <param name="cipherText">Ciphertext to be decrypted.</param>
         /// <param name="dataEncryptionKeyId">Identifier of the data encryption key.</param>
         /// <param name="encryptionAlgorithm">Identifier for the encryption algorithm.</param>
+        /// <param name="requestOptions">The options for the request.</param>
         /// <param name="cancellationToken">Token for cancellation.</param>
         /// <returns>Plain text.</returns>
         public abstract Task<byte[]> DecryptAsync(
             byte[] cipherText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default);
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/KeyVault/AzureKeyVaultCosmosEncryptor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/KeyVault/AzureKeyVaultCosmosEncryptor.cs
@@ -69,12 +69,14 @@ namespace Microsoft.Azure.Cosmos.Encryption
             byte[] plainText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
             return this.cosmosEncryptor.EncryptAsync(
                 plainText,
                 dataEncryptionKeyId,
                 encryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
         }
 
@@ -83,12 +85,14 @@ namespace Microsoft.Azure.Cosmos.Encryption
             byte[] cipherText,
             string dataEncryptionKeyId,
             string encryptionAlgorithm,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken = default)
         {
             return this.cosmosEncryptor.DecryptAsync(
                 cipherText,
                 dataEncryptionKeyId,
                 encryptionAlgorithm,
+                requestOptions,
                 cancellationToken);
         }
     }

--- a/Microsoft.Azure.Cosmos.Encryption/src/KeyVault/AzureKeyVaultKeyWrapProvider.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/KeyVault/AzureKeyVaultKeyWrapProvider.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         public override async Task<EncryptionKeyUnwrapResult> UnwrapKeyAsync(
             byte[] wrappedKey,
             EncryptionKeyWrapMetadata metadata,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken)
         {
             if (metadata.Type != AzureKeyVaultKeyWrapMetadata.TypeConstant)
@@ -71,6 +72,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         public override async Task<EncryptionKeyWrapResult> WrapKeyAsync(
             byte[] key,
             EncryptionKeyWrapMetadata metadata,
+            RequestOptions requestOptions,
             CancellationToken cancellationToken)
         {
             if (metadata.Type != AzureKeyVaultKeyWrapMetadata.TypeConstant)
@@ -80,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
 
             if (!KeyVaultKeyUriProperties.TryParse(new Uri(metadata.Value), out KeyVaultKeyUriProperties keyVaultUriProperties))
             {
-                throw new ArgumentException("KeyVault Key Uri {0} is invalid.",metadata.Value);
+                throw new ArgumentException("KeyVault Key Uri {0} is invalid.", metadata.Value);
             }
 
             if (!await this.keyVaultAccessClient.ValidatePurgeProtectionAndSoftDeleteSettingsAsync(keyVaultUriProperties, cancellationToken))

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Contracts/DotNetSDKEncryptionAPI.json
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Contracts/DotNetSDKEncryptionAPI.json
@@ -18,15 +18,15 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task InitializeAsync(Microsoft.Azure.Cosmos.Database, System.String)"
         },
-        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "Void .ctor(Azure.Core.TokenCredential)": {
           "Type": "Constructor",
@@ -84,17 +84,17 @@
           ],
           "MethodInfo": "System.Threading.Tasks.Task InitializeAsync(Microsoft.Azure.Cosmos.Database, System.String, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosDataEncryptionKeyProvider+<FetchDataEncryptionKeyAsync>d__15))]": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosDataEncryptionKeyProvider+<FetchDataEncryptionKeyAsync>d__15))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan])": {
+        "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan], Boolean)": {
           "Type": "Constructor",
           "Attributes": [],
-          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan])"
+          "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan], Boolean)"
         }
       },
       "NestedTypes": {}
@@ -125,19 +125,19 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.DataEncryptionKeyProvider get_DataEncryptionKeyProvider()"
         },
-        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<DecryptAsync>d__4))]": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<DecryptAsync>d__4))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<EncryptAsync>d__5))]": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<EncryptAsync>d__5))]": {
           "Type": "Method",
           "Attributes": [
             "AsyncStateMachineAttribute"
           ],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
         "Void .ctor(Microsoft.Azure.Cosmos.Encryption.DataEncryptionKeyProvider)": {
           "Type": "Constructor",
@@ -393,27 +393,27 @@
               ],
               "MethodInfo": "System.Threading.Tasks.Task InitializeAsync(Microsoft.Azure.Cosmos.Database, System.String, System.Threading.CancellationToken)"
             },
-            "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosDataEncryptionKeyProvider+<FetchDataEncryptionKeyAsync>d__15))]": {
+            "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosDataEncryptionKeyProvider+<FetchDataEncryptionKeyAsync>d__15))]": {
               "Type": "Method",
               "Attributes": [
                 "AsyncStateMachineAttribute"
               ],
-              "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)"
+              "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
             },
-            "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan])": {
+            "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan], Boolean)": {
               "Type": "Constructor",
               "Attributes": [],
-              "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan])"
+              "MethodInfo": "Void .ctor(Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapProvider, System.Nullable`1[System.TimeSpan], Boolean)"
             }
           },
           "NestedTypes": {}
         }
       },
       "Members": {
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.DataEncryptionKey] FetchDataEncryptionKeyAsync(System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         }
       },
       "NestedTypes": {}
@@ -649,15 +649,15 @@
     "EncryptionKeyWrapProvider": {
       "Subclasses": {},
       "Members": {
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyUnwrapResult] UnwrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyUnwrapResult] UnwrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyUnwrapResult] UnwrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyUnwrapResult] UnwrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapResult] WrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapResult] WrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapResult] WrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapResult] WrapKeyAsync(Byte[], Microsoft.Azure.Cosmos.Encryption.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         }
       },
       "NestedTypes": {}
@@ -864,15 +864,15 @@
               "Attributes": [],
               "MethodInfo": "System.Threading.Tasks.Task InitializeAsync(Microsoft.Azure.Cosmos.Database, System.String)"
             },
-            "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+            "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
             },
-            "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+            "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
             },
             "Void .ctor(Azure.Core.TokenCredential)": {
               "Type": "Constructor",
@@ -902,19 +902,19 @@
               ],
               "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.DataEncryptionKeyProvider get_DataEncryptionKeyProvider()"
             },
-            "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<DecryptAsync>d__4))]": {
+            "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<DecryptAsync>d__4))]": {
               "Type": "Method",
               "Attributes": [
                 "AsyncStateMachineAttribute"
               ],
-              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
             },
-            "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<EncryptAsync>d__5))]": {
+            "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)[System.Runtime.CompilerServices.AsyncStateMachineAttribute(typeof(Microsoft.Azure.Cosmos.Encryption.CosmosEncryptor+<EncryptAsync>d__5))]": {
               "Type": "Method",
               "Attributes": [
                 "AsyncStateMachineAttribute"
               ],
-              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+              "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
             },
             "Void .ctor(Microsoft.Azure.Cosmos.Encryption.DataEncryptionKeyProvider)": {
               "Type": "Constructor",
@@ -926,15 +926,15 @@
         }
       },
       "Members": {
-        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] DecryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         },
-        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken)"
+          "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, Microsoft.Azure.Cosmos.RequestOptions, System.Threading.CancellationToken)"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/EncryptionProcessorTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/EncryptionProcessorTests.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             };
 
             EncryptionProcessorTests.mockEncryptor = new Mock<Encryptor>();
-            EncryptionProcessorTests.mockEncryptor.Setup(m => m.EncryptAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] plainText, string dekId, string algo, CancellationToken t) =>
+            EncryptionProcessorTests.mockEncryptor.Setup(m => m.EncryptAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestOptions>(),It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[] plainText, string dekId, string algo, RequestOptions requestOptions, CancellationToken t) =>
                     dekId == EncryptionProcessorTests.dekId ? TestCommon.EncryptData(plainText) : throw new InvalidOperationException("DEK not found."));
-            EncryptionProcessorTests.mockEncryptor.Setup(m => m.DecryptAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync((byte[] cipherText, string dekId, string algo, CancellationToken t) => 
+            EncryptionProcessorTests.mockEncryptor.Setup(m => m.DecryptAsync(It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestOptions>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((byte[] cipherText, string dekId, string algo, RequestOptions requestOptions, CancellationToken t) => 
                     dekId == EncryptionProcessorTests.dekId ? TestCommon.DecryptData(cipherText) : throw new InvalidOperationException("Null DEK was returned."));
         }
 
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                     testDoc.ToStream(),
                     EncryptionProcessorTests.mockEncryptor.Object,
                     encryptionOptionsWithInvalidPathToEncrypt,
+                    new RequestOptions(),
                     new CosmosDiagnosticsContext(),
                     CancellationToken.None);
 
@@ -79,6 +80,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             JObject decryptedDoc = await EncryptionProcessor.DecryptAsync(
                 encryptedDoc,
                 EncryptionProcessorTests.mockEncryptor.Object,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -97,6 +99,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             JObject decryptedDoc = await EncryptionProcessor.DecryptAsync(
                 encryptedDoc,
                 EncryptionProcessorTests.mockEncryptor.Object,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -114,12 +117,14 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 testDoc.ToStream(),
                 EncryptionProcessorTests.mockEncryptor.Object,
                 EncryptionProcessorTests.encryptionOptions,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
             Stream decryptedStream = await EncryptionProcessor.DecryptAsync(
                 encryptedStream,
                 EncryptionProcessorTests.mockEncryptor.Object,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -138,6 +143,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             Stream decryptedStream = await EncryptionProcessor.DecryptAsync(
                 docStream,
                 EncryptionProcessorTests.mockEncryptor.Object,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -152,6 +158,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 testDoc.ToStream(),
                 EncryptionProcessorTests.mockEncryptor.Object,
                 EncryptionProcessorTests.encryptionOptions,
+                new RequestOptions(),
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 


### PR DESCRIPTION
# Pull Request Template

## Description

Teams is planning to implement DEK Cache on their end to have more control over the cache behavior. They'd like to control the memory usage, expiration policy (eg not absolute expiry, but sliding), eviction policy (LRU…), etc. It's not an issue currently with CK-only encryption, but with MS Managed Key (MMK) support they'll potentially have hundreds of thousands or millions tenant encryption keys to handle. They'll need to be able to adjust most of the parts of the flow. We are making the usage of unwrapped DEK cache optional on our end, which can be configured through setting a flag.

Also, another requirement they have is for us to make a call to them for each request to get the unwrapped DEK - which would be the case since we won't have raw DEK cached. They need the context for the request as well in that case, for which they plan to use RequestOptions.Properties. Passing RequestOptions as parameter to the Wrap / Unwrap call to address this.

## Type of change

- [] New feature (non-breaking change which adds functionality)
