### PR TITLE
[Internal] Change Feed Estimator: Fixes Task.Run

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
@@ -49,16 +49,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                   monitoredContainer,
                   leaseContainer,
                   changeFeedEstimatorRequestOptions,
-                  (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
-                  {
-                      return ResultSetIteratorUtils.BuildResultSetIterator(
+                  (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) => ResultSetIteratorUtils.BuildResultSetIterator(
                           partitionKeyRangeId: partitionKeyRangeId,
                           continuationToken: continuationToken,
                           maxItemCount: 1,
                           container: monitoredContainer,
                           startTime: null,
-                          startFromBeginning: string.IsNullOrEmpty(continuationToken));
-                  })
+                          startFromBeginning: string.IsNullOrEmpty(continuationToken)))
         {
         }
 
@@ -98,10 +95,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 throw new ArgumentOutOfRangeException($"{nameof(this.changeFeedEstimatorRequestOptions.MaxItemCount)} value should be a positive integer.");
             }
 
-            this.lazyLeaseDocuments = new AsyncLazy<TryCatch<IReadOnlyList<DocumentServiceLease>>>(valueFactory: (innerCancellationToken) =>
-            {
-                return this.TryInitializeLeaseDocumentsAsync(innerCancellationToken);
-            });
+            this.lazyLeaseDocuments = new AsyncLazy<TryCatch<IReadOnlyList<DocumentServiceLease>>>(valueFactory: (innerCancellationToken) => this.TryInitializeLeaseDocumentsAsync(innerCancellationToken));
             this.hasMoreResults = true;
 
             this.monitoredContainerFeedCreator = monitoredContainerFeedCreator;
@@ -168,12 +162,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             IEnumerable<DocumentServiceLease> leasesForCurrentPage = this.lazyLeaseDocuments.Result.Result.Skip(this.currentPage * this.pageSize).Take(this.pageSize);
             IEnumerable<Task<(ChangeFeedProcessorState, ResponseMessage)>> tasks = leasesForCurrentPage
-                .Select(lease => Task.Run(async () =>
-                {
-                    (long estimation, ResponseMessage responseMessage) = await this.GetRemainingWorkAsync(lease, cancellationToken);
-
-                    return (new ChangeFeedProcessorState(lease.CurrentLeaseToken, estimation, lease.Owner), responseMessage);
-                })).ToArray();
+                .Select(lease => this.GetRemainingWorkAsync(lease, cancellationToken)).ToArray();
 
             IEnumerable<(ChangeFeedProcessorState, ResponseMessage)> results = await Task.WhenAll(tasks);
 
@@ -238,8 +227,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
         private static long TryConvertToNumber(string number)
         {
-            long parsed = 0;
-            if (!long.TryParse(number, NumberStyles.Number, CultureInfo.InvariantCulture, out parsed))
+            if (!long.TryParse(number, NumberStyles.Number, CultureInfo.InvariantCulture, out long parsed))
             {
                 DefaultTrace.TraceWarning("Cannot parse number '{0}'.", number);
                 return 0;
@@ -260,7 +248,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 response.Content);
         }
 
-        private async Task<(long, ResponseMessage)> GetRemainingWorkAsync(
+        private async Task<(ChangeFeedProcessorState, ResponseMessage)> GetRemainingWorkAsync(
             DocumentServiceLease existingLease,
             CancellationToken cancellationToken)
         {
@@ -286,11 +274,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     : parsedLSNFromSessionToken;
                 if (lastQueryLSN < 0)
                 {
-                    return (1, response);
+                    return (new ChangeFeedProcessorState(existingLease.CurrentLeaseToken, 1, existingLease.Owner), response);
                 }
 
                 long leaseTokenRemainingWork = parsedLSNFromSessionToken - lastQueryLSN;
-                return (leaseTokenRemainingWork < 0 ? 0 : leaseTokenRemainingWork, response);
+                long estimation = leaseTokenRemainingWork < 0 ? 0 : leaseTokenRemainingWork;
+                return (new ChangeFeedProcessorState(existingLease.CurrentLeaseToken, estimation, existingLease.Owner), response);
             }
             catch (Exception clientException)
             {
@@ -342,8 +331,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             {
                 this.cosmosDiagnostics = cosmosDiagnostics ?? throw new ArgumentNullException(nameof(cosmosDiagnostics));
                 this.remainingLeaseWorks = remainingLeaseWorks ?? throw new ArgumentNullException(nameof(remainingLeaseWorks));
-                this.headers = new Headers();
-                this.headers.RequestCharge = ruCost;
+                this.headers = new Headers
+                {
+                    RequestCharge = ruCost
+                };
             }
 
             public override string ContinuationToken => throw new NotSupportedException();
@@ -358,7 +349,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             public override CosmosDiagnostics Diagnostics => this.cosmosDiagnostics;
 
-            public override IEnumerator<ChangeFeedProcessorState> GetEnumerator() => this.remainingLeaseWorks.GetEnumerator();
+            public override IEnumerator<ChangeFeedProcessorState> GetEnumerator()
+            {
+                return this.remainingLeaseWorks.GetEnumerator();
+            }
         }
 
         private class ChangeFeedEstimatorEmptyFeedResponse : FeedResponse<ChangeFeedProcessorState>
@@ -385,7 +379,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             public override CosmosDiagnostics Diagnostics => this.cosmosDiagnostics;
 
-            public override IEnumerator<ChangeFeedProcessorState> GetEnumerator() => ChangeFeedEstimatorEmptyFeedResponse.remainingLeaseWorks.GetEnumerator();
+            public override IEnumerator<ChangeFeedProcessorState> GetEnumerator()
+            {
+                return ChangeFeedEstimatorEmptyFeedResponse.remainingLeaseWorks.GetEnumerator();
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedEstimatorIteratorTests.cs
@@ -2,20 +2,20 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Moq;
-using Newtonsoft.Json.Linq;
-
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json.Linq;
+
     [TestClass]
     [TestCategory("ChangeFeed")]
     public class ChangeFeedEstimatorIteratorTests
@@ -37,11 +37,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             List<string> requestedPKRanges = new List<string>();
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 requestedPKRanges.Add(partitionKeyRangeId);
                 return mockIterator.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 feedCreator,
                 null);
 
-            await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            await remainingWorkEstimator.ReadNextAsync(default);
             CollectionAssert.AreEquivalent(expectedPKRanges, requestedPKRanges);
         }
 
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 if (partitionKeyRangeId == "0")
                 {
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 }
 
                 return mockIteratorPKRange1.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             long estimation = 0;
             while (remainingWorkEstimator.HasMoreResults)
             {
-                FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+                FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default);
                 estimation += response.Sum(e => e.EstimatedLag);
             }
 
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 if (partitionKeyRangeId == "0")
                 {
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 }
 
                 return mockIteratorPKRange1.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             long estimation = 0;
             while (remainingWorkEstimator.HasMoreResults)
             {
-                FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+                FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default);
                 estimation += response.Sum(e => e.EstimatedLag);
             }
 
