### PR TITLE
Internal InternalsVisibleTo: Adds Microsoft.Azure.Cosmos.Analytics.Core 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ClientOfficialVersion>3.15.0</ClientOfficialVersion>
     <ClientPreviewVersion>3.15.2</ClientPreviewVersion>
-    <DirectVersion>3.15.3</DirectVersion>
+    <DirectVersion>3.15.4</DirectVersion>
     <EncryptionVersion>1.0.0-preview7</EncryptionVersion>
     <HybridRowVersion>1.1.0-preview1</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
@@ -25,3 +25,5 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.EmulatorTests" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.NetFramework.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.NetFramework.Tests" + AssemblyKeys.TestPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Analytics.Core" + AssemblyKeys.ProductPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Analytics.Core" + AssemblyKeys.TestPublicKey)]


### PR DESCRIPTION
## Description

Add InternalsVisibleTo Microsoft.Azure.Cosmos.Analytics.Core and bump Direct version which I already released.

Microsoft.Azure.Cosmos.Analytics.Core uses the SDK to create the required request to call the Snapshot API which is not part of the public API.

