### PR TITLE
CosmosDiagnostics: Fixes memory leak due to unbounded growth of CosmosDiagnosticsContextCore and removes reference to response stream.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ClientOfficialVersion>3.16.0</ClientOfficialVersion>
     <ClientPreviewVersion>3.15.2</ClientPreviewVersion>
-    <DirectVersion>3.15.4</DirectVersion>
+    <DirectVersion>3.17.0</DirectVersion>
     <EncryptionVersion>1.0.0-preview9</EncryptionVersion>
     <HybridRowVersion>1.1.0-preview1</HybridRowVersion>
     <AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/BoundedList.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/BoundedList.cs
@@ -1,0 +1,98 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///  A list that can grow only up to a specified capacity.
+    ///  In the growth phase, it uses the standard List type.
+    ///  At capacity, it switches to a circular queue implementation.
+    /// </summary>
+    internal sealed class BoundedList<T> : IEnumerable<T>
+    {
+        private readonly int capacity;
+
+        private List<T> elementList;
+
+        private CircularQueue<T> circularQueue;
+
+        private BoundedList(int capacity)
+        {
+            this.capacity = capacity;
+            this.elementList = new List<T>();
+            this.circularQueue = null;
+        }
+
+        internal static bool TryCreate(int capacity, out BoundedList<T> boundedList)
+        {
+            boundedList = null;
+
+            if (capacity > 0)
+            {
+                boundedList = new BoundedList<T>(capacity);
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Add(T element)
+        {
+            if (this.circularQueue != null)
+            {
+                this.circularQueue.Add(element);
+            }
+            else if (this.elementList.Count < this.capacity)
+            {
+                this.elementList.Add(element);
+            }
+            else
+            {
+                _ = CircularQueue<T>.TryCreate(this.capacity, out this.circularQueue);
+                this.circularQueue.AddRange(this.elementList);
+                this.elementList = null;
+                this.circularQueue.Add(element);
+            }
+        }
+
+        public void AddRange(IEnumerable<T> elements)
+        {
+            foreach (T element in elements)
+            {
+                this.Add(element);
+            }
+        }
+
+        public IEnumerator<T> GetListEnumerator()
+        {
+            // Using a for loop with a yield prevents Issue #1467 which causes
+            // ThrowInvalidOperationException if a new diagnostics is getting added
+            // while the enumerator is being used.
+            List<T> elements = this.elementList;
+            for (int index = 0; index < elements.Count; ++index)
+            {
+                yield return elements[index];
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (this.circularQueue != null)
+            {
+                return this.circularQueue.GetEnumerator();
+            }
+            else
+            {
+                return this.GetListEnumerator();
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/BoundedList.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/BoundedList.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Diagnostics
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
 
@@ -19,24 +20,16 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 
         private CircularQueue<T> circularQueue;
 
-        private BoundedList(int capacity)
+        public BoundedList(int capacity)
         {
+            if (capacity < 1)
+            {
+                throw new ArgumentOutOfRangeException("BoundedList capacity must be positive");
+            }
+
             this.capacity = capacity;
             this.elementList = new List<T>();
             this.circularQueue = null;
-        }
-
-        internal static bool TryCreate(int capacity, out BoundedList<T> boundedList)
-        {
-            boundedList = null;
-
-            if (capacity > 0)
-            {
-                boundedList = new BoundedList<T>(capacity);
-                return true;
-            }
-
-            return false;
         }
 
         public void Add(T element)
@@ -51,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             }
             else
             {
-                _ = CircularQueue<T>.TryCreate(this.capacity, out this.circularQueue);
+                this.circularQueue = new CircularQueue<T>(this.capacity);
                 this.circularQueue.AddRange(this.elementList);
                 this.elementList = null;
                 this.circularQueue.Add(element);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
@@ -36,29 +36,16 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         /// Initializes a new instance of the <see cref="CircularQueue{T}"/> class.
         /// </summary>
         /// <param name="capacity"></param>
-        private CircularQueue(int capacity)
+        public CircularQueue(int capacity)
         {
-            this.head = 0;
-            this.tail = 0;
-            this.buffer = new T[capacity];
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CircularQueue{T}"/> class.
-        /// </summary>
-        /// <param name="capacity"></param>
-        /// <param name="queue">the newly created queue</param>
-        /// <returns>True if successful, false otherwise</returns>
-        public static bool TryCreate(int capacity, out CircularQueue<T> queue)
-        {
-            queue = null;
-            if (capacity > 0)
+            if (capacity < 1)
             {
-                queue = new CircularQueue<T>(capacity + 1);
-                return true;
+                throw new ArgumentOutOfRangeException("circular queue capacity must be positive");
             }
 
-            return false;
+            this.head = 0;
+            this.tail = 0;
+            this.buffer = new T[capacity + 1]; // one empty slot
         }
 
         /// <summary>
@@ -96,14 +83,11 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         private bool TryPop(out T element)
         {
             element = default;
-            if (!this.Empty)
-            {
-                element = this.buffer[this.head];
-                this.head = this.GetNextIndex(this.head);
-                return true;
-            }
+            if (this.Empty) return false;
 
-            return false;
+            element = this.buffer[this.head];
+            this.head = this.GetNextIndex(this.head);
+            return true;
         }
 
         /// <inheritdoc/>

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
@@ -1,0 +1,128 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///  simple circular queue that preallocates the underlying buffer
+    /// </summary>
+    internal sealed class CircularQueue<T> : IEnumerable<T>
+    {
+        private readonly T[] buffer;
+
+        private int head;
+        private int tail;
+
+        /// <summary>
+        /// Capacity of the queue.
+        /// </summary>
+        public int Capacity { get; }
+
+        /// <summary>
+        /// True if adding an element will cause one to be evicted.
+        /// </summary>
+        public bool Full => this.Increment(this.tail) == this.head;
+
+        /// <summary>
+        /// True when the queue is empty.
+        /// </summary>
+        public bool Empty => this.tail == this.head;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularQueue{T}"/> class.
+        /// </summary>
+        /// <param name="capacity"></param>
+        private CircularQueue(int capacity)
+        {
+            this.head = 0;
+            this.tail = 0;
+            this.Capacity = capacity;
+            this.buffer = new T[capacity];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CircularQueue{T}"/> class.
+        /// </summary>
+        /// <param name="capacity"></param>
+        /// <param name="queue">the newly created queue</param>
+        /// <returns>True if successful, false otherwise</returns>
+        public static bool TryCreate(int capacity, out CircularQueue<T> queue)
+        {
+            queue = null;
+            if (capacity > 0)
+            {
+                queue = new CircularQueue<T>(capacity + 1);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Adds a new element to the queue. Can cause an older element to be evicted.
+        /// </summary>
+        /// <param name="element"></param>
+        public void Add(T element)
+        {
+            if (this.Full)
+            {
+                this.TryPop(out _);
+            }
+
+            this.buffer[this.tail] = element;
+            this.tail = this.Increment(this.tail);
+        }
+
+        /// <summary>
+        /// Adds a subrange of the argument to the queue depending on capacity.
+        /// </summary>
+        /// <param name="elements"></param>
+        public void AddRange(IEnumerable<T> elements)
+        {
+            foreach (T element in elements)
+            {
+                this.Add(element);
+            }
+        }
+
+        private int Increment(int index)
+        {
+            return (index + 1) % this.Capacity;
+        }
+
+        private bool TryPop(out T element)
+        {
+            element = default;
+            if (!this.Empty)
+            {
+                element = this.buffer[this.head];
+                this.head = this.Increment(this.head);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        public IEnumerator<T> GetEnumerator()
+        {
+            if (!this.Empty)
+            {
+                for (int i = this.head; i != this.tail; i = this.Increment(i))
+                {
+                    yield return this.buffer[i];
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CircularQueue.cs
@@ -20,12 +20,12 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         /// <summary>
         /// Capacity of the queue.
         /// </summary>
-        public int Capacity { get; }
+        public int Capacity => this.buffer.Length;
 
         /// <summary>
         /// True if adding an element will cause one to be evicted.
         /// </summary>
-        public bool Full => this.Increment(this.tail) == this.head;
+        public bool Full => this.GetNextIndex(this.tail) == this.head;
 
         /// <summary>
         /// True when the queue is empty.
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             this.head = 0;
             this.tail = 0;
-            this.Capacity = capacity;
             this.buffer = new T[capacity];
         }
 
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             }
 
             this.buffer[this.tail] = element;
-            this.tail = this.Increment(this.tail);
+            this.tail = this.GetNextIndex(this.tail);
         }
 
         /// <summary>
@@ -89,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             }
         }
 
-        private int Increment(int index)
+        private int GetNextIndex(int index)
         {
             return (index + 1) % this.Capacity;
         }
@@ -100,7 +99,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             if (!this.Empty)
             {
                 element = this.buffer[this.head];
-                this.head = this.Increment(this.head);
+                this.head = this.GetNextIndex(this.head);
                 return true;
             }
 
@@ -118,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             if (!this.Empty)
             {
-                for (int i = this.head; i != this.tail; i = this.Increment(i))
+                for (int i = this.head; i != this.tail; i = this.GetNextIndex(i))
                 {
                     yield return this.buffer[i];
                 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class CosmosDiagnosticsContextCore : CosmosDiagnosticsContext
     {
         private static readonly string DefaultUserAgentString;
-        internal static Func<int> Capacity = () => 5120;
+        internal static int Capacity = 5120;
         private readonly CosmosDiagnosticScope overallScope;
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos
             this.UserAgent = userAgentString ?? throw new ArgumentNullException(nameof(userAgentString));
             this.OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
             this.StartUtc = DateTime.UtcNow;
-            this.ContextList = new BoundedList<CosmosDiagnosticsInternal>(Capacity());
+            this.ContextList = new BoundedList<CosmosDiagnosticsInternal>(Capacity);
             this.Diagnostics = new CosmosDiagnosticsCore(this);
             this.overallScope = new CosmosDiagnosticScope("Overall");
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class CosmosDiagnosticsContextCore : CosmosDiagnosticsContext
     {
         private static readonly string DefaultUserAgentString;
+        internal static Func<int> Capacity = () => 256;
         private readonly CosmosDiagnosticScope overallScope;
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace Microsoft.Azure.Cosmos
             this.UserAgent = userAgentString ?? throw new ArgumentNullException(nameof(userAgentString));
             this.OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
             this.StartUtc = DateTime.UtcNow;
-            _ = BoundedList<CosmosDiagnosticsInternal>.TryCreate(256, out BoundedList<CosmosDiagnosticsInternal> boundedList);
+            _ = BoundedList<CosmosDiagnosticsInternal>.TryCreate(Capacity(), out BoundedList<CosmosDiagnosticsInternal> boundedList);
             this.ContextList = boundedList;
             this.Diagnostics = new CosmosDiagnosticsCore(this);
             this.overallScope = new CosmosDiagnosticScope("Overall");

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -200,9 +200,9 @@ namespace Microsoft.Azure.Cosmos
             // while the enumerator is being used.
             lock (this.ContextList)
             {
-                for (int i = 0; i < this.ContextList.Count; i++)
+                foreach (CosmosDiagnosticsInternal context in this.ContextList)
                 {
-                    yield return this.ContextList[i];
+                    yield return context;
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Detailed view of all the operations.
         /// </summary>
-        private List<CosmosDiagnosticsInternal> ContextList { get; }
+        private BoundedList<CosmosDiagnosticsInternal> ContextList { get; }
 
         private int totalResponseCount = 0;
         private int failedResponseCount = 0;
@@ -49,7 +49,8 @@ namespace Microsoft.Azure.Cosmos
             this.UserAgent = userAgentString ?? throw new ArgumentNullException(nameof(userAgentString));
             this.OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
             this.StartUtc = DateTime.UtcNow;
-            this.ContextList = new List<CosmosDiagnosticsInternal>();
+            _ = BoundedList<CosmosDiagnosticsInternal>.TryCreate(256, out BoundedList<CosmosDiagnosticsInternal> boundedList);
+            this.ContextList = boundedList;
             this.Diagnostics = new CosmosDiagnosticsCore(this);
             this.overallScope = new CosmosDiagnosticScope("Overall");
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class CosmosDiagnosticsContextCore : CosmosDiagnosticsContext
     {
         private static readonly string DefaultUserAgentString;
-        internal static Func<int> Capacity = () => 256;
+        internal static Func<int> Capacity = () => 5120;
         private readonly CosmosDiagnosticScope overallScope;
 
         /// <summary>
@@ -50,8 +50,7 @@ namespace Microsoft.Azure.Cosmos
             this.UserAgent = userAgentString ?? throw new ArgumentNullException(nameof(userAgentString));
             this.OperationName = operationName ?? throw new ArgumentNullException(nameof(operationName));
             this.StartUtc = DateTime.UtcNow;
-            _ = BoundedList<CosmosDiagnosticsInternal>.TryCreate(Capacity(), out BoundedList<CosmosDiagnosticsInternal> boundedList);
-            this.ContextList = boundedList;
+            this.ContextList = new BoundedList<CosmosDiagnosticsInternal>(Capacity());
             this.Diagnostics = new CosmosDiagnosticsCore(this);
             this.overallScope = new CosmosDiagnosticScope("Overall");
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -138,9 +138,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal override void AddDiagnosticsInternal(StoreResponseStatistics storeResponseStatistics)
         {
-            if (storeResponseStatistics.StatusCode.HasValue)
+            if (storeResponseStatistics.StoreResultStatistics != null)
             {
-                this.AddResponseCount((int)storeResponseStatistics.StatusCode.Value);
+                this.AddResponseCount((int)storeResponseStatistics.StoreResultStatistics.StatusCode);
             }
 
             this.AddToContextList(storeResponseStatistics);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -137,9 +137,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal override void AddDiagnosticsInternal(StoreResponseStatistics storeResponseStatistics)
         {
-            if (storeResponseStatistics.StoreResult != null)
+            if (storeResponseStatistics.StatusCode.HasValue)
             {
-                this.AddResponseCount((int)storeResponseStatistics.StoreResult.StatusCode);
+                this.AddResponseCount((int)storeResponseStatistics.StatusCode.Value);
             }
 
             this.AddToContextList(storeResponseStatistics);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -244,16 +244,12 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.jsonWriter.WritePropertyName("LocationEndpoint");
             this.jsonWriter.WriteValue(storeResponseStatistics.LocationEndpoint);
 
-            if (storeResponseStatistics.ActivityId != null)
+            if (storeResponseStatistics.StoreResultStatistics != null)
             {
                 this.jsonWriter.WritePropertyName("ActivityId");
-                this.jsonWriter.WriteValue(storeResponseStatistics.ActivityId);
-            }
-
-            if (storeResponseStatistics.StoreResult != null)
-            {
+                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResultStatistics.ActivityId);
                 this.jsonWriter.WritePropertyName("StoreResult");
-                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult);
+                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResultStatistics.ToString());
             }
 
             this.jsonWriter.WriteEndObject();

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -244,13 +244,16 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.jsonWriter.WritePropertyName("LocationEndpoint");
             this.jsonWriter.WriteValue(storeResponseStatistics.LocationEndpoint);
 
-            if (storeResponseStatistics.StoreResult != null)
+            if (storeResponseStatistics.ActivityId != null)
             {
                 this.jsonWriter.WritePropertyName("ActivityId");
-                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult.ActivityId);
+                this.jsonWriter.WriteValue(storeResponseStatistics.ActivityId);
+            }
 
+            if (storeResponseStatistics.StoreResult != null)
+            {
                 this.jsonWriter.WritePropertyName("StoreResult");
-                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult.ToString());
+                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult);
             }
 
             this.jsonWriter.WriteEndObject();

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
@@ -35,6 +35,8 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             {
                 this.StoreResultStatistics = new StoreResultStatistics(
                     exception: storeResult.Exception,
+                    statusCode: storeResult.StatusCode,
+                    subStatusCode: storeResult.SubStatusCode,
                     partitionKeyRangeId: storeResult.PartitionKeyRangeId,
                     lsn: storeResult.LSN,
                     requestCharge: storeResult.RequestCharge,

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         public readonly OperationType RequestOperationType;
         public readonly Uri LocationEndpoint;
         public readonly bool IsSupplementalResponse;
-        public readonly StatusCodes? StatusCode;
-        public readonly string ActivityId;
-        public readonly string StoreResult;
+        public readonly StoreResultStatistics StoreResultStatistics;
 
         public StoreResponseStatistics(
             DateTime? requestStartTime,
@@ -30,11 +28,24 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.RequestResponseTime = requestResponseTime;
             this.RequestResourceType = resourceType;
             this.RequestOperationType = operationType;
-            this.StatusCode = storeResult?.StatusCode;
-            this.ActivityId = storeResult?.ActivityId;
-            this.StoreResult = storeResult?.ToString();
             this.LocationEndpoint = locationEndpoint;
             this.IsSupplementalResponse = operationType == OperationType.Head || operationType == OperationType.HeadFeed;
+
+            if (storeResult != null)
+            {
+                this.StoreResultStatistics = new StoreResultStatistics(
+                    exception: storeResult.Exception,
+                    partitionKeyRangeId: storeResult.PartitionKeyRangeId,
+                    lsn: storeResult.LSN,
+                    requestCharge: storeResult.RequestCharge,
+                    isValid: storeResult.IsValid,
+                    storePhysicalAddress: storeResult.StorePhysicalAddress,
+                    globalCommittedLSN: storeResult.GlobalCommittedLSN,
+                    itemLSN: storeResult.ItemLSN,
+                    sessionToken: storeResult.SessionToken,
+                    usingLocalLSN: storeResult.UsingLocalLSN,
+                    activityId: storeResult.ActivityId);
+            }
         }
 
         public override void Accept(CosmosDiagnosticsInternalVisitor visitor)

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
@@ -10,11 +10,13 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     {
         public readonly DateTime? RequestStartTime;
         public readonly DateTime RequestResponseTime;
-        public readonly StoreResult StoreResult;
         public readonly ResourceType RequestResourceType;
         public readonly OperationType RequestOperationType;
         public readonly Uri LocationEndpoint;
         public readonly bool IsSupplementalResponse;
+        public readonly StatusCodes? StatusCode;
+        public readonly string ActivityId;
+        public readonly string StoreResult;
 
         public StoreResponseStatistics(
             DateTime? requestStartTime,
@@ -26,9 +28,11 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             this.RequestStartTime = requestStartTime;
             this.RequestResponseTime = requestResponseTime;
-            this.StoreResult = storeResult;
             this.RequestResourceType = resourceType;
             this.RequestOperationType = operationType;
+            this.StatusCode = storeResult?.StatusCode;
+            this.ActivityId = storeResult?.ActivityId;
+            this.StoreResult = storeResult?.ToString();
             this.LocationEndpoint = locationEndpoint;
             this.IsSupplementalResponse = operationType == OperationType.Head || operationType == OperationType.HeadFeed;
         }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResultStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResultStatistics.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 
         public StoreResultStatistics(
             DocumentClientException exception,
+            StatusCodes statusCode,
+            SubStatusCodes subStatusCode,
             string partitionKeyRangeId,
             long lsn,
             double requestCharge,
@@ -50,6 +52,8 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             string activityId)
         {
             this.Exception = exception;
+            this.StatusCode = statusCode;
+            this.SubStatusCode = subStatusCode;
             this.PartitionKeyRangeId = partitionKeyRangeId;
             this.LSN = lsn;
             this.RequestCharge = requestCharge;

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResultStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResultStatistics.cs
@@ -1,0 +1,90 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System;
+    using System.Globalization;
+    using System.Text;
+    using Microsoft.Azure.Documents;
+
+    internal sealed class StoreResultStatistics
+    {
+        public DocumentClientException Exception { get; }
+
+        public long LSN { get; }
+
+        public string PartitionKeyRangeId { get; }
+
+        public long GlobalCommittedLSN { get; }
+
+        public long ItemLSN { get; }
+
+        public ISessionToken SessionToken { get; }
+
+        public bool UsingLocalLSN { get; }
+
+        public bool IsValid { get; }
+
+        public Uri StorePhysicalAddress { get; }
+
+        public StatusCodes StatusCode { get; }
+
+        public SubStatusCodes SubStatusCode { get; }
+
+        public string ActivityId { get; }
+
+        public double RequestCharge { get; }
+
+        public StoreResultStatistics(
+            DocumentClientException exception,
+            string partitionKeyRangeId,
+            long lsn,
+            double requestCharge,
+            bool isValid,
+            Uri storePhysicalAddress,
+            long globalCommittedLSN,
+            long itemLSN,
+            ISessionToken sessionToken,
+            bool usingLocalLSN,
+            string activityId)
+        {
+            this.Exception = exception;
+            this.PartitionKeyRangeId = partitionKeyRangeId;
+            this.LSN = lsn;
+            this.RequestCharge = requestCharge;
+            this.IsValid = isValid;
+            this.StorePhysicalAddress = storePhysicalAddress;
+            this.GlobalCommittedLSN = globalCommittedLSN;
+            this.ItemLSN = itemLSN;
+            this.SessionToken = sessionToken;
+            this.UsingLocalLSN = usingLocalLSN;
+            this.ActivityId = activityId;
+        }
+
+        public override string ToString()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "StorePhysicalAddress: {0}, LSN: {1}, GlobalCommittedLsn: {2}, PartitionKeyRangeId: {3}, IsValid: {4}, StatusCode: {5}, SubStatusCode: {6}, " +
+                "RequestCharge: {7}, ItemLSN: {8}, SessionToken: {9}, UsingLocalLSN: {10}, TransportException: {11}",
+                this.StorePhysicalAddress,
+                this.LSN,
+                this.GlobalCommittedLSN,
+                this.PartitionKeyRangeId,
+                this.IsValid,
+                (int)this.StatusCode,
+                (int)this.SubStatusCode,
+                this.RequestCharge,
+                this.ItemLSN,
+                this.SessionToken?.ConvertToString(),
+                this.UsingLocalLSN,
+                this.Exception?.InnerException is TransportException ? this.Exception.InnerException.Message : "null");
+
+            return stringBuilder.ToString();
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Regions.cs
+++ b/Microsoft.Azure.Cosmos/src/Regions.cs
@@ -314,5 +314,10 @@ namespace Microsoft.Azure.Cosmos
         /// Name of the Azure Jio India West region in the Azure Cosmos DB service.
         /// </summary>
         public const string JioIndiaWest = "Jio India West";
+
+        /// <summary>
+        /// Name of the Azure US SLV region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string EastUSSLV = "East US SLV";
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -233,6 +233,8 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     GC.WaitForPendingFinalizers();
                     GC.Collect();
                     await Task.Delay(500 /*ms*/);
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
 
                     Assert.IsFalse(weakReference.IsAlive);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/DiagnosticValidators.cs
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Cosmos
 
         private static void ValidateStoreResponseStatistics(StoreResponseStatistics stats, DateTime startTimeUtc)
         {
-            Assert.IsNotNull(stats.StoreResult);
+            Assert.IsNotNull(stats.StoreResultStatistics);
             Assert.IsNotNull(stats.LocationEndpoint);
             Assert.IsTrue(startTimeUtc < stats.RequestResponseTime);
             Assert.IsTrue(stats.RequestResponseTime < DateTime.UtcNow);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
@@ -4596,6 +4596,11 @@
           "Attributes": [],
           "MethodInfo": "System.String EastUS2EUAP;IsInitOnly:False;IsStatic:True;"
         },
+        "System.String EastUSSLV": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String EastUSSLV;IsInitOnly:False;IsStatic:True;"
+        },
         "System.String FranceCentral": {
           "Type": "Field",
           "Attributes": [],

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosDiagnosticsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosDiagnosticsUnitTests.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [DataRow(10, 100000, 5120, DisplayName = "Bounded")]
         public void ValidateDiagnosticsAppendContextConcurrentCalls(int threadCount, int itemCountPerThread, int expectedCount)
         {
-            CosmosDiagnosticsContextCore.Capacity = () => expectedCount;
+            CosmosDiagnosticsContextCore.Capacity = expectedCount;
 
             ConcurrentStack<Exception> concurrentStack = new ConcurrentStack<Exception>();
             CosmosDiagnosticsContext cosmosDiagnostics = new CosmosDiagnosticsContextCore(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosDiagnosticsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosDiagnosticsUnitTests.cs
@@ -230,22 +230,6 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             using (cosmosDiagnostics.GetOverallScope())
             {
-                // Test all the different operations on diagnostics context
-                using (cosmosDiagnostics.CreateScope("ValidateScope"))
-                {
-                    Thread.Sleep(TimeSpan.FromSeconds(2));
-                }
-
-                cosmosDiagnostics2 = new CosmosDiagnosticsContextCore(
-                    nameof(ValidateDiagnosticsAppendContext),
-                    "MyCustomUserAgentString");
-                cosmosDiagnostics2.GetOverallScope().Dispose();
-
-                using (cosmosDiagnostics.CreateScope("CosmosDiagnostics2Scope"))
-                {
-                    Thread.Sleep(TimeSpan.FromMilliseconds(100));
-                }
-
                 bool insertIntoDiagnostics1 = true;
                 bool isInsertDiagnostics = false;
                 // Start a background thread and ensure that no exception occurs even if items are getting added to the context
@@ -257,13 +241,30 @@ namespace Microsoft.Azure.Cosmos.Tests
                         cpuLoadHistory: new Documents.Rntbd.CpuLoadHistory(new List<Documents.Rntbd.CpuLoad>().AsReadOnly(), TimeSpan.FromSeconds(1)));
                     while (insertIntoDiagnostics1)
                     {
+                        Task.Delay(TimeSpan.FromMilliseconds(1)).Wait();
                         cosmosDiagnostics.AddDiagnosticsInternal(cosmosSystemInfo);
                     }
                 });
 
                 while (!isInsertDiagnostics)
                 {
-                    Task.Delay(TimeSpan.FromMilliseconds(10)).Wait();
+                    Task.Delay(TimeSpan.FromMilliseconds(5)).Wait();
+                }
+
+                // Test all the different operations on diagnostics context
+                using (cosmosDiagnostics.CreateScope("ValidateScope"))
+                {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(3));
+                }
+
+                cosmosDiagnostics2 = new CosmosDiagnosticsContextCore(
+                    nameof(ValidateDiagnosticsAppendContext),
+                    "MyCustomUserAgentString");
+                cosmosDiagnostics2.GetOverallScope().Dispose();
+
+                using (cosmosDiagnostics.CreateScope("CosmosDiagnostics2Scope"))
+                {
+                    Thread.Sleep(TimeSpan.FromMilliseconds(3));
                 }
 
                 cosmosDiagnostics2.AddDiagnosticsInternal(cosmosDiagnostics);
@@ -280,7 +281,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         [TestMethod]
         [DataRow(10, 100000, 1000001, DisplayName = "Unbounded")]
-        [DataRow(10, 100000, 256, DisplayName = "Bounded")]
+        [DataRow(10, 100000, 5120, DisplayName = "Bounded")]
         public void ValidateDiagnosticsAppendContextConcurrentCalls(int threadCount, int itemCountPerThread, int expectedCount)
         {
             CosmosDiagnosticsContextCore.Capacity = () => expectedCount;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/BoundedListTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/BoundedListTests.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Diagnostics
 {
+    using System;
     using System.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,24 +15,24 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             foreach (int x in new[] {-512, -256, -1, 0 })
             {
-                Assert.IsFalse(BoundedList<int>.TryCreate(x, out _));
+                Assert.ThrowsException<ArgumentOutOfRangeException>(() => new BoundedList<int>(x));
             }
 
             foreach (int x in new[] { 1, 2, 8, 256 })
             {
-                Assert.IsTrue(BoundedList<int>.TryCreate(x, out _));
+                Assert.IsNotNull(new BoundedList<int>(x));
             }
         }
 
         [TestMethod]
-        [DataRow(   3,   21, DisplayName = "Extra small")]
-        [DataRow(   5,   25, DisplayName = "Small")]
-        [DataRow(  64,  256, DisplayName = "Medium")]
-        [DataRow( 256, 1024, DisplayName = "Large")]
-        [DataRow(2048, 4096, DisplayName = "Extra large")]
+        [DataRow(    3,    21, DisplayName = "Extra small")]
+        [DataRow(    5,    25, DisplayName = "Small")]
+        [DataRow(  256,  1024, DisplayName = "Medium")]
+        [DataRow( 5120, 10240, DisplayName = "Large")]
+        [DataRow(10240, 20480, DisplayName = "Large")]
         public void BasicTests(int capacity, int numElements)
         {
-            Assert.IsTrue(BoundedList<int>.TryCreate(capacity, out BoundedList<int> boundedList));
+            BoundedList<int> boundedList = new BoundedList<int>(capacity);
 
             for (int i = 0; i < numElements; ++i)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/BoundedListTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/BoundedListTests.cs
@@ -1,0 +1,49 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System.Linq;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class BoundedListTests
+    {
+        [TestMethod]
+        public void CapacityValidationTests()
+        {
+            foreach (int x in new[] {-512, -256, -1, 0 })
+            {
+                Assert.IsFalse(BoundedList<int>.TryCreate(x, out _));
+            }
+
+            foreach (int x in new[] { 1, 2, 8, 256 })
+            {
+                Assert.IsTrue(BoundedList<int>.TryCreate(x, out _));
+            }
+        }
+
+        [TestMethod]
+        [DataRow(   3,   21, DisplayName = "Extra small")]
+        [DataRow(   5,   25, DisplayName = "Small")]
+        [DataRow(  64,  256, DisplayName = "Medium")]
+        [DataRow( 256, 1024, DisplayName = "Large")]
+        [DataRow(2048, 4096, DisplayName = "Extra large")]
+        public void BasicTests(int capacity, int numElements)
+        {
+            Assert.IsTrue(BoundedList<int>.TryCreate(capacity, out BoundedList<int> boundedList));
+
+            for (int i = 0; i < numElements; ++i)
+            {
+                boundedList.Add(i);
+
+                int expected = (i >= capacity) ? (i - capacity + 1) : 0; 
+                foreach(int actual in boundedList)
+                {
+                    Assert.AreEqual(expected, actual);
+                    ++expected;
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/CircularQueueTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/CircularQueueTests.cs
@@ -1,0 +1,44 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System.Linq;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CircularQueueTests
+    {
+        [TestMethod]
+        public void BasicTests()
+        {
+            Assert.IsTrue(CircularQueue<int>.TryCreate(4, out CircularQueue<int> queue));
+
+            Assert.IsTrue(queue.Empty);
+            Assert.IsFalse(queue.Full);
+
+            queue.Add(1);
+            Assert.IsFalse(queue.Empty);
+            Assert.IsFalse(queue.Full);
+
+            queue.Add(2);
+            queue.Add(3);
+
+            int expected = 0;
+            foreach (int actual in queue)
+            {
+                Assert.AreEqual(++expected, actual);
+            }
+
+            queue.Add(4);
+            Assert.IsTrue(queue.Full);
+            CollectionAssert.AreEquivalent(new[] { 1, 2, 3, 4 }, queue.ToArray());
+
+            queue.Add(5);
+            queue.Add(6);
+            Assert.IsTrue(queue.Full);
+            Assert.IsFalse(queue.Empty);
+            CollectionAssert.AreEquivalent(new[] { 3, 4, 5, 6 }, queue.ToList());
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/CircularQueueTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/CircularQueueTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         [TestMethod]
         public void BasicTests()
         {
-            Assert.IsTrue(CircularQueue<int>.TryCreate(4, out CircularQueue<int> queue));
+            CircularQueue<int> queue = new CircularQueue<int>(4);
 
             Assert.IsTrue(queue.Empty);
             Assert.IsFalse(queue.Full);


### PR DESCRIPTION
# Pull Request Template

## Description

NetworkAttachedDocumentContainer holds on to a single CosmosDiagnostics context, and adds diagnostics for each response to this context. for long running queries, this amounts to growing the size of CosmosDiagnostics without bound.

In addition StoreResponseStatistics was holding on the entire StoreResult object including the response stream, which leads to the very high memory consumption.

This change severs the link between StoreResponseStatistics and the StoreResult, and it also uses a bounded circular buffer instead of a list to store child contexts in CosmosDiagnosticsCore


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber