### PR TITLE
Internal Headers: Fixes ExtractResponseHeaders

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal static INameValueCollection ExtractResponseHeaders(HttpResponseMessage responseMessage)
         {
+            // Use DictionaryNameValueCollection because some Compute scenarios have duplicate headers
             INameValueCollection headers = new DictionaryNameValueCollection();
 
             foreach (KeyValuePair<string, IEnumerable<string>> headerPair in responseMessage.Headers)

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal static INameValueCollection ExtractResponseHeaders(HttpResponseMessage responseMessage)
         {
-            INameValueCollection headers = new StoreResponseNameValueCollection();
+            INameValueCollection headers = new DictionaryNameValueCollection();
 
             foreach (KeyValuePair<string, IEnumerable<string>> headerPair in responseMessage.Headers)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

This reverts gateway store ExtractResponseHeaders to use DictionaryNameValueCollection which is needed because some compute scenarios have duplicate header values which causes an exception for StoreResponseNameValueCollection. A bug will be filed against the service to remove the duplicate value to reduce overhead.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber