### PR TITLE
[Internal] Bulk: Adds retry on CompletingSplit

### DIFF
--- a/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Cosmos
             string resourceIdOrFullName)
         {
             if (statusCode == HttpStatusCode.Gone
-                && (subStatusCode == SubStatusCodes.PartitionKeyRangeGone || subStatusCode == SubStatusCodes.NameCacheIsStale)
+                && (subStatusCode == SubStatusCodes.PartitionKeyRangeGone || subStatusCode == SubStatusCodes.NameCacheIsStale || subStatusCode == SubStatusCodes.CompletingSplit)
                 && this.retriesAttempted < MaxRetries)
             {
                 this.retriesAttempted++;

--- a/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
@@ -36,8 +36,7 @@ namespace Microsoft.Azure.Cosmos
 
             ShouldRetryResult shouldRetryResult = this.ShouldRetryInternal(
                 clientException?.StatusCode,
-                clientException?.GetSubStatus(),
-                clientException?.ResourceAddress);
+                clientException?.GetSubStatus());
 
             if (shouldRetryResult != null)
             {
@@ -57,8 +56,7 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken)
         {
             ShouldRetryResult shouldRetryResult = this.ShouldRetryInternal(cosmosResponseMessage?.StatusCode,
-                cosmosResponseMessage?.Headers.SubStatusCode,
-                cosmosResponseMessage?.GetResourceAddress());
+                cosmosResponseMessage?.Headers.SubStatusCode);
             if (shouldRetryResult != null)
             {
                 return Task.FromResult(shouldRetryResult);
@@ -79,11 +77,13 @@ namespace Microsoft.Azure.Cosmos
 
         private ShouldRetryResult ShouldRetryInternal(
             HttpStatusCode? statusCode,
-            SubStatusCodes? subStatusCode,
-            string resourceIdOrFullName)
+            SubStatusCodes? subStatusCode)
         {
             if (statusCode == HttpStatusCode.Gone
-                && (subStatusCode == SubStatusCodes.PartitionKeyRangeGone || subStatusCode == SubStatusCodes.NameCacheIsStale || subStatusCode == SubStatusCodes.CompletingSplit)
+                && (subStatusCode == SubStatusCodes.PartitionKeyRangeGone 
+                || subStatusCode == SubStatusCodes.NameCacheIsStale 
+                || subStatusCode == SubStatusCodes.CompletingSplit
+                || subStatusCode == SubStatusCodes.CompletingPartitionMigration)
                 && this.retriesAttempted < MaxRetries)
             {
                 this.retriesAttempted++;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
@@ -160,6 +160,48 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return new PartitionKeyRangeBatchExecutionResult(request.PartitionKeyRangeId, request.Operations, batchresponse);
             };
 
+        private BatchAsyncBatcherExecuteDelegate ExecutorWithCompletingPartitionMigration
+            = async (PartitionKeyRangeServerBatchRequest request, CancellationToken cancellationToken) =>
+            {
+                List<TransactionalBatchOperationResult> results = new List<TransactionalBatchOperationResult>();
+                ItemBatchOperation[] arrayOperations = new ItemBatchOperation[request.Operations.Count];
+                int index = 0;
+                foreach (ItemBatchOperation operation in request.Operations)
+                {
+                    results.Add(
+                    new TransactionalBatchOperationResult(HttpStatusCode.Gone)
+                    {
+                        ETag = operation.Id,
+                        SubStatusCode = SubStatusCodes.CompletingSplit
+                    });
+
+                    arrayOperations[index++] = operation;
+                }
+
+                MemoryStream responseContent = await new BatchResponsePayloadWriter(results).GeneratePayloadAsync();
+
+                SinglePartitionKeyServerBatchRequest batchRequest = await SinglePartitionKeyServerBatchRequest.CreateAsync(
+                    partitionKey: null,
+                    operations: new ArraySegment<ItemBatchOperation>(arrayOperations),
+                    serializerCore: MockCosmosUtil.Serializer,
+                cancellationToken: cancellationToken);
+
+                ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.Gone)
+                {
+                    Content = responseContent
+                };
+                responseMessage.Headers.SubStatusCode = SubStatusCodes.CompletingPartitionMigration;
+
+                TransactionalBatchResponse batchresponse = await TransactionalBatchResponse.FromResponseMessageAsync(
+                    responseMessage,
+                    batchRequest,
+                    MockCosmosUtil.Serializer,
+                    true,
+                    CancellationToken.None);
+
+                return new PartitionKeyRangeBatchExecutionResult(request.PartitionKeyRangeId, request.Operations, batchresponse);
+            };
+
         // The response will include all but 2 operation responses
         private BatchAsyncBatcherExecuteDelegate ExecutorWithLessResponses
             = async (PartitionKeyRangeServerBatchRequest request, CancellationToken cancellationToken) =>
@@ -446,6 +488,33 @@ namespace Microsoft.Azure.Cosmos.Tests
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
             BatchAsyncBatcher batchAsyncBatcher = new BatchAsyncBatcher(2, 1000, MockCosmosUtil.Serializer, this.ExecutorWithCompletingSplit, retryDelegate.Object);
+            Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
+            Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
+            await batchAsyncBatcher.DispatchAsync(metric);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            Assert.IsNull(operation1.DiagnosticsContext, "Batch operations do not have diagnostics per operation");
+            Assert.IsNull(operation2.DiagnosticsContext, "Batch operations do not have diagnostics per operation");
+        }
+
+        [TestMethod]
+        public async Task RetrierGetsCalledOnCompletingPartitionMigration()
+        {
+            IDocumentClientRetryPolicy retryPolicy1 = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+
+            IDocumentClientRetryPolicy retryPolicy2 = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+
+            ItemBatchOperation operation1 = this.CreateItemBatchOperation();
+            ItemBatchOperation operation2 = this.CreateItemBatchOperation();
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+
+            Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
+
+            BatchAsyncBatcher batchAsyncBatcher = new BatchAsyncBatcher(2, 1000, MockCosmosUtil.Serializer, this.ExecutorWithCompletingPartitionMigration, retryDelegate.Object);
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty));
-            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);
         }
 
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
-            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);
         }
 
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
-            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
-            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
 
@@ -132,7 +132,19 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
-            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
+
+        [TestMethod]
+        public async Task ShouldRetry_WithPolicy_OnCompletingPartitionMigration()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };
+            ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -123,5 +123,17 @@ namespace Microsoft.Azure.Cosmos.Tests
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
+
+        [TestMethod]
+        public async Task ShouldRetry_WithPolicy_OnCompletingSplit()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
+            ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default(CancellationToken));
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
-            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);            
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
-            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
 
@@ -42,7 +42,18 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
-            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default(CancellationToken));
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
+
+        [TestMethod]
+        public async Task RetriesOnCompletingSplits()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
@@ -56,5 +56,16 @@ namespace Microsoft.Azure.Cosmos.Tests
             ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
+
+        [TestMethod]
+        public async Task RetriesOnCompletingPartitionMigrationSplits()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                new ResourceThrottleRetryPolicy(1));
+
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a retry when the backend returns CompletingSplit and CompletingPartitionMigration, to process it the same way as PartitionKeyRangeGone and retry the operation.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
