### PR TITLE
CosmosException: Fixes substatuscode to get the correct value instead of 0 when it is not in the enum.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -359,6 +359,12 @@ namespace Microsoft.Azure.Cosmos
 
         internal CosmosMessageHeadersInternal CosmosMessageHeaders { get; }
 
+        internal static int GetIntValueOrDefault(string value)
+        {
+            int.TryParse(value, out int number);
+            return number;
+        }
+
         internal static SubStatusCodes GetSubStatusCodes(string value)
         {
             if (uint.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out uint nSubStatus))

--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -284,8 +284,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>True or false if the header name existed in the header collection.</returns>
         public virtual bool TryGetValue(string headerName, out string value)
         {
-            value = this.CosmosMessageHeaders.Get(headerName);
-            return value != null;
+            return this.CosmosMessageHeaders.TryGetValue(headerName, out value);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosExceptionFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosExceptionFactory.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
     using System;
     using System.IO;
     using System.Net;
-    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Documents;
 
     internal static class CosmosExceptionFactory

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosExceptionFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosExceptionFactory.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
     using System;
     using System.IO;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Documents;
 
     internal static class CosmosExceptionFactory
@@ -15,22 +16,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
             DocumentClientException dce,
             CosmosDiagnosticsContext diagnosticsContext)
         {
-            Headers headers = new Headers();
-            if (dce.Headers != null)
-            {
-                foreach (string key in dce.Headers)
-                {
-                    string value = dce.Headers[key];
-                    if (value == null)
-                    {
-                        throw new ArgumentNullException(
-                            message: $"{nameof(key)}: {key};",
-                            innerException: dce);
-                    }
-
-                    headers.Add(key, value);
-                }
-            }
+            Headers headers = dce.Headers == null ? new Headers() : new Headers(dce.Headers);
 
             HttpStatusCode httpStatusCode;
             if (dce.StatusCode.HasValue)
@@ -48,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 
             return CosmosExceptionFactory.Create(
                 httpStatusCode,
-                (int)dce.GetSubStatus(),
+                Headers.GetIntValueOrDefault(headers.SubStatusCodeLiteral),
                 dce.Message,
                 dce.StackTrace,
                 dce.ActivityId,
@@ -108,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 
             return CosmosExceptionFactory.Create(
                 responseMessage.StatusCode,
-                (int)responseMessage.Headers.SubStatusCode,
+                Headers.GetIntValueOrDefault(responseMessage.Headers.SubStatusCodeLiteral),
                 errorMessage,
                 responseMessage?.CosmosException?.StackTrace,
                 responseMessage.Headers.ActivityId,
@@ -144,7 +130,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 
             return CosmosExceptionFactory.Create(
                 statusCode: documentServiceResponse.StatusCode,
-                subStatusCode: (int)responseHeaders.SubStatusCode,
+                subStatusCode: Headers.GetIntValueOrDefault(responseHeaders.SubStatusCodeLiteral),
                 message: errorMessage,
                 stackTrace: null,
                 activityId: responseHeaders.ActivityId,
@@ -175,7 +161,7 @@ namespace Microsoft.Azure.Cosmos.Resource.CosmosExceptions
 
             return CosmosExceptionFactory.Create(
                 statusCode: storeResponse.StatusCode,
-                subStatusCode: (int)headers.SubStatusCode,
+                subStatusCode: Headers.GetIntValueOrDefault(headers.SubStatusCodeLiteral),
                 message: errorMessage,
                 stackTrace: null,
                 activityId: headers.ActivityId,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
@@ -1,0 +1,34 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class HttpClientHandlerHelper : DelegatingHandler
+    {
+        public HttpClientHandlerHelper() : base(new HttpClientHandler())
+        {
+        }
+
+        public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> RequestCallBack { get; set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if(this.RequestCallBack != null)
+            {
+                Task<HttpResponseMessage> response = this.RequestCallBack(request, cancellationToken);
+                if(response != null)
+                {
+                    return response;
+                }
+            }
+            
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -97,17 +97,8 @@ namespace Microsoft.Azure.Cosmos
             string headerValue = "Test" + Guid.NewGuid();
             dce.Headers.Add(headerValue, null);
 
-            try
-            {
-                ResponseMessage responseMessage = dce.ToCosmosResponseMessage(null);
-                Assert.Fail("Should throw exception");
-            }
-            catch (ArgumentNullException ane)
-            {
-                Assert.IsTrue(ane.ToString().Contains(headerValue));
-                Assert.IsTrue(ane.ToString().Contains(errorMessage));
-                Assert.IsTrue(ane.InnerException is DocumentClientException);
-            }
+            ResponseMessage responseMessage = dce.ToCosmosResponseMessage(null);
+            Assert.IsNull(responseMessage.Headers.Get(headerValue));
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

 The document client exception that is thrown internally will return default value if the SubStatusCode is not defined in the enum. This changes the logic to parse and use the int from the headers so the exception always shows the correct value. This allows the SDK to properly handle unexpected or newer substatuscodes that it is not aware of.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber