### PR TITLE
Internal Query: Adds Order Filter Resume Workaround

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -29,7 +29,7 @@
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ShippingScope>External</ShippingScope>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -867,7 +867,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             // For the target filter we can make an optimization to just return "true",
             // since we already have the backend continuation token to resume with.
-            return (left.ToString(), TrueFilter, right.ToString());
+            return (left.ToString(), target.ToString(), right.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
# Internal Query: Adds Order Filter Resume Workaround

## Description

When a user uses a v2 continuation token with the v3 it takes a while to rehydrate the query iterator. This is because the rid that v2 uses lags behind the rid that the v3 sdk uses. The only v2 worked efficiently is because it injects a filter for the target partition. We are mimicking the same thing here for v3 SDK. Technically this is undefined behavior since are essentially taking a continuation token and using it with a modified query text, which is why its not going to make it to the official release. This is only to help customers migrate from v2 to v3 sdk. 