### PR TITLE
Performance: Adds AuthorizationHelper improvements

### DIFF
--- a/Microsoft.Azure.Cosmos/src/AuthorizationHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/AuthorizationHelper.cs
@@ -719,10 +719,12 @@ namespace Microsoft.Azure.Cosmos
 
                 // Double the size to allow the URL encode to use the same buffer
                 Span<byte> encodingBufferSpan = stackalloc byte[Base64.GetMaxEncodedToUtf8Length(hashPayLoad.Length) * 2];
+
+                // This replaces the Convert.ToBase64String
                 OperationStatus status = Base64.EncodeToUtf8(
                     hashPayLoad,
                     encodingBufferSpan,
-                    out int bytesConsumed,
+                    out int _,
                     out int bytesWritten);
 
                 if (status != OperationStatus.Done)
@@ -739,9 +741,16 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
+        /// <summary>
+        /// This does HttpUtility.UrlEncode functionality with Span buffer. It does an in place update to avoid
+        /// creating the new buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer that include the bytes to url encode.</param>
+        /// <param name="count">The size of the buffer that is used for the bytes to encode</param>
+        /// <returns>The URLEncoded string of the bytes in the buffer</returns>
         public unsafe static string UrlEncodeSpanInPlace(Span<byte> buffer, int count)
         {
-            if (buffer.Length < count)
+            if (buffer.Length < count || count == 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count), $"buffer length: {buffer.Length}, buffer count: {count}");
             }


### PR DESCRIPTION
# Pull Request Template

## Description

1. Created a static string to avoid rebuilding and encoding the constant part of the string.
2. Generate auth returns the UrlEncoded payload. This avoids converting it to string and back to a byte array.
3. Changed the HttpUtility.UrlEncode to use span and to use the existing buffer to avoid more allocations.

Roughly 25% improvement in speed and almost 40% decrease in memory usage
```
|                      Method |     Mean |     Error |    StdDev |    StdErr |   Median |      Min |       Q1 |       Q3 |      Max |      Op/s |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------- |---------:|----------:|----------:|----------:|---------:|---------:|---------:|---------:|---------:|----------:|-------:|------:|------:|----------:|
| AuthEncodeOptimizationStack | 2.709 us | 0.0066 us | 0.0339 us | 0.0020 us | 2.706 us | 2.645 us | 2.683 us | 2.732 us | 2.802 us | 369,111.7 | 0.0267 |     - |     - |     536 B |
|                AuthOriginal | 3.684 us | 0.0069 us | 0.0350 us | 0.0021 us | 3.678 us | 3.612 us | 3.658 us | 3.707 us | 3.787 us | 271,431.3 | 0.0458 |     - |     - |     904 B |

```

stackalloc vs arraypool
```
|     Method | Capacity |      Mean |     Error |    StdDev |    StdErr |    Median |       Min |        Q1 |        Q3 |       Max |          Op/s | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------- |--------- |----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|----------:|--------------:|------:|------:|------:|----------:|
| StackAlloc |       10 |  1.504 ns | 0.0042 ns | 0.0217 ns | 0.0013 ns |  1.502 ns |  1.449 ns |  1.488 ns |  1.518 ns |  1.569 ns | 664,757,574.8 |     - |     - |     - |         - |
| RentReturn |       10 | 30.909 ns | 0.0656 ns | 0.3312 ns | 0.0197 ns | 30.889 ns | 30.286 ns | 30.643 ns | 31.141 ns | 31.834 ns |  32,353,427.3 |     - |     - |     - |         - |
| StackAlloc |      100 |  4.189 ns | 0.0070 ns | 0.0358 ns | 0.0021 ns |  4.184 ns |  4.107 ns |  4.164 ns |  4.210 ns |  4.300 ns | 238,727,690.5 |     - |     - |     - |         - |
| RentReturn |      100 | 34.824 ns | 1.0247 ns | 5.2487 ns | 0.3082 ns | 31.366 ns | 30.359 ns | 30.945 ns | 41.937 ns | 42.952 ns |  28,715,709.8 |     - |     - |     - |         - |
| StackAlloc |      200 |  8.256 ns | 0.0142 ns | 0.0727 ns | 0.0043 ns |  8.245 ns |  8.075 ns |  8.204 ns |  8.300 ns |  8.494 ns | 121,130,238.0 |     - |     - |     - |         - |
| RentReturn |      200 | 31.705 ns | 0.1547 ns | 0.7856 ns | 0.0465 ns | 31.775 ns | 30.334 ns | 30.873 ns | 32.428 ns | 33.157 ns |  31,540,997.4 |     - |     - |     - |         - |
| StackAlloc |      300 | 12.287 ns | 0.0155 ns | 0.0794 ns | 0.0047 ns | 12.277 ns | 12.130 ns | 12.233 ns | 12.332 ns | 12.550 ns |  81,384,465.2 |     - |     - |     - |         - |
| RentReturn |      300 | 32.512 ns | 0.2732 ns | 1.3546 ns | 0.0821 ns | 31.819 ns | 30.623 ns | 31.463 ns | 34.238 ns | 35.313 ns |  30,757,781.3 |     - |     - |     - |         - |
| StackAlloc |      400 | 16.315 ns | 0.0164 ns | 0.0840 ns | 0.0049 ns | 16.308 ns | 16.119 ns | 16.257 ns | 16.353 ns | 16.547 ns |  61,295,115.1 |     - |     - |     - |         - |
| RentReturn |      400 | 31.454 ns | 0.1868 ns | 0.9551 ns | 0.0562 ns | 30.958 ns | 30.293 ns | 30.711 ns | 32.514 ns | 33.562 ns |  31,792,286.0 |     - |     - |     - |         - |
| StackAlloc |      500 | 21.156 ns | 0.0197 ns | 0.1005 ns | 0.0059 ns | 21.151 ns | 20.955 ns | 21.073 ns | 21.225 ns | 21.489 ns |  47,266,945.7 |     - |     - |     - |         - |
| RentReturn |      500 | 31.030 ns | 0.0741 ns | 0.3797 ns | 0.0223 ns | 30.942 ns | 30.365 ns | 30.751 ns | 31.252 ns | 32.335 ns |  32,226,773.5 |     - |     - |     - |         - |
| StackAlloc |      600 | 25.224 ns | 0.0241 ns | 0.1239 ns | 0.0073 ns | 25.212 ns | 24.954 ns | 25.123 ns | 25.316 ns | 25.604 ns |  39,645,300.9 |     - |     - |     - |         - |
| RentReturn |      600 | 32.291 ns | 0.3719 ns | 1.9151 ns | 0.1119 ns | 31.177 ns | 30.255 ns | 30.824 ns | 34.792 ns | 35.482 ns |  30,968,626.7 |     - |     - |     - |         - |
| StackAlloc |      700 | 29.245 ns | 0.0282 ns | 0.1451 ns | 0.0085 ns | 29.232 ns | 28.959 ns | 29.140 ns | 29.339 ns | 29.651 ns |  34,193,406.4 |     - |     - |     - |         - |
| RentReturn |      700 | 30.804 ns | 0.0636 ns | 0.3225 ns | 0.0191 ns | 30.780 ns | 30.165 ns | 30.523 ns | 31.067 ns | 31.573 ns |  32,462,963.3 |     - |     - |     - |         - |
| StackAlloc |      800 | 33.264 ns | 0.0302 ns | 0.1555 ns | 0.0091 ns | 33.244 ns | 32.920 ns | 33.155 ns | 33.350 ns | 33.754 ns |  30,062,713.7 |     - |     - |     - |         - |
| RentReturn |      800 | 31.478 ns | 0.0462 ns | 0.2373 ns | 0.0139 ns | 31.449 ns | 30.717 ns | 31.306 ns | 31.632 ns | 32.092 ns |  31,768,476.1 |     - |     - |     - |         - |
| StackAlloc |      900 | 37.991 ns | 0.0303 ns | 0.1548 ns | 0.0091 ns | 37.977 ns | 37.645 ns | 37.878 ns | 38.097 ns | 38.543 ns |  26,322,097.7 |     - |     - |     - |         - |
| RentReturn |      900 | 31.691 ns | 0.1562 ns | 0.7943 ns | 0.0470 ns | 31.327 ns | 30.624 ns | 31.055 ns | 32.646 ns | 33.313 ns |  31,554,304.8 |     - |     - |     - |         - |
| StackAlloc |     1000 | 42.342 ns | 0.0901 ns | 0.4608 ns | 0.0271 ns | 42.130 ns | 41.719 ns | 41.985 ns | 42.818 ns | 43.452 ns |  23,617,214.0 |     - |     - |     - |         - |
| RentReturn |     1000 | 37.499 ns | 0.8877 ns | 4.4990 ns | 0.2670 ns | 38.858 ns | 30.958 ns | 31.543 ns | 42.004 ns | 42.798 ns |  26,667,461.3 |     - |     - |     - |         - |
```


## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber