### PR TITLE
Performance: Fixes HashSet usage on Address refresh path

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -258,8 +258,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
 
             List<Task> tasks = new List<Task>();
-            HashSet<PartitionKeyRangeIdentity> pkRangeIds;
-            if (this.serverPartitionAddressToPkRangeIdMap.TryGetValue(serverKey, out pkRangeIds))
+            if (this.serverPartitionAddressToPkRangeIdMap.TryRemove(serverKey, out HashSet<PartitionKeyRangeIdentity> pkRangeIds))
             {
                 foreach (PartitionKeyRangeIdentity pkRangeId in pkRangeIds)
                 {
@@ -270,10 +269,6 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                     tasks.Add(this.serverPartitionAddressCache.RemoveAsync(pkRangeId));
                 }
-
-                // remove the server key from the map since we are updating the addresses
-                HashSet<PartitionKeyRangeIdentity> ignorePkRanges;
-                this.serverPartitionAddressToPkRangeIdMap.TryRemove(serverKey, out ignorePkRanges);
             }
 
             return Task.WhenAll(tasks);

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -262,9 +262,9 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 PartitionKeyRangeIdentity[] pkRangeIdsCopy;
                 lock (pkRangeIds)
-                {​​​​
+                {
                     pkRangeIdsCopy = pkRangeIds.ToArray();
-                }​​​​
+                }
 
                 foreach (PartitionKeyRangeIdentity pkRangeId in pkRangeIdsCopy)
                 {

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -542,13 +542,12 @@ namespace Microsoft.Azure.Cosmos.Routing
                        partitionKeyRangeIdentity.PartitionKeyRangeId,
                        addressInfo.PhysicalUri);
 
-                    this.serverPartitionAddressToPkRangeIdMap.AddOrUpdate(
-                        new ServerKey(new Uri(addressInfo.PhysicalUri)), new HashSet<PartitionKeyRangeIdentity>() { partitionKeyRangeIdentity },
-                        (serverKey, pkRangeIds) =>
-                        {
-                            pkRangeIds.Add(partitionKeyRangeIdentity);
-                            return pkRangeIds;
-                        });
+                    HashSet<PartitionKeyRangeIdentity> pkRangeIdSet = this.serverPartitionAddressToPkRangeIdMap.GetOrAdd(
+                        new ServerKey(new Uri(addressInfo.PhysicalUri)), new HashSet<PartitionKeyRangeIdentity>());
+                    lock (pkRangeIdSet)
+                    {
+                        pkRangeIdSet.Add(partitionKeyRangeIdentity);
+                    }
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -260,7 +260,13 @@ namespace Microsoft.Azure.Cosmos.Routing
             List<Task> tasks = new List<Task>();
             if (this.serverPartitionAddressToPkRangeIdMap.TryRemove(serverKey, out HashSet<PartitionKeyRangeIdentity> pkRangeIds))
             {
-                foreach (PartitionKeyRangeIdentity pkRangeId in pkRangeIds)
+                PartitionKeyRangeIdentity[] pkRangeIdsCopy;
+                lock (pkRangeIds)
+                {​​​​
+                    pkRangeIdsCopy = pkRangeIds.ToArray();
+                }​​​​
+
+                foreach (PartitionKeyRangeIdentity pkRangeId in pkRangeIdsCopy)
                 {
                     DefaultTrace.TraceInformation("Remove addresses for collectionRid :{0}, pkRangeId: {1}, serviceEndpoint: {2}",
                        pkRangeId.CollectionRid,


### PR DESCRIPTION
# Pull Request Template

## Description

Update lambda on `AddOrUpdate` on ConcurrentDictionary is not thread-safe, so there could be scenarios where a loop can be generated causing high CPU usage on the code path.