### PR TITLE
Diagnostics: Fixes substatuscode when recording internal DocumentClientException

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/TransientHttpClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/TransientHttpClientRetryPolicy.cs
@@ -47,10 +47,11 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken)
         {
             HttpRequestMessage httpRequestMessage = this.getHttpReqestMessage();
+
             this.diagnosticsContext.AddDiagnosticsInternal(
                 new PointOperationStatistics(
                     activityId: Trace.CorrelationManager.ActivityId.ToString(),
-                    statusCode: HttpStatusCode.InternalServerError,
+                    statusCode: exception is OperationCanceledException ? HttpStatusCode.RequestTimeout : HttpStatusCode.ServiceUnavailable,
                     subStatusCode: SubStatusCodes.Unknown,
                     responseTimeUtc: DateTime.UtcNow,
                     requestCharge: 0,

--- a/Microsoft.Azure.Cosmos/src/HttpClient/TransientHttpClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/TransientHttpClientRetryPolicy.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
             this.diagnosticsContext.AddDiagnosticsInternal(
                 new PointOperationStatistics(
                     activityId: Trace.CorrelationManager.ActivityId.ToString(),
-                    statusCode: exception is OperationCanceledException ? HttpStatusCode.RequestTimeout : HttpStatusCode.ServiceUnavailable,
+                    statusCode: HttpStatusCode.RequestTimeout,
                     subStatusCode: SubStatusCodes.Unknown,
                     responseTimeUtc: DateTime.UtcNow,
                     requestCharge: 0,

--- a/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
             PointOperationStatistics pointOperationStatistics = new PointOperationStatistics(
                 activityId: cosmosException.Headers.ActivityId,
                 statusCode: cosmosException.StatusCode,
-                subStatusCode: documentClientException.GetSubStatus(),
+                subStatusCode: cosmosException.Headers.SubStatusCode,
                 responseTimeUtc: DateTime.UtcNow,
                 requestCharge: cosmosException.Headers.RequestCharge,
                 errorMessage: documentClientException.ToString(),

--- a/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
             PointOperationStatistics pointOperationStatistics = new PointOperationStatistics(
                 activityId: cosmosException.Headers.ActivityId,
                 statusCode: cosmosException.StatusCode,
-                subStatusCode: (int)SubStatusCodes.Unknown,
+                subStatusCode: documentClientException.GetSubStatus(),
                 responseTimeUtc: DateTime.UtcNow,
                 requestCharge: cosmosException.Headers.RequestCharge,
                 errorMessage: documentClientException.ToString(),


### PR DESCRIPTION
# Pull Request Template

## Description

The PointOperationStatistic was recording the default substatus code instead of getting the value from the exception. 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber