### PR TITLE
[Internal] TimerWheel: Fixes tests to avoid flakyness

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const int timerTimeout = 1000;
             const int buckets = 20;
             const int resolution = 500;
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), buckets); // 20 buckets of 500 ms go up to 10000ms
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), buckets); // 20 buckets of 500 ms go up to 10000ms
             List<Task<(int, long)>> tasks = new List<Task<(int, long)>>();
             for (int i = 0; i < 10; i++)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CreatesTimerWheel()
         {
-            Assert.IsNotNull(TimerWheel.CreateTimerWheel(TimeSpan.FromMilliseconds(50), 1));
+            using TimerWheel wheel = TimerWheel.CreateTimerWheel(TimeSpan.FromMilliseconds(50), 1);
+            Assert.IsNotNull(wheel);
         }
 
         [DataTestMethod]
@@ -34,7 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CreatesTimer()
         {
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 10);
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 10);
             TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(90));
             Assert.IsNotNull(timer);
         }
@@ -48,14 +49,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void InvalidTimeout(int timeout)
         {
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 10);
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 10);
             wheel.CreateTimer(TimeSpan.FromMilliseconds(timeout));
         }
 
         [TestMethod]
         public void IndexMovesAsTimerPasses()
         {
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 3, timer: null); // deactivate timer to fire manually
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(30), 3, timer: null); // deactivate timer to fire manually
             TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(90));
             Task timerTask = timer.StartTimerAsync();
             wheel.OnTimer(null);
@@ -101,12 +102,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Timeout(1000)]
+        [Timeout(10000)]
         public async Task TimeoutFires()
         {
-            const int timerTimeout = 200;
-            const int resolution = 50;
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), 10); // 10 buckets of 50 ms go up to 500ms
+            const int timerTimeout = 2000;
+            const int resolution = 500;
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), 10); // 10 buckets of 500 ms go up to 5000ms
             TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(timerTimeout));
             Stopwatch stopwatch = Stopwatch.StartNew();
             await timer.StartTimerAsync();
@@ -115,12 +116,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Timeout(1000)]
+        [Timeout(10000)]
         public async Task TimeoutFires_SameTimeout()
         {
-            const int timerTimeout = 200;
-            const int resolution = 50;
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), 10); // 10 buckets of 50 ms go up to 500ms
+            const int timerTimeout = 2000;
+            const int resolution = 500;
+            using TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), 10); // 10 buckets of 500 ms go up to 5000ms
             TimerWheelTimer timer = wheel.CreateTimer(TimeSpan.FromMilliseconds(timerTimeout));
             TimerWheelTimer timer2 = wheel.CreateTimer(TimeSpan.FromMilliseconds(timerTimeout));
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -131,13 +132,13 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Timeout(2000)]
+        [Timeout(20000)]
         public async Task MultipleTimeouts()
         {
-            const int timerTimeout = 100;
+            const int timerTimeout = 1000;
             const int buckets = 20;
-            const int resolution = 50;
-            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), buckets); // 20 buckets of 50 ms go up to 1000ms
+            const int resolution = 500;
+            TimerWheelCore wheel = new TimerWheelCore(TimeSpan.FromMilliseconds(resolution), buckets); // 20 buckets of 500 ms go up to 10000ms
             List<Task<(int, long)>> tasks = new List<Task<(int, long)>>();
             for (int i = 0; i < 10; i++)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

Recently, TimerWheel tests that were time sensitive have began to randomly fail. This could be related to CI machine resources. To reduce flakyness, this PR extends the expected times, from the correctness perspective, nothing is changing.

Also adding `using` clauses to dispose of timers after test executes.