### PR TITLE
Benchmark: Adds Azure VM info to summary

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
@@ -10,6 +10,7 @@ namespace CosmosBenchmark
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Newtonsoft.Json;
 
     internal class ParallelExecutionStrategy : IExecutionStrategy
     {
@@ -136,7 +137,7 @@ namespace CosmosBenchmark
                     runSummary.Top95PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(95);
                     runSummary.Top99PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(99);
 
-                    string summary = JsonHelper.ToString(runSummary);
+                    string summary = JsonConvert.SerializeObject(runSummary);
                     Utility.TeeTraceInformation(summary);
                 }
                 else

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -74,7 +74,7 @@ namespace CosmosBenchmark
             {
                 using HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest);
                 string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();
-                Utility.TeePrint(jsonVmInfo);
+                Console.WriteLine(jsonVmInfo);
                 RunSummary.AzureVmInfo = jsonVmInfo;
                 JObject jObject = JObject.Parse(jsonVmInfo);
                 RunSummary.Location = jObject["compute"]["location"].ToString();

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -73,9 +73,9 @@ namespace CosmosBenchmark
             try
             {
                 using HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest);
-                string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();  
-                RunSummary.AzureVmInfo = jsonVmInfo;
+                string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();
                 JObject jObject = JObject.Parse(jsonVmInfo);
+                RunSummary.AzureVmInfo = jObject;
                 RunSummary.Location = jObject["compute"]["location"].ToString();
                 Console.WriteLine($"Azure VM Location:{RunSummary.Location}");
             }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -74,6 +74,7 @@ namespace CosmosBenchmark
             {
                 using HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest);
                 string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();
+                Utility.TeePrint(jsonVmInfo);
                 RunSummary.AzureVmInfo = jsonVmInfo;
                 JObject jObject = JObject.Parse(jsonVmInfo);
                 RunSummary.Location = jObject["compute"]["location"].ToString();

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -73,11 +73,11 @@ namespace CosmosBenchmark
             try
             {
                 using HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest);
-                string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();
-                Console.WriteLine(jsonVmInfo);
+                string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();  
                 RunSummary.AzureVmInfo = jsonVmInfo;
                 JObject jObject = JObject.Parse(jsonVmInfo);
                 RunSummary.Location = jObject["compute"]["location"].ToString();
+                Console.WriteLine($"Azure VM Location:{RunSummary.Location}");
             }
             catch(Exception e)
             {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -15,6 +15,9 @@ namespace CosmosBenchmark
     using System.Collections.Generic;
     using System.Reflection;
     using System.Diagnostics;
+    using System.Net.Http;
+    using System.Runtime.CompilerServices;
+    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// This sample demonstrates how to achieve high performance writes using Azure Comsos DB.
@@ -30,6 +33,8 @@ namespace CosmosBenchmark
             try
             {
                 BenchmarkConfig config = BenchmarkConfig.From(args);
+                await Program.AddAzureInfoToRunSummary();
+                
                 ThreadPool.SetMinThreads(config.MinThreadPoolSize, config.MinThreadPoolSize);
 
                 if (config.EnableLatencyPercentiles)
@@ -54,6 +59,28 @@ namespace CosmosBenchmark
                     Console.WriteLine("Press any key to exit...");
                     Console.ReadLine();
                 }
+            }
+        }
+
+        private static async Task AddAzureInfoToRunSummary()
+        {
+            using HttpClient httpClient = new HttpClient();
+            using HttpRequestMessage httpRequest = new HttpRequestMessage(
+                HttpMethod.Get,
+                "http://169.254.169.254/metadata/instance?api-version=2020-06-01");
+            httpRequest.Headers.Add("Metadata", "true");
+
+            try
+            {
+                using HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest);
+                string jsonVmInfo = await httpResponseMessage.Content.ReadAsStringAsync();
+                RunSummary.AzureVmInfo = jsonVmInfo;
+                JObject jObject = JObject.Parse(jsonVmInfo);
+                RunSummary.Location = jObject["compute"]["location"].ToString();
+            }
+            catch(Exception e)
+            {
+                Console.WriteLine("Failed to get Azure VM info:" + e.ToString());
             }
         }
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -6,6 +6,7 @@ namespace CosmosBenchmark
 {
     using System;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     public class RunSummary
     {
@@ -43,7 +44,7 @@ namespace CosmosBenchmark
         [JsonProperty]
         public static string Location { get; set; }
         [JsonProperty]
-        public static string AzureVmInfo { get; set; }
+        public static JObject AzureVmInfo { get; set; }
 
         public double Top10PercentAverageRps { get; set; }
         public double Top20PercentAverageRps { get; set; }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -6,7 +6,7 @@ namespace CosmosBenchmark
 {
     using System;
 
-    class RunSummary
+    public class RunSummary
     {
         public string pk { get; set; } 
 
@@ -29,11 +29,13 @@ namespace CosmosBenchmark
         public int Concurrency { get; set; }
         public int TotalOps { get; set; }
 
-        public string MachineName { get; set; } = Environment.MachineName;
-        public string OS { get; set; } = Environment.OSVersion.Platform.ToString();
-        public string OSVersion { get; set; } = Environment.OSVersion.VersionString;
-        public string RuntimeVersion { get; set; } = Environment.Version.ToString();
-        public int Cores { get; set; } = Environment.ProcessorCount;
+        public static string MachineName { get; set; } = Environment.MachineName;
+        public static string OS { get; set; } = Environment.OSVersion.Platform.ToString();
+        public static string OSVersion { get; set; } = Environment.OSVersion.VersionString;
+        public static string RuntimeVersion { get; set; } = Environment.Version.ToString();
+        public static int Cores { get; set; } = Environment.ProcessorCount;
+        public static string Location { get; set; }
+        public static string AzureVmInfo { get; set; }
 
         public double Top10PercentAverageRps { get; set; }
         public double Top20PercentAverageRps { get; set; }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -5,6 +5,7 @@
 namespace CosmosBenchmark
 {
     using System;
+    using Newtonsoft.Json;
 
     public class RunSummary
     {
@@ -29,12 +30,19 @@ namespace CosmosBenchmark
         public int Concurrency { get; set; }
         public int TotalOps { get; set; }
 
+        [JsonProperty]
         public static string MachineName { get; set; } = Environment.MachineName;
+        [JsonProperty]
         public static string OS { get; set; } = Environment.OSVersion.Platform.ToString();
+        [JsonProperty]
         public static string OSVersion { get; set; } = Environment.OSVersion.VersionString;
+        [JsonProperty]
         public static string RuntimeVersion { get; set; } = Environment.Version.ToString();
+        [JsonProperty]
         public static int Cores { get; set; } = Environment.ProcessorCount;
+        [JsonProperty]
         public static string Location { get; set; }
+        [JsonProperty]
         public static string AzureVmInfo { get; set; }
 
         public double Top10PercentAverageRps { get; set; }


### PR DESCRIPTION
# Pull Request Template

## Description

This adds the Azure VM instance info the run summary, and the location. This will make it easier to run in multiple regions.
https://docs.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber