### PR TITLE
Samples: Fix ChangeFeed sample to have correct setup for old processor

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
@@ -284,14 +284,13 @@
             ChangeFeedProcessorLibrary.ChangeFeedProcessorBuilder builder = new ChangeFeedProcessorLibrary.ChangeFeedProcessorBuilder();
             var oldChangeFeedProcessor = await builder
                 .WithHostName("consoleHost")
-                .WithProcessorOptions(new ChangeFeedProcessorLibrary.ChangeFeedProcessorOptions {
+                .WithProcessorOptions(new ChangeFeedProcessorLibrary.ChangeFeedProcessorOptions
+                {
                     StartFromBeginning = true,
-                    LeasePrefix = "MyLeasePrefix" })
-                 .WithProcessorOptions(new ChangeFeedProcessorLibrary.ChangeFeedProcessorOptions()
-                 {
-                     MaxItemCount = 10,
-                     FeedPollDelay = TimeSpan.FromSeconds(1)
-                 })
+                    LeasePrefix = "MyLeasePrefix",
+                    MaxItemCount = 10,
+                    FeedPollDelay = TimeSpan.FromSeconds(1)
+                })
                 .WithFeedCollection(monitoredCollectionInfo)
                 .WithLeaseCollection(leaseCollectionInfo)
                 .WithObserver<ChangeFeedObserver>()


### PR DESCRIPTION
# Pull Request Template

## Description

When instance of old changefeed processor is configured, `ChangeFeedProcessorBuilder.WithProcessorOptions` method is called 2 times, and options are overridden and default values are used for `StartFromBeginning`/`LeasePrefix` properties. This PR removes duplication by merging setups.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #1915