### PR TITLE
Routing Map: Adds Non Aggressive Cache Refresh

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
@@ -130,10 +130,25 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 if (IsSplitException(exception))
                 {
                     // Handle split
-                    await this.feedRangeProvider.MonadicRefreshProviderAsync(this.cancellationToken);
-                    IEnumerable<FeedRangeInternal> childRanges = await this.feedRangeProvider.GetChildRangeAsync(
+                    List<FeedRangeEpk> childRanges = await this.feedRangeProvider.GetChildRangeAsync(
                         currentPaginator.Range,
                         cancellationToken: this.cancellationToken);
+                    if (childRanges.Count == 0)
+                    {
+                        throw new InvalidOperationException("Got back no children");
+                    }
+
+                    if (childRanges.Count == 1)
+                    {
+                        // We optimistically assumed that the cache is not stale.
+                        // In the event that it is (where we only get back one child / the partition that we think got split)
+                        // Then we need to refresh the cache
+                        await this.feedRangeProvider.RefreshProviderAsync(this.cancellationToken);
+                        childRanges = await this.feedRangeProvider.GetChildRangeAsync(
+                            currentPaginator.Range,
+                            cancellationToken: this.cancellationToken);
+                    }
+
                     if (childRanges.Count() <= 1)
                     {
                         throw new InvalidOperationException("Expected more than 1 child");

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -278,10 +278,25 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         {
             this.cancellationToken.ThrowIfCancellationRequested();
 
-            await this.documentContainer.RefreshProviderAsync(this.cancellationToken);
-            IEnumerable<FeedRangeInternal> childRanges = await this.documentContainer.GetChildRangeAsync(
+            IReadOnlyList<FeedRangeEpk> childRanges = await this.documentContainer.GetChildRangeAsync(
                 uninitializedEnumerator.Range,
-                cancellationToken: this.cancellationToken);
+                cancellationToken: this.cancellationToken); 
+            if (childRanges.Count == 0)
+            {
+                throw new InvalidOperationException("Got back no children");
+            }
+
+            if (childRanges.Count == 1)
+            {
+                // We optimistically assumed that the cache is not stale.
+                // In the event that it is (where we only get back one child / the partition that we think got split)
+                // Then we need to refresh the cache
+                await this.documentContainer.RefreshProviderAsync(this.cancellationToken);
+                childRanges = await this.documentContainer.GetChildRangeAsync(
+                    uninitializedEnumerator.Range,
+                    cancellationToken: this.cancellationToken);
+            }
+
             if (childRanges.Count() <= 1)
             {
                 throw new InvalidOperationException("Expected more than 1 child");


### PR DESCRIPTION
# Routing Map: Adds Non Aggressive Cache Refresh

## Description

We noticed that for read feed requests we always start off the feed ranges using the full range. This leads to an issue where the code detects that a split has happened (which it has, since it's no longer one partition), but we technically don't need to do a cache refresh in these scenarios, since the partition topology is up to date. In general the partition topology could have gotten updated by another request, which means we shouldn't update the cache in these scenarios. 

The code now optimistically assumes that the cache is already updated and in the event that we only get back one child range / the range that know to have split (since we got a 410 / 1002) then we will update the cache.  