### PR TITLE
Remove EnableAuthorization config from CosmosAccountServiceConfiguration

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosAccountServiceConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/CosmosAccountServiceConfiguration.cs
@@ -49,8 +49,6 @@ namespace Microsoft.Azure.Cosmos
 
         public string ResourceSeedKey => throw new NotImplementedException();
 
-        public bool EnableAuthorization => true;
-
         public string SubscriptionId => throw new NotImplementedException();
 
         public async Task InitializeAsync()


### PR DESCRIPTION
Having EnableAuthorization configuration in code is dangerous. Currently this configuration is only used in tests. This PR removes all references of EnableAuthorization configuration from SDK.

corresponding PRs in CosmosDB repo:
https://dev.azure.com/msdata/CosmosDB/_git/CosmosDB/pullrequest/405614
https://dev.azure.com/msdata/CosmosDB/_git/CosmosDB/pullrequest/459655