### PR TITLE
[Internal] Tests: Fixes flaky verifications

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             Assert.AreEqual(2, response.Headers.RequestCharge, "Should contain the sum of all RU charges for each partition read."); // Each request costs 1 RU
 
-            Assert.AreEqual(2, response.Diagnostics.ToString().Split("PointOperationStatistics").Length - 1, $"Should contain one Diagnostics for each partition read. {response.Diagnostics.ToString()}");
+            Assert.AreEqual(2, response.Count, $"Should contain one result per range");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
@@ -264,10 +264,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
-            {
-                return mockIterator.Object;
-            };
+            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) => mockIterator.Object;
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -279,15 +276,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
 
             Assert.AreEqual(2, response.Headers.RequestCharge, "Should contain the sum of all RU charges for each partition read."); // Each request costs 1 RU
-            string diagnotics = response.Diagnostics.ToString();
-            int index = -1;
-            int count = 0;
-            while ((index = diagnotics.IndexOf("PointOperation", index + 1)) > 0)
-            {
-                count++;
-            }
 
-            Assert.AreEqual(2, count, "Should contain one Diagnostics for each partition read.");
+            Assert.AreEqual(2, response.Diagnostics.ToString().Split("PointOperationStatistics").Length - 1, $"Should contain one Diagnostics for each partition read. {response.Diagnostics.ToString()}");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/TimerWheel/TimerWheelCoreTests.cs
@@ -112,8 +112,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             Stopwatch stopwatch = Stopwatch.StartNew();
             await timer.StartTimerAsync();
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution, $"{stopwatch.ElapsedMilliseconds} >= {timerTimeout - resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds <= timerTimeout + resolution, $"{stopwatch.ElapsedMilliseconds} <= {timerTimeout + resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
         }
 
         [TestMethod]
@@ -128,8 +126,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             Stopwatch stopwatch = Stopwatch.StartNew();
             await Task.WhenAll(timer.StartTimerAsync(), timer2.StartTimerAsync());
             stopwatch.Stop();
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds >= timerTimeout - resolution, $"{stopwatch.ElapsedMilliseconds} >= {timerTimeout - resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
-            Assert.IsTrue(stopwatch.ElapsedMilliseconds <= timerTimeout + resolution, $"{stopwatch.ElapsedMilliseconds} <= {timerTimeout + resolution}, timerTimeout: {timerTimeout}, resolution: {resolution}");
         }
 
         [TestMethod]
@@ -154,10 +150,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
 
             await Task.WhenAll(tasks);
-            foreach (Task<(int, long)> task in tasks)
-            {
-                Assert.IsTrue(task.Result.Item2 >= task.Result.Item1  - resolution && task.Result.Item2 <= task.Result.Item1 + resolution, $"Timer configured with {task.Result.Item1} took {task.Result.Item2} to fire.");
-            }
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Time based verifications are susceptible to machine based issues. This PR eliminates the time checks while maintaining the verification of correctness over the timer actually firing.