### PR TITLE
Internal Pagination: Fixes APIs to be cleaner.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerable.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 innerState,
                 cancellationToken);
 
-            return new ChangeFeedCrossFeedRangeAsyncEnumerator(innerEnumerator);
+            return new ChangeFeedCrossFeedRangeAsyncEnumerator(
+                innerEnumerator, 
+                this.changeFeedRequestOptions?.JsonSerializationFormatOptions);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerator.cs
@@ -10,14 +10,19 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Serializer;
 
     internal sealed class ChangeFeedCrossFeedRangeAsyncEnumerator : IAsyncEnumerator<TryCatch<ChangeFeedPage>>
     {
         private readonly CrossPartitionChangeFeedAsyncEnumerator enumerator;
+        private readonly JsonSerializationFormatOptions jsonSerializationFormatOptions;
 
-        public ChangeFeedCrossFeedRangeAsyncEnumerator(CrossPartitionChangeFeedAsyncEnumerator enumerator)
+        public ChangeFeedCrossFeedRangeAsyncEnumerator(
+            CrossPartitionChangeFeedAsyncEnumerator enumerator,
+            JsonSerializationFormatOptions jsonSerializationFormatOptions)
         {
             this.enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
+            this.jsonSerializationFormatOptions = jsonSerializationFormatOptions;
         }
 
         public TryCatch<ChangeFeedPage> Current { get; private set; }
@@ -44,10 +49,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             ChangeFeedPage page = innerChangeFeedPage.Page switch
             {
                 Pagination.ChangeFeedSuccessPage successPage => ChangeFeedPage.CreatePageWithChanges(
-                    CosmosQueryClientCore.ParseElementsFromRestStream(
-                        successPage.Content, 
-                        Documents.ResourceType.Document, 
-                        cosmosSerializationOptions: null),
+                    RestFeedResponseParser.ParseRestFeedResponse(
+                        successPage.Content,
+                        this.jsonSerializationFormatOptions),
                     successPage.RequestCharge,
                     successPage.ActivityId,
                     state),

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         public ChangeFeedIteratorCore(
             IDocumentContainer documentContainer,
             ChangeFeedMode changeFeedMode,
-            ChangeFeedRequestOptions changeFeedRequestOptions,            
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedStartFrom changeFeedStartFrom)
         {
             if (changeFeedStartFrom == null)
@@ -153,11 +153,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                                 innerException: monadicChangeFeedCrossFeedRangeState.Exception));
                     }
 
+                    Dictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+                    foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
+                    {
+                        additionalHeaders[keyValuePair.Key] = keyValuePair.Value.ToString();
+                    }
+
                     CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                         documentContainer,
-                        changeFeedMode,
-                        changeFeedRequestOptions,
                         new CrossFeedRangeState<ChangeFeedState>(monadicChangeFeedCrossFeedRangeState.Result.FeedRangeStates),
+                        new ChangeFeedPaginationOptions(
+                            changeFeedMode,
+                            changeFeedRequestOptions.PageSizeHint,
+                            changeFeedRequestOptions.JsonSerializationFormatOptions?.JsonSerializationFormat,
+                            additionalHeaders),
                         cancellationToken: default);
 
                     TryCatch<CrossPartitionChangeFeedAsyncEnumerator> monadicEnumerator = TryCatch<CrossPartitionChangeFeedAsyncEnumerator>.FromResult(enumerator);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -153,10 +153,21 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                                 innerException: monadicChangeFeedCrossFeedRangeState.Exception));
                     }
 
-                    Dictionary<string, string> additionalHeaders = new Dictionary<string, string>();
-                    foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
+                    Dictionary<string, string> additionalHeaders;
+                    if (changeFeedRequestOptions?.Properties != null)
                     {
-                        additionalHeaders[keyValuePair.Key] = keyValuePair.Value.ToString();
+                        additionalHeaders = new Dictionary<string, string>();
+                        foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
+                        {
+                            if (keyValuePair.Value is string stringValue)
+                            {
+                                additionalHeaders[keyValuePair.Key] = stringValue;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        additionalHeaders = null;
                     }
 
                     CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
@@ -164,8 +175,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                         new CrossFeedRangeState<ChangeFeedState>(monadicChangeFeedCrossFeedRangeState.Result.FeedRangeStates),
                         new ChangeFeedPaginationOptions(
                             changeFeedMode,
-                            changeFeedRequestOptions.PageSizeHint,
-                            changeFeedRequestOptions.JsonSerializationFormatOptions?.JsonSerializationFormat,
+                            changeFeedRequestOptions?.PageSizeHint,
+                            changeFeedRequestOptions?.JsonSerializationFormatOptions?.JsonSerializationFormat,
                             additionalHeaders),
                         cancellationToken: default);
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -157,13 +157,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     if (changeFeedRequestOptions?.Properties != null)
                     {
                         additionalHeaders = new Dictionary<string, string>();
+                        Dictionary<string, object> nonStringHeaders = new Dictionary<string, object>();
                         foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
                         {
                             if (keyValuePair.Value is string stringValue)
                             {
                                 additionalHeaders[keyValuePair.Key] = stringValue;
                             }
+                            else
+                            {
+                                nonStringHeaders[keyValuePair.Key] = keyValuePair.Value;
+                            }
                         }
+
+                        changeFeedRequestOptions.Properties = nonStringHeaders;
                     }
                     else
                     {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed
 {
     using System;
+    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
@@ -106,6 +107,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     // Set time headers if any
                     ChangeFeedStartFromRequestOptionPopulator visitor = new ChangeFeedStartFromRequestOptionPopulator(requestMessage);
                     this.changeFeedStartFrom.Accept(visitor);
+
+                    if (this.changeFeedOptions.PageSizeHint.HasValue)
+                    {
+                        requestMessage.Headers.Add(
+                            HttpConstants.HttpHeaders.PageSize,
+                            this.changeFeedOptions.PageSizeHint.Value.ToString(CultureInfo.InvariantCulture));
+                    }
+
+                    requestMessage.Headers.Add(
+                        HttpConstants.HttpHeaders.A_IM,
+                        HttpConstants.A_IMHeaderValues.IncrementalFeed);
                 },
                 feedRange: this.changeFeedStartFrom.FeedRange,
                 streamPayload: default,

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedNotModifiedPage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedNotModifiedPage.cs
@@ -4,14 +4,22 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
     internal sealed class ChangeFeedNotModifiedPage : ChangeFeedPage
     {
+        private static readonly ImmutableHashSet<string> bannedHeaders = new HashSet<string>().ToImmutableHashSet();
+
         public ChangeFeedNotModifiedPage(
             double requestCharge,
             string activityId,
+            IReadOnlyDictionary<string, string> additionalHeaders,
             ChangeFeedState state)
-            : base(requestCharge, activityId, state)
+            : base(requestCharge, activityId, additionalHeaders, state)
         {
         }
+
+        protected override ImmutableHashSet<string> DerivedClassBannedHeaders => bannedHeaders;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPage.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
-    using System;
+    using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.Pagination;
 
     internal abstract class ChangeFeedPage : Page<ChangeFeedState>
@@ -12,15 +12,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         protected ChangeFeedPage(
             double requestCharge,
             string activityId,
+            IReadOnlyDictionary<string, string> additionalHeaders,
             ChangeFeedState state)
-            : base(state)
+            : base(requestCharge, activityId, additionalHeaders, state)
         {
-            this.RequestCharge = requestCharge < 0 ? throw new ArgumentOutOfRangeException(nameof(requestCharge)) : requestCharge;
-            this.ActivityId = activityId ?? throw new ArgumentNullException(nameof(activityId));
         }
-
-        public double RequestCharge { get; }
-
-        public string ActivityId { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPage.cs
@@ -5,10 +5,20 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
     using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Documents;
 
     internal abstract class ChangeFeedPage : Page<ChangeFeedState>
     {
+        public static readonly ImmutableHashSet<string> BannedHeaders = new HashSet<string>()
+        {
+            HttpConstants.HttpHeaders.ETag,
+        }
+        .Concat(Page<ChangeFeedState>.BannedHeadersBase)
+        .ToImmutableHashSet();
+
         protected ChangeFeedPage(
             double requestCharge,
             string activityId,

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPaginationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPaginationOptions.cs
@@ -1,0 +1,32 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Pagination;
+
+    internal sealed class ChangeFeedPaginationOptions : PaginationOptions
+    {
+        public static readonly ChangeFeedPaginationOptions Default = new ChangeFeedPaginationOptions(
+            mode: ChangeFeedMode.Incremental);
+
+        public ChangeFeedPaginationOptions(
+            ChangeFeedMode mode,
+            int? pageSizeHint = null,
+            JsonSerializationFormat? jsonSerializationFormat = null,
+            Dictionary<string, string> additionalHeaders = null)
+            : base(pageSizeHint, jsonSerializationFormat, additionalHeaders)
+        {
+            this.Mode = mode ?? throw new ArgumentNullException(nameof(mode));
+        }
+
+        public ChangeFeedMode Mode { get; }
+
+        protected override ImmutableHashSet<string> BannedAdditionalHeaders => throw new System.NotImplementedException();
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -17,12 +18,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         private readonly IChangeFeedDataSource changeFeedDataSource;
         private readonly int pageSize;
         private readonly ChangeFeedMode changeFeedMode;
+        private readonly JsonSerializationFormat? jsonSerializationFormat;
 
         public ChangeFeedPartitionRangePageAsyncEnumerator(
             IChangeFeedDataSource changeFeedDataSource,
             FeedRangeInternal range,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ChangeFeedState state,
             CancellationToken cancellationToken)
             : base(range, cancellationToken, state)
@@ -30,15 +33,19 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             this.changeFeedDataSource = changeFeedDataSource ?? throw new ArgumentNullException(nameof(changeFeedDataSource));
             this.changeFeedMode = changeFeedMode ?? throw new ArgumentNullException(nameof(changeFeedMode));
             this.pageSize = pageSize;
+            this.jsonSerializationFormat = jsonSerializationFormat;
         }
 
         public override ValueTask DisposeAsync() => default;
 
-        protected override Task<TryCatch<ChangeFeedPage>> GetNextPageAsync(ITrace trace, CancellationToken cancellationToken) => this.changeFeedDataSource.MonadicChangeFeedAsync(
+        protected override Task<TryCatch<ChangeFeedPage>> GetNextPageAsync(
+            ITrace trace, 
+            CancellationToken cancellationToken) => this.changeFeedDataSource.MonadicChangeFeedAsync(
             this.State,
             this.Range,
             this.pageSize,
             this.changeFeedMode,
+            this.jsonSerializationFormat,
             trace,
             cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
@@ -7,33 +7,24 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Microsoft.Azure.Documents;
 
     internal sealed class ChangeFeedPartitionRangePageAsyncEnumerator : PartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState>
     {
         private readonly IChangeFeedDataSource changeFeedDataSource;
-        private readonly int pageSize;
-        private readonly ChangeFeedMode changeFeedMode;
-        private readonly JsonSerializationFormat? jsonSerializationFormat;
+        private readonly ChangeFeedPaginationOptions changeFeedPaginationOptions;
 
         public ChangeFeedPartitionRangePageAsyncEnumerator(
             IChangeFeedDataSource changeFeedDataSource,
-            FeedRangeInternal range,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
-            ChangeFeedState state,
+            FeedRangeState<ChangeFeedState> feedRangeState,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             CancellationToken cancellationToken)
-            : base(range, cancellationToken, state)
+            : base(feedRangeState, cancellationToken)
         {
             this.changeFeedDataSource = changeFeedDataSource ?? throw new ArgumentNullException(nameof(changeFeedDataSource));
-            this.changeFeedMode = changeFeedMode ?? throw new ArgumentNullException(nameof(changeFeedMode));
-            this.pageSize = pageSize;
-            this.jsonSerializationFormat = jsonSerializationFormat;
+            this.changeFeedPaginationOptions = changeFeedPaginationOptions ?? throw new ArgumentNullException(nameof(changeFeedPaginationOptions));
         }
 
         public override ValueTask DisposeAsync() => default;
@@ -41,11 +32,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         protected override Task<TryCatch<ChangeFeedPage>> GetNextPageAsync(
             ITrace trace, 
             CancellationToken cancellationToken) => this.changeFeedDataSource.MonadicChangeFeedAsync(
-            this.State,
-            this.Range,
-            this.pageSize,
-            this.changeFeedMode,
-            this.jsonSerializationFormat,
+            this.FeedRangeState,
+            this.changeFeedPaginationOptions,
             trace,
             cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedSuccessPage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedSuccessPage.cs
@@ -5,20 +5,27 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.IO;
 
     internal sealed class ChangeFeedSuccessPage : ChangeFeedPage
     {
+        private static readonly ImmutableHashSet<string> bannedHeaders = new HashSet<string>().ToImmutableHashSet();
+
         public ChangeFeedSuccessPage(
             Stream content,
             double requestCharge,
             string activityId,
+            IReadOnlyDictionary<string, string> additionalHeaders,
             ChangeFeedState state)
-            : base(requestCharge, activityId, state)
+            : base(requestCharge, activityId, additionalHeaders, state)
         {
             this.Content = content ?? throw new ArgumentNullException(nameof(content));
         }
 
         public Stream Content { get; }
+
+        protected override ImmutableHashSet<string> DerivedClassBannedHeaders => bannedHeaders;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -106,6 +106,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                                 changeFeedSuccessPage.Content,
                                 totalRequestCharge,
                                 changeFeedSuccessPage.ActivityId,
+                                changeFeedSuccessPage.AdditionalHeaders,
                                 changeFeedSuccessPage.State);
                         }
                         else
@@ -113,6 +114,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                             backendPage = new ChangeFeedNotModifiedPage(
                                 totalRequestCharge,
                                 backendPage.ActivityId,
+                                backendPage.AdditionalHeaders,
                                 backendPage.State);
                         }
                     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -130,30 +129,22 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 
         public static CrossPartitionChangeFeedAsyncEnumerator Create(
             IDocumentContainer documentContainer,
-            ChangeFeedMode changeFeedMode,
-            ChangeFeedRequestOptions changeFeedRequestOptions,
             CrossFeedRangeState<ChangeFeedState> state,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             CancellationToken cancellationToken)
         {
-            changeFeedRequestOptions ??= new ChangeFeedRequestOptions();
+            changeFeedPaginationOptions ??= ChangeFeedPaginationOptions.Default;
 
             if (documentContainer == null)
             {
                 throw new ArgumentNullException(nameof(documentContainer));
             }
 
-            if (changeFeedMode == null)
-            {
-                throw new ArgumentNullException(nameof(changeFeedMode));
-            }
-
             CrossPartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState> crossPartitionEnumerator = new CrossPartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState>(
                 documentContainer,
                 CrossPartitionChangeFeedAsyncEnumerator.MakeCreateFunction(
                     documentContainer,
-                    changeFeedRequestOptions.PageSizeHint.GetValueOrDefault(int.MaxValue),
-                    changeFeedMode,
-                    changeFeedRequestOptions?.JsonSerializationFormatOptions?.JsonSerializationFormat,
+                    changeFeedPaginationOptions,
                     cancellationToken),
                 comparer: default /* this uses a regular queue instead of prioirty queue */,
                 maxConcurrency: default,
@@ -169,16 +160,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 
         private static CreatePartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState> MakeCreateFunction(
             IChangeFeedDataSource changeFeedDataSource,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
-            CancellationToken cancellationToken) => (FeedRangeInternal range, ChangeFeedState state) => new ChangeFeedPartitionRangePageAsyncEnumerator(
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
+            CancellationToken cancellationToken) => (FeedRangeState<ChangeFeedState> feedRangeState) => new ChangeFeedPartitionRangePageAsyncEnumerator(
                 changeFeedDataSource,
-                range,
-                pageSize,
-                changeFeedMode,
-                jsonSerializationFormat,
-                state,
+                feedRangeState,
+                changeFeedPaginationOptions,
                 cancellationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -152,6 +153,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                     documentContainer,
                     changeFeedRequestOptions.PageSizeHint.GetValueOrDefault(int.MaxValue),
                     changeFeedMode,
+                    changeFeedRequestOptions?.JsonSerializationFormatOptions?.JsonSerializationFormat,
                     cancellationToken),
                 comparer: default /* this uses a regular queue instead of prioirty queue */,
                 maxConcurrency: default,
@@ -169,11 +171,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             IChangeFeedDataSource changeFeedDataSource,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             CancellationToken cancellationToken) => (FeedRangeInternal range, ChangeFeedState state) => new ChangeFeedPartitionRangePageAsyncEnumerator(
                 changeFeedDataSource,
                 range,
                 pageSize,
                 changeFeedMode,
+                jsonSerializationFormat,
                 state,
                 cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
@@ -6,18 +6,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Microsoft.Azure.Documents;
 
     internal interface IChangeFeedDataSource : IMonadicChangeFeedDataSource
     {
         Task<ChangeFeedPage> ChangeFeedAsync(
-            ChangeFeedState state,
-            FeedRangeInternal feedRange,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
+            FeedRangeState<ChangeFeedState> feedRangeState,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
 
     internal interface IChangeFeedDataSource : IMonadicChangeFeedDataSource
     {
@@ -15,6 +17,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
@@ -6,18 +6,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal interface IMonadicChangeFeedDataSource
     {
         Task<TryCatch<ChangeFeedPage>> MonadicChangeFeedAsync(
-            ChangeFeedState state,
-            FeedRangeInternal feedRange,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
+            FeedRangeState<ChangeFeedState> feedRangeState,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
 
@@ -16,6 +17,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosString.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosString.cs
@@ -78,6 +78,11 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
         public static CosmosString Create(string value)
         {
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
             return value.Length == 0 ? EagerCosmosString.Empty : new EagerCosmosString(value);
         }
 

--- a/Microsoft.Azure.Cosmos/src/Headers/StoreRequestNameValueCollection.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/StoreRequestNameValueCollection.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 return new string[] { value };
             }
-            
+
             return null;
         }
 
@@ -311,42 +311,42 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.HttpDate;
                     }
-                
+
                     break;
                 case 6:
                     if (string.Equals(HttpConstants.HttpHeaders.Prefer, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.Prefer;
                     }
-                
+
                     break;
                 case 9:
                     if (string.Equals(HttpConstants.HttpHeaders.XDate, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.XDate;
                     }
-                
+
                     break;
                 case 12:
                     if (string.Equals(HttpConstants.HttpHeaders.Version, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.Version;
                     }
-                
+
                     break;
                 case 13:
                     if (string.Equals(HttpConstants.HttpHeaders.Authorization, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.Authorization;
                     }
-                
+
                     break;
                 case 15:
                     if (string.Equals(HttpConstants.HttpHeaders.TargetLsn, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TargetLsn;
                     }
-                
+
                     break;
                 case 17:
                     if (object.ReferenceEquals(HttpConstants.HttpHeaders.Continuation, key))
@@ -361,40 +361,40 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.Continuation;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.TransactionId, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TransactionId;
                     }
-                
+
                     break;
                 case 18:
                     if (string.Equals(HttpConstants.HttpHeaders.SessionToken, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.SessionToken;
                     }
-                
+
                     break;
                 case 21:
                     if (string.Equals(WFConstants.BackendHeaders.TransactionCommit, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TransactionCommit;
                     }
-                
+
                     break;
                 case 22:
                     if (string.Equals(HttpConstants.HttpHeaders.ConsistencyLevel, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.ConsistencyLevel;
                     }
-                
+
                     break;
                 case 24:
                     if (string.Equals(HttpConstants.HttpHeaders.IsBatchAtomic, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.IsBatchAtomic;
                     }
-                
+
                     break;
                 case 25:
                     if (object.ReferenceEquals(HttpConstants.HttpHeaders.IsBatchOrdered, key))
@@ -417,22 +417,22 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.IsBatchOrdered;
                     }
-                
+
                     if (string.Equals(HttpConstants.HttpHeaders.IsUpsert, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.IsUpsert;
                     }
-                
+
                     if (string.Equals(HttpConstants.HttpHeaders.TransportRequestID, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TransportRequestID;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.ResourceTypes, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.ResourceTypes;
                     }
-                
+
                     break;
                 case 28:
                     if (object.ReferenceEquals(HttpConstants.HttpHeaders.PartitionKey, key))
@@ -451,17 +451,17 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.PartitionKey;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.EffectivePartitionKey, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.EffectivePartitionKey;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.TimeToLiveInSeconds, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TimeToLiveInSeconds;
                     }
-                
+
                     break;
                 case 30:
                     if (object.ReferenceEquals(HttpConstants.HttpHeaders.ResourceTokenExpiry, key))
@@ -480,31 +480,31 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.ResourceTokenExpiry;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.CollectionRid, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.CollectionRid;
                     }
-                
+
                     if (string.Equals(WFConstants.BackendHeaders.ExcludeSystemProperties, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.ExcludeSystemProperties;
                     }
-                
+
                     break;
                 case 31:
                     if (string.Equals(HttpConstants.HttpHeaders.ClientRetryAttemptCount, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.ClientRetryAttemptCount;
                     }
-                
+
                     break;
                 case 32:
                     if (string.Equals(HttpConstants.HttpHeaders.TargetGlobalCommittedLsn, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.TargetGlobalCommittedLsn;
                     }
-                
+
                     break;
                 case 35:
                     if (object.ReferenceEquals(HttpConstants.HttpHeaders.RemainingTimeInMsOnClientRequest, key))
@@ -519,12 +519,12 @@ namespace Microsoft.Azure.Cosmos
                     {
                         return this.RemainingTimeInMsOnClientRequest;
                     }
-                
+
                     if (string.Equals(HttpConstants.HttpHeaders.ShouldBatchContinueOnError, key, StringComparison.OrdinalIgnoreCase))
                     {
                         return this.ShouldBatchContinueOnError;
                     }
-                
+
                     break;
                 default:
                     break;
@@ -535,7 +535,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 return value;
             }
-            
+
             return null;
         }
 
@@ -552,8 +552,8 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.UpdateHelper(
-                key: key, 
-                value: value, 
+                key: key,
+                value: value,
                 throwIfAlreadyExists: true);
         }
 
@@ -565,8 +565,8 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.UpdateHelper(
-                key: key, 
-                value: null, 
+                key: key,
+                value: null,
                 throwIfAlreadyExists: false);
         }
 
@@ -584,13 +584,13 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.UpdateHelper(
-                key: key, 
-                value: value, 
+                key: key,
+                value: value,
                 throwIfAlreadyExists: false);
         }
 
         public void UpdateHelper(
-            string key, 
+            string key,
             string value,
             bool throwIfAlreadyExists)
         {

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -113,7 +113,7 @@
 
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
     <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
@@ -141,8 +141,8 @@
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
     <None Include="$(OutputPath)\Cosmos.CRTCompat.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
     <None Include="$(OutputPath)\Microsoft.Azure.Cosmos.ServiceInterop.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
-    <None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Serialization.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Core.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Serialization.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Serialization.HybridRow.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
+    <None Include="$(NugetPackageRoot)\Microsoft.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Core.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
+    <None Include="$(NugetPackageRoot)\Microsoft.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Serialization.HybridRow.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
     <None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Direct\$(DirectVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Direct.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
     <None Include="$(MSBuildThisFileDirectory)\Microsoft.Azure.Cosmos.targets" Pack="true" PackagePath="build\netstandard2.0">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Microsoft.Azure.Cosmos/src/Pagination/BufferedPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/BufferedPartitionRangePageAsyncEnumerator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
         private TryCatch<TPage>? bufferedPage;
 
         public BufferedPartitionRangePageAsyncEnumerator(PartitionRangePageAsyncEnumerator<TPage, TState> enumerator, CancellationToken cancellationToken)
-            : base(enumerator.Range, cancellationToken, enumerator.State)
+            : base(enumerator.FeedRangeState, cancellationToken)
         {
             this.enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
         }

--- a/Microsoft.Azure.Cosmos/src/Pagination/CreatePartitionRangeAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CreatePartitionRangeAsyncEnumerator.cs
@@ -5,8 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Pagination
 {
     internal delegate PartitionRangePageAsyncEnumerator<TPage, TState> CreatePartitionRangePageAsyncEnumerator<TPage, TState>(
-        FeedRangeInternal feedRange,
-        TState state)
+        FeedRangeState<TState> feedRangeState)
             where TPage : Page<TState>
             where TState : State;
 }

--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossFeedRangePage.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossFeedRangePage.cs
@@ -4,16 +4,23 @@
 
 namespace Microsoft.Azure.Cosmos.Pagination
 {
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
     internal sealed class CrossFeedRangePage<TBackendPage, TBackendState> : Page<CrossFeedRangeState<TBackendState>>
         where TBackendPage : Page<TBackendState>
         where TBackendState : State
     {
+        private static readonly ImmutableHashSet<string> bannedHeaders = new HashSet<string>().ToImmutableHashSet();
+
         public CrossFeedRangePage(TBackendPage backendEndPage, CrossFeedRangeState<TBackendState> state)
-            : base(state)
+            : base(backendEndPage.RequestCharge, backendEndPage.ActivityId, backendEndPage.AdditionalHeaders, state)
         {
             this.Page = backendEndPage;
         }
 
         public TBackendPage Page { get; }
+
+        protected override ImmutableHashSet<string> DerivedClassBannedHeaders => bannedHeaders;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 for (int i = 0; i < rangeAndStates.Length; i++)
                 {
                     FeedRangeState<TState> feedRangeState = rangeAndStates.Span[i];
-                    PartitionRangePageAsyncEnumerator<TPage, TState> enumerator = createPartitionRangeEnumerator(feedRangeState.FeedRange, feedRangeState.State);
+                    PartitionRangePageAsyncEnumerator<TPage, TState> enumerator = createPartitionRangeEnumerator(feedRangeState);
                     BufferedPartitionRangePageAsyncEnumerator<TPage, TState> bufferedEnumerator = new BufferedPartitionRangePageAsyncEnumerator<TPage, TState>(enumerator, cancellationToken);
                     bufferedEnumerators.Add(bufferedEnumerator);
                 }
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                         // Handle split
 
                         List<FeedRangeEpk> childRanges = await this.feedRangeProvider.GetChildRangeAsync(
-                            currentPaginator.Range,
+                            currentPaginator.FeedRangeState.FeedRange,
                             childTrace,
                             this.cancellationToken);
                         if (childRanges.Count == 0)
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                             // Then we need to refresh the cache
                             await this.feedRangeProvider.RefreshProviderAsync(childTrace, this.cancellationToken);
                             childRanges = await this.feedRangeProvider.GetChildRangeAsync(
-                                currentPaginator.Range,
+                                currentPaginator.FeedRangeState.FeedRange,
                                 childTrace,
                                 this.cancellationToken);
                         }
@@ -173,8 +173,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                         foreach (FeedRangeInternal childRange in childRanges)
                         {
                             PartitionRangePageAsyncEnumerator<TPage, TState> childPaginator = this.createPartitionRangeEnumerator(
-                                childRange,
-                                currentPaginator.State);
+                                new FeedRangeState<TState>(currentPaginator.FeedRangeState.FeedRange, currentPaginator.FeedRangeState.State));
                             enumerators.Enqueue(childPaginator);
                         }
 
@@ -186,11 +185,11 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     enumerators.Enqueue(currentPaginator);
 
                     this.Current = TryCatch<CrossFeedRangePage<TPage, TState>>.FromException(currentPaginator.Current.Exception);
-                    this.CurrentRange = currentPaginator.Range;
+                    this.CurrentRange = currentPaginator.FeedRangeState.FeedRange;
                     return true;
                 }
 
-                if (currentPaginator.State != default)
+                if (currentPaginator.FeedRangeState.State != default)
                 {
                     // Don't enqueue the paginator otherwise it's an infinite loop.
                     enumerators.Enqueue(currentPaginator);
@@ -207,7 +206,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     int i = 0;
                     foreach (PartitionRangePageAsyncEnumerator<TPage, TState> enumerator in enumerators)
                     {
-                        feedRangeAndStates[i++] = new FeedRangeState<TState>(enumerator.Range, enumerator.State);
+                        feedRangeAndStates[i++] = enumerator.FeedRangeState;
                     }
 
                     crossPartitionState = new CrossFeedRangeState<TState>(feedRangeAndStates);
@@ -215,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
 
                 this.Current = TryCatch<CrossFeedRangePage<TPage, TState>>.FromResult(
                     new CrossFeedRangePage<TPage, TState>(currentPaginator.Current.Result, crossPartitionState));
-                this.CurrentRange = currentPaginator.Range;
+                this.CurrentRange = currentPaginator.FeedRangeState.FeedRange;
                 return true;
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
@@ -143,7 +143,6 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     if (IsSplitException(exception))
                     {
                         // Handle split
-
                         List<FeedRangeEpk> childRanges = await this.feedRangeProvider.GetChildRangeAsync(
                             currentPaginator.FeedRangeState.FeedRange,
                             childTrace,
@@ -173,7 +172,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                         foreach (FeedRangeInternal childRange in childRanges)
                         {
                             PartitionRangePageAsyncEnumerator<TPage, TState> childPaginator = this.createPartitionRangeEnumerator(
-                                new FeedRangeState<TState>(currentPaginator.FeedRangeState.FeedRange, currentPaginator.FeedRangeState.State));
+                                new FeedRangeState<TState>(childRange, currentPaginator.FeedRangeState.State));
                             enumerators.Enqueue(childPaginator);
                         }
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
@@ -10,13 +10,11 @@ namespace Microsoft.Azure.Cosmos.Pagination
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Microsoft.Azure.Documents;
 
     /// <summary>
     /// Composes a <see cref="IMonadicDocumentContainer"/> and creates an <see cref="IDocumentContainer"/>.
@@ -103,61 +101,49 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 cancellationToken);
 
         public Task<TryCatch<ReadFeedPage>> MonadicReadFeedAsync(
-            ReadFeedState readFeedState,
-            FeedRangeInternal feedRange,
-            QueryRequestOptions queryRequestOptions,
-            int pageSize,
+            FeedRangeState<ReadFeedState> feedRangeState,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => this.monadicDocumentContainer.MonadicReadFeedAsync(
-                readFeedState,
-                feedRange,
-                queryRequestOptions,
-                pageSize,
+                feedRangeState,
+                readFeedPaginationOptions,
                 trace,
                 cancellationToken);
 
         public Task<ReadFeedPage> ReadFeedAsync(
-            ReadFeedState readFeedState,
-            FeedRangeInternal feedRange,
-            QueryRequestOptions queryRequestOptions,
-            int pageSize,
+            FeedRangeState<ReadFeedState> feedRangeState,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => TryCatch<ReadFeedPage>.UnsafeGetResultAsync(
                 this.MonadicReadFeedAsync(
-                    readFeedState,
-                    feedRange,
-                    queryRequestOptions,
-                    pageSize,
+                    feedRangeState,
+                    readFeedPaginationOptions,
                     trace,
                     cancellationToken),
                 cancellationToken);
 
         public Task<TryCatch<QueryPage>> MonadicQueryAsync(
             SqlQuerySpec sqlQuerySpec,
-            string continuationToken,
-            FeedRangeInternal feedRange,
-            int pageSize,
+            FeedRangeState<QueryState> feedRangeState,
+            QueryPaginationOptions queryPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => this.monadicDocumentContainer.MonadicQueryAsync(
                 sqlQuerySpec,
-                continuationToken,
-                feedRange,
-                pageSize,
+                feedRangeState,
+                queryPaginationOptions,
                 trace,
                 cancellationToken);
 
         public Task<QueryPage> QueryAsync(
             SqlQuerySpec sqlQuerySpec,
-            string continuationToken,
-            FeedRangeInternal feedRange,
-            int pageSize,
+            FeedRangeState<QueryState> feedRangeState,
+            QueryPaginationOptions queryPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => TryCatch<QueryPage>.UnsafeGetResultAsync(
                 this.MonadicQueryAsync(
                     sqlQuerySpec,
-                    continuationToken,
-                    feedRange,
-                    pageSize,
+                    feedRangeState,
+                    queryPaginationOptions,
                     trace,
                     cancellationToken),
                 cancellationToken);
@@ -195,36 +181,24 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 cancellationToken);
 
         public Task<ChangeFeedPage> ChangeFeedAsync(
-            ChangeFeedState state,
-            FeedRangeInternal feedRange,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
+            FeedRangeState<ChangeFeedState> feedRangeState,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => TryCatch<ChangeFeedPage>.UnsafeGetResultAsync(
                 this.MonadicChangeFeedAsync(
-                    state,
-                    feedRange,
-                    pageSize,
-                    changeFeedMode,
-                    jsonSerializationFormat,
+                    feedRangeState,
+                    changeFeedPaginationOptions,
                     trace,
                     cancellationToken), 
                 cancellationToken);
 
         public Task<TryCatch<ChangeFeedPage>> MonadicChangeFeedAsync(
-            ChangeFeedState state,
-            FeedRangeInternal feedRange,
-            int pageSize,
-            ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
+            FeedRangeState<ChangeFeedState> state,
+            ChangeFeedPaginationOptions changeFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken) => this.monadicDocumentContainer.MonadicChangeFeedAsync(
                 state,
-                feedRange,
-                pageSize,
-                changeFeedMode,
-                jsonSerializationFormat,
+                changeFeedPaginationOptions,
                 trace,
                 cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
@@ -10,11 +10,13 @@ namespace Microsoft.Azure.Cosmos.Pagination
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
 
     /// <summary>
     /// Composes a <see cref="IMonadicDocumentContainer"/> and creates an <see cref="IDocumentContainer"/>.
@@ -197,6 +199,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken) => TryCatch<ChangeFeedPage>.UnsafeGetResultAsync(
                 this.MonadicChangeFeedAsync(
@@ -204,6 +207,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     feedRange,
                     pageSize,
                     changeFeedMode,
+                    jsonSerializationFormat,
                     trace,
                     cancellationToken), 
                 cancellationToken);
@@ -213,12 +217,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken) => this.monadicDocumentContainer.MonadicChangeFeedAsync(
                 state,
                 feedRange,
                 pageSize,
                 changeFeedMode,
+                jsonSerializationFormat,
                 trace,
                 cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/IDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/IDocumentContainer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/IMonadicDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/IMonadicDocumentContainer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/JsonSerializationFormatExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/JsonSerializationFormatExtensions.cs
@@ -1,0 +1,27 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Json
+{
+    using System;
+    using Microsoft.Azure.Documents;
+
+    internal static class JsonSerializationFormatExtensions
+    {
+        private static readonly string Text = ContentSerializationFormat.JsonText.ToString();
+        private static readonly string Binary = ContentSerializationFormat.CosmosBinary.ToString();
+        private static readonly string HybridRow = ContentSerializationFormat.HybridRow.ToString();
+
+        public static string ToContentSerializationFormatString(this JsonSerializationFormat jsonSerializationFormat)
+        {
+            return jsonSerializationFormat switch
+            {
+                JsonSerializationFormat.Text => Text,
+                JsonSerializationFormat.Binary => Binary,
+                JsonSerializationFormat.HybridRow => HybridRow,
+                _ => throw new ArgumentOutOfRangeException($"Unknown {nameof(JsonSerializationFormat)}: {jsonSerializationFormat}"),
+            };
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
@@ -80,9 +81,9 @@ namespace Microsoft.Azure.Cosmos.Pagination
             long ticks = Number64.ToLong(((CosmosNumber)insertedDocument["_ts"]).Value);
 
             Record record = new Record(
-                resourceIdentifier, 
+                resourceIdentifier,
                 new DateTime(ticks: ticks, DateTimeKind.Utc),
-                identifier, 
+                identifier,
                 insertedDocument);
 
             return TryCatch<Record>.FromResult(record);
@@ -278,6 +279,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken)
         {
@@ -294,7 +296,13 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     state.Accept(ChangeFeedStateRequestMessagePopulator.Singleton, request);
 
                     request.Headers.PageSize = pageSize.ToString();
+
                     changeFeedMode.Accept(request);
+
+                    if (jsonSerializationFormat.HasValue)
+                    {
+                        request.Headers[HttpConstants.HttpHeaders.ContentSerializationFormat] = jsonSerializationFormat.Value.ToContentSerializationFormatString();
+                    }
                 },
                 feedRange: feedRange,
                 streamPayload: default,

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 sqlQuerySpec,
                 feedRangeState.State == null ? null : ((CosmosString)feedRangeState.State.Value).Value,
                 isContinuationExpected: false,
-                queryPaginationOptions.PageSizeHint ?? int.MaxValue,
+                queryPaginationOptions.PageSizeLimit ?? int.MaxValue,
                 trace,
                 cancellationToken);
 
@@ -312,9 +312,9 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 cosmosContainerCore: this.container,
                 requestEnricher: (request) =>
                 {
-                    if (changeFeedPaginationOptions.PageSizeHint.HasValue)
+                    if (changeFeedPaginationOptions.PageSizeLimit.HasValue)
                     {
-                        request.Headers[HttpConstants.HttpHeaders.PageSize] = changeFeedPaginationOptions.PageSizeHint.Value.ToString();
+                        request.Headers[HttpConstants.HttpHeaders.PageSize] = changeFeedPaginationOptions.PageSizeLimit.Value.ToString();
                     }
 
                     feedRangeState.State.Accept(ChangeFeedStateRequestMessagePopulator.Singleton, request);

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -180,14 +180,10 @@ namespace Microsoft.Azure.Cosmos.Pagination
                    cosmosContainerCore: this.container,
                    requestEnricher: request =>
                    {
+                       // We don't set page size here, since it's already set by the query request options.
                        if (feedRangeState.State is ReadFeedContinuationState readFeedContinuationState)
                        {
                            request.Headers.ContinuationToken = ((CosmosString)readFeedContinuationState.ContinuationToken).Value;
-                       }
-
-                       if (readFeedPaginationOptions.PageSizeHint.HasValue)
-                       {
-                           request.Headers.PageSize = readFeedPaginationOptions.PageSizeHint.Value.ToString();
                        }
 
                        if (readFeedPaginationOptions.JsonSerializationFormat.HasValue)

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -312,7 +312,10 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 cosmosContainerCore: this.container,
                 requestEnricher: (request) =>
                 {
-                    // We don't set page size here, since it's already set by the query request options.
+                    if (changeFeedPaginationOptions.PageSizeHint.HasValue)
+                    {
+                        request.Headers[HttpConstants.HttpHeaders.PageSize] = changeFeedPaginationOptions.PageSizeHint.Value.ToString();
+                    }
 
                     feedRangeState.State.Accept(ChangeFeedStateRequestMessagePopulator.Singleton, request);
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                     ReadFeedState state = responseMessage.Headers.ContinuationToken != null ? ReadFeedState.Continuation(CosmosString.Create(responseMessage.Headers.ContinuationToken)) : null;
                     Dictionary<string, string> additionalHeaders = GetAdditionalHeaders(
                         responseMessage.Headers.CosmosMessageHeaders,
-                        ReadFeedPaginationOptions.BannedHeaders);
+                        ReadFeedPage.BannedHeaders);
 
                     ReadFeedPage readFeedPage = new ReadFeedPage(
                         responseMessage.Content,
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
             ChangeFeedState state = ChangeFeedState.Continuation(CosmosString.Create(responseMessage.Headers.ETag));
             Dictionary<string, string> additionalHeaders = GetAdditionalHeaders(
                 responseMessage.Headers.CosmosMessageHeaders, 
-                ChangeFeedPaginationOptions.BannedHeaders);
+                ChangeFeedPage.BannedHeaders);
 
             TryCatch<ChangeFeedPage> monadicChangeFeedPage;
             if (responseMessage.StatusCode == HttpStatusCode.OK)

--- a/Microsoft.Azure.Cosmos/src/Pagination/Page.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/Page.cs
@@ -4,14 +4,53 @@
 
 namespace Microsoft.Azure.Cosmos.Pagination
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
     internal abstract class Page<TState>
         where TState : State
     {
-        protected Page(TState state)
+        protected static readonly ImmutableHashSet<string> BannedHeadersBase = new HashSet<string>()
         {
+            Microsoft.Azure.Documents.HttpConstants.HttpHeaders.RequestCharge,
+            Microsoft.Azure.Documents.HttpConstants.HttpHeaders.ActivityId,
+        }.ToImmutableHashSet();
+
+        private static readonly ImmutableDictionary<string, string> EmptyDictionary = new Dictionary<string, string>().ToImmutableDictionary();
+
+        protected Page(
+            double requestCharge, 
+            string activityId,
+            IReadOnlyDictionary<string, string> additionalHeaders,
+            TState state)
+        {
+            this.RequestCharge = requestCharge < 0 ? throw new ArgumentOutOfRangeException(nameof(requestCharge)) : requestCharge;
+            this.ActivityId = activityId ?? throw new ArgumentNullException(nameof(activityId));
             this.State = state;
+
+            if (additionalHeaders != null)
+            {
+                foreach (string key in additionalHeaders.Keys)
+                {
+                    if (BannedHeadersBase.Contains(key) || this.DerivedClassBannedHeaders.Contains(key))
+                    {
+                        throw new ArgumentOutOfRangeException($"'{key}' is not allowed as an additional header, since it's already defined in the schema.");
+                    }
+                }
+            }
+
+            this.AdditionalHeaders = additionalHeaders == null ? EmptyDictionary : additionalHeaders.ToImmutableDictionary();
         }
 
+        public double RequestCharge { get; }
+
+        public string ActivityId { get; }
+
+        public ImmutableDictionary<string, string> AdditionalHeaders { get; }
+
         public TState State { get; }
+
+        protected abstract ImmutableHashSet<string> DerivedClassBannedHeaders { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Pagination/Page.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/Page.cs
@@ -20,13 +20,13 @@ namespace Microsoft.Azure.Cosmos.Pagination
         private static readonly ImmutableDictionary<string, string> EmptyDictionary = new Dictionary<string, string>().ToImmutableDictionary();
 
         protected Page(
-            double requestCharge, 
+            double requestCharge,
             string activityId,
             IReadOnlyDictionary<string, string> additionalHeaders,
             TState state)
         {
             this.RequestCharge = requestCharge < 0 ? throw new ArgumentOutOfRangeException(nameof(requestCharge)) : requestCharge;
-            this.ActivityId = activityId ?? throw new ArgumentNullException(nameof(activityId));
+            this.ActivityId = activityId;
             this.State = state;
 
             if (additionalHeaders != null)

--- a/Microsoft.Azure.Cosmos/src/Pagination/PaginationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/PaginationOptions.cs
@@ -1,0 +1,49 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Pagination
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Documents;
+
+    internal abstract class PaginationOptions
+    {
+        private static readonly ImmutableHashSet<string> bannedAdditionalHeaders = new HashSet<string>()
+        {
+            HttpConstants.HttpHeaders.PageSize,
+        }.ToImmutableHashSet<string>();
+
+        private static readonly ImmutableDictionary<string, string> EmptyDictionary = new Dictionary<string, string>()
+            .ToImmutableDictionary<string, string>();
+
+        protected PaginationOptions(
+            int? pageSizeHint = null,
+            JsonSerializationFormat? jsonSerializationFormat = null,
+            Dictionary<string, string> additionalHeaders = null)
+        {
+            this.PageSizeHint = pageSizeHint;
+            this.JsonSerializationFormat = jsonSerializationFormat;
+            this.AdditionalHeaders = additionalHeaders != null ? additionalHeaders.ToImmutableDictionary<string, string>() : EmptyDictionary;
+
+            foreach (string key in this.AdditionalHeaders.Keys)
+            {
+                if (bannedAdditionalHeaders.Contains(key) || this.BannedAdditionalHeaders.Contains(key))
+                {
+                    throw new ArgumentOutOfRangeException($"The following http header is not allowed: '{key}'");
+                }
+            }
+        }
+
+        public int? PageSizeHint { get; }
+
+        public JsonSerializationFormat? JsonSerializationFormat { get; }
+
+        public ImmutableDictionary<string, string> AdditionalHeaders { get; }
+
+        protected abstract ImmutableHashSet<string> BannedAdditionalHeaders { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Pagination/PaginationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/PaginationOptions.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Azure.Cosmos.Pagination
             .ToImmutableDictionary<string, string>();
 
         protected PaginationOptions(
-            int? pageSizeHint = null,
+            int? pageSizeLimit = null,
             JsonSerializationFormat? jsonSerializationFormat = null,
             Dictionary<string, string> additionalHeaders = null)
         {
-            this.PageSizeHint = pageSizeHint;
+            this.PageSizeLimit = pageSizeLimit;
             this.JsonSerializationFormat = jsonSerializationFormat;
             this.AdditionalHeaders = additionalHeaders != null ? additionalHeaders.ToImmutableDictionary<string, string>() : EmptyDictionary;
 
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
             }
         }
 
-        public int? PageSizeHint { get; }
+        public int? PageSizeLimit { get; }
 
         public JsonSerializationFormat? JsonSerializationFormat { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/PartitionRangePageAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/PartitionRangePageAsyncEnumerable.cs
@@ -13,17 +13,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
         where TPage : Page<TState>
         where TState : State
     {
-        private readonly FeedRangeInternal range;
-        private readonly TState state;
+        private readonly FeedRangeState<TState> feedRangeState;
         private readonly CreatePartitionRangePageAsyncEnumerator<TPage, TState> createPartitionRangeEnumerator;
 
         public PartitionRangePageAsyncEnumerable(
-            FeedRangeInternal range,
-            TState state,
+            FeedRangeState<TState> feedRangeState,
             CreatePartitionRangePageAsyncEnumerator<TPage, TState> createPartitionRangeEnumerator)
         {
-            this.range = range ?? throw new ArgumentNullException(nameof(range));
-            this.state = state;
+            this.feedRangeState = feedRangeState;
             this.createPartitionRangeEnumerator = createPartitionRangeEnumerator ?? throw new ArgumentNullException(nameof(createPartitionRangeEnumerator));
         }
 
@@ -31,7 +28,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return this.createPartitionRangeEnumerator(this.range, this.state);
+            return this.createPartitionRangeEnumerator(this.feedRangeState);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Pagination/RestFeedResponseParser.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/RestFeedResponseParser.cs
@@ -1,0 +1,129 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Pagination
+{
+    using System;
+    using System.IO;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Serializer;
+    using Microsoft.Azure.Documents;
+
+    internal static class RestFeedResponseParser
+    {
+        public static CosmosArray ParseRestFeedResponse(
+            Stream stream, 
+            JsonSerializationFormatOptions jsonSerializationFormatOptions)
+        {
+            return ParseRestFeedResponse(stream, ResourceType.Document, jsonSerializationFormatOptions);
+        }
+
+        public static CosmosArray ParseRestFeedResponse(
+            Stream stream, 
+            ResourceType resourceType,
+            JsonSerializationFormatOptions jsonSerializationFormatOptions)
+        {
+            // Parse out the document from the REST response like this:
+            // {
+            //    "_rid": "qHVdAImeKAQ=",
+            //    "Documents": [{
+            //        "id": "03230",
+            //        "_rid": "qHVdAImeKAQBAAAAAAAAAA==",
+            //        "_self": "dbs\/qHVdAA==\/colls\/qHVdAImeKAQ=\/docs\/qHVdAImeKAQBAAAAAAAAAA==\/",
+            //        "_etag": "\"410000b0-0000-0000-0000-597916b00000\"",
+            //        "_attachments": "attachments\/",
+            //        "_ts": 1501107886
+            //    }],
+            //    "_count": 1
+            // }
+            // You want to create a CosmosElement for each document in "Documents".
+
+            ReadOnlyMemory<byte> content = StreamToBytes(stream);
+            IJsonNavigator jsonNavigator = CreateNavigatorFromContent(content, jsonSerializationFormatOptions);
+            string arrayKeyName = ResourceTypeToArrayKeyName(resourceType);
+            return GetResourceArrayFromNavigator(jsonNavigator, arrayKeyName);
+        }
+
+        private static ReadOnlyMemory<byte> StreamToBytes(Stream stream)
+        {
+            if (!(stream is MemoryStream memoryStream))
+            {
+                memoryStream = new MemoryStream();
+                stream.CopyTo(memoryStream);
+            }
+
+            if (!memoryStream.CanRead)
+            {
+                throw new InvalidDataException("Stream can not be read");
+            }
+
+            ReadOnlyMemory<byte> content = memoryStream.TryGetBuffer(out ArraySegment<byte> buffer) ? buffer : (ReadOnlyMemory<byte>)memoryStream.ToArray();
+            return content;
+        }
+
+        private static IJsonNavigator CreateNavigatorFromContent(ReadOnlyMemory<byte> content, JsonSerializationFormatOptions jsonSerializationFormatOptions)
+        {
+            IJsonNavigator jsonNavigator;
+            if (jsonSerializationFormatOptions != null)
+            {
+                if (jsonSerializationFormatOptions is JsonSerializationFormatOptions.CustomJsonSerializationFormatOptions customOptions)
+                {
+                    jsonNavigator = customOptions.createNavigator(content);
+                    if (jsonNavigator == null)
+                    {
+                        throw new InvalidOperationException("The CosmosSerializationOptions did not return a JSON navigator.");
+                    }
+                }
+                else if (jsonSerializationFormatOptions is JsonSerializationFormatOptions.NativelySupportedJsonSerializationFormatOptions)
+                {
+                    jsonNavigator = JsonNavigator.Create(content);
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException($"Unknown {nameof(JsonSerializationFormatOptions)} type: {jsonSerializationFormatOptions.GetType()}");
+                }
+            }
+            else
+            {
+                jsonNavigator = JsonNavigator.Create(content);
+            }
+
+            return jsonNavigator;
+        }
+
+        private static string ResourceTypeToArrayKeyName(ResourceType resourceType)
+        {
+            return resourceType switch
+            {
+                ResourceType.Database => "Databases",
+                ResourceType.Collection => "DocumentCollections",
+                ResourceType.Document => "Documents",
+                _ => throw new ArgumentOutOfRangeException($"Unknown {nameof(resourceType)}: {resourceType}"),
+            };
+        }
+        
+        private static CosmosArray GetResourceArrayFromNavigator(
+            IJsonNavigator jsonNavigator, 
+            string arrayKeyName)
+        {
+            if (!jsonNavigator.TryGetObjectProperty(
+                jsonNavigator.GetRootNode(),
+                arrayKeyName,
+                out ObjectProperty objectProperty))
+            {
+                throw new InvalidOperationException($"Response Body Contract was violated. FeedResponse did not have property: {arrayKeyName}");
+            }
+
+            if (!(CosmosElement.Dispatch(
+                jsonNavigator,
+                objectProperty.ValueNode) is CosmosArray cosmosArray))
+            {
+                throw new InvalidOperationException($"FeedResponse did not have an array of : {arrayKeyName}");
+            }
+
+            return cosmosArray;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class AggregateQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                     responseLengthInBytes: responseLengthBytes,
                     cosmosQueryExecutionInfo: default,
                     disallowContinuationTokenMessage: default,
+                    additionalHeaders: default,
                     state: default);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Compute.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class AggregateQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Compute.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                         responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                        additionalHeaders: sourcePage.AdditionalHeaders,
                         state: queryState);
 
                     queryPage = emptyPage;
@@ -169,6 +170,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                         responseLengthInBytes: default,
                         cosmosQueryExecutionInfo: default,
                         disallowContinuationTokenMessage: default,
+                        additionalHeaders: default,
                         state: default);
 
                     queryPage = finalPage;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CatchAllQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CatchAllQueryPipelineStage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal sealed class CatchAllQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Tokens;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
@@ -367,7 +368,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                             isMinInclusive: true,
                             isMaxInclusive: false)))
                     .ToList(),
-                pageSize: inputParameters.MaxItemCount,
+                queryPaginationOptions: new QueryPaginationOptions(
+                    pageSizeHint: inputParameters.MaxItemCount),
                 partitionKey: inputParameters.PartitionKey,
                 maxConcurrency: inputParameters.MaxConcurrency,
                 cancellationToken: cancellationToken,
@@ -424,7 +426,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     .ToList(),
                 partitionKey: inputParameters.PartitionKey,
                 queryInfo: partitionedQueryExecutionInfo.QueryInfo,
-                pageSize: (int)optimalPageSize,
+                queryPaginationOptions: new QueryPaginationOptions(
+                    pageSizeHint: (int)optimalPageSize),
                 maxConcurrency: inputParameters.MaxConcurrency,
                 requestContinuationToken: inputParameters.InitialUserContinuationToken,
                 requestCancellationToken: cancellationToken);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                         responseLengthInBytes: 0,
                         cosmosQueryExecutionInfo: default,
                         disallowContinuationTokenMessage: default,
+                        additionalHeaders: default,
                         state: this.state));
                 return true;
             }
@@ -147,6 +148,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                                 responseLengthInBytes: 0,
                                 cosmosQueryExecutionInfo: default,
                                 disallowContinuationTokenMessage: default,
+                                additionalHeaders: default,
                                 state: null));
                         this.returnedFinalPage = true;
                         return true;
@@ -167,6 +169,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                         responseLengthInBytes: page.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: page.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: page.DisallowContinuationTokenMessage,
+                        additionalHeaders: page.AdditionalHeaders,
                         state: this.state));
             }
 
@@ -227,6 +230,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                             responseLengthInBytes: 0,
                             cosmosQueryExecutionInfo: default,
                             disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
                             state: null));
                     this.returnedFinalPage = true;
                     return true;
@@ -270,6 +274,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                     responseLengthInBytes: page.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: page.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: page.DisallowContinuationTokenMessage,
+                    additionalHeaders: page.AdditionalHeaders,
                     state: InitializingQueryState));
 
             return true;
@@ -397,6 +402,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                                 responseLengthInBytes: 0,
                                 cosmosQueryExecutionInfo: default,
                                 disallowContinuationTokenMessage: default,
+                                additionalHeaders: default,
                                 state: this.state));
                         return new ValueTask<bool>(true);
                     }
@@ -451,6 +457,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                     responseLengthInBytes: 0,
                     cosmosQueryExecutionInfo: default,
                     disallowContinuationTokenMessage: default,
+                    additionalHeaders: default,
                     state: this.state));
 
             if (state == null)
@@ -517,6 +524,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                             responseLengthInBytes: 0,
                             cosmosQueryExecutionInfo: default,
                             disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
                             state: null));
                     this.returnedFinalPage = true;
                     return new ValueTask<bool>(true);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             // Try to form a page with as many items in the sorted order without having to do async work.
             List<OrderByQueryResult> results = new List<OrderByQueryResult>();
-            while (results.Count < this.queryPaginationOptions.PageSizeHint.GetValueOrDefault(int.MaxValue))
+            while (results.Count < this.queryPaginationOptions.PageSizeLimit.GetValueOrDefault(int.MaxValue))
             {
                 currentEnumerator = this.enumerators.Dequeue();
                 orderByQueryResult = new OrderByQueryResult(currentEnumerator.Current.Result.Enumerator.Current);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByEnumeratorComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByEnumeratorComparer.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             if (enumerator1.Current.Failed && enumerator2.Current.Failed)
             {
-                return string.CompareOrdinal(((FeedRangeEpk)enumerator1.Range).Range.Min, ((FeedRangeEpk)enumerator2.Range).Range.Min);
+                return string.CompareOrdinal(((FeedRangeEpk)enumerator1.FeedRangeState.FeedRange).Range.Min, ((FeedRangeEpk)enumerator2.FeedRangeState.FeedRange).Range.Min);
             }
 
             OrderByQueryResult result1 = new OrderByQueryResult(enumerator1.Current.Result.Enumerator.Current);
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             }
 
             // If there is a tie, then break the tie by picking the one from the left most partition.
-            return string.CompareOrdinal(((FeedRangeEpk)enumerator1.Range).Range.Min, ((FeedRangeEpk)enumerator2.Range).Range.Min);
+            return string.CompareOrdinal(((FeedRangeEpk)enumerator1.FeedRangeState.FeedRange).Range.Min, ((FeedRangeEpk)enumerator2.FeedRangeState.FeedRange).Range.Min);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPage.cs
@@ -6,14 +6,21 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
 
     internal sealed class OrderByQueryPage : Page<QueryState>
     {
+        private static readonly ImmutableHashSet<string> bannedHeaders = new HashSet<string>()
+        {
+            Microsoft.Azure.Documents.HttpConstants.HttpHeaders.Continuation,
+            Microsoft.Azure.Documents.HttpConstants.HttpHeaders.ContinuationToken,
+        }.ToImmutableHashSet();
+
         public OrderByQueryPage(QueryPage queryPage)
-            : base(queryPage.State)
+            : base(queryPage.RequestCharge, queryPage.ActivityId, queryPage.AdditionalHeaders, queryPage.State)
         {
             this.Page = queryPage ?? throw new ArgumentNullException(nameof(queryPage));
             this.Enumerator = queryPage.Documents.GetEnumerator();
@@ -22,5 +29,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         public QueryPage Page { get; }
 
         public IEnumerator<CosmosElement> Enumerator { get; }
+
+        protected override ImmutableHashSet<string> DerivedClassBannedHeaders => bannedHeaders;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
     using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
 
     internal sealed class OrderByQueryPage : Page<QueryState>
     {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryPartitionRangePageAsyncEnumerator.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 return this.queryDataSource
                     .MonadicQueryAsync(
                         sqlQuerySpec: this.SqlQuerySpec,
-                        feedRangeState: this.FeedRangeState,
+                        feedRangeState: new FeedRangeState<QueryState>(feedRange, this.FeedRangeState.State),
                         queryPaginationOptions: this.queryPaginationOptions,
                         trace: trace,
                         cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 backendQueryPage.ResponseLengthInBytes,
                 backendQueryPage.CosmosQueryExecutionInfo,
                 backendQueryPage.DisallowContinuationTokenMessage,
+                backendQueryPage.AdditionalHeaders,
                 queryState);
 
             this.Current = TryCatch<QueryPage>.FromResult(crossPartitionQueryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using static Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.PartitionMapper;
 
@@ -137,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             SqlQuerySpec sqlQuerySpec,
             IReadOnlyList<FeedRangeEpk> targetRanges,
             Cosmos.PartitionKey? partitionKey,
-            int pageSize,
+            QueryPaginationOptions queryPaginationOptions,
             int maxConcurrency,
             CosmosElement continuationToken,
             CancellationToken cancellationToken)
@@ -152,11 +153,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 throw new ArgumentException($"{nameof(targetRanges)} must have some elements");
             }
 
-            if (pageSize <= 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(pageSize));
-            }
-
             TryCatch<CrossFeedRangeState<QueryState>> monadicExtractState = MonadicExtractState(continuationToken, targetRanges);
             if (monadicExtractState.Failed)
             {
@@ -167,7 +163,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
 
             CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState> crossPartitionPageEnumerator = new CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState>(
                 documentContainer,
-                ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, pageSize, partitionKey, cancellationToken),
+                ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, queryPaginationOptions, partitionKey, cancellationToken),
                 comparer: Comparer.Singleton,
                 maxConcurrency,
                 state: state,
@@ -251,16 +247,15 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
         private static CreatePartitionRangePageAsyncEnumerator<QueryPage, QueryState> MakeCreateFunction(
             IQueryDataSource queryDataSource,
             SqlQuerySpec sqlQuerySpec,
-            int pageSize,
+            QueryPaginationOptions queryPaginationOptions,
             Cosmos.PartitionKey? partitionKey,
-            CancellationToken cancellationToken) => (FeedRangeInternal range, QueryState state) => new QueryPartitionRangePageAsyncEnumerator(
+            CancellationToken cancellationToken) => (FeedRangeState<QueryState> feedRangeState) => new QueryPartitionRangePageAsyncEnumerator(
                 queryDataSource,
                 sqlQuerySpec,
-                range,
+                feedRangeState,
                 partitionKey,
-                pageSize,
-                cancellationToken: cancellationToken,
-                state);
+                queryPaginationOptions,
+                cancellationToken);
 
         public void SetCancellationToken(CancellationToken cancellationToken)
         {
@@ -283,8 +278,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
 
                 // Either both don't have results or both do.
                 return string.CompareOrdinal(
-                    ((FeedRangeEpk)partitionRangePageEnumerator1.Range).Range.Min,
-                    ((FeedRangeEpk)partitionRangePageEnumerator2.Range).Range.Min);
+                    ((FeedRangeEpk)partitionRangePageEnumerator1.FeedRangeState.FeedRange).Range.Min,
+                    ((FeedRangeEpk)partitionRangePageEnumerator2.FeedRangeState.FeedRange).Range.Min);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 throw new ArgumentNullException(nameof(trace));
             }
 
+            // We sadly need to check the partition key, since a user can set a partition key in the request options with a different continuation token.
+            // In the future the partition filtering and continuation information needs to be a tightly bounded contract (like cross feed range state).
             FeedRangeInternal feedRange = this.partitionKey.HasValue ? new FeedRangePartitionKey(this.partitionKey.Value) : this.FeedRangeState.FeedRange;
             return this.queryDataSource.MonadicQueryAsync(
               sqlQuerySpec: this.sqlQuerySpec,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Client.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Client.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -73,6 +74,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
 
                 double requestCharge = 0;
                 long responseLengthBytes = 0;
+                ImmutableDictionary<string, string> additionalHeaders = null;
                 while (await this.inputStage.MoveNextAsync(trace))
                 {
                     TryCatch<QueryPage> tryGetPageFromSource = this.inputStage.Current;
@@ -86,6 +88,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
 
                     requestCharge += sourcePage.RequestCharge;
                     responseLengthBytes += sourcePage.ResponseLengthInBytes;
+                    additionalHeaders = sourcePage.AdditionalHeaders;
 
                     this.cancellationToken.ThrowIfCancellationRequested();
                     this.count += sourcePage.Documents.Count;
@@ -105,6 +108,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
                     responseLengthInBytes: responseLengthBytes,
                     cosmosQueryExecutionInfo: default,
                     disallowContinuationTokenMessage: default,
+                    additionalHeaders: additionalHeaders,
                     state: default);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Compute.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/DCount/DCountQueryPipelineStage.Compute.cs
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
                         responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                        additionalHeaders: sourcePage.AdditionalHeaders,
                         state: queryState);
 
                     queryPage = emptyPage;
@@ -151,6 +152,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount
                         responseLengthInBytes: default,
                         cosmosQueryExecutionInfo: default,
                         disallowContinuationTokenMessage: default,
+                        additionalHeaders: default,
                         state: default);
 
                     queryPage = finalPage;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Client.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Client.cs
@@ -174,6 +174,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                         responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                        additionalHeaders: sourcePage.AdditionalHeaders,
                         state: state);
                 }
                 else
@@ -185,6 +186,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                         responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: ClientDistinctQueryPipelineStage.DisallowContinuationTokenMessage,
+                        additionalHeaders: sourcePage.AdditionalHeaders,
                         state: null);
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Compute.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.Compute.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                     responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: ComputeDistinctQueryPipelineStage.UseTryGetContinuationTokenMessage,
+                    additionalHeaders: sourcePage.AdditionalHeaders,
                     state: queryState);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/EmptyQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/EmptyQueryPipelineStage.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Reactive;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/FaultedQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/FaultedQueryPipelineStage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Reactive;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Client.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -82,6 +83,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
 
                 double requestCharge = 0.0;
                 long responseLengthInBytes = 0;
+                ImmutableDictionary<string, string> addtionalHeaders = null;
 
                 while (await this.inputStage.MoveNextAsync(trace))
                 {
@@ -100,6 +102,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
 
                     requestCharge += sourcePage.RequestCharge;
                     responseLengthInBytes += sourcePage.ResponseLengthInBytes;
+                    addtionalHeaders = sourcePage.AdditionalHeaders;
                     this.AggregateGroupings(sourcePage.Documents);
                 }
 
@@ -114,11 +117,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
                 QueryPage queryPage = new QueryPage(
                     documents: results,
                     requestCharge: requestCharge,
-                    activityId: null,
+                    activityId: default,
                     responseLengthInBytes: responseLengthInBytes,
-                    cosmosQueryExecutionInfo: null,
+                    cosmosQueryExecutionInfo: default,
                     disallowContinuationTokenMessage: ClientGroupByQueryPipelineStage.ContinuationTokenNotSupportedWithGroupBy,
-                    state: null);
+                    additionalHeaders: addtionalHeaders,
+                    state: default);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);
                 return true;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Client.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class GroupByQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Compute.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
                         responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                         cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: null,
+                        additionalHeaders: sourcePage.AdditionalHeaders,
                         state: state);
                 }
                 else
@@ -172,6 +173,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
                         responseLengthInBytes: default,
                         cosmosQueryExecutionInfo: default,
                         disallowContinuationTokenMessage: default,
+                        additionalHeaders: default,
                         state: state);
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.Compute.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class GroupByQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/IQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/IQueryPipelineStage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal interface IQueryPipelineStage : IAsyncEnumerator<TryCatch<QueryPage>>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/LazyQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/LazyQueryPipelineStage.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal sealed class LazyQueryPipelineStage : IQueryPipelineStage

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/NameCacheStaleRetryQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/NameCacheStaleRetryQueryPipelineStage.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/IMonadicQueryDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/IMonadicQueryDataSource.cs
@@ -2,21 +2,20 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition
+namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
 
-    internal interface IQueryDataSource : IMonadicQueryDataSource
+    internal interface IMonadicQueryDataSource
     {
-        Task<QueryPage> QueryAsync(
+        Task<TryCatch<QueryPage>> MonadicQueryAsync(
             SqlQuerySpec sqlQuerySpec,
-            string continuationToken,
-            FeedRangeInternal feedRange,
-            int pageSize,
+            FeedRangeState<QueryState> feedRangeState,
+            QueryPaginationOptions queryPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/IQueryDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/IQueryDataSource.cs
@@ -2,20 +2,20 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition
+namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Tracing;
 
-    internal interface IMonadicQueryDataSource
+    internal interface IQueryDataSource : IMonadicQueryDataSource
     {
-        Task<TryCatch<QueryPage>> MonadicQueryAsync(
+        Task<QueryPage> QueryAsync(
             SqlQuerySpec sqlQuerySpec,
-            string continuationToken,
-            FeedRangeInternal feedRange,
-            int pageSize,
+            FeedRangeState<QueryState> feedRangeState,
+            QueryPaginationOptions queryPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryPage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryPage.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
+namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination
 {
     using System;
     using System.Collections.Generic;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryPaginationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryPaginationOptions.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Pagination;
+
+    internal sealed class QueryPaginationOptions : PaginationOptions
+    {
+        public static readonly QueryPaginationOptions Default = new QueryPaginationOptions();
+
+        public QueryPaginationOptions(
+            int? pageSizeHint = null,
+            JsonSerializationFormat? jsonSerializationFormat = null,
+            Dictionary<string, string> additionalHeaders = null)
+            : base(pageSizeHint, jsonSerializationFormat, additionalHeaders)
+        {
+        }
+
+        private static readonly ImmutableHashSet<string> bannedAdditionalHeaders = new HashSet<string>().ToImmutableHashSet();
+
+        protected override ImmutableHashSet<string> BannedAdditionalHeaders => bannedAdditionalHeaders;
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryState.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Pagination/QueryState.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
+namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination
 {
     using System;
     using Microsoft.Azure.Cosmos.CosmosElements;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.DCount;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
             IReadOnlyList<FeedRangeEpk> targetRanges,
             PartitionKey? partitionKey,
             QueryInfo queryInfo,
-            int pageSize,
+            QueryPaginationOptions queryPaginationOptions,
             int maxConcurrency,
             CosmosElement requestContinuationToken,
             CancellationToken requestCancellationToken)
@@ -73,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     orderByColumns: queryInfo
                         .OrderByExpressions
                         .Zip(queryInfo.OrderBy, (expression, sortOrder) => new OrderByColumn(expression, sortOrder)).ToList(),
-                    pageSize: pageSize,
+                    queryPaginationOptions: queryPaginationOptions,
                     maxConcurrency: maxConcurrency,
                     continuationToken: continuationToken,
                     cancellationToken: cancellationToken);
@@ -84,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     documentContainer: documentContainer,
                     sqlQuerySpec: sqlQuerySpec,
                     targetRanges: targetRanges,
-                    pageSize: pageSize,
+                    queryPaginationOptions: queryPaginationOptions,
                     partitionKey: partitionKey,
                     maxConcurrency: maxConcurrency,
                     continuationToken: continuationToken,
@@ -127,7 +128,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     queryInfo.GroupByAliasToAggregateType,
                     queryInfo.GroupByAliases,
                     queryInfo.HasSelectValue,
-                    pageSize);
+                    (queryPaginationOptions ?? QueryPaginationOptions.Default).PageSizeHint.GetValueOrDefault(int.MaxValue));
             }
 
             if (queryInfo.HasOffset)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     queryInfo.GroupByAliasToAggregateType,
                     queryInfo.GroupByAliases,
                     queryInfo.HasSelectValue,
-                    (queryPaginationOptions ?? QueryPaginationOptions.Default).PageSizeHint.GetValueOrDefault(int.MaxValue));
+                    (queryPaginationOptions ?? QueryPaginationOptions.Default).PageSizeLimit.GetValueOrDefault(int.MaxValue));
             }
 
             if (queryInfo.HasOffset)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/QueryPipelineStageBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/QueryPipelineStageBase.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract class QueryPipelineStageBase : IQueryPipelineStage

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
                     responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                    additionalHeaders: sourcePage.AdditionalHeaders,
                     state: state);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Compute.cs
@@ -126,6 +126,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
                     responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                    additionalHeaders: sourcePage.AdditionalHeaders,
                     state: state);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Compute.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class SkipQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/SkipEmptyPageQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/SkipEmptyPageQueryPipelineStage.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal sealed class SkipEmptyPageQueryPipelineStage : IQueryPipelineStage

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
@@ -231,6 +231,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                    additionalHeaders: sourcePage.AdditionalHeaders,
                     state: state);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Newtonsoft.Json;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal abstract partial class TakeQueryPipelineStage : QueryPipelineStageBase

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     responseLengthInBytes: sourcePage.ResponseLengthInBytes,
                     cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
                     disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                    additionalHeaders: sourcePage.AdditionalHeaders,
                     state: queryState);
 
                 this.Current = TryCatch<QueryPage>.FromResult(queryPage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryContext.cs
@@ -7,11 +7,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;
     using OperationType = Documents.OperationType;
-    using PartitionKeyRangeIdentity = Documents.PartitionKeyRangeIdentity;
     using ResourceType = Documents.ResourceType;
 
     internal abstract class CosmosQueryContext

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -372,6 +372,15 @@ namespace Microsoft.Azure.Cosmos
                         queryState = default;
                     }
 
+                    Dictionary<string, string> additionalHeaders = new Dictionary<string, string>();
+                    foreach (string key in cosmosResponseMessage.Headers)
+                    {
+                        if (!QueryPage.BannedHeaders.Contains(key))
+                        {
+                            additionalHeaders[key] = cosmosResponseMessage.Headers[key];
+                        }
+                    }
+
                     QueryPage response = new QueryPage(
                         documents,
                         cosmosResponseMessage.Headers.RequestCharge,
@@ -379,6 +388,7 @@ namespace Microsoft.Azure.Cosmos
                         responseLengthBytes,
                         cosmosQueryExecutionInfo,
                         disallowContinuationTokenMessage: null,
+                        additionalHeaders,
                         queryState);
 
                     return TryCatch<QueryPage>.FromResult(response);

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Json;
-    using Microsoft.Azure.Cosmos.Linq;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryContextCore.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.Query
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tracing;

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -208,22 +208,29 @@ namespace Microsoft.Azure.Cosmos.Query
                         this.hasMoreResults = false;
                     }
 
+                    CosmosQueryResponseMessageHeaders headers = new CosmosQueryResponseMessageHeaders(
+                            tryGetQueryPage.Result.State?.Value.ToString(),
+                            tryGetQueryPage.Result.DisallowContinuationTokenMessage,
+                            this.cosmosQueryContext.ResourceTypeEnum,
+                            this.cosmosQueryContext.ContainerResourceId)
+                    {
+                        RequestCharge = tryGetQueryPage.Result.RequestCharge,
+                        ActivityId = tryGetQueryPage.Result.ActivityId,
+                        SubStatusCode = Documents.SubStatusCodes.Unknown
+                    };
+
+                    foreach (KeyValuePair<string, string> kvp in tryGetQueryPage.Result.AdditionalHeaders)
+                    {
+                        headers[kvp.Key] = kvp.Value;
+                    }
+
                     return QueryResponse.CreateSuccess(
                         result: tryGetQueryPage.Result.Documents,
                         count: tryGetQueryPage.Result.Documents.Count,
                         responseLengthBytes: tryGetQueryPage.Result.ResponseLengthInBytes,
                         diagnostics: diagnostics,
                         serializationOptions: this.cosmosSerializationFormatOptions,
-                        responseHeaders: new CosmosQueryResponseMessageHeaders(
-                            tryGetQueryPage.Result.State?.Value.ToString(),
-                            tryGetQueryPage.Result.DisallowContinuationTokenMessage,
-                            this.cosmosQueryContext.ResourceTypeEnum,
-                            this.cosmosQueryContext.ContainerResourceId)
-                        {
-                            RequestCharge = tryGetQueryPage.Result.RequestCharge,
-                            ActivityId = tryGetQueryPage.Result.ActivityId,
-                            SubStatusCode = Documents.SubStatusCodes.Unknown
-                        });
+                        responseHeaders: headers);
                 }
 
                 CosmosException cosmosException = ExceptionToCosmosException.CreateFromException(tryGetQueryPage.Exception);

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/IMonadicReadFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/IMonadicReadFeedDataSource.cs
@@ -6,16 +6,15 @@ namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal interface IMonadicReadFeedDataSource
     {
         Task<TryCatch<ReadFeedPage>> MonadicReadFeedAsync(
-            ReadFeedState readFeedState,
-            FeedRangeInternal feedRange,
-            QueryRequestOptions queryRequestOptions,
-            int pageSize,
+            FeedRangeState<ReadFeedState> feedRangeState,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/IReadFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/IReadFeedDataSource.cs
@@ -6,15 +6,14 @@ namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal interface IReadFeedDataSource : IMonadicReadFeedDataSource
     {
         Task<ReadFeedPage> ReadFeedAsync(
-            ReadFeedState readFeedState,
-            FeedRangeInternal feedRange,
-            QueryRequestOptions queryRequestOptions,
-            int pageSize,
+            FeedRangeState<ReadFeedState> feedRangeState,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/ReadFeedPaginationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/ReadFeedPaginationOptions.cs
@@ -1,0 +1,36 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Pagination;
+
+    internal sealed class ReadFeedPaginationOptions : PaginationOptions
+    {
+        public static readonly ReadFeedPaginationOptions Default = new ReadFeedPaginationOptions();
+
+        public ReadFeedPaginationOptions(
+            PaginationDirection? paginationDirection = null,
+            int? pageSizeHint = null,
+            JsonSerializationFormat? jsonSerializationFormat = null,
+            Dictionary<string, string> additionalHeaders = null)
+            : base(pageSizeHint, jsonSerializationFormat, additionalHeaders)
+        {
+            this.Direction = paginationDirection;
+        }
+
+        public PaginationDirection? Direction { get; }
+
+        protected override ImmutableHashSet<string> BannedAdditionalHeaders => throw new System.NotImplementedException();
+
+        public enum PaginationDirection
+        {
+            Forward,
+            Reverse,
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/ReadFeedPartitionRangeEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/ReadFeedPartitionRangeEnumerator.cs
@@ -15,33 +15,24 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     internal sealed class ReadFeedPartitionRangeEnumerator : PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>
     {
         private readonly IReadFeedDataSource readFeedDataSource;
-        private readonly QueryRequestOptions queryRequestOptions;
-        private readonly int pageSize;
+        private readonly ReadFeedPaginationOptions readFeedPaginationOptions;
 
         public ReadFeedPartitionRangeEnumerator(
             IReadFeedDataSource readFeedDataSource,
-            FeedRangeInternal feedRange,
-            QueryRequestOptions queryRequestOptions,
-            int pageSize,
-            CancellationToken cancellationToken,
-            ReadFeedState state)
-            : base(
-                  feedRange,
-                  cancellationToken,
-                  state)
+            FeedRangeState<ReadFeedState> feedRangeState,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
+            CancellationToken cancellationToken)
+            : base(feedRangeState, cancellationToken)
         {
             this.readFeedDataSource = readFeedDataSource ?? throw new ArgumentNullException(nameof(readFeedDataSource));
-            this.queryRequestOptions = queryRequestOptions;
-            this.pageSize = pageSize;
+            this.readFeedPaginationOptions = readFeedPaginationOptions;
         }
 
         public override ValueTask DisposeAsync() => default;
 
         protected override Task<TryCatch<ReadFeedPage>> GetNextPageAsync(ITrace trace, CancellationToken cancellationToken = default) => this.readFeedDataSource.MonadicReadFeedAsync(
-            feedRange: this.Range,
-            readFeedState: this.State,
-            queryRequestOptions: this.queryRequestOptions,
-            pageSize: this.pageSize,
+            feedRangeState: this.FeedRangeState,
+            readFeedPaginationOptions: this.readFeedPaginationOptions,
             trace: trace,
             cancellationToken: cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedCrossFeedRangeAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedCrossFeedRangeAsyncEnumerable.cs
@@ -14,17 +14,17 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
     internal sealed class ReadFeedCrossFeedRangeAsyncEnumerable : IAsyncEnumerable<TryCatch<ReadFeedPage>>
     {
         private readonly IDocumentContainer documentContainer;
-        private readonly QueryRequestOptions requestOptions;
         private readonly ReadFeedCrossFeedRangeState state;
+        private readonly ReadFeedPaginationOptions readFeedPaginationOptions;
 
         public ReadFeedCrossFeedRangeAsyncEnumerable(
             IDocumentContainer documentContainer,
-            QueryRequestOptions requestOptions,
-            ReadFeedCrossFeedRangeState state)
+            ReadFeedCrossFeedRangeState state,
+            ReadFeedPaginationOptions readFeedPaginationOptions)
         {
             this.documentContainer = documentContainer ?? throw new ArgumentNullException(nameof(documentContainer));
-            this.requestOptions = requestOptions;
             this.state = state;
+            this.readFeedPaginationOptions = readFeedPaginationOptions;
         }
 
         public IAsyncEnumerator<TryCatch<ReadFeedPage>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
@@ -32,9 +32,8 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
             CrossFeedRangeState<ReadFeedState> innerState = new CrossFeedRangeState<ReadFeedState>(this.state.FeedRangeStates);
             CrossPartitionReadFeedAsyncEnumerator innerEnumerator = CrossPartitionReadFeedAsyncEnumerator.Create(
                 this.documentContainer,
-                this.requestOptions,
                 innerState,
-                this.requestOptions?.MaxItemCount ?? int.MaxValue,
+                this.readFeedPaginationOptions,
                 cancellationToken);
 
             return new ReadFeedCrossFeedRangeAsyncEnumerator(innerEnumerator);

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
@@ -27,12 +27,13 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
 
         public ReadFeedIteratorCore(
             IDocumentContainer documentContainer,
-            QueryRequestOptions queryRequestOptions,
             string continuationToken,
-            int pageSize,
+            ReadFeedPaginationOptions readFeedPaginationOptions,
+            QueryRequestOptions queryRequestOptions,
             CancellationToken cancellationToken)
         {
             this.queryRequestOptions = queryRequestOptions;
+            readFeedPaginationOptions ??= ReadFeedPaginationOptions.Default;
 
             if (!string.IsNullOrEmpty(continuationToken))
             {
@@ -127,11 +128,11 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
                 FeedRange feedRange;
                 if ((this.queryRequestOptions != null) && this.queryRequestOptions.PartitionKey.HasValue)
                 {
-                    feedRange = new FeedRangePartitionKey(queryRequestOptions.PartitionKey.Value);
+                    feedRange = new FeedRangePartitionKey(this.queryRequestOptions.PartitionKey.Value);
                 }
-                else if ((this.queryRequestOptions != null) && (queryRequestOptions.FeedRange != null))
+                else if ((this.queryRequestOptions != null) && (this.queryRequestOptions.FeedRange != null))
                 {
-                    feedRange = queryRequestOptions.FeedRange;
+                    feedRange = this.queryRequestOptions.FeedRange;
                 }
                 else
                 {
@@ -154,9 +155,8 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
                 this.monadicEnumerator = TryCatch<CrossPartitionReadFeedAsyncEnumerator>.FromResult(
                     CrossPartitionReadFeedAsyncEnumerator.Create(
                         documentContainer,
-                        queryRequestOptions,
                         new CrossFeedRangeState<ReadFeedState>(monadicReadFeedState.Result.FeedRangeStates),
-                        pageSize,
+                        readFeedPaginationOptions,
                         cancellationToken));
             }
 
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
                 {
                     outerFeedRange = new FeedRangePartitionKey(this.queryRequestOptions.PartitionKey.Value);
                 }
-                else if ((this.queryRequestOptions != null) && (queryRequestOptions.FeedRange != null))
+                else if ((this.queryRequestOptions != null) && (this.queryRequestOptions.FeedRange != null))
                 {
                     outerFeedRange = (FeedRangeInternal)this.queryRequestOptions.FeedRange;
                 }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/ReadFeedIteratorCore.cs
@@ -298,15 +298,21 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
             }
 
             Pagination.ReadFeedPage page = crossFeedRangePage.Page;
+            Headers headers = new Headers()
+            {
+                RequestCharge = page.RequestCharge,
+                ActivityId = page.ActivityId,
+                ContinuationToken = continuationToken,
+            };
+            foreach (KeyValuePair<string, string> kvp in page.AdditionalHeaders)
+            {
+                headers[kvp.Key] = kvp.Value;
+            }
+
             return new ResponseMessage(
                 statusCode: System.Net.HttpStatusCode.OK,
                 requestMessage: default,
-                headers: new Headers()
-                {
-                    RequestCharge = page.RequestCharge,
-                    ActivityId = page.ActivityId,
-                    ContinuationToken = continuationToken,
-                },
+                headers: headers,
                 cosmosException: default,
                 diagnostics: page.Diagnostics)
             {

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Diagnostics;
     using System.Globalization;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -99,6 +101,16 @@ namespace Microsoft.Azure.Cosmos
             get => throw new NotSupportedException($"{nameof(ChangeFeedRequestOptions)} does not use the {nameof(this.IfNoneMatchEtag)} property.");
             set => throw new NotSupportedException($"{nameof(ChangeFeedRequestOptions)} does not use the {nameof(this.IfNoneMatchEtag)} property.");
         }
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable SA1601 // Partial elements should be documented
+        public
+#else
+        internal
+#endif
+        JsonSerializationFormatOptions JsonSerializationFormatOptions { get; set; }
 
         internal ChangeFeedRequestOptions Clone()
         {

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Diagnostics;
     using System.Globalization;
-    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
 

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ChangeFeedRequestOptions.cs
@@ -66,17 +66,6 @@ namespace Microsoft.Azure.Cosmos
             Debug.Assert(request != null);
 
             base.PopulateRequestOptions(request);
-
-            if (this.PageSizeHint.HasValue)
-            {
-                request.Headers.Add(
-                    HttpConstants.HttpHeaders.PageSize,
-                    this.PageSizeHint.Value.ToString(CultureInfo.InvariantCulture));
-            }
-
-            request.Headers.Add(
-                HttpConstants.HttpHeaders.A_IM,
-                HttpConstants.A_IMHeaderValues.IncrementalFeed);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed;
     using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Linq;
@@ -25,6 +26,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.ReadFeed;
+    using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -133,7 +135,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosDiagnosticsContext diagnosticsContext,
             Stream streamPayload,
             PartitionKey partitionKey,
-            ITrace trace, 
+            ITrace trace,
             ItemRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default)
         {
@@ -576,7 +578,7 @@ namespace Microsoft.Azure.Cosmos
         {
             Routing.PartitionKeyRangeCache pkRangeCache = await this.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync();
             string containerRid = await this.GetCachedRIDAsync(
-                forceRefresh: false, 
+                forceRefresh: false,
                 cancellationToken: cancellationToken);
             IReadOnlyList<Documents.PartitionKeyRange> allRanges = await pkRangeCache.TryGetOverlappingRangesAsync(
                         containerRid,
@@ -601,11 +603,31 @@ namespace Microsoft.Azure.Cosmos
                 new CosmosDiagnosticsContextCore());
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
+            Dictionary<string, string> additionalHeaders;
+            if ((changeFeedRequestOptions?.Properties != null) && changeFeedRequestOptions.Properties.Any())
+            {
+                additionalHeaders = new Dictionary<string, string>();
+                foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
+                {
+                    additionalHeaders[keyValuePair.Key] = keyValuePair.Value.ToString();
+                }
+            }
+            else
+            {
+                additionalHeaders = null;
+            }
+
+            ChangeFeedPaginationOptions changeFeedPaginationOptions = new ChangeFeedPaginationOptions(
+                changeFeedMode,
+                changeFeedRequestOptions?.PageSizeHint,
+                changeFeedRequestOptions?.JsonSerializationFormatOptions?.JsonSerializationFormat,
+                additionalHeaders);
+
             return new ChangeFeedCrossFeedRangeAsyncEnumerable(
                 documentContainer,
-                changeFeedMode,
-                changeFeedRequestOptions,
-                state);
+                state,
+                changeFeedPaginationOptions,
+                changeFeedRequestOptions?.JsonSerializationFormatOptions);
         }
 
         public override FeedIterator GetStandByFeedIterator(
@@ -657,11 +679,21 @@ namespace Microsoft.Azure.Cosmos
 
                 DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
+                ReadFeedPaginationOptions.PaginationDirection? direction = null;
+                if ((requestOptions.Properties != null) && requestOptions.Properties.TryGetValue(HttpConstants.HttpHeaders.EnumerationDirection, out object enumerationDirection))
+                {
+                    direction = (byte)enumerationDirection == (byte)RntbdConstants.RntdbEnumerationDirection.Reverse ? ReadFeedPaginationOptions.PaginationDirection.Reverse : ReadFeedPaginationOptions.PaginationDirection.Forward;
+                }
+
+                ReadFeedPaginationOptions readFeedPaginationOptions = new ReadFeedPaginationOptions(
+                    direction,
+                    pageSizeHint: requestOptions.MaxItemCount ?? int.MaxValue);
+
                 return new ReadFeedIteratorCore(
-                    documentContainer: documentContainer,
-                    queryRequestOptions: requestOptions,
-                    continuationToken: continuationToken,
-                    pageSize: requestOptions.MaxItemCount ?? int.MaxValue,
+                    documentContainer,
+                    continuationToken,
+                    readFeedPaginationOptions,
+                    requestOptions,
                     cancellationToken: default);
             }
 
@@ -688,6 +720,8 @@ namespace Microsoft.Azure.Cosmos
             string continuationToken,
             int pageSize)
         {
+            queryRequestOptions ??= new QueryRequestOptions();
+
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
                 this,
                 this.queryClient,
@@ -717,18 +751,28 @@ namespace Microsoft.Azure.Cosmos
             }
             else
             {
+                ReadFeedPaginationOptions.PaginationDirection? direction = null;
+                if ((queryRequestOptions.Properties != null) && queryRequestOptions.Properties.TryGetValue(HttpConstants.HttpHeaders.EnumerationDirection, out object enumerationDirection))
+                {
+                    direction = (byte)enumerationDirection == (byte)RntbdConstants.RntdbEnumerationDirection.Reverse ? ReadFeedPaginationOptions.PaginationDirection.Reverse : ReadFeedPaginationOptions.PaginationDirection.Forward;
+                }
+
+                ReadFeedPaginationOptions readFeedPaginationOptions = new ReadFeedPaginationOptions(
+                    direction,
+                    pageSizeHint: queryRequestOptions.MaxItemCount ?? int.MaxValue);
+
                 feedIterator = new ReadFeedIteratorCore(
                     documentContainer: documentContainer,
                     queryRequestOptions: queryRequestOptions,
                     continuationToken: continuationToken,
-                    pageSize: queryRequestOptions?.MaxItemCount ?? int.MaxValue,
+                    readFeedPaginationOptions: readFeedPaginationOptions,
                     cancellationToken: default);
             }
 
             return feedIterator;
         }
 
-        public override IAsyncEnumerable<TryCatch<ReadFeedPage>> GetReadFeedAsyncEnumerable(
+        public override IAsyncEnumerable<TryCatch<ReadFeed.ReadFeedPage>> GetReadFeedAsyncEnumerable(
             ReadFeedCrossFeedRangeState state,
             QueryRequestOptions queryRequestOptions = default)
         {
@@ -738,10 +782,20 @@ namespace Microsoft.Azure.Cosmos
                 new CosmosDiagnosticsContextCore());
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
+            ReadFeedPaginationOptions.PaginationDirection? direction = null;
+            if ((queryRequestOptions.Properties != null) && queryRequestOptions.Properties.TryGetValue(HttpConstants.HttpHeaders.EnumerationDirection, out object enumerationDirection))
+            {
+                direction = (byte)enumerationDirection == (byte)RntbdConstants.RntdbEnumerationDirection.Reverse ? ReadFeedPaginationOptions.PaginationDirection.Reverse : ReadFeedPaginationOptions.PaginationDirection.Forward;
+            }
+
+            ReadFeedPaginationOptions readFeedPaginationOptions = new ReadFeedPaginationOptions(
+                direction,
+                pageSizeHint: queryRequestOptions.MaxItemCount ?? int.MaxValue);
+
             return new ReadFeedCrossFeedRangeAsyncEnumerable(
                 documentContainer,
-                queryRequestOptions,
-                state);
+                state,
+                readFeedPaginationOptions);
         }
 
         // Extracted partition key might be invalid as CollectionCache might be stale.

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.ReadFeed;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -787,14 +787,14 @@ namespace Microsoft.Azure.Cosmos
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             ReadFeedPaginationOptions.PaginationDirection? direction = null;
-            if ((queryRequestOptions.Properties != null) && queryRequestOptions.Properties.TryGetValue(HttpConstants.HttpHeaders.EnumerationDirection, out object enumerationDirection))
+            if ((queryRequestOptions?.Properties != null) && queryRequestOptions.Properties.TryGetValue(HttpConstants.HttpHeaders.EnumerationDirection, out object enumerationDirection))
             {
                 direction = (byte)enumerationDirection == (byte)RntbdConstants.RntdbEnumerationDirection.Reverse ? ReadFeedPaginationOptions.PaginationDirection.Reverse : ReadFeedPaginationOptions.PaginationDirection.Forward;
             }
 
             ReadFeedPaginationOptions readFeedPaginationOptions = new ReadFeedPaginationOptions(
                 direction,
-                pageSizeHint: queryRequestOptions.MaxItemCount ?? int.MaxValue);
+                pageSizeHint: queryRequestOptions?.MaxItemCount);
 
             return new ReadFeedCrossFeedRangeAsyncEnumerable(
                 documentContainer,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -600,7 +600,8 @@ namespace Microsoft.Azure.Cosmos
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
                 this,
                 this.queryClient,
-                new CosmosDiagnosticsContextCore());
+                new CosmosDiagnosticsContextCore(),
+                changeFeedRequestOptions: changeFeedRequestOptions);
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             Dictionary<string, string> additionalHeaders;

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -605,8 +605,10 @@ namespace Microsoft.Azure.Cosmos
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             Dictionary<string, string> additionalHeaders;
+            
             if ((changeFeedRequestOptions?.Properties != null) && changeFeedRequestOptions.Properties.Any())
             {
+                Dictionary<string, object> additionalNonStringHeaders = new Dictionary<string, object>();
                 additionalHeaders = new Dictionary<string, string>();
                 foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
                 {
@@ -614,7 +616,13 @@ namespace Microsoft.Azure.Cosmos
                     {
                         additionalHeaders[keyValuePair.Key] = stringValue;
                     }
+                    else
+                    {
+                        additionalNonStringHeaders[keyValuePair.Key] = keyValuePair.Value;
+                    }
                 }
+
+                changeFeedRequestOptions.Properties = additionalNonStringHeaders;
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -782,7 +782,8 @@ namespace Microsoft.Azure.Cosmos
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
                 this,
                 this.queryClient,
-                new CosmosDiagnosticsContextCore());
+                new CosmosDiagnosticsContextCore(),
+                queryRequestOptions);
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             ReadFeedPaginationOptions.PaginationDirection? direction = null;

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -609,7 +609,10 @@ namespace Microsoft.Azure.Cosmos
                 additionalHeaders = new Dictionary<string, string>();
                 foreach (KeyValuePair<string, object> keyValuePair in changeFeedRequestOptions.Properties)
                 {
-                    additionalHeaders[keyValuePair.Key] = keyValuePair.Value.ToString();
+                    if (keyValuePair.Value is string stringValue)
+                    {
+                        additionalHeaders[keyValuePair.Key] = stringValue;
+                    }
                 }
             }
             else

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -391,7 +391,8 @@ namespace Microsoft.Azure.Cosmos
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
                 this,
                 this.queryClient,
-                new CosmosDiagnosticsContextCore());
+                new CosmosDiagnosticsContextCore(),
+                changeFeedRequestOptions: changeFeedRequestOptions);
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             ChangeFeedIteratorCore changeFeedIteratorCore = new ChangeFeedIteratorCore(

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -363,7 +363,8 @@ namespace Microsoft.Azure.Cosmos
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
                 this,
                 this.queryClient,
-                new CosmosDiagnosticsContextCore());
+                new CosmosDiagnosticsContextCore(),
+                changeFeedRequestOptions: changeFeedRequestOptions);
             DocumentContainer documentContainer = new DocumentContainer(networkAttachedDocumentContainer);
 
             return new ChangeFeedIteratorCore(

--- a/Microsoft.Azure.Cosmos/src/Serializer/JsonSerializationFormatOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/JsonSerializationFormatOptions.cs
@@ -1,0 +1,67 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Serializer
+{
+    using System;
+    using Microsoft.Azure.Cosmos.Json;
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+#pragma warning disable SA1601 // Partial elements should be documented
+    public
+#else
+    internal
+#endif
+        abstract class JsonSerializationFormatOptions
+    {
+        public delegate IJsonNavigator CreateNavigator(ReadOnlyMemory<byte> content);
+
+        protected JsonSerializationFormatOptions(
+            JsonSerializationFormat jsonSerializationFormat)
+        {
+            this.JsonSerializationFormat = jsonSerializationFormat;
+        }
+
+        public JsonSerializationFormat JsonSerializationFormat { get; }
+
+        public static JsonSerializationFormatOptions Create(
+            JsonSerializationFormat jsonSerializationFormat)
+        {
+            return new NativelySupportedJsonSerializationFormatOptions(jsonSerializationFormat);
+        }
+
+        public static JsonSerializationFormatOptions Create(
+            JsonSerializationFormat jsonSerializationFormat,
+            CreateNavigator createNavigator)
+        {
+            return new CustomJsonSerializationFormatOptions(
+                jsonSerializationFormat,
+                createNavigator);
+        }
+
+        public sealed class NativelySupportedJsonSerializationFormatOptions : JsonSerializationFormatOptions
+        {
+            public NativelySupportedJsonSerializationFormatOptions(
+                JsonSerializationFormat jsonSerializationFormat)
+                : base(jsonSerializationFormat)
+            {
+            }
+        }
+
+        public sealed class CustomJsonSerializationFormatOptions : JsonSerializationFormatOptions
+        {
+            public CustomJsonSerializationFormatOptions(
+                JsonSerializationFormat jsonSerializationFormat,
+                CreateNavigator createNavigator)
+                : base(jsonSerializationFormat)
+            {
+                this.createNavigator = createNavigator ?? throw new ArgumentNullException(nameof(jsonSerializationFormat));
+            }
+
+            public CreateNavigator createNavigator { get; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
@@ -13,9 +13,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
+    using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [SDK.EmulatorTests.TestClass]
@@ -269,6 +271,52 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             await foreach (TryCatch<ChangeFeedPage> monadicPage in asyncEnumerable.WithCancellation(cancellationTokenSource.Token))
             {
                 monadicPage.ThrowIfFailed();
+            }
+        }
+
+        [TestMethod]
+        public async Task TestContentSerializationOptions()
+        {
+            {
+                // Native format
+                IAsyncEnumerable<TryCatch<ChangeFeedPage>> asyncEnumerable = this.Container.GetChangeFeedAsyncEnumerable(
+                    ChangeFeedCrossFeedRangeState.CreateFromBeginning(),
+                    ChangeFeedMode.Incremental,
+                    new ChangeFeedRequestOptions()
+                    {
+                        JsonSerializationFormatOptions = JsonSerializationFormatOptions.Create(JsonSerializationFormat.Binary)
+                    });
+                await foreach (TryCatch<ChangeFeedPage> monadicPage in asyncEnumerable)
+                {
+                    monadicPage.ThrowIfFailed();
+
+                    if (monadicPage.Result.NotModified)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            {
+                // Custom format
+                IAsyncEnumerable<TryCatch<ChangeFeedPage>> asyncEnumerable = this.Container.GetChangeFeedAsyncEnumerable(
+                    ChangeFeedCrossFeedRangeState.CreateFromBeginning(),
+                    ChangeFeedMode.Incremental,
+                    new ChangeFeedRequestOptions()
+                    {
+                        JsonSerializationFormatOptions = JsonSerializationFormatOptions.Create(
+                            JsonSerializationFormat.Binary,
+                            (content) => JsonNavigator.Create(content))
+                    });
+                await foreach (TryCatch<ChangeFeedPage> monadicPage in asyncEnumerable)
+                {
+                    monadicPage.ThrowIfFailed();
+
+                    if (monadicPage.Result.NotModified)
+                    {
+                        break;
+                    }
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
@@ -343,13 +343,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             }
         }
 
-        [TestMethod]
-        [Ignore]
-        public async Task TestAdditionalResponseHeadersAsync()
-        {
-            // TODO Wire up additional headers on ChangeFeedPage and ReadFeedPage.
-        }
-
         private static async Task<(int, ChangeFeedCrossFeedRangeState)> PartialDrainAsync(IAsyncEnumerable<TryCatch<ChangeFeedPage>> asyncEnumerable)
         {
             ChangeFeedCrossFeedRangeState state = default;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
@@ -322,6 +322,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         }
 
         [TestMethod]
+        [Ignore]
         public async Task TestCustomRequestOptionsAsync()
         {
             IAsyncEnumerable<TryCatch<ChangeFeedPage>> asyncEnumerable = this.Container.GetChangeFeedAsyncEnumerable(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Newtonsoft.Json.Linq;
     using Newtonsoft.Json;
 
     [SDK.EmulatorTests.TestClass]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
     <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/MockCosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/MockCosmosQueryClient.cs
@@ -10,6 +10,7 @@
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
 
     /// <summary>
     /// A helper that forces the SDK to use the gateway or the service interop for the query plan

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/PartitioningQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/PartitioningQueryTests.cs
@@ -38,7 +38,7 @@
                 ImplementationAsync,
                 "/key");
 
-            async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
+            static async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {
                 Assert.AreEqual(0, (await QueryTestsBase.RunQueryAsync(
                     container,
@@ -79,16 +79,7 @@
 
                     if (i < keys.Length - 1)
                     {
-                        string key;
-                        if (keys[i] is string)
-                        {
-                            key = "'" + keys[i].ToString() + "'";
-                        }
-                        else
-                        {
-                            key = keys[i].ToString();
-                        }
-
+                        string key = keys[i] is string ? "'" + keys[i].ToString() + "'" : keys[i].ToString();
                         queries.Add((string.Format(CultureInfo.InvariantCulture, @"SELECT * FROM Root r WHERE r.key = {0} ORDER BY r.prop", key), expectedOrderByResult));
                     }
 
@@ -109,7 +100,10 @@
                         }
 
                         string resultDocIds = string.Join(",", result.Select(doc => doc.Id));
-                        Assert.AreEqual(queryAndExpectedResult.Item2, resultDocIds);
+                        Assert.AreEqual(
+                            queryAndExpectedResult.Item2,
+                            resultDocIds,
+                            $"Query: {queryAndExpectedResult.Item1} with partition key: {keys[i]} failed.");
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Microsoft.Azure.Cosmos.Performance.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Microsoft.Azure.Cosmos.Performance.Tests.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
     <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/CrossPartitionChangeFeedAsyncEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/CrossPartitionChangeFeedAsyncEnumeratorTests.cs
@@ -27,13 +27,12 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems: 0);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions(),
                 new CrossFeedRangeState<ChangeFeedState>(
                     new FeedRangeState<ChangeFeedState>[]
                     {
                         new FeedRangeState<ChangeFeedState>(FeedRangeEpk.FullRange, ChangeFeedState.Beginning())
                     }),
+                ChangeFeedPaginationOptions.Default,
                 cancellationToken: default);
 
             Assert.IsTrue(await enumerator.MoveNextAsync());
@@ -48,13 +47,12 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems: 1);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions(),
                 new CrossFeedRangeState<ChangeFeedState>(
                     new FeedRangeState<ChangeFeedState>[]
                     {
                         new FeedRangeState<ChangeFeedState>(FeedRangeEpk.FullRange, ChangeFeedState.Beginning())
                     }),
+                ChangeFeedPaginationOptions.Default,
                 cancellationToken: default);
 
             // First page should be true and skip the 304 not modified
@@ -77,13 +75,12 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions(),
                 new CrossFeedRangeState<ChangeFeedState>(
                     new FeedRangeState<ChangeFeedState>[]
                     {
                         new FeedRangeState<ChangeFeedState>(FeedRangeEpk.FullRange, ChangeFeedState.Beginning())
                     }),
+                ChangeFeedPaginationOptions.Default,
                 cancellationToken: default);
 
             int globalCount = await (useContinuations
@@ -101,13 +98,12 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions(),
                 new CrossFeedRangeState<ChangeFeedState>(
                     new FeedRangeState<ChangeFeedState>[]
                     {
                         new FeedRangeState<ChangeFeedState>(FeedRangeEpk.FullRange, ChangeFeedState.Time(DateTime.UtcNow))
                     }),
+                ChangeFeedPaginationOptions.Default,
                 cancellationToken: default);
 
             for (int i = 0; i < numItems; i++)
@@ -140,13 +136,12 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions(),
                 new CrossFeedRangeState<ChangeFeedState>(
                     new FeedRangeState<ChangeFeedState>[]
                     {
                         new FeedRangeState<ChangeFeedState>(FeedRangeEpk.FullRange, ChangeFeedState.Now())
                     }),
+                ChangeFeedPaginationOptions.Default,
                 cancellationToken: default);
 
             Assert.AreEqual(0, await (useContinuations
@@ -214,9 +209,8 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
 
                 enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                     documentContainer,
-                    ChangeFeedMode.Incremental,
-                    new ChangeFeedRequestOptions(),
                     enumerator.Current.Result.State,
+                    ChangeFeedPaginationOptions.Default,
                     cancellationToken: default);
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentContainerChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentContainerChangeFeedTests.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 ranges[0],
                 pageSize: 10,
                 changeFeedMode: ChangeFeedMode.Incremental,
+                jsonSerializationFormat: null,
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 
@@ -54,6 +55,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: int.MaxValue,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -69,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: 10,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -91,6 +94,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: 10,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -120,6 +124,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: int.MaxValue,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -141,6 +146,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: 10,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -175,6 +181,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     ranges[0],
                     pageSize: 10,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -206,6 +213,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 new FeedRangePartitionKey(new Cosmos.PartitionKey(0)),
                 pageSize: int.MaxValue,
                 changeFeedMode: ChangeFeedMode.Incremental,
+                jsonSerializationFormat: null,
                 NoOpTrace.Singleton,
                 cancellationToken: default);
 
@@ -250,6 +258,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                             isMaxInclusive: false)),
                     pageSize: int.MaxValue,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     NoOpTrace.Singleton,
                     cancellationToken: default);
 
@@ -304,6 +313,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                     child,
                     pageSize: 1000,
                     changeFeedMode: ChangeFeedMode.Incremental,
+                    jsonSerializationFormat: null,
                     trace: NoOpTrace.Singleton,
                     cancellationToken: default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -61,11 +61,8 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 Mock.Of<CosmosDiagnosticsContext>());
 
             await networkAttachedDocumentContainer.MonadicChangeFeedAsync(
-                state: ChangeFeedState.Beginning(),
-                feedRange: new FeedRangePartitionKeyRange("0"),
-                pageSize: 10,
-                changeFeedMode: ChangeFeedMode.Incremental,
-                jsonSerializationFormat: null,
+                feedRangeState: new FeedRangeState<ChangeFeedState>(new FeedRangePartitionKeyRange("0"), ChangeFeedState.Beginning()),
+                changeFeedPaginationOptions: new ChangeFeedPaginationOptions(ChangeFeedMode.Incremental, pageSizeHint: 10),
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 
@@ -125,11 +122,8 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 Mock.Of<CosmosDiagnosticsContext>());
 
             await networkAttachedDocumentContainer.MonadicChangeFeedAsync(
-                state: ChangeFeedState.Beginning(),
-                feedRange: new FeedRangePartitionKeyRange("0"),
-                pageSize: 10,
-                changeFeedMode: ChangeFeedMode.FullFidelity,
-                jsonSerializationFormat: null,
+                feedRangeState: new FeedRangeState<ChangeFeedState>(new FeedRangePartitionKeyRange("0"), ChangeFeedState.Beginning()),
+                changeFeedPaginationOptions: new ChangeFeedPaginationOptions(ChangeFeedMode.Incremental, pageSizeHint: 10),
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 feedRange: new FeedRangePartitionKeyRange("0"),
                 pageSize: 10,
                 changeFeedMode: ChangeFeedMode.Incremental,
+                jsonSerializationFormat: null,
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 
@@ -128,6 +129,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 feedRange: new FeedRangePartitionKeyRange("0"),
                 pageSize: 10,
                 changeFeedMode: ChangeFeedMode.FullFidelity,
+                jsonSerializationFormat: null,
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
 
             await networkAttachedDocumentContainer.MonadicChangeFeedAsync(
                 feedRangeState: new FeedRangeState<ChangeFeedState>(new FeedRangePartitionKeyRange("0"), ChangeFeedState.Beginning()),
-                changeFeedPaginationOptions: new ChangeFeedPaginationOptions(ChangeFeedMode.Incremental, pageSizeHint: 10),
+                changeFeedPaginationOptions: new ChangeFeedPaginationOptions(ChangeFeedMode.FullFidelity, pageSizeHint: 10),
                 trace: NoOpTrace.Singleton,
                 cancellationToken: default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryUnitTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.ReadFeed;
+    using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
     using Microsoft.Azure.Cosmos.Tests.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -168,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
                 documentContainer,
                 queryRequestOptions: null,
                 continuationToken: continuationToken,
-                pageSize: pageSize,
+                readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: pageSize),
                 cancellationToken: default);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/ReadFeedTokenIteratorCoreTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -143,6 +144,25 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
             }
 
             Assert.AreEqual(numItems, count);
+        }
+
+        [TestMethod]
+        public async Task ReadFeedIteratorCore_ResponseHeaders()
+        {
+            int numItems = 100;
+            IDocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems);
+            FeedIterator iterator = CreateReadFeedIterator(
+                documentContainer,
+                continuationToken: null,
+                pageSize: 10);
+
+            while (iterator.HasMoreResults)
+            {
+                ResponseMessage message = await iterator.ReadNextAsync();
+                CosmosArray documents = GetDocuments(message.Content);
+
+                Assert.IsTrue(message.Headers.AllKeys().Contains("test-header"));
+            }
         }
 
         private static CosmosArray GetDocuments(Stream stream)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
     <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Serialization.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -64,7 +64,7 @@
   </ItemGroup>  
 
   <ItemGroup Condition="$(OS) != 'Linux' AND '$(ProjectRef)' != 'True' ">
-    <None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Serialization.HybridRow\$(HybridRowVersion)\microsoft.azure.cosmos.serialization.hybridrow.nuspec">
+    <None Include="$(NugetPackageRoot)\Microsoft.HybridRow\$(HybridRowVersion)\microsoft.hybridrow.nuspec">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Direct\$(DirectVersion)\Microsoft.Azure.Cosmos.Direct.nuspec">

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/BufferedPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/BufferedPartitionRangeEnumeratorTests.cs
@@ -100,15 +100,14 @@
                 foreach (int partitionKeyRangeId in new int[] { 1, 2 })
                 {
                     PartitionRangePageAsyncEnumerable<ReadFeedPage, ReadFeedState> enumerable = new PartitionRangePageAsyncEnumerable<ReadFeedPage, ReadFeedState>(
-                        range: new FeedRangePartitionKeyRange(partitionKeyRangeId: partitionKeyRangeId.ToString()),
-                        state: state,
-                        (range, state) => new ReadFeedPartitionRangeEnumerator(
-                                inMemoryCollection,
-                                feedRange: range,
-                                pageSize: 10,
-                                queryRequestOptions: default,
-                                cancellationToken: default,
-                                state: state));
+                        feedRangeState: new FeedRangeState<ReadFeedState>(
+                            new FeedRangePartitionKeyRange(partitionKeyRangeId: partitionKeyRangeId.ToString()),
+                            state),
+                        (feedRangeState) => new ReadFeedPartitionRangeEnumerator(
+                            inMemoryCollection,
+                            feedRangeState: feedRangeState,
+                            readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                            cancellationToken: default));
                     HashSet<string> resourceIdentifiers = await this.DrainFullyAsync(enumerable);
 
                     childIdentifiers.UnionWith(resourceIdentifiers);
@@ -125,11 +124,11 @@
                 BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator = new BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
                     new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
-                        feedRange: new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
-                        pageSize: 10,
-                        queryRequestOptions: default,
-                        cancellationToken: default,
-                        state: ReadFeedState.Beginning()),
+                        feedRangeState: new FeedRangeState<ReadFeedState>(
+                            new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
+                            ReadFeedState.Beginning()),
+                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                        cancellationToken: default),
                     cancellationToken: default);
 
                 int count = 0;
@@ -169,11 +168,11 @@
                     BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator = new BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
                     new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
-                        feedRange: new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
-                        pageSize: 10,
-                        queryRequestOptions: default,
-                        cancellationToken: default,
-                        state: ReadFeedState.Beginning()),
+                        feedRangeState: new FeedRangeState<ReadFeedState>(
+                            new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
+                            ReadFeedState.Beginning()),
+                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                        cancellationToken: default),
                     cancellationToken: default);
 
                     if ((random.Next() % 2) == 0)
@@ -204,16 +203,15 @@
             public override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
                 ReadFeedState state = null) => new PartitionRangePageAsyncEnumerable<ReadFeedPage, ReadFeedState>(
-                    range: new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
-                    state: state ?? ReadFeedState.Beginning(),
-                    (range, state) => new BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
+                    feedRangeState: new FeedRangeState<ReadFeedState>( 
+                        new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
+                        state ?? ReadFeedState.Beginning()),
+                    (feedRangeState) => new BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
                         new ReadFeedPartitionRangeEnumerator(
                             documentContainer,
-                            feedRange: range,
-                            pageSize: 10,
-                            queryRequestOptions: default,
-                            cancellationToken: default,
-                            state: state),
+                            feedRangeState: feedRangeState,
+                            readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                            cancellationToken: default),
                         cancellationToken: default));
 
             public override IAsyncEnumerator<TryCatch<ReadFeedPage>> CreateEnumerator(
@@ -221,11 +219,11 @@
                 ReadFeedState state = null) => new BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
                     new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
-                        feedRange: new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
-                        pageSize: 10,
-                        queryRequestOptions: default,
-                        cancellationToken: default,
-                        state: state ?? ReadFeedState.Beginning()),
+                        feedRangeState: new FeedRangeState<ReadFeedState>(
+                            new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
+                            state ?? ReadFeedState.Beginning()),
+                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                        cancellationToken: default),
                     cancellationToken: default);
 
             private async Task BufferMoreInBackground(BufferedPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -128,14 +128,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 CrossFeedRangeState<ReadFeedState> state = null)
             {
                 PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> createEnumerator(
-                    FeedRangeInternal range,
-                    ReadFeedState state) => new ReadFeedPartitionRangeEnumerator(
+                    FeedRangeState<ReadFeedState> feedRangeState) => new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
-                        feedRange: range,
-                        pageSize: 10,
-                        queryRequestOptions: default,
-                        cancellationToken: default,
-                        state: state);
+                        feedRangeState: feedRangeState,
+                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                        cancellationToken: default);
 
                 return new CrossPartitionRangePageAsyncEnumerable<ReadFeedPage, ReadFeedState>(
                     feedRangeProvider: inMemoryCollection,
@@ -154,14 +151,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 CrossFeedRangeState<ReadFeedState> state = null)
             {
                 PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> createEnumerator(
-                    FeedRangeInternal range,
-                    ReadFeedState state) => new ReadFeedPartitionRangeEnumerator(
+                    FeedRangeState<ReadFeedState> feedRangeState) => new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
-                        feedRange: range,
-                        pageSize: 10,
-                        queryRequestOptions: default,
-                        cancellationToken: default,
-                        state: state);
+                        feedRangeState: feedRangeState,
+                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                        cancellationToken: default);
 
                 CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator = new CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
                     feedRangeProvider: inMemoryCollection,
@@ -198,8 +192,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
                     // Either both don't have results or both do.
                     return string.CompareOrdinal(
-                        ((FeedRangeEpk)partitionRangePageEnumerator1.Range).Range.Min,
-                        ((FeedRangeEpk)partitionRangePageEnumerator2.Range).Range.Min);
+                        ((FeedRangeEpk)partitionRangePageEnumerator1.FeedRangeState.FeedRange).Range.Min,
+                        ((FeedRangeEpk)partitionRangePageEnumerator2.FeedRangeState.FeedRange).Range.Min);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/DocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/DocumentContainerTests.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         state: ChangeFeedState.Beginning(),
                         pageSize: 1,
                         changeFeedMode: ChangeFeedMode.Incremental,
+                        jsonSerializationFormat: null,
                         trace: NoOpTrace.Singleton,
                         cancellationToken: default);
 
@@ -95,6 +96,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             state: resumeState,
                             pageSize: 1,
                             changeFeedMode: ChangeFeedMode.Incremental,
+                            jsonSerializationFormat: null,
                             trace: NoOpTrace.Singleton,
                             cancellationToken: default);
                         resumeState = page.State;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
@@ -129,7 +129,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             requestCharge: 42,
                             activityId: Guid.NewGuid().ToString(),
                             diagnostics: CosmosDiagnosticsContext.Create(default),
-                            nonNullState)));
+                            additionalHeaders: null,
+                            state: nonNullState)));
             }
 
             return this.documentContainer.MonadicReadFeedAsync(
@@ -167,6 +168,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             responseLengthInBytes: "[]".Length,
                             cosmosQueryExecutionInfo: default,
                             disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
                             state: feedRangeState.State ?? StateForStartedButNoDocumentsReturned)));
             }
 
@@ -197,6 +199,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             content: new MemoryStream(Encoding.UTF8.GetBytes("{\"Documents\": [], \"_count\": 0, \"_rid\": \"asdf\"}")),
                             requestCharge: 42,
                             activityId: Guid.NewGuid().ToString(),
+                            additionalHeaders: default,
                             state: feedRangeState.State)));
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
@@ -199,6 +200,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             FeedRangeInternal feedRange, 
             int pageSize, 
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken)
         {
@@ -223,6 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 feedRange,
                 pageSize,
                 changeFeedMode,
+                jsonSerializationFormat,
                 trace,
                 cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -440,6 +440,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     requestCharge: 42,
                     activityId: Guid.NewGuid().ToString(),
                     CosmosDiagnosticsContext.Create(default),
+                    additionalHeaders: null,
                     continuationState);
 
                 return Task.FromResult(TryCatch<ReadFeedPage>.FromResult(readFeedPage));
@@ -638,6 +639,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             responseLengthInBytes: 1337,
                             cosmosQueryExecutionInfo: default,
                             disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
                             state: queryState)));
             }
         }
@@ -692,6 +694,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         new ChangeFeedNotModifiedPage(
                             requestCharge: 42,
                             activityId: Guid.NewGuid().ToString(),
+                            additionalHeaders: default,
                             notModifiedResponseState)));
                 }
 
@@ -734,6 +737,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             responseStream,
                             requestCharge: 42,
                             activityId: Guid.NewGuid().ToString(),
+                            additionalHeaders: default,
                             responseState)));
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -648,6 +648,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             FeedRangeInternal feedRange,
             int pageSize,
             ChangeFeedMode changeFeedMode,
+            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             return record.ResourceIdentifier.Document > rangeIdAndIndex.documentIndex;
                         }
                     })
-                    .Take(readFeedPaginationOptions.PageSizeHint.GetValueOrDefault(int.MaxValue))
+                    .Take(readFeedPaginationOptions.PageSizeLimit.GetValueOrDefault(int.MaxValue))
                     .ToList();
 
                 List<CosmosObject> documents = new List<CosmosObject>();
@@ -597,7 +597,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     continuationSkipCount = 0;
                 }
 
-                queryPageResults = queryPageResults.Take((queryPaginationOptions ?? QueryPaginationOptions.Default).PageSizeHint.GetValueOrDefault(int.MaxValue));
+                queryPageResults = queryPageResults.Take((queryPaginationOptions ?? QueryPaginationOptions.Default).PageSizeLimit.GetValueOrDefault(int.MaxValue));
                 List<CosmosElement> queryPageResultList = queryPageResults.ToList();
                 QueryState queryState;
                 if (queryPageResultList.LastOrDefault() is CosmosObject lastDocument)
@@ -686,7 +686,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 List<Change> filteredChanges = changes
                     .Where(change => IsRecordWithinFeedRange(change.Record, feedRangeState.FeedRange, this.partitionKeyDefinition))
                     .Where(change => feedRangeState.State.Accept(ChangeFeedPredicate.Singleton, change))
-                    .Take((changeFeedPaginationOptions ?? ChangeFeedPaginationOptions.Default).PageSizeHint.GetValueOrDefault(int.MaxValue))
+                    .Take((changeFeedPaginationOptions ?? ChangeFeedPaginationOptions.Default).PageSizeLimit.GetValueOrDefault(int.MaxValue))
                     .ToList();
 
                 if (filteredChanges.Count == 0)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -440,7 +440,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     requestCharge: 42,
                     activityId: Guid.NewGuid().ToString(),
                     CosmosDiagnosticsContext.Create(default),
-                    additionalHeaders: null,
+                    additionalHeaders: new Dictionary<string, string>()
+                    {
+                        { "test-header", "test-value" }
+                    },
                     continuationState);
 
                 return Task.FromResult(TryCatch<ReadFeedPage>.FromResult(readFeedPage));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -514,7 +514,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     }
 
                     SqlOrderByItem orderByItem = sqlQuery.OrderByClause.OrderByItems[0];
-                    CosmosObject parsedContinuationToken = (CosmosObject)feedRangeState.State.Value;
+                    CosmosObject parsedContinuationToken = CosmosObject.Parse(((CosmosString)feedRangeState.State.Value).Value);
                     SqlBinaryScalarExpression resumeFilter = SqlBinaryScalarExpression.Create(
                         orderByItem.IsDescending ? SqlBinaryScalarOperatorKind.LessThan : SqlBinaryScalarOperatorKind.GreaterThan,
                         orderByItem.Expression,
@@ -548,7 +548,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
                 if ((sqlQuery.OrderByClause == null) && (feedRangeState.State != null))
                 {
-                    CosmosObject parsedContinuationToken = (CosmosObject)feedRangeState.State.Value;
+                    CosmosObject parsedContinuationToken = CosmosObject.Parse(((CosmosString)feedRangeState.State.Value).Value);
                     continuationResourceId = ((CosmosString)parsedContinuationToken["resourceId"]).Value;
                     continuationSkipCount = (int)Number64.ToLong(((CosmosNumber64)parsedContinuationToken["skipCount"]).Value);
 
@@ -623,7 +623,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
                     CosmosObject queryStateValue = CosmosObject.Create(queryStateDictionary);
 
-                    queryState = new QueryState(queryStateValue);
+                    queryState = new QueryState(CosmosString.Create(queryStateValue.ToString()));
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggregateQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggregateQueryPipelineStageTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DCountQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DCountQueryPipelineStageTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using PageList = System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<Microsoft.Azure.Cosmos.CosmosElements.CosmosElement>>;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
 
     [TestClass]
     public sealed class DCountQueryPipelineStageTests

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DistinctQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DistinctQueryPipelineStageTests.cs
@@ -10,6 +10,7 @@
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/EnumerableStage.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/EnumerableStage.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using System.Threading;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
 
     internal sealed class EnumerableStage : IAsyncEnumerable<TryCatch<QueryPage>>
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FactoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FactoryTests.cs
@@ -9,9 +9,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
-    using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -30,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 partitionKey: null,
                 queryInfo: new QueryInfo() { },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 requestCancellationToken: default,
                 requestContinuationToken: default); ;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Tests.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -351,7 +352,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer.GetFeedRangesAsync(NoOpTrace.Singleton, cancellationToken: default).Result,
                 partitionKey: null,
                 GetQueryPlan(query),
-                pageSize: pageSize,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 requestCancellationToken: default,
                 requestContinuationToken: state);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/GroupByQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/GroupByQueryPipelineStageTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests;
     using Microsoft.Azure.Cosmos.Tracing;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 responseLengthInBytes: default,
                 cosmosQueryExecutionInfo: default,
                 disallowContinuationTokenMessage: default,
+                additionalHeaders: default,
                 state: state);
             this.Current = TryCatch<QueryPage>.FromResult(page);
             return new ValueTask<bool>(true);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tests.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: null);
@@ -61,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: CosmosObject.Create(new Dictionary<string, CosmosElement>()));
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>()));
@@ -105,7 +106,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { CosmosString.Create("asdf") }));
@@ -138,7 +139,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(
@@ -189,7 +190,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("_ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: CosmosArray.Create(
@@ -222,7 +223,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 {
                     new OrderByColumn("c._ts", SortOrder.Ascending)
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
                 cancellationToken: default,
                 continuationToken: null);
@@ -274,7 +275,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     {
                         new OrderByColumn("c.pk", SortOrder.Ascending)
                     },
-                    pageSize: 10,
+                    queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     maxConcurrency: 10,
                     cancellationToken: default,
                     continuationToken: continuationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tests.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer: mockDocumentContainer.Object,
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer: mockDocumentContainer.Object,
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -68,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer: mockDocumentContainer.Object,
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -86,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer: mockDocumentContainer.Object,
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -108,7 +109,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documentContainer: mockDocumentContainer.Object,
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { new FeedRangeEpk(new Documents.Routing.Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)) },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -137,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     new FeedRangeEpk(new Documents.Routing.Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)),
                     new FeedRangeEpk(new Documents.Routing.Range<string>(min: "B", max: "C", isMinInclusive: true, isMaxInclusive: false)),
                 },
-                pageSize: 10,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
                 maxConcurrency: 10,
                 cancellationToken: default,
@@ -169,7 +170,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     targetRanges: await documentContainer.GetFeedRangesAsync(
                         trace: NoOpTrace.Singleton,
                         cancellationToken: default),
-                    pageSize: 10,
+                    queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     partitionKey: null,
                     maxConcurrency: 10,
                     cancellationToken: default,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipQueryPipelineStageTests.cs
@@ -9,6 +9,7 @@
     using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/TakeQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/TakeQueryPipelineStageTests.cs
@@ -8,6 +8,7 @@
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
@@ -6,8 +6,6 @@
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tests.Pagination;
@@ -100,7 +98,7 @@
                             sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                             feedRangeState: feedRangeState,
                             partitionKey: null,
-                            queryPaginationOptions: null,
+                            queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                             cancellationToken: default));
                     HashSet<string> resourceIdentifiers = await this.DrainFullyAsync(enumerable);
 
@@ -141,7 +139,7 @@
                         sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                         feedRangeState: feedRangeState,
                         partitionKey: null,
-                        queryPaginationOptions: null,
+                        queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                         cancellationToken: default));
             }
 
@@ -158,7 +156,7 @@
                     sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                     feedRangeState: new FeedRangeState<QueryState>(ranges[0], state),
                     partitionKey: null,
-                    queryPaginationOptions: null,
+                    queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     cancellationToken: default);
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/EndToEndTraceTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/EndToEndTraceTests.cs
@@ -11,6 +11,7 @@
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.ReadFeed;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
@@ -62,9 +63,8 @@
             IDocumentContainer documentContainer = await this.CreateDocumentContainerAsync(numItems);
             CrossPartitionReadFeedAsyncEnumerator enumerator = CrossPartitionReadFeedAsyncEnumerator.Create(
                 documentContainer,
-                new QueryRequestOptions(),
                 new CrossFeedRangeState<ReadFeedState>(ReadFeedCrossFeedRangeState.CreateFromBeginning().FeedRangeStates),
-                pageSize: 10,
+                new ReadFeedPaginationOptions(pageSizeHint: 10),
                 cancellationToken: default);
 
             int numChildren = 1; // One extra since we need to read one past the last user page to get the null continuation.
@@ -115,13 +115,9 @@
             IDocumentContainer documentContainer = await this.CreateDocumentContainerAsync(numItems);
             CrossPartitionChangeFeedAsyncEnumerator enumerator = CrossPartitionChangeFeedAsyncEnumerator.Create(
                 documentContainer,
-                ChangeFeedMode.Incremental,
-                new ChangeFeedRequestOptions()
-                { 
-                    PageSizeHint = int.MaxValue
-                },
                 new CrossFeedRangeState<ChangeFeedState>(
                     ChangeFeedCrossFeedRangeState.CreateFromBeginning().FeedRangeStates),
+                new ChangeFeedPaginationOptions(ChangeFeedMode.Incremental, pageSizeHint: int.MaxValue),
                 cancellationToken: default);
 
             int numChildren = 0;
@@ -159,7 +155,7 @@
                 new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 partitionKey: null,
                 GetQueryPlan(query),
-                pageSize: pageSize,
+                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: pageSize),
                 maxConcurrency: 10,
                 requestCancellationToken: default,
                 requestContinuationToken: state);

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,6 +2,5 @@
 <configuration>
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-    <add key="MyGet" value="https://www.myget.org/F/azure-cosmos/api/v3/index.json" />
  </packageSources>
 </configuration>


### PR DESCRIPTION
# Internal Pagination: Fixes APIs to be cleaner.

## Description

This PR cleans up the pagination API by creating `PaginationOptions`, which groups together all the static options for a particular FeedOperation. We also wired through raw headers on the request and response path for custom headers on compute gateway. Finally we used the `FeedRangeState<TState>` which is a composite of FeedRange and State to lower the number of parameters on most functions that require both. 