### PR TITLE
Internal TestTokenCredentialBackgroundRefreshAsync: Fixes timing failures 

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosAuthorizationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosAuthorizationTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             using AuthorizationTokenProvider cosmosAuthorization = new AuthorizationTokenProviderResourceToken("VGhpcyBpcyBhIHNhbXBsZSBzdHJpbmc=");
 
-            { 
+            {
                 StoreResponseNameValueCollection headers = new StoreResponseNameValueCollection();
                 (string token, string payload) = await cosmosAuthorization.GetUserAuthorizationAsync(
                     "dbs\\test",
@@ -341,9 +341,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string t2 = await tokenCredentialCache.GetTokenAsync(new CosmosDiagnosticsContextCore());
                 Assert.AreEqual(token1, t2);
 
-                // After waiting for another 3 seconds (5 seconds for background refresh), token1 is still valid,
+                // After waiting for another 4 seconds (5 seconds for background refresh with .5 second delay), token1 is still valid,
                 // but cached token has been refreshed to token2 by the background task started before.
-                await Task.Delay(TimeSpan.FromSeconds(3.6));
+                await Task.Delay(TimeSpan.FromSeconds(4));
                 string t3 = await tokenCredentialCache.GetTokenAsync(new CosmosDiagnosticsContextCore());
                 Assert.AreEqual(token2, t3);
 


### PR DESCRIPTION
# Pull Request Template

## Description

TestTokenCredentialBackgroundRefreshAsync delay timing is increased to avoid transient failures caused by slow machines used in the gates.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber