### PR TITLE
[Internal] Change Feed: Fixes estimator diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Globalization;


### PR DESCRIPTION
## Description

The Estimator was using a Partitioner to issue concurrent estimations and construct the result pages, but the diagnostics were being added concurrently through a thread-unsafe method.

This PR removes the Partitioner (which really was not adding any benefit) and makes sure the diagnostics are added non-concurrently.

This PR also removes flakyness in tests at https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs due to randomly not having the expected diagnostics.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)