### PR TITLE
CosmosClientOptions and ClientBuilder: Fixes ArgumentException when setting null value on HttpClientFactory or WebProxy 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -371,16 +371,12 @@ namespace Microsoft.Azure.Cosmos
             get => this.webProxy;
             set
             {
-                this.webProxy = value;
-                if (this.ConnectionMode != ConnectionMode.Gateway)
-                {
-                    throw new ArgumentException($"{nameof(this.WebProxy)} requires {nameof(this.ConnectionMode)} to be set to {nameof(ConnectionMode.Gateway)}");
-                }
-
-                if (this.HttpClientFactory != null)
+                if (value != null && this.HttpClientFactory != null)
                 {
                     throw new ArgumentException($"{nameof(this.WebProxy)} cannot be set along {nameof(this.HttpClientFactory)}");
                 }
+
+                this.webProxy = value;
             }
         }
 
@@ -494,7 +490,7 @@ namespace Microsoft.Azure.Cosmos
             get => this.httpClientFactory;
             set
             {
-                if (this.WebProxy != null)
+                if (value != null && this.WebProxy != null)
                 {
                     throw new ArgumentException($"{nameof(this.HttpClientFactory)} cannot be set along {nameof(this.WebProxy)}");
                 }

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -318,7 +318,8 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
         /// <seealso cref="CosmosClientOptions.ConnectionMode"/>
         /// <seealso cref="CosmosClientOptions.GatewayModeMaxConnectionLimit"/>
-        public CosmosClientBuilder WithConnectionModeGateway(int? maxConnectionLimit = null,
+        public CosmosClientBuilder WithConnectionModeGateway(
+            int? maxConnectionLimit = null,
             IWebProxy webProxy = null)
         {
             this.clientOptions.ConnectionMode = ConnectionMode.Gateway;
@@ -329,10 +330,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
                 this.clientOptions.GatewayModeMaxConnectionLimit = maxConnectionLimit.Value;
             }
 
-            if (webProxy != null)
-            {
-                this.clientOptions.WebProxy = webProxy;
-            }
+            this.clientOptions.WebProxy = webProxy;
 
             return this;
         }

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -329,7 +329,10 @@ namespace Microsoft.Azure.Cosmos.Fluent
                 this.clientOptions.GatewayModeMaxConnectionLimit = maxConnectionLimit.Value;
             }
 
-            this.clientOptions.WebProxy = webProxy;
+            if (webProxy != null)
+            {
+                this.clientOptions.WebProxy = webProxy;
+            }
 
             return this;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -291,17 +291,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void VerifyHttpClientHandlerSettingsThrowIfNotUsedInGatewayMode()
-        {
-            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
-            {
-                ConnectionMode = ConnectionMode.Direct
-            };
-
-            Assert.ThrowsException<ArgumentException>(() => { cosmosClientOptions.WebProxy = new TestWebProxy(); });
-        }
-
-        [TestMethod]
         public void VerifyHttpClientFactoryBlockedWithConnectionLimit()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .WithHttpClientFactory(() => new HttpClient())
                 .WithConnectionModeGateway();
 
-            // Validate that setting it to null does throw an argument exception
+            // Validate that setting it to null does not throw an argument exception
             _ = new CosmosClientOptions()
             {
                 HttpClientFactory = null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -82,12 +83,20 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.ThrowsException<ArgumentException>(() => new CosmosClient(""));
             Assert.ThrowsException<ArgumentNullException>(() => new CosmosClient(null));
         }
-
+        
         [TestMethod]
         public void Builder_InvalidConnectionString()
         {
             Assert.ThrowsException<ArgumentException>(() => new CosmosClientBuilder(""));
             Assert.ThrowsException<ArgumentNullException>(() => new CosmosClientBuilder(null));
+        }
+
+        [TestMethod]
+        public void Builder_ValidateHttpFactory()
+        {
+            _ = new CosmosClientBuilder("<<endpoint-here>>", "<<key-here>>")
+                .WithHttpClientFactory(() => new HttpClient())
+                .WithConnectionModeGateway();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -6,10 +6,12 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
 
     [TestClass]
     public class CosmosClientTests
@@ -97,6 +99,31 @@ namespace Microsoft.Azure.Cosmos.Tests
             _ = new CosmosClientBuilder("<<endpoint-here>>", "<<key-here>>")
                 .WithHttpClientFactory(() => new HttpClient())
                 .WithConnectionModeGateway();
+
+            // Validate that setting it to null does throw an argument exception
+            _ = new CosmosClientOptions()
+            {
+                HttpClientFactory = null,
+                WebProxy = new Mock<IWebProxy>().Object,
+            };
+
+            _ = new CosmosClientOptions()
+            {
+                WebProxy = new Mock<IWebProxy>().Object,
+                HttpClientFactory = null,
+            };
+
+            _ = new CosmosClientOptions()
+            {
+                WebProxy = null,
+                HttpClientFactory = () => new HttpClient(),
+            };
+
+            _ = new CosmosClientOptions()
+            {
+                HttpClientFactory = () => new HttpClient(),
+                WebProxy = null,
+            };
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes the following issues:
1. Previously WebProxy would get set even if an argument exception was thrown
2. Setting a null value caused an ArgumentException which is not necessary for null values.
3. WebProxy can now be set without being in gateway mode like HttpClientFactory. It's possible users want custom HttpClient settings even when in direct mode because control plane operation like Database and Container still go through HttpClient.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

closes #1953