### PR TITLE
[Internal] MockItemBenchmarks: Fixes benchmarks to pass valid master key format

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             Action < CosmosClientBuilder> customizeClientBuilder = null)
         {
             MockDocumentClient documentClient = new MockDocumentClient();
-            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
             cosmosClientBuilder.WithConnectionModeDirect();
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 {
     using System;
     using System.Globalization;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
@@ -43,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             Action < CosmosClientBuilder> customizeClientBuilder = null)
         {
             MockDocumentClient documentClient = new MockDocumentClient();
-            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
             cosmosClientBuilder.WithConnectionModeDirect();
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             Action < CosmosClientBuilder> customizeClientBuilder = null)
         {
             MockDocumentClient documentClient = new MockDocumentClient();
-            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Guid.NewGuid().ToString());
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder("http://localhost", Convert.ToBase64String(Guid.NewGuid().ToByteArray()));
             cosmosClientBuilder.WithConnectionModeDirect();
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Program.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Program.cs
@@ -5,19 +5,37 @@
 namespace Microsoft.Azure.Cosmos.Performance.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Reports;
     using BenchmarkDotNet.Running;
 
     class Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
             //CosmosDBConfiguration environmentConfiguration = ConfigurationService.Configuration;
             //Console.WriteLine($"Starting benchmark and dropping results on {environmentConfiguration.ReportsPath}.");
             //BenchmarkRunner.Run<ItemBenchmark>(new CustomBenchmarkConfiguration(environmentConfiguration));
 
-            BenchmarkSwitcher
+            IEnumerable<Summary> summaries = BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
                 .Run(args);
+
+            foreach (Summary summary in summaries)
+            {
+                string[] content = summary.Table.Columns.First(x => string.Equals(@"Op/s", x.Header)).Content;
+                foreach (string ops in content)
+                {
+                    if (string.Equals(@"NA", ops))
+                    {
+                        return -1;
+                    }
+                }
+            }
+
+            return 0;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Program.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Program.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
                 .FromAssembly(typeof(Program).Assembly)
                 .Run(args);
 
+            // If any of the operations have NA then something failed. Returning -1 will cause the gates to fail.
             foreach (Summary summary in summaries)
             {
                 string[] content = summary.Table.Columns.First(x => string.Equals(@"Op/s", x.Header)).Content;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/README.md
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/README.md
@@ -1,3 +1,3 @@
 ﻿Sample usage pattern 
 
-> dotnet run -c Release --framework netcoreapp3.0 -- -j Medium -f *MockedItemBenchmark* -m --allStats --join
+> dotnet run -c Release --framework netcoreapp3.1 -- -j Medium -f *MockedItemBenchmark* -m --allStats --join

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
@@ -111,7 +111,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             Stopwatch stopwatch = Stopwatch.StartNew();
             await timer.StartTimerAsync();
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution && stopwatch.ElapsedMilliseconds <= timerTimeout + resolution);
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution, $"{stopwatch.ElapsedMilliseconds} >= {timerTimeout - resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds <= timerTimeout + resolution, $"{stopwatch.ElapsedMilliseconds} <= {timerTimeout + resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

Recent auth changes always creates the compute function in the constructor now causing non-base64 string to throw an exception.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber