### PR TITLE
CosmosDiagnostics: Fixes concurrent operations

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -5,13 +5,9 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Security.Policy;
+    using System.Threading;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Documents;
-    using Microsoft.Azure.Documents.Rntbd;
 
     /// <summary>
     /// This represents the core diagnostics object used in the SDK.
@@ -105,14 +101,16 @@ namespace Microsoft.Azure.Cosmos
         {
             CosmosDiagnosticScope scope = new CosmosDiagnosticScope(name);
 
-            this.ContextList.Add(scope);
+            this.AddToContextList(scope);
+
             return scope;
         }
 
         internal override IDisposable CreateRequestHandlerScopeScope(RequestHandler requestHandler)
         {
             RequestHandlerScope requestHandlerScope = new RequestHandlerScope(requestHandler);
-            this.ContextList.Add(requestHandlerScope);
+            this.AddToContextList(requestHandlerScope);
+
             return requestHandlerScope;
         }
 
@@ -123,7 +121,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(processInfo));
             }
 
-            this.ContextList.Add(processInfo);
+            this.AddToContextList(processInfo);
         }
 
         internal override void AddDiagnosticsInternal(PointOperationStatistics pointOperationStatistics)
@@ -134,8 +132,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.AddResponseCount((int)pointOperationStatistics.StatusCode);
-
-            this.ContextList.Add(pointOperationStatistics);
+            this.AddToContextList(pointOperationStatistics);
         }
 
         internal override void AddDiagnosticsInternal(StoreResponseStatistics storeResponseStatistics)
@@ -145,22 +142,22 @@ namespace Microsoft.Azure.Cosmos
                 this.AddResponseCount((int)storeResponseStatistics.StoreResult.StatusCode);
             }
 
-            this.ContextList.Add(storeResponseStatistics);
+            this.AddToContextList(storeResponseStatistics);
         }
 
         internal override void AddDiagnosticsInternal(AddressResolutionStatistics addressResolutionStatistics)
         {
-            this.ContextList.Add(addressResolutionStatistics);
+            this.AddToContextList(addressResolutionStatistics);
         }
 
         internal override void AddDiagnosticsInternal(CosmosClientSideRequestStatistics clientSideRequestStatistics)
         {
-            this.ContextList.Add(clientSideRequestStatistics);
+            this.AddToContextList(clientSideRequestStatistics);
         }
 
         internal override void AddDiagnosticsInternal(FeedRangeStatistics feedRangeStatistics)
         {
-            this.ContextList.Add(feedRangeStatistics);
+            this.AddToContextList(feedRangeStatistics);
         }
 
         internal override void AddDiagnosticsInternal(QueryPageDiagnostics queryPageDiagnostics)
@@ -175,14 +172,14 @@ namespace Microsoft.Azure.Cosmos
                 this.AddSummaryInfo(queryPageDiagnostics.DiagnosticsContext);
             }
 
-            this.ContextList.Add(queryPageDiagnostics);
+            this.AddToContextList(queryPageDiagnostics);
         }
 
         internal override void AddDiagnosticsInternal(CosmosDiagnosticsContext newContext)
         {
             this.AddSummaryInfo(newContext);
 
-            this.ContextList.Add(newContext);
+            this.AddToContextList(newContext);
         }
 
         public override void Accept(CosmosDiagnosticsInternalVisitor cosmosDiagnosticsInternalVisitor)
@@ -200,9 +197,20 @@ namespace Microsoft.Azure.Cosmos
             // Using a for loop with a yield prevents Issue #1467 which causes
             // ThrowInvalidOperationException if a new diagnostics is getting added
             // while the enumerator is being used.
-            for (int i = 0; i < this.ContextList.Count; i++)
+            lock (this.ContextList)
             {
-                yield return this.ContextList[i];
+                for (int i = 0; i < this.ContextList.Count; i++)
+                {
+                    yield return this.ContextList[i];
+                }
+            }
+        }
+
+        private void AddToContextList(CosmosDiagnosticsInternal cosmosDiagnosticsInternal)
+        {
+            lock (this.ContextList)
+            {
+                this.ContextList.Add(cosmosDiagnosticsInternal);
             }
         }
 
@@ -211,12 +219,12 @@ namespace Microsoft.Azure.Cosmos
             this.totalResponseCount++;
             if (statusCode < 200 || statusCode > 299)
             {
-                this.failedResponseCount++;
+                Interlocked.Increment(ref this.failedResponseCount);
             }
 
             if (statusCode == (int)StatusCodes.TooManyRequests || statusCode == (int)StatusCodes.RetryWith)
             {
-                this.retriableResponseCount++;
+                Interlocked.Increment(ref this.retriableResponseCount);
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This makes the CosmosDiagnostics thread safe by adding a lock to adding information to the diagnostic list.  Benchmarks showed no changes from adding the lock which is likely because most of the diagnostics is not done concurrently.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber