### PR TITLE
Bulk: Adds retry on RequestEntityTooLarge

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos
 
             string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(operation, cancellationToken).ConfigureAwait(false);
             BatchAsyncStreamer streamer = this.GetOrAddStreamerForPartitionKeyRange(resolvedPartitionKeyRangeId);
-            ItemBatchOperationContext context = new ItemBatchOperationContext(resolvedPartitionKeyRangeId, BatchAsyncContainerExecutor.GetRetryPolicy(this.cosmosContainer, this.retryOptions));
+            ItemBatchOperationContext context = new ItemBatchOperationContext(resolvedPartitionKeyRangeId, BatchAsyncContainerExecutor.GetRetryPolicy(this.cosmosContainer, operation.OperationType, this.retryOptions));
             operation.AttachContext(context);
             streamer.Add(operation);
             return await context.OperationTask;
@@ -133,10 +133,12 @@ namespace Microsoft.Azure.Cosmos
 
         private static IDocumentClientRetryPolicy GetRetryPolicy(
             ContainerInternal containerInternal,
+            OperationType operationType,
             RetryOptions retryOptions)
         {
             return new BulkExecutionRetryPolicy(
                containerInternal,
+               operationType,
                new ResourceThrottleRetryPolicy(
                 retryOptions.MaxRetryAttemptsOnThrottledRequests,
                 retryOptions.MaxRetryWaitTimeInSeconds));

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerInternal containerInternal,
             RetryOptions retryOptions)
         {
-            return new BulkPartitionKeyRangeGoneRetryPolicy(
+            return new BulkExecutionRetryPolicy(
                containerInternal,
                new ResourceThrottleRetryPolicy(
                 retryOptions.MaxRetryAttemptsOnThrottledRequests,

--- a/Microsoft.Azure.Cosmos/src/BulkExecutionRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkExecutionRetryPolicy.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     /// <see cref="BatchAsyncBatcher"/>
     /// <see cref="ItemBatchOperationContext"/>
-    internal sealed class BulkPartitionKeyRangeGoneRetryPolicy : IDocumentClientRetryPolicy
+    internal sealed class BulkExecutionRetryPolicy : IDocumentClientRetryPolicy
     {
         private readonly IDocumentClientRetryPolicy nextRetryPolicy;
         private readonly ContainerInternal container;
 
-        public BulkPartitionKeyRangeGoneRetryPolicy(
+        public BulkExecutionRetryPolicy(
             ContainerInternal container,
             IDocumentClientRetryPolicy nextRetryPolicy)
         {

--- a/Microsoft.Azure.Cosmos/src/BulkExecutionRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkExecutionRetryPolicy.cs
@@ -19,13 +19,16 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class BulkExecutionRetryPolicy : IDocumentClientRetryPolicy
     {
         private readonly IDocumentClientRetryPolicy nextRetryPolicy;
+        private readonly OperationType operationType;
         private readonly ContainerInternal container;
 
         public BulkExecutionRetryPolicy(
             ContainerInternal container,
+            OperationType operationType,
             IDocumentClientRetryPolicy nextRetryPolicy)
         {
             this.container = container ?? throw new ArgumentNullException(nameof(container));
+            this.operationType = operationType;
             this.nextRetryPolicy = nextRetryPolicy;
         }
 
@@ -80,6 +83,8 @@ namespace Microsoft.Azure.Cosmos
             this.nextRetryPolicy.OnBeforeSendRequest(request);
         }
 
+        private bool IsReadRequest => this.operationType == OperationType.Read;
+
         private async Task<ShouldRetryResult> ShouldRetryInternalAsync(
             HttpStatusCode? statusCode,
             SubStatusCodes? subStatusCode,
@@ -105,7 +110,8 @@ namespace Microsoft.Azure.Cosmos
 
             // Batch API can return 413 which means the response is bigger than 4Mb.
             // Operations that exceed the 4Mb limit are returned as 413, while the operations within the 4Mb limit will be 200
-            if (statusCode == HttpStatusCode.RequestEntityTooLarge)
+            if (this.IsReadRequest
+                && statusCode == HttpStatusCode.RequestEntityTooLarge)
             {
                 return ShouldRetryResult.RetryAfter(TimeSpan.Zero);
             }

--- a/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
 
+            // Batch API can return 413 which means the response is bigger than 4Mb.
+            // Operations that exceed the 4Mb limit are returned as 413, while the operations within the 4Mb limit will be 200
             if (statusCode == HttpStatusCode.RequestEntityTooLarge)
             {
                 return ShouldRetryResult.RetryAfter(TimeSpan.Zero);

--- a/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/BulkPartitionKeyRangeGoneRetryPolicy.cs
@@ -103,6 +103,11 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
 
+            if (statusCode == HttpStatusCode.RequestEntityTooLarge)
+            {
+                return ShouldRetryResult.RetryAfter(TimeSpan.Zero);
+            }
+
             return null;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
@@ -501,11 +501,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetrierGetsCalledOnSplit()
         {
-            IDocumentClientRetryPolicy retryPolicy1 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
-            IDocumentClientRetryPolicy retryPolicy2 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -530,11 +530,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetrierGetsCalledOnCompletingSplit()
         {
-            IDocumentClientRetryPolicy retryPolicy1 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
-            IDocumentClientRetryPolicy retryPolicy2 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -559,11 +559,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetrierGetsCalledOnCompletingPartitionMigration()
         {
-            IDocumentClientRetryPolicy retryPolicy1 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
-            IDocumentClientRetryPolicy retryPolicy2 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -608,11 +608,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetrierGetsCalledOn413()
         {
-            IDocumentClientRetryPolicy retryPolicy1 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
-            IDocumentClientRetryPolicy retryPolicy2 = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -118,6 +118,19 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task ShouldRetry_WithPolicy_On413()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                Mock.Of<ContainerInternal>(),
+                new ResourceThrottleRetryPolicy(1));
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
+            ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
+
+        [TestMethod]
         public async Task ShouldRetry_WithPolicy_OnSplit()
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_OnSuccess()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_On429()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_On413()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_OnSplit()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_OnCompletingSplit()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task ShouldRetry_WithPolicy_OnCompletingPartitionMigration()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
@@ -42,6 +42,18 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task RetriesOn413()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+                Mock.Of<ContainerInternal>(),
+                new ResourceThrottleRetryPolicy(1));
+
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
+            Assert.IsTrue(shouldRetryResult.ShouldRetry);
+        }
+
+        [TestMethod]
         public async Task RetriesOnSplits()
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task NotRetryOnSuccess()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetriesOn429()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetriesOn413()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetriesOnSplits()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetriesOnCompletingSplits()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task RetriesOnCompletingPartitionMigrationSplits()
         {
-            IDocumentClientRetryPolicy retryPolicy = new BulkPartitionKeyRangeGoneRetryPolicy(
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 new ResourceThrottleRetryPolicy(1));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BulkPartitionKeyRangeGoneRetryPolicyTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
@@ -42,10 +44,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public async Task RetriesOn413()
+        public async Task RetriesOn413_OnRead()
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
@@ -54,10 +57,24 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task RetriesOn413_OnWrite()
+        {
+            IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
+                Mock.Of<ContainerInternal>(),
+                OperationType.Create,
+                new ResourceThrottleRetryPolicy(1));
+
+            TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
+            ShouldRetryResult shouldRetryResult = await retryPolicy.ShouldRetryAsync(result.ToResponseMessage(), default);
+            Assert.IsFalse(shouldRetryResult.ShouldRetry);
+        }
+
+        [TestMethod]
         public async Task RetriesOnSplits()
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
@@ -70,6 +87,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
@@ -82,6 +100,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
+                OperationType.Read,
                 new ResourceThrottleRetryPolicy(1));
 
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };


### PR DESCRIPTION
When Bulk mode is turned on, and the user is using it for Read operations, it is possible to request a volume of documents which total size is larger than the 4Mb service limit.

In that case, the backend will return HTTP 200 for those operations within the boundary, but 413 for those that exceed it.

This PR adds the behavior of retrying those operations that exceed the boundary limit into another Bulk request.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update