@@ -192,10 +192,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 return mockIterator.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 feedCreator,
                 changeFeedEstimatorRequestOptions);
 
-            FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default);
 
             Assert.IsFalse(remainingWorkEstimator.HasMoreResults);
             Assert.AreEqual(ranges.Count, response.Count);
@@ -226,10 +226,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 return mockIterator.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -238,12 +238,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 feedCreator,
                 new ChangeFeedEstimatorRequestOptions() { MaxItemCount = pageSize }); // Expect multiple pages
 
-            FeedResponse<ChangeFeedProcessorState> firstResponse = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            FeedResponse<ChangeFeedProcessorState> firstResponse = await remainingWorkEstimator.ReadNextAsync(default);
 
             Assert.IsTrue(remainingWorkEstimator.HasMoreResults);
             Assert.AreEqual(pageSize, firstResponse.Count);
 
-            FeedResponse<ChangeFeedProcessorState> secondResponse = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            FeedResponse<ChangeFeedProcessorState> secondResponse = await remainingWorkEstimator.ReadNextAsync(default);
 
             Assert.IsFalse(remainingWorkEstimator.HasMoreResults);
             Assert.AreEqual(pageSize, secondResponse.Count);
@@ -264,7 +264,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) => mockIterator.Object;
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
+            {
+                return mockIterator.Object;
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -273,7 +276,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 feedCreator,
                 null);
 
-            FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            FeedResponse<ChangeFeedProcessorState> response = await remainingWorkEstimator.ReadNextAsync(default);
 
             Assert.AreEqual(2, response.Headers.RequestCharge, "Should contain the sum of all RU charges for each partition read."); // Each request costs 1 RU
 
@@ -299,10 +302,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<DocumentServiceLeaseContainer> mockContainer = new Mock<DocumentServiceLeaseContainer>();
             mockContainer.Setup(c => c.GetAllLeasesAsync()).ReturnsAsync(leases);
 
-            Func<string, string, bool, FeedIterator> feedCreator = (string partitionKeyRangeId, string continuationToken, bool startFromBeginning) =>
+            FeedIterator feedCreator(string partitionKeyRangeId, string continuationToken, bool startFromBeginning)
             {
                 return mockIterator.Object;
-            };
+            }
 
             ChangeFeedEstimatorIterator remainingWorkEstimator = new ChangeFeedEstimatorIterator(
                 Mock.Of<ContainerInternal>(),
@@ -311,7 +314,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 feedCreator,
                 null);
 
-            FeedResponse<ChangeFeedProcessorState> firstResponse = await remainingWorkEstimator.ReadNextAsync(default(CancellationToken));
+            FeedResponse<ChangeFeedProcessorState> firstResponse = await remainingWorkEstimator.ReadNextAsync(default);
 
             ChangeFeedProcessorState remainingLeaseWork = firstResponse.First();
 
@@ -351,8 +354,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             message.DiagnosticsContext.AddDiagnosticsInternal(new Diagnostics.PointOperationStatistics(Guid.NewGuid().ToString(), statusCode, Documents.SubStatusCodes.Unknown, DateTime.UtcNow, 1, "", HttpMethod.Post, "https://localhost", localLsn, localLsn));
             if (!string.IsNullOrEmpty(itemLsn))
             {
-                JObject firstDocument = new JObject();
-                firstDocument["_lsn"] = itemLsn;
+                JObject firstDocument = new JObject
+                {
+                    ["_lsn"] = itemLsn
+                };
 
                 message.Content = new CosmosJsonDotNetSerializer().ToStream( new { Documents = new List<JObject>() { firstDocument } });
             }


### PR DESCRIPTION
# Pull Request Template

## Description

Estimator was using `Task.Run` to trigger parallel operations on the leases, which seems to be causing flakyness during test runs in some cases.

This refactor removes the `Task.Run` need and simplifies it. Also cleans up some code style complains from editorConfig.