### PR TITLE
Internal ReadFeed: Adds Partition Elimination 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
@@ -122,11 +122,11 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
             if (continuationToken == null)
             {
                 FeedRange feedRange;
-                if (queryRequestOptions.PartitionKey.HasValue)
+                if ((this.queryRequestOptions != null) && this.queryRequestOptions.PartitionKey.HasValue)
                 {
                     feedRange = new FeedRangePartitionKey(queryRequestOptions.PartitionKey.Value);
                 }
-                else if (queryRequestOptions.FeedRange != null)
+                else if ((this.queryRequestOptions != null) && (queryRequestOptions.FeedRange != null))
                 {
                     feedRange = queryRequestOptions.FeedRange;
                 }
@@ -259,11 +259,11 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
                 }
 
                 FeedRangeInternal outerFeedRange;
-                if (this.queryRequestOptions.PartitionKey.HasValue)
+                if ((this.queryRequestOptions != null) && this.queryRequestOptions.PartitionKey.HasValue)
                 {
                     outerFeedRange = new FeedRangePartitionKey(this.queryRequestOptions.PartitionKey.Value);
                 }
-                else if (this.queryRequestOptions.FeedRange != null)
+                else if ((this.queryRequestOptions != null) && (queryRequestOptions.FeedRange != null))
                 {
                     outerFeedRange = (FeedRangeInternal)this.queryRequestOptions.FeedRange;
                 }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
             int pageSize,
             CancellationToken cancellationToken)
         {
+            this.queryRequestOptions = queryRequestOptions;
+
             if (!string.IsNullOrEmpty(continuationToken))
             {
                 bool isNewArrayFormat = (continuationToken.Length >= 2) && (continuationToken[0] == '[') && (continuationToken[continuationToken.Length - 1] == ']');
@@ -156,8 +158,6 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
                         pageSize,
                         cancellationToken));
             }
-
-            this.queryRequestOptions = queryRequestOptions;
 
             this.hasMoreResults = true;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
@@ -274,16 +274,17 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await this.LargerContainer.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await this.LargerContainer.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
             }
 
-            ContainerInternal itemsCore = this.Container;
-            FeedIterator feedIterator = itemsCore.GetItemQueryStreamIterator(requestOptions: new QueryRequestOptions() { PartitionKey = new PartitionKey(pkToRead) });
+            ContainerInternal itemsCore = this.LargerContainer;
+            FeedIterator feedIterator = itemsCore.GetItemQueryStreamIterator(
+                requestOptions: new QueryRequestOptions() { PartitionKey = new PartitionKey(pkToRead), MaxItemCount = 1 });
             while (feedIterator.HasMoreResults)
             {
                 using (ResponseMessage responseMessage =


### PR DESCRIPTION
# Pull Request Template

## Internal ReadFeed: Adds Partition Elimination 

Before the ReadFeedIterator was not special casing partition key requests. It was fanning out to all ranges with the partition key header meaning that all but one range would return empty streams. This change special cases the logical partition key input and filters out the other partitions. 