### PR TITLE
[Internal] Tests: Fixes CFP tests not stopping

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -107,21 +107,33 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
             leaseStoreManager.Setup(l => l.LeaseStore).Returns(leaseStore.Object);
             leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
-            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
-            processor.ApplyBuildConfiguration(
-                leaseStoreManager.Object,
-                null,
-                "something",
-                "instanceName",
-                new ChangeFeedLeaseOptions(),
-                new ChangeFeedProcessorOptions(),
-                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
 
-            await processor.StartAsync();
-            Mock.Get(leaseStore.Object)
-                .Verify(store => store.IsInitializedAsync(), Times.Once);
-            Mock.Get(leaseContainer.Object)
-                .Verify(store => store.GetOwnedLeasesAsync(), Times.Once);
+            ChangeFeedProcessorCore<MyDocument> processor = null;
+            try
+            {
+                processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+                processor.ApplyBuildConfiguration(
+                    leaseStoreManager.Object,
+                    null,
+                    "something",
+                    "instanceName",
+                    new ChangeFeedLeaseOptions(),
+                    new ChangeFeedProcessorOptions(),
+                    ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+
+                await processor.StartAsync();
+                Mock.Get(leaseStore.Object)
+                    .Verify(store => store.IsInitializedAsync(), Times.Once);
+                Mock.Get(leaseContainer.Object)
+                    .Verify(store => store.GetOwnedLeasesAsync(), Times.Once);
+            }
+            finally
+            {
+                if (processor != null)
+                {
+                    await processor.StopAsync();
+                }
+            }
         }
 
         [TestMethod]
@@ -147,23 +159,34 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             leaseStoreManager.Setup(l => l.LeaseManager).Returns(Mock.Of<DocumentServiceLeaseManager>);
             leaseStoreManager.Setup(l => l.LeaseStore).Returns(leaseStore.Object);
             leaseStoreManager.Setup(l => l.LeaseCheckpointer).Returns(Mock.Of<DocumentServiceLeaseCheckpointer>);
-            ChangeFeedProcessorCore<MyDocument> processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
-            processor.ApplyBuildConfiguration(
-                leaseStoreManager.Object,
-                null,
-                "something",
-                "instanceName",
-                new ChangeFeedLeaseOptions(),
-                new ChangeFeedProcessorOptions(),
-                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
+            ChangeFeedProcessorCore<MyDocument> processor = null;
+            try
+            {
+                processor = ChangeFeedProcessorCoreTests.CreateProcessor(out Mock<ChangeFeedObserverFactory<MyDocument>> factory, out Mock<ChangeFeedObserver<MyDocument>> observer);
+                processor.ApplyBuildConfiguration(
+                    leaseStoreManager.Object,
+                    null,
+                    "something",
+                    "instanceName",
+                    new ChangeFeedLeaseOptions(),
+                    new ChangeFeedProcessorOptions(),
+                    ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"));
 
-            await processor.StartAsync();
+                await processor.StartAsync();
 
-            Mock.Get(factory.Object)
-                .Verify(mock => mock.CreateObserver(), Times.Once);
+                Mock.Get(factory.Object)
+                    .Verify(mock => mock.CreateObserver(), Times.Once);
 
-            Mock.Get(observer.Object)
-                .Verify(mock => mock.OpenAsync(It.Is<ChangeFeedObserverContext>((context) => context.LeaseToken == ownedLeases.First().CurrentLeaseToken)), Times.Once);
+                Mock.Get(observer.Object)
+                    .Verify(mock => mock.OpenAsync(It.Is<ChangeFeedObserverContext>((context) => context.LeaseToken == ownedLeases.First().CurrentLeaseToken)), Times.Once);
+            }
+            finally
+            {
+                if (processor != null)
+                {
+                    await processor.StopAsync();
+                }
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

Some unit tests were starting CFP processors and CF estimators, evaluating that initialization, but not stopping the instances. This didn't fail the test because the test was covering the initialization process, but it left Tasks running in the back that would fail with NullReferenceExceptions because the mocked instances were not mocking all methods, just mocking the methods on the test scope.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)