### PR TITLE
Blazor: Fixes not supported HTTP features

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -97,11 +97,30 @@ namespace Microsoft.Azure.Cosmos
         public static HttpMessageHandler CreateHttpClientHandler(int gatewayModeMaxConnectionLimit, IWebProxy webProxy)
         {
             // https://docs.microsoft.com/en-us/archive/blogs/timomta/controlling-the-number-of-outgoing-connections-from-httpclient-net-core-or-full-framework
-            return new HttpClientHandler
+            try
             {
-                Proxy = webProxy,
-                MaxConnectionsPerServer = gatewayModeMaxConnectionLimit
-            };
+                return new HttpClientHandler
+                {
+                    Proxy = webProxy,
+                    MaxConnectionsPerServer = gatewayModeMaxConnectionLimit
+                };
+            }
+            catch (PlatformNotSupportedException)
+            {
+                try
+                {
+                    //Some platforms might not support Proxy
+                    return new HttpClientHandler
+                    {
+                        MaxConnectionsPerServer = gatewayModeMaxConnectionLimit
+                    };
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // Proxy and MaxConnectionsPerServer are not supported
+                    return new HttpClientHandler();
+                }
+            }
         }
 
         private static HttpMessageHandler CreateHttpMessageHandler(

--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -107,19 +107,8 @@ namespace Microsoft.Azure.Cosmos
             }
             catch (PlatformNotSupportedException)
             {
-                try
-                {
-                    //Some platforms might not support Proxy
-                    return new HttpClientHandler
-                    {
-                        MaxConnectionsPerServer = gatewayModeMaxConnectionLimit
-                    };
-                }
-                catch (PlatformNotSupportedException)
-                {
-                    // Proxy and MaxConnectionsPerServer are not supported
-                    return new HttpClientHandler();
-                }
+                // Proxy and MaxConnectionsPerServer are not supported on some platforms.
+                return new HttpClientHandler();
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Creation of the `CosmosHttpClient` tries to set the Proxy and MaxConnectionsPerServer properties on `HttpClientHandler`, but these are not supported on all platforms.

This fix conditionally attempts to set them and detects `PlatformNotSupportedException` and retries without these parameters.

Due to the nature of the issue, no mocking can be done to test it.

Testing was done with a real Blazor WASM application.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1860 
Closes #1862 