### PR TITLE
Internal Query: Adds catch for aggregate exception carrying timeout

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CatchAllQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CatchAllQueryPipelineStage.cs
@@ -36,6 +36,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                 // Per cancellationToken.ThrowIfCancellationRequested(); line above, this function should still throw OperationCanceledException.
                 throw;
             }
+            catch (AggregateException e) when (e.InnerException is OperationCanceledException ex && this.cancellationToken.IsCancellationRequested)
+            {
+                throw ex;
+            }
             catch (Exception ex)
             {
                 CosmosException cosmosException = ExceptionToCosmosException.CreateFromException(ex);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/CatchQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/CatchQueryPipelineStageTests.cs
@@ -1,0 +1,41 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Query
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class CatchQueryPipelineStageTests
+    {
+        [TestMethod]
+        [Owner("flnarenj")]
+        public async Task TestAggregateExceptionTimeoutAsync()
+        {
+            Mock<IQueryPipelineStage> throwingPipelineStage = new Mock<IQueryPipelineStage>();
+            CancellationTokenSource cts = new CancellationTokenSource();
+
+            throwingPipelineStage
+                .Setup(p => p.MoveNextAsync())
+                .Callback(() => cts.Cancel())
+                .ThrowsAsync(new AggregateException(new OperationCanceledException()));
+
+            CatchAllQueryPipelineStage catchAllQueryPipelineStage = new CatchAllQueryPipelineStage(throwingPipelineStage.Object, cts.Token);
+
+            try
+            {
+                await catchAllQueryPipelineStage.MoveNextAsync();
+                Assert.Fail("Expected exception.");
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

StoreReader from Direct can throw an AggregateException carrying an OperationCanceledException, as it directly accesses Task.Result as part of StoreReader.ReadMultipleReplicasInternalAsync.
In a very specific race condition, this causes the query pipeline to return an InternalServerError instead of throwing the expected exception. Adding a specific handler for that case to CatchAllQueryPipelineStage.

This is causing flakiness for my Mongo timeout tests & could happen in prod as well.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber