### PR TITLE
Diagnostics: Fixes unnecessary reference to StoreResult object in StoreResponseStatistics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsContextCore.cs
@@ -137,9 +137,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal override void AddDiagnosticsInternal(StoreResponseStatistics storeResponseStatistics)
         {
-            if (storeResponseStatistics.StoreResult != null)
+            if (storeResponseStatistics.StatusCode.HasValue)
             {
-                this.AddResponseCount((int)storeResponseStatistics.StoreResult.StatusCode);
+                this.AddResponseCount((int)storeResponseStatistics.StatusCode.Value);
             }
 
             this.AddToContextList(storeResponseStatistics);

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnosticsSerializerVisitor.cs
@@ -244,13 +244,16 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
             this.jsonWriter.WritePropertyName("LocationEndpoint");
             this.jsonWriter.WriteValue(storeResponseStatistics.LocationEndpoint);
 
-            if (storeResponseStatistics.StoreResult != null)
+            if (storeResponseStatistics.ActivityId != null)
             {
                 this.jsonWriter.WritePropertyName("ActivityId");
-                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult.ActivityId);
+                this.jsonWriter.WriteValue(storeResponseStatistics.ActivityId);
+            }
 
+            if (storeResponseStatistics.StoreResult != null)
+            {
                 this.jsonWriter.WritePropertyName("StoreResult");
-                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult.ToString());
+                this.jsonWriter.WriteValue(storeResponseStatistics.StoreResult);
             }
 
             this.jsonWriter.WriteEndObject();

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/StoreResponseStatistics.cs
@@ -10,11 +10,13 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     {
         public readonly DateTime? RequestStartTime;
         public readonly DateTime RequestResponseTime;
-        public readonly StoreResult StoreResult;
         public readonly ResourceType RequestResourceType;
         public readonly OperationType RequestOperationType;
         public readonly Uri LocationEndpoint;
         public readonly bool IsSupplementalResponse;
+        public readonly StatusCodes? StatusCode;
+        public readonly string ActivityId;
+        public readonly string StoreResult;
 
         public StoreResponseStatistics(
             DateTime? requestStartTime,
@@ -26,9 +28,11 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             this.RequestStartTime = requestStartTime;
             this.RequestResponseTime = requestResponseTime;
-            this.StoreResult = storeResult;
             this.RequestResourceType = resourceType;
             this.RequestOperationType = operationType;
+            this.StatusCode = storeResult?.StatusCode;
+            this.ActivityId = storeResult?.ActivityId;
+            this.StoreResult = storeResult?.ToString();
             this.LocationEndpoint = locationEndpoint;
             this.IsSupplementalResponse = operationType == OperationType.Head || operationType == OperationType.HeadFeed;
         }


### PR DESCRIPTION
## Description

Currently the StoreResponseStatistics object holds on to the entire StoreResult object. This aggravates an existing memory leak in the NetworkAttachedDocumentContainer. Severing the link between StoreResponseSatistics and StoreResult reduces the memory consumption by several orders of magnitude.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber