### PR TITLE
Query: Fixes Parallelism for every request. 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                     cancellationToken),
                 comparer: default /* this uses a regular queue instead of prioirty queue */,
                 maxConcurrency: default,
+                isStreamingOperation: true,
                 cancellationToken,
                 state);
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerable.cs
@@ -18,12 +18,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
         private readonly IComparer<PartitionRangePageAsyncEnumerator<TPage, TState>> comparer;
         private readonly IFeedRangeProvider feedRangeProvider;
         private readonly int maxConcurrency;
+        private readonly bool isStreamingOperation;
 
         public CrossPartitionRangePageAsyncEnumerable(
             IFeedRangeProvider feedRangeProvider,
             CreatePartitionRangePageAsyncEnumerator<TPage, TState> createPartitionRangeEnumerator,
             IComparer<PartitionRangePageAsyncEnumerator<TPage, TState>> comparer,
             int maxConcurrency,
+            bool isStreamingOperation,
             CrossFeedRangeState<TState> state = default)
         {
             this.feedRangeProvider = feedRangeProvider ?? throw new ArgumentNullException(nameof(comparer));
@@ -31,6 +33,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
             this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
             this.state = state;
             this.maxConcurrency = maxConcurrency < 0 ? throw new ArgumentOutOfRangeException(nameof(maxConcurrency)) : maxConcurrency;
+            this.isStreamingOperation = isStreamingOperation;
         }
 
         public IAsyncEnumerator<TryCatch<CrossFeedRangePage<TPage, TState>>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -42,6 +45,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 this.createPartitionRangeEnumerator,
                 this.comparer,
                 this.maxConcurrency,
+                this.isStreamingOperation,
                 cancellationToken,
                 this.state);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -370,6 +370,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 pageSize: inputParameters.MaxItemCount,
                 partitionKey: inputParameters.PartitionKey,
                 maxConcurrency: inputParameters.MaxConcurrency,
+                isStreamingOperation: true,
                 cancellationToken: cancellationToken,
                 continuationToken: inputParameters.InitialUserContinuationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             Cosmos.PartitionKey? partitionKey,
             int pageSize,
             int maxConcurrency,
+            bool isStreamingOperation,
             CosmosElement continuationToken,
             CancellationToken cancellationToken)
         {
@@ -170,6 +171,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, pageSize, partitionKey, cancellationToken),
                 comparer: Comparer.Singleton,
                 maxConcurrency,
+                isStreamingOperation,
                 state: state,
                 cancellationToken: cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
             }
             else
             {
+                bool isStreamingOperation = !(queryInfo.HasAggregates || queryInfo.HasGroupBy);
                 monadicCreatePipelineStage = (continuationToken, cancellationToken) => ParallelCrossPartitionQueryPipelineStage.MonadicCreate(
                     documentContainer: documentContainer,
                     sqlQuerySpec: sqlQuerySpec,
@@ -87,6 +88,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     pageSize: pageSize,
                     partitionKey: partitionKey,
                     maxConcurrency: maxConcurrency,
+                    isStreamingOperation: isStreamingOperation,
                     continuationToken: continuationToken,
                     cancellationToken: cancellationToken);
             }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/CrossPartitionReadFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/CrossPartitionReadFeedAsyncEnumerator.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
                     cancellationToken),
                 comparer: comparer,
                 maxConcurrency: default,
+                isStreamingOperation: true,
                 cancellationToken,
                 crossFeedRangeState);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     createPartitionRangeEnumerator: createEnumerator,
                     comparer: PartitionRangePageAsyncEnumeratorComparer.Singleton,
                     maxConcurrency: 10,
+                    isStreamingOperation: true,
                     state: state ?? new CrossFeedRangeState<ReadFeedState>(
                         new FeedRangeState<ReadFeedState>[]
                         {
@@ -168,6 +169,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     createPartitionRangeEnumerator: createEnumerator,
                     comparer: PartitionRangePageAsyncEnumeratorComparer.Singleton,
                     maxConcurrency: 10,
+                    isStreamingOperation: true,
                     cancellationToken: default,
                     state: state ?? new CrossFeedRangeState<ReadFeedState>(
                         new FeedRangeState<ReadFeedState>[]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: null);
             Assert.IsTrue(monadicCreate.Succeeded);
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: CosmosObject.Create(new Dictionary<string, CosmosElement>()));
             Assert.IsTrue(monadicCreate.Failed);
@@ -71,6 +73,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>()));
             Assert.IsTrue(monadicCreate.Failed);
@@ -89,6 +92,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { CosmosString.Create("asdf") }));
             Assert.IsTrue(monadicCreate.Failed);
@@ -111,6 +115,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { ParallelContinuationToken.ToCosmosElement(token) }));
             Assert.IsTrue(monadicCreate.Succeeded);
@@ -140,6 +145,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 pageSize: 10,
                 partitionKey: null,
                 maxConcurrency: 10,
+                isStreamingOperation: true,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(
                     new List<CosmosElement>()
@@ -172,6 +178,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     pageSize: 10,
                     partitionKey: null,
                     maxConcurrency: 10,
+                    isStreamingOperation: true,
                     cancellationToken: default,
                     continuationToken: continuationToken);
                 Assert.IsTrue(monadicQueryPipelineStage.Succeeded);


### PR DESCRIPTION
# Query: Fixes Parallelism for every request. 

## Description

For aggregate queries that don't leverage the index (or any group by queries) we saw an issue where queries were taking a lot of time. This was due to the client visiting every partition in serial and the individual requests taking about 5 seconds. 

One solution is to just go full parallel (up to the max degree of concurrency) every time, but we found that this led to issues with unobserved task cancellation exception and inconsistent reporting of RUs due to us essentially randomly swapping out the global RU tracker atomically (the RU would only be consistent if we fully drained the query). This led us to switch to a model where we prefetch in parallel once from every partition, but only on the calling thread. We only do this on the first request, since we don't want to block the caller from receiving a page of results just because we are prefetching from another potentially slow partition. 

The hybrid solution is that we always prefetch if the query isn't streamable (aggregates and groupby), since the user won't be able to see any of the results until we fully drain all the backend partitions anyways, so it's okay to block the calling thread here. 