### PR TITLE
Internal PartitionKeyRangeCache: Adds RID refresh on NotFound in GetRoutingMapAsync

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 collectionRid = await this.GetCachedRIDAsync(
                     forceRefresh: true,
-                    cancellationToken: cancellationToken);
+                    cancellationToken);
 
                 collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
                     collectionRid,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/PartitionKeyRangeCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/PartitionKeyRangeCacheTests.cs
@@ -1,0 +1,53 @@
+﻿// unset
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class PartitionKeyRangeCacheTests
+    {
+        [TestMethod]
+        [Owner("flnarenj")]
+        public async Task TestRidRefreshOnNotFoundAsync()
+        {
+            CosmosClient resourceClient = TestCommon.CreateCosmosClient();
+
+            string dbName = Guid.NewGuid().ToString();
+            string containerName = Guid.NewGuid().ToString();
+
+            Database db = await resourceClient.CreateDatabaseAsync(dbName);
+            Container container = await db.CreateContainerAsync(containerName, "/_id");
+
+            CosmosClient testClient = TestCommon.CreateCosmosClient();
+            ContainerInternal testContainer = (ContainerInlineCore)testClient.GetContainer(dbName, containerName);
+
+            // Populate the RID cache.
+            string cachedRidAsync = await testContainer.GetCachedRIDAsync(forceRefresh: false);
+
+            // Delete the container (using resource client).
+            await container.DeleteContainerAsync();
+
+            // Because the RID is cached, this will now try to resolve the collection routing map.
+            Assert.AreEqual(cachedRidAsync, await testContainer.GetCachedRIDAsync(forceRefresh: false));
+            CosmosException notFoundException = await Assert.ThrowsExceptionAsync<CosmosException>(() => testContainer.GetRoutingMapAsync(cancellationToken: default));
+            Assert.AreEqual(HttpStatusCode.NotFound, notFoundException.StatusCode);
+
+            await db.CreateContainerAsync(containerName, "/_id");
+
+            CollectionRoutingMap collectionRoutingMap = await testContainer.GetRoutingMapAsync(cancellationToken: default);
+            Assert.IsNotNull(collectionRoutingMap);
+            Assert.AreNotEqual(cachedRidAsync, await testContainer.GetCachedRIDAsync(forceRefresh: false));
+
+            // Delete the container (using resource client).
+            await container.DeleteContainerAsync();
+
+            CollectionRoutingMap collectionRoutingMapFromCache = await testContainer.GetRoutingMapAsync(cancellationToken: default);
+            Assert.AreEqual(collectionRoutingMap, collectionRoutingMapFromCache);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

In GetRoutingMapAsync, we read the RID from cache & then look up the associated collection routing map.
In the case where the RID is stale & the collection routing map is not found, the stale RID should be invalidated & the operation retried.

I am also switching a method written using ContinueWith to be async instead as I found during testing that this style can cause AggregateException to be thrown which callers do not typically expect (e.g. a NotFound would end up as a 500 because of that).

Triage source is CRI.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber