### PR TITLE
Availability: Fixes read session not available retries on multi master accounts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -291,8 +291,8 @@ namespace Microsoft.Azure.Cosmos
                     {
                         this.retryContext = new RetryContext()
                         {
-                            RetryLocationIndex = this.sessionTokenRetryCount - 1,
-                            RetryRequestOnPreferredLocations = this.sessionTokenRetryCount > 1
+                            RetryLocationIndex = this.sessionTokenRetryCount,
+                            RetryRequestOnPreferredLocations = true
                         };
 
                         return ShouldRetryResult.RetryAfter(TimeSpan.Zero);
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Cosmos
                     {
                         this.retryContext = new RetryContext
                         {
-                            RetryLocationIndex = this.sessionTokenRetryCount - 1,
+                            RetryLocationIndex = 0,
                             RetryRequestOnPreferredLocations = false
                         };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -261,15 +261,15 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                             }
                             else if (retryCount == 1)
                             {
-                                // Second request must go to first write endpoint
-                                Uri expectedEndpoint = new Uri(this.databaseAccount.WriteLocationsInternal[0].Endpoint);
+                                // Second request must go to the next preferred location
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[1]];
 
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else if (retryCount == 2)
                             {
-                                // Second request must go to first write endpoint
-                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[1]];
+                                // Third request must go to first preferred location
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[0]];
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else
@@ -303,10 +303,17 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
             const bool useMultipleWriteLocations = true;
             bool enableEndpointDiscovery = true;
 
+            ReadOnlyCollection<string> preferredList = new List<string>() {
+                "location3",
+                "location2",
+                "location1"
+            }.AsReadOnly();
+
             this.Initialize(
                 useMultipleWriteLocations: useMultipleWriteLocations,
                 enableEndpointDiscovery: enableEndpointDiscovery,
-                isPreferredLocationsListEmpty: false);
+                isPreferredLocationsListEmpty: false,
+                preferedRegionListOverride: preferredList);
 
             await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = new ClientRetryPolicy(this.endpointManager, enableEndpointDiscovery, new RetryOptions());
@@ -324,27 +331,25 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
                             if (retryCount == 0)
                             {
-                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[this.preferredLocations[0]];
-
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[0]];
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else if (retryCount == 1)
                             {
-                                // Second request must go to first write endpoint
-                                Uri expectedEndpoint = new Uri(this.databaseAccount.WriteLocationsInternal[0].Endpoint);
-
+                                // Second request must go to the next preferred location
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[1]];
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else if (retryCount == 2)
                             {
-                                // Second request must go to first write endpoint
-                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[this.preferredLocations[1]];
+                                // Third request must go to the next preferred location
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[2]];
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else if (retryCount == 3)
                             {
-                                // Second request must go to first write endpoint
-                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[this.preferredLocations[2]];
+                                // Fourth request must go to first preferred location
+                                Uri expectedEndpoint = LocationCacheTests.EndpointByLocation[preferredList[0]];
                                 Assert.AreEqual(expectedEndpoint, request.RequestContext.LocationEndpointToRoute);
                             }
                             else


### PR DESCRIPTION
When the account is set as Multi master and preferred regions are provided (either through CosmosClientOptions.ApplicationRegion or CosmosClientOptions.ApplicationPreferredRegions), the first retry on a ReadSessionNotAvailable (HTTP 404 / substatus 1002) would retry on the same region that got the original error.

> On every region, there is 5 seconds of local retries before the failure bubbles up to the ClientRetryPolicy

For example, if the client has regions A, B, and C as preferred regions. The current retry mechanism would do:

1. Original request goes to A, and fails
2. First retry goes again to A
3. Second retry goes to B
4. Third retry goes to C

With this PR, this is fixed to direct the first retry to the second region instead:

1. Original request goes to A, and fails
2. First retry goes again to B
3. Second retry goes to C
4. Third retry goes to A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #2108