### PR TITLE
[Internal] CTL: Adds Dockerfile to produce a docker image to run

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
+COPY ../../../. /usr/src/.
+RUN dotnet publish usr/src/CosmosCTL.csproj -c Release -o /usr/app/
+COPY run_ctl.sh /usr/app
+WORKDIR /usr/app
+RUN chmod +x run_ctl.sh
+CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+dotnetparameters="$dotnetparameters --ctl_endpoint $ctl_endpoint  --ctl_key $ctl_key"
+
+if [ -z "$ctl_operation" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_operation $ctl_operation"
+fi
+
+if [ -z "$ctl_concurrency" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_concurrency $ctl_concurrency"
+fi
+
+if [ -z "$ctl_consistency_level" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_consistency_level $ctl_consistency_level"
+fi
+
+if [ -z "$ctl_throughput" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_throughput $ctl_throughput"
+fi
+
+if [ -z "$ctl_read_write_query_pct" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_read_write_query_pct $ctl_read_write_query_pct"
+fi
+
+if [ -z "$ctl_number_of_operations" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_number_of_operations $ctl_number_of_operations"
+fi
+
+if [ -z "$ctl_max_running_time_duration" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_max_running_time_duration $ctl_max_running_time_duration"
+fi
+
+if [ -z "$ctl_number_Of_collection" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_number_Of_collection $ctl_number_Of_collection"
+fi
+
+if [ -z "$ctl_diagnostics_threshold_duration" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_diagnostics_threshold_duration $ctl_diagnostics_threshold_duration"
+fi
+
+if [ -z "$ctl_database" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_database $ctl_database"
+fi
+
+if [ -z "$ctl_collection" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_collection $ctl_collection"
+fi
+
+if [ -z "$ctl_graphite_endpoint" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_graphite_endpoint $ctl_graphite_endpoint"
+fi
+
+if [ -z "$ctl_graphite_port" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_graphite_port $ctl_graphite_port"
+fi
+
+if [ -z "$ctl_reporting_interval" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_reporting_interval $ctl_reporting_interval"
+fi
+
+if [ -z "$ctl_content_response_on_write" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_content_response_on_write $ctl_content_response_on_write"
+fi
+
+if [ -z "$ctl_output_event_traces" ]
+then
+dotnetparameters="$dotnetparameters"
+else
+dotnetparameters="$dotnetparameters --ctl_output_event_traces $ctl_output_event_traces"
+fi
+
+log_filename="/tmp/dotnetctl.log"
+
+echo "Log file name is $log_filename"
+
+echo "$dotnetparameters" > $log_filename
+
+./CosmosCTL $dotnetparameters 2>&1 | tee -a "$log_filename"


### PR DESCRIPTION
This PR adds a Dockerfile and shell file that can be used to containerize the CTL project into a docker image.

Running `docker build -t <my-image-name> -f Dockerfile . ` on the CTL project folder will build the docker image. The build process will run `dotnet publish` on the CTL project and also copy the required Shell file.

After the image is built, it can be run by:

`docker run -it -e ctl_endpoint="<endpoint>" -e ctl_key="<key>" --rm <my-image-name>`