### PR TITLE
RequestOption.Properties: Fixes RequestOption.Properties for CreateContainerIfNotExistsAsync

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Cosmos
 
         public Task<ResponseMessage> ReadContainerStreamAsync(
             CosmosDiagnosticsContext diagnosticsContext,
-            ContainerRequestOptions requestOptions = null,
+            RequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
             return this.ProcessStreamAsync(
@@ -489,8 +489,8 @@ namespace Microsoft.Azure.Cosmos
             CosmosDiagnosticsContext diagnosticsContext,
             Stream streamPayload,
             OperationType operationType,
-            ContainerRequestOptions requestOptions = null,
-            CancellationToken cancellationToken = default)
+            RequestOptions requestOptions,
+            CancellationToken cancellationToken)
         {
             return this.ProcessResourceOperationStreamAsync(
                 diagnosticsContext: diagnosticsContext,

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/DatabaseCore.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerCore container = (ContainerCore)this.GetContainer(containerProperties.Id);
             using (ResponseMessage readResponse = await container.ReadContainerStreamAsync(
                 diagnosticsContext: diagnosticsContext,
+                requestOptions: requestOptions,
                 cancellationToken: cancellationToken))
             {
                 if (readResponse.StatusCode != HttpStatusCode.NotFound)
@@ -227,6 +228,7 @@ namespace Microsoft.Azure.Cosmos
             // so for the remaining ones we should do a Read instead of throwing Conflict exception
             using (ResponseMessage readResponseAfterCreate = await container.ReadContainerStreamAsync(
                 diagnosticsContext: diagnosticsContext,
+                requestOptions: requestOptions,
                 cancellationToken: cancellationToken))
             {
                 return this.ClientContext.ResponseFactory.CreateContainerResponse(container, readResponseAfterCreate);


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes a bug where the RequestOption.Properties was not being sent to all the calls in the CreateContainerIfNotExistsAsync method.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

closes #1948