### PR TITLE
Change Feed Processor: Fixes failures during initialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                         return null;
                     }
 
+                    response.EnsureSuccessStatusCode();
+
                     return new ItemResponse<T>(response.StatusCode, response.Headers, CosmosContainerExtensions.DefaultJsonSerializer.FromStream<T>(response.Content), response.Diagnostics);
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreCosmosTests.cs
@@ -5,9 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
-    using System.Runtime.Serialization.Formatters.Binary;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreCosmosTests.cs
@@ -1,0 +1,128 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+
+    public class DocumentServiceLeaseStoreCosmosTests
+    {
+        [TestMethod]
+        public async Task IsInitializedAsync_IfExists()
+        {
+            string prefix = "prefix";
+            Mock<Container> container = new Mock<Container>();
+            container.Setup(c => c.ReadItemStreamAsync(
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new ResponseMessage(System.Net.HttpStatusCode.OK));
+            Mock<RequestOptionsFactory> requestOptionsFactory = new Mock<RequestOptionsFactory>();
+            DocumentServiceLeaseStoreCosmos documentServiceLeaseStoreCosmos = new DocumentServiceLeaseStoreCosmos(
+                container.Object,
+                prefix,
+                requestOptionsFactory.Object);
+
+            Assert.IsTrue(await documentServiceLeaseStoreCosmos.IsInitializedAsync());
+        }
+
+        [TestMethod]
+        public async Task IsInitializedAsync_IfDoesNotExist()
+        {
+            string prefix = "prefix";
+            Mock<Container> container = new Mock<Container>();
+            container.Setup(c => c.ReadItemStreamAsync(
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new ResponseMessage(System.Net.HttpStatusCode.NotFound));
+            Mock<RequestOptionsFactory> requestOptionsFactory = new Mock<RequestOptionsFactory>();
+            DocumentServiceLeaseStoreCosmos documentServiceLeaseStoreCosmos = new DocumentServiceLeaseStoreCosmos(
+                container.Object,
+                prefix,
+                requestOptionsFactory.Object);
+
+            Assert.IsFalse(await documentServiceLeaseStoreCosmos.IsInitializedAsync());
+        }
+
+        [TestMethod]
+        public async Task AcquireInitializationLockAsync_ConcurrentConflict()
+        {
+            string prefix = "prefix";
+            Mock<Container> container = new Mock<Container>();
+            container.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new ResponseMessage(System.Net.HttpStatusCode.Conflict));
+            Mock<RequestOptionsFactory> requestOptionsFactory = new Mock<RequestOptionsFactory>();
+            DocumentServiceLeaseStoreCosmos documentServiceLeaseStoreCosmos = new DocumentServiceLeaseStoreCosmos(
+                container.Object,
+                prefix,
+                requestOptionsFactory.Object);
+
+            Assert.IsFalse(await documentServiceLeaseStoreCosmos.AcquireInitializationLockAsync(TimeSpan.FromSeconds(1)));
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(CosmosException))]
+        public async Task AcquireInitializationLockAsync_OnFailure()
+        {
+            string prefix = "prefix";
+            Mock<Container> container = new Mock<Container>();
+            container.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(new ResponseMessage(System.Net.HttpStatusCode.TooManyRequests));
+            Mock<RequestOptionsFactory> requestOptionsFactory = new Mock<RequestOptionsFactory>();
+            DocumentServiceLeaseStoreCosmos documentServiceLeaseStoreCosmos = new DocumentServiceLeaseStoreCosmos(
+                container.Object,
+                prefix,
+                requestOptionsFactory.Object);
+
+            await documentServiceLeaseStoreCosmos.AcquireInitializationLockAsync(TimeSpan.FromSeconds(1));
+        }
+
+        [TestMethod]
+        public async Task AcquireInitializationLockAsync_Success()
+        {
+            string prefix = "prefix";
+            string etag = Guid.NewGuid().ToString();
+
+            dynamic lockDocument = new { id = Guid.NewGuid().ToString() };
+
+            ResponseMessage response = new ResponseMessage(System.Net.HttpStatusCode.OK) 
+            { 
+                Content = new CosmosJsonDotNetSerializer().ToStream(lockDocument)
+            };
+
+            Mock<Container> container = new Mock<Container>();
+            container.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(response);
+
+            Mock<RequestOptionsFactory> requestOptionsFactory = new Mock<RequestOptionsFactory>();
+            DocumentServiceLeaseStoreCosmos documentServiceLeaseStoreCosmos = new DocumentServiceLeaseStoreCosmos(
+                container.Object,
+                prefix,
+                requestOptionsFactory.Object);
+
+            Assert.IsTrue(await documentServiceLeaseStoreCosmos.AcquireInitializationLockAsync(TimeSpan.FromSeconds(1)));
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

If during initialization, the lease collection is getting throttled (or has other issues, like, not existing), the error was not getting correctly handled and resulted in a null reference exception.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #1883