### PR TITLE
CosmosDiagnostics: Fixes IndexOutOfRangeException

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Cosmos
         {
             this.AddSummaryInfo(newContext);
 
-            this.ContextList.AddRange(newContext);
+            this.ContextList.Add(newContext);
         }
 
         public override void Accept(CosmosDiagnosticsInternalVisitor cosmosDiagnosticsInternalVisitor)

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     {
         private const string DiagnosticsVersion = "2";
         private readonly JsonWriter jsonWriter;
+        private bool rootDiagnosticContextVisited = false;
 
         public CosmosDiagnosticsSerializerVisitor(TextWriter textWriter)
         {
@@ -63,6 +64,19 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 
         public override void Visit(CosmosDiagnosticsContext cosmosDiagnosticsContext)
         {
+            // Nested diagnostics should not include the summary
+            if (this.rootDiagnosticContextVisited)
+            {
+                foreach (CosmosDiagnosticsInternal cosmosDiagnosticsInternal in cosmosDiagnosticsContext)
+                {
+                    cosmosDiagnosticsInternal.Accept(this);
+                }
+
+                return;
+            }
+
+            this.rootDiagnosticContextVisited = true;
+
             this.jsonWriter.WriteStartObject();
 
             this.jsonWriter.WritePropertyName("DiagnosticVersion");

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Cosmos.Query
             {
                 CosmosDiagnosticsContext current = this.diagnosticsContext;
                 this.diagnosticsContext = CosmosDiagnosticsContext.Create(new RequestOptions());
+                current.GetOverallScope().Dispose();
                 return current;
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task GatewayQueryPlanDiagnostic()
         {
-            int totalItems = 10;
+            int totalItems = 3;
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(
                 this.Container,
                 pkCount: totalItems,
@@ -553,7 +553,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-      //  [DataRow(true)]
+        [DataRow(true)]
         [DataRow(false)]
         public async Task QueryOperationDiagnostic(bool disableDiagnostics)
         {
@@ -564,12 +564,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 perPKItemCount: 1,
                 randomPartitionKey: true);
 
-            //long readFeedTotalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(
-            //    queryText: null,
-            //    expectedItemCount: totalItems,
-            //    disableDiagnostics: disableDiagnostics);
+            long readFeedTotalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(
+                queryText: null,
+                expectedItemCount: totalItems,
+                disableDiagnostics: disableDiagnostics);
 
-            //Assert.AreEqual(totalItems, readFeedTotalOutputDocumentCount);
+            Assert.AreEqual(totalItems, readFeedTotalOutputDocumentCount);
 
             //Checking query metrics on typed query
             long totalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
+                throughput: 20000,
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Container);
@@ -510,7 +511,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task GatewayQueryPlanDiagnostic()
         {
-            int totalItems = 3;
+            int totalItems = 10;
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(
                 this.Container,
                 pkCount: totalItems,
@@ -552,7 +553,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DataRow(true)]
+      //  [DataRow(true)]
         [DataRow(false)]
         public async Task QueryOperationDiagnostic(bool disableDiagnostics)
         {
@@ -563,12 +564,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 perPKItemCount: 1,
                 randomPartitionKey: true);
 
-            long readFeedTotalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(
-                queryText: null,
-                expectedItemCount: totalItems,
-                disableDiagnostics: disableDiagnostics);
+            //long readFeedTotalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(
+            //    queryText: null,
+            //    expectedItemCount: totalItems,
+            //    disableDiagnostics: disableDiagnostics);
 
-            Assert.AreEqual(totalItems, readFeedTotalOutputDocumentCount);
+            //Assert.AreEqual(totalItems, readFeedTotalOutputDocumentCount);
 
             //Checking query metrics on typed query
             long totalOutputDocumentCount = await this.ExecuteQueryAndReturnOutputDocumentCount(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
@@ -379,12 +379,17 @@ namespace Microsoft.Azure.Cosmos
 
             public override void Visit(CosmosDiagnosticsContext cosmosDiagnosticsContext)
             {
-                Assert.IsFalse(this.isContextVisited, "Point operations should only have a single context");
-                this.isContextVisited = true;
                 this.StartTimeUtc = cosmosDiagnosticsContext.StartUtc;
                 this.TotalElapsedTime = cosmosDiagnosticsContext.GetRunningElapsedTime();
 
-                DiagnosticValidator.ValidateCosmosDiagnosticsContext(cosmosDiagnosticsContext);
+                // Only the first context needs to be validated. Inner contexts that were appended only
+                // require the content to validated.
+                if (!this.isContextVisited)
+                {
+                    DiagnosticValidator.ValidateCosmosDiagnosticsContext(cosmosDiagnosticsContext);
+                }
+
+                this.isContextVisited = true;
 
                 foreach (CosmosDiagnosticsInternal diagnosticsInternal in cosmosDiagnosticsContext)
                 {


### PR DESCRIPTION
# Pull Request Template

## Description

To avoid any IndexOutOfRangeException the CosmosDiagnostics is refactored to remove the AddRange call. This will avoid any indexing issues caused by the possibility of the CosmosDiagnosticsContext getting modified in another task at the same time it is getting append to a parent CosmosDiagnosticContext.

This should also help improve performance by reducing the number of copies required when combining multiple CosmosDiangosticsContext.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2075