### PR TITLE
Client Side Encryption : Adds fix for Encryption Package not picking up Cryptography DLL.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <ClientOfficialVersion>3.15.1</ClientOfficialVersion>
     <ClientPreviewVersion>3.15.2</ClientPreviewVersion>
     <DirectVersion>3.15.4</DirectVersion>
-    <EncryptionVersion>1.0.0-preview8</EncryptionVersion>
+    <EncryptionVersion>1.0.0-preview9</EncryptionVersion>
     <HybridRowVersion>1.1.0-preview1</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
     <DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>

--- a/Microsoft.Azure.Cosmos.Encryption/changelog.md
+++ b/Microsoft.Azure.Cosmos.Encryption/changelog.md
@@ -5,8 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### <a name="1.0.0-preview9"/> [1.0.0-preview9](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-preview9) - 2021-01-06
 
-#### Added 
-- [#2105](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2105) Adds fix for Encryption Package not picking up Cryptography DLL.
+#### Fixes 
+- [#2105](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2105) Fixes the nuget generation to include Cryptography DLL.
 
 ### <a name="1.0.0-preview8"/> [1.0.0-preview8](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-preview8) - 2021-01-05
 

--- a/Microsoft.Azure.Cosmos.Encryption/changelog.md
+++ b/Microsoft.Azure.Cosmos.Encryption/changelog.md
@@ -3,6 +3,11 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### <a name="1.0.0-preview9"/> [1.0.0-preview9](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-preview9) - 2021-01-06
+
+#### Added 
+- [#2105](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2105) Adds fix for Encryption Package not picking up Cryptography DLL.
+
 ### <a name="1.0.0-preview8"/> [1.0.0-preview8](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-preview8) - 2021-01-05
 
 #### Added 

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -40,7 +40,11 @@
   <ItemGroup>
     <Folder Include="Custom\" />
   </ItemGroup>
-  
+	
+  <ItemGroup>
+	<None Include="..\src\Custom\MdeServices\MdeCryptographyLib\Microsoft.Data.Encryption.Cryptography.dll" Pack="true" PackagePath="lib\netstandard2.0" />
+  </ItemGroup>
+	
   <ItemGroup>
     <Reference Include="Microsoft.Data.Encryption.Cryptography">
       <HintPath>..\src\Custom\MdeServices\MdeCryptographyLib\Microsoft.Data.Encryption.Cryptography.dll</HintPath>

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-	<None Include="..\src\Custom\MdeServices\MdeCryptographyLib\Microsoft.Data.Encryption.Cryptography.dll" Pack="true" PackagePath="lib\netstandard2.0" />
+    <None Include="..\src\Custom\MdeServices\MdeCryptographyLib\Microsoft.Data.Encryption.Cryptography.dll" Pack="true" PackagePath="lib\netstandard2.0" />
   </ItemGroup>
 	
   <ItemGroup>


### PR DESCRIPTION
## Description

This fixes the issue of Encryption package not picking up Cryptography.dll when building the Nuget package.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

