### PR TITLE
Internal PartitionKeyRangeHandler : Adds code to expose bug

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedRangeIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedRangeIteratorCore.cs
@@ -182,15 +182,13 @@ namespace Microsoft.Azure.Cosmos
                streamPayload: stream,
                requestEnricher: request =>
                {
-                   // FeedRangeContinuationRequestMessagePopulatorVisitor needs to run before FeedRangeRequestMessagePopulatorVisitor,
-                   // since they both set EPK range headers and in the case of split we need to run on the child range and not the parent range.
+                   FeedRangeRequestMessagePopulatorVisitor feedRangeVisitor = new FeedRangeRequestMessagePopulatorVisitor(request);
+                   this.FeedRangeInternal.Accept(feedRangeVisitor);
+
                    FeedRangeContinuationRequestMessagePopulatorVisitor feedRangeContinuationVisitor = new FeedRangeContinuationRequestMessagePopulatorVisitor(
                        request,
                        QueryRequestOptions.FillContinuationToken);
                    this.FeedRangeContinuation.Accept(feedRangeContinuationVisitor);
-
-                   FeedRangeRequestMessagePopulatorVisitor feedRangeVisitor = new FeedRangeRequestMessagePopulatorVisitor(request);
-                   this.FeedRangeInternal.Accept(feedRangeVisitor);
 
                    if (this.querySpec != null)
                    {


### PR DESCRIPTION
# Internal PartitionKeyRangeHandler : Adds code to expose bug

## Description

This code reverses the priority of epk ranges. It now favors the parent epk range over the child. If PartitionKeyRangeHandler was working properly it would return a split exception and and the FeedRangeIteratorCore class would handle it. Currently it just sends the request to the first of the children and pretends nothing went wrong. This is a bug that will be caught in integration tests. 

Related to :
https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1935