### PR TITLE
Revert "Internal: Adding latency percentiles"

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
@@ -6,19 +6,18 @@
     <AssemblyName>CosmosBenchmark</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <None Include="KeyValue.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Player.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
-    <PackageReference Include="MathNet.Numerics" Version="4.12.0" />
+    <PackageReference Include="HdrHistogram" Version="2.5.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="*" />
   </ItemGroup>
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/IExecutionStrategy.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/IExecutionStrategy.cs
@@ -11,7 +11,7 @@ namespace CosmosBenchmark
     {
         public static IExecutionStrategy StartNew(
             BenchmarkConfig config,
-            Func<IBenchmarkOperation> benchmarkOperation)
+            Func<IBenchmarkOperatrion> benchmarkOperation)
         {
             return new ParallelExecutionStrategy(benchmarkOperation);
         }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
@@ -13,12 +13,12 @@ namespace CosmosBenchmark
 
     internal class ParallelExecutionStrategy : IExecutionStrategy
     {
-        private readonly Func<IBenchmarkOperation> benchmarkOperation;
+        private readonly Func<IBenchmarkOperatrion> benchmarkOperation;
 
         private volatile int pendingExecutorCount;
 
         public ParallelExecutionStrategy(
-            Func<IBenchmarkOperation> benchmarkOperation)
+            Func<IBenchmarkOperatrion> benchmarkOperation)
         {
             this.benchmarkOperation = benchmarkOperation;
         }
@@ -79,7 +79,7 @@ namespace CosmosBenchmark
                     IExecutor executor = executors[i];
                     Summary executorSummary = new Summary()
                     {
-                        successfulOpsCount = executor.SuccessOperationCount,
+                        succesfulOpsCount = executor.SuccessOperationCount,
                         failedOpsCount = executor.FailedOperationCount,
                         ruCharges = executor.TotalRuCharges,
                     };
@@ -93,7 +93,7 @@ namespace CosmosBenchmark
                 Summary diff = currentTotalSummary - lastSummary;
                 lastSummary = currentTotalSummary;
 
-                diff.Print(currentTotalSummary.failedOpsCount + currentTotalSummary.successfulOpsCount);
+                diff.Print(currentTotalSummary.failedOpsCount + currentTotalSummary.succesfulOpsCount);
                 perLoopCounters.Add((int)diff.Rps());
 
                 await Task.Delay(TimeSpan.FromSeconds(outputLoopDelayInSeconds));
@@ -105,7 +105,7 @@ namespace CosmosBenchmark
                 Console.WriteLine();
                 Console.WriteLine("Summary:");
                 Console.WriteLine("--------------------------------------------------------------------- ");
-                lastSummary.Print(lastSummary.failedOpsCount + lastSummary.successfulOpsCount);
+                lastSummary.Print(lastSummary.failedOpsCount + lastSummary.succesfulOpsCount);
 
                 // Skip first 5 and last 5 counters as outliers
                 IEnumerable<int> exceptFirst5 = perLoopCounters.Skip(5);
@@ -115,6 +115,7 @@ namespace CosmosBenchmark
 
                 if (summaryCounters.Length > 10)
                 {
+
                     Console.WriteLine();
                     Utility.TeeTraceInformation("After Excluding outliers");
 
@@ -129,12 +130,6 @@ namespace CosmosBenchmark
                     runSummary.Top90PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.9 * summaryCounters.Length)).Average(), 0);
                     runSummary.Top95PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.95 * summaryCounters.Length)).Average(), 0);
                     runSummary.AverageRps = Math.Round(summaryCounters.Average(), 0);
-
-                    runSummary.Top50PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(50);
-                    runSummary.Top75PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(75);
-                    runSummary.Top90PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(90);
-                    runSummary.Top95PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(95);
-                    runSummary.Top99PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(99);
 
                     string summary = JsonHelper.ToString(runSummary);
                     Utility.TeeTraceInformation(summary);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/SerialOperationExecutor.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/SerialOperationExecutor.cs
@@ -11,12 +11,12 @@ namespace CosmosBenchmark
 
     internal class SerialOperationExecutor : IExecutor
     {
-        private readonly IBenchmarkOperation operation;
+        private readonly IBenchmarkOperatrion operation;
         private readonly string executorId;
 
         public SerialOperationExecutor(
             string executorId,
-            IBenchmarkOperation benchmarkOperation)
+            IBenchmarkOperatrion benchmarkOperation)
         {
             this.executorId = executorId;
             this.operation = benchmarkOperation;
@@ -33,7 +33,7 @@ namespace CosmosBenchmark
         public async Task ExecuteAsync(
                 int iterationCount,
                 bool isWarmup,
-                bool traceFailures,
+                bool traceFaiures,
                 Action completionCallback)
         {
             Trace.TraceInformation($"Executor {this.executorId} started");
@@ -45,7 +45,7 @@ namespace CosmosBenchmark
                 {
                     OperationResult? operationResult = null;
 
-                    await this.operation.PrepareAsync();
+                    await this.operation.Prepare();
 
                     using (TelemetrySpan telemetrySpan = TelemetrySpan.StartNew(
                                 () => operationResult.Value,
@@ -61,7 +61,7 @@ namespace CosmosBenchmark
                         }
                         catch (Exception ex)
                         {
-                            if (traceFailures)
+                            if (traceFaiures)
                             {
                                 Console.WriteLine(ex.ToString());
                             }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/Summary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/Summary.cs
@@ -11,7 +11,7 @@ namespace CosmosBenchmark
     {
         private const int MsPerSecond = 1000;
 
-        public long successfulOpsCount;
+        public long succesfulOpsCount;
         public long failedOpsCount;
         public double ruCharges;
         public double elapsedMs;
@@ -25,7 +25,7 @@ namespace CosmosBenchmark
 
         public double Rps()
         {
-            long total = this.successfulOpsCount + this.failedOpsCount;
+            long total = this.succesfulOpsCount + this.failedOpsCount;
             return Math.Round(
                     Math.Min(total / this.elapsedMs * Summary.MsPerSecond, total),
                     2);
@@ -35,7 +35,7 @@ namespace CosmosBenchmark
         {
             Utility.TeePrint("Stats, total: {0,5}   success: {1,5}   fail: {2,3}   RPs: {3,5}   RUps: {4,5}",
                 globalTotal,
-                this.successfulOpsCount,
+                this.succesfulOpsCount,
                 this.failedOpsCount,
                 this.Rps(),
                 this.Rups());
@@ -45,7 +45,7 @@ namespace CosmosBenchmark
         {
             return new Summary()
             {
-                successfulOpsCount = arg1.successfulOpsCount + arg2.successfulOpsCount,
+                succesfulOpsCount = arg1.succesfulOpsCount + arg2.succesfulOpsCount,
                 failedOpsCount = arg1.failedOpsCount + arg2.failedOpsCount,
                 ruCharges = arg1.ruCharges + arg2.ruCharges,
                 elapsedMs = arg1.elapsedMs + arg2.elapsedMs,
@@ -56,7 +56,7 @@ namespace CosmosBenchmark
         {
             return new Summary()
             {
-                successfulOpsCount = arg1.successfulOpsCount - arg2.successfulOpsCount,
+                succesfulOpsCount = arg1.succesfulOpsCount - arg2.succesfulOpsCount,
                 failedOpsCount = arg1.failedOpsCount - arg2.failedOpsCount,
                 ruCharges = arg1.ruCharges - arg2.ruCharges,
                 elapsedMs = arg1.elapsedMs - arg2.elapsedMs,

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/IBenchmarkOperatrion.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/IBenchmarkOperatrion.cs
@@ -6,9 +6,9 @@ namespace CosmosBenchmark
 {
     using System.Threading.Tasks;
 
-    internal interface IBenchmarkOperation
+    internal interface IBenchmarkOperatrion
     {
-        Task PrepareAsync();
+        Task Prepare();
 
         Task<OperationResult> ExecuteOnceAsync();
     }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs
@@ -33,10 +33,7 @@ namespace CosmosBenchmark
 
         public static MemoryStream ToStream<T>(T input)
         {
-            byte[] blob = System.Buffers.ArrayPool<byte>.Shared.Rent(JsonHelper.DefaultCapacity);
-            MemoryStream memStreamPayload = new MemoryStream(blob, 0, JsonHelper.DefaultCapacity, writable: true, publiclyVisible: true);
-            memStreamPayload.SetLength(0);
-            memStreamPayload.Position = 0;
+            MemoryStream memStreamPayload = new MemoryStream(JsonHelper.DefaultCapacity);
             using (StreamWriter streamWriter = new StreamWriter(memStreamPayload,
                 encoding: JsonHelper.DefaultEncoding,
                 bufferSize: JsonHelper.DefaultCapacity,

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -5,6 +5,8 @@
 namespace CosmosBenchmark
 {
     using System;
+    using System.Collections.Generic;
+    using System.Text;
 
     class RunSummary
     {
@@ -45,13 +47,6 @@ namespace CosmosBenchmark
         public double Top80PercentAverageRps { get; set; }
         public double Top90PercentAverageRps { get; set; }
         public double Top95PercentAverageRps { get; set; }
-
-        public double? Top50PercentLatencyInMs { get; set; }
-        public double? Top75PercentLatencyInMs { get; set; }
-        public double? Top90PercentLatencyInMs { get; set; }
-        public double? Top95PercentLatencyInMs { get; set; }
-        public double? Top99PercentLatencyInMs { get; set; }
-
         public double AverageRps { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/InsertV2BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/InsertV2BenchmarkOperation.cs
@@ -10,7 +10,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
 
-    internal class InsertV2BenchmarkOperation : IBenchmarkOperation
+    internal class InsertV2BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly DocumentClient documentClient;
         private readonly Uri containerUri;
@@ -58,7 +58,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public Task PrepareAsync()
+        public Task Prepare()
         {
             string newPartitionKey = Guid.NewGuid().ToString();
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadFeedStreamV2BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadFeedStreamV2BenchmarkOperation.cs
@@ -12,7 +12,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
 
-    internal class ReadFeedStreamV2BenchmarkOperation : IBenchmarkOperation
+    internal class ReadFeedStreamV2BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly DocumentClient documentClient;
         private readonly string partitionKeyPath;
@@ -57,7 +57,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadNotExistsV2BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadNotExistsV2BenchmarkOperation.cs
@@ -13,7 +13,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
 
-    internal class ReadNotExistsV2BenchmarkOperation : IBenchmarkOperation
+    internal class ReadNotExistsV2BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly string databsaeName;
         private readonly string containerName;
@@ -66,7 +66,7 @@ namespace CosmosBenchmark
             }
         }
 
-        public Task PrepareAsync()
+        public Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadStreamExistsV2BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadStreamExistsV2BenchmarkOperation.cs
@@ -12,7 +12,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
 
-    internal class ReadStreamExistsV2BenchmarkOperation : IBenchmarkOperation
+    internal class ReadStreamExistsV2BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly string partitionKeyPath;
         private readonly Dictionary<string, object> sampleJObject;
@@ -61,7 +61,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))
@@ -73,15 +73,12 @@ namespace CosmosBenchmark
                 this.sampleJObject[this.partitionKeyPath] = this.nextExecutionItemPartitionKey;
 
                 Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.databsaeName, this.containerName);
-                using (MemoryStream inputStream = JsonHelper.ToStream(this.sampleJObject))
+                using (Stream inputStream = JsonHelper.ToStream(this.sampleJObject))
                 {
                     ResourceResponse<Document> itemResponse = await this.documentClient.CreateDocumentAsync(
                             collectionUri,
                             this.sampleJObject,
                             new RequestOptions() { PartitionKey = new PartitionKey(this.nextExecutionItemPartitionKey) });
-
-                    System.Buffers.ArrayPool<byte>.Shared.Return(inputStream.GetBuffer());
-
                     if (itemResponse.StatusCode != HttpStatusCode.Created)
                     {
                         throw new Exception($"Create failed with statuscode: {itemResponse.StatusCode}");

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadTExistsV2BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v2/ReadTExistsV2BenchmarkOperation.cs
@@ -13,7 +13,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Documents.Client;
     using Newtonsoft.Json.Linq;
 
-    internal class ReadTExistsV2BenchmarkOperation : IBenchmarkOperation
+    internal class ReadTExistsV2BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly string partitionKeyPath;
         private readonly Dictionary<string, object> sampleJObject;
@@ -62,7 +62,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))
@@ -74,15 +74,12 @@ namespace CosmosBenchmark
                 this.sampleJObject[this.partitionKeyPath] = this.nextExecutionItemPartitionKey;
 
                 Uri collectionUri = UriFactory.CreateDocumentCollectionUri(this.databsaeName, this.containerName);
-                using (MemoryStream inputStream = JsonHelper.ToStream(this.sampleJObject))
+                using (Stream inputStream = JsonHelper.ToStream(this.sampleJObject))
                 {
                     ResourceResponse<Document> itemResponse = await this.documentClient.CreateDocumentAsync(
                             collectionUri,
                             this.sampleJObject,
                             new RequestOptions() { PartitionKey = new PartitionKey(this.nextExecutionItemPartitionKey) });
-
-                    System.Buffers.ArrayPool<byte>.Shared.Return(inputStream.GetBuffer());
-
                     if (itemResponse.StatusCode != HttpStatusCode.Created)
                     {
                         throw new Exception($"Create failed with statuscode: {itemResponse.StatusCode}");

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadFeedStreamV3BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadFeedStreamV3BenchmarkOperation.cs
@@ -11,7 +11,7 @@ namespace CosmosBenchmark
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
 
-    internal class ReadFeedStreamV3BenchmarkOperation : IBenchmarkOperation
+    internal class ReadFeedStreamV3BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly Container container;
         private readonly string partitionKeyPath;
@@ -63,7 +63,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))
@@ -74,14 +74,11 @@ namespace CosmosBenchmark
                 this.sampleJObject["id"] = this.nextExecutionItemId;
                 this.sampleJObject[this.partitionKeyPath] = this.nextExecutionItemPartitionKey;
 
-                using (MemoryStream inputStream = JsonHelper.ToStream(this.sampleJObject))
+                using (Stream inputStream = JsonHelper.ToStream(this.sampleJObject))
                 {
                     ResponseMessage itemResponse = await this.container.CreateItemStreamAsync(
                             inputStream,
                             new Microsoft.Azure.Cosmos.PartitionKey(this.nextExecutionItemPartitionKey));
-
-                    System.Buffers.ArrayPool<byte>.Shared.Return(inputStream.GetBuffer());
-
                     if (itemResponse.StatusCode != HttpStatusCode.Created)
                     {
                         throw new Exception($"Create failed with statuscode: {itemResponse.StatusCode}");

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadNotExistsV3BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadNotExistsV3BenchmarkOperation.cs
@@ -9,7 +9,7 @@ namespace CosmosBenchmark
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
 
-    internal class ReadNotExistsV3BenchmarkOperation : IBenchmarkOperation
+    internal class ReadNotExistsV3BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly Container container;
 
@@ -54,7 +54,7 @@ namespace CosmosBenchmark
             }
         }
 
-        public Task PrepareAsync()
+        public Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadStreamExistsV3BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadStreamExistsV3BenchmarkOperation.cs
@@ -11,7 +11,7 @@ namespace CosmosBenchmark
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
 
-    internal class ReadStreamExistsV3BenchmarkOperation : IBenchmarkOperation
+    internal class ReadStreamExistsV3BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly Container container;
         private readonly string partitionKeyPath;
@@ -61,7 +61,7 @@ namespace CosmosBenchmark
             }
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))
@@ -72,14 +72,11 @@ namespace CosmosBenchmark
                 this.sampleJObject["id"] = this.nextExecutionItemId;
                 this.sampleJObject[this.partitionKeyPath] = this.nextExecutionItemPartitionKey;
 
-                using (MemoryStream inputStream = JsonHelper.ToStream(this.sampleJObject))
+                using (Stream inputStream = JsonHelper.ToStream(this.sampleJObject))
                 {
                     ResponseMessage itemResponse = await this.container.CreateItemStreamAsync(
                             inputStream,
                             new PartitionKey(this.nextExecutionItemPartitionKey));
-
-                    System.Buffers.ArrayPool<byte>.Shared.Return(inputStream.GetBuffer());
-
                     if (itemResponse.StatusCode != HttpStatusCode.Created)
                     {
                         throw new Exception($"Create failed with statuscode: {itemResponse.StatusCode}");

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadTExistsV3BenchmarkOperation.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/v3/ReadTExistsV3BenchmarkOperation.cs
@@ -12,7 +12,7 @@ namespace CosmosBenchmark
     using Microsoft.Azure.Cosmos;
     using Newtonsoft.Json.Linq;
 
-    internal class ReadTExistsV3BenchmarkOperation : IBenchmarkOperation
+    internal class ReadTExistsV3BenchmarkOperation : IBenchmarkOperatrion
     {
         private readonly Container container;
         private readonly string partitionKeyPath;
@@ -60,7 +60,7 @@ namespace CosmosBenchmark
             };
         }
 
-        public async Task PrepareAsync()
+        public async Task Prepare()
         {
             if (string.IsNullOrEmpty(this.nextExecutionItemId) ||
                 string.IsNullOrEmpty(this.nextExecutionItemPartitionKey))
@@ -71,14 +71,11 @@ namespace CosmosBenchmark
                 this.sampleJObject["id"] = this.nextExecutionItemId;
                 this.sampleJObject[this.partitionKeyPath] = this.nextExecutionItemPartitionKey;
 
-                using (MemoryStream inputStream = JsonHelper.ToStream(this.sampleJObject))
+                using (Stream inputStream = JsonHelper.ToStream(this.sampleJObject))
                 {
                     ResponseMessage itemResponse = await this.container.CreateItemStreamAsync(
                             inputStream,
                             new Microsoft.Azure.Cosmos.PartitionKey(this.nextExecutionItemPartitionKey));
-
-                    System.Buffers.ArrayPool<byte>.Shared.Return(inputStream.GetBuffer());
-
                     if (itemResponse.StatusCode != HttpStatusCode.Created)
                     {
                         throw new Exception($"Create failed with statuscode: {itemResponse.StatusCode}");


### PR DESCRIPTION
Reverts Azure/azure-cosmos-dotnet-v3#1874

There is a null reference exception if enable latency percentiles is disabled causing the benchmark to fail. Will create new PR with the fix.