### PR TITLE
[Internal] Authorization : Refactors Authorization Token Helper to remove URL encoding used by compute

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationHelper.cs
@@ -654,12 +654,49 @@ namespace Microsoft.Azure.Cosmos
         }
 
         // This function is used by Compute
-        internal static string GenerateUrlEncodedAuthorizationTokenWithHashCore(
+        internal static string GenerateAuthorizationTokenWithHashCore(
             string verb,
             string resourceId,
             string resourceType,
             INameValueCollection headers,
             IComputeHash stringHMACSHA256Helper,
+            out ArrayOwner payload)
+        {
+            return AuthorizationHelper.GenerateAuthorizationTokenWithHashCore(
+                verb,
+                resourceId,
+                resourceType,
+                headers,
+                stringHMACSHA256Helper,
+                urlEncode: false,
+                out payload);
+        }
+
+        private static string GenerateUrlEncodedAuthorizationTokenWithHashCore(
+            string verb,
+            string resourceId,
+            string resourceType,
+            INameValueCollection headers,
+            IComputeHash stringHMACSHA256Helper,
+            out ArrayOwner payload)
+        {
+            return AuthorizationHelper.GenerateAuthorizationTokenWithHashCore(
+                verb,
+                resourceId,
+                resourceType,
+                headers,
+                stringHMACSHA256Helper,
+                urlEncode: true,
+                out payload);
+        }
+
+        private static string GenerateAuthorizationTokenWithHashCore(
+            string verb,
+            string resourceId,
+            string resourceType,
+            INameValueCollection headers,
+            IComputeHash stringHMACSHA256Helper,
+            bool urlEncode,
             out ArrayOwner payload)
         {
             // resourceId can be null for feed-read of /dbs
@@ -706,7 +743,7 @@ namespace Microsoft.Azure.Cosmos
 
                 payload = new ArrayOwner(ArrayPool<byte>.Shared, new ArraySegment<byte>(buffer, 0, length));
                 byte[] hashPayLoad = stringHMACSHA256Helper.ComputeHash(payload.Buffer);
-                return AuthorizationHelper.OptimizedConvertToBase64string(hashPayLoad);
+                return AuthorizationHelper.OptimizedConvertToBase64string(hashPayLoad, urlEncode);
             }
             catch
             {
@@ -716,10 +753,10 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// This an optimized version of doing HttpUtility.UrlEncode(Convert.ToBase64String(hashPayLoad)).
+        /// This an optimized version of doing Convert.ToBase64String(hashPayLoad) with an optional wrapping HttpUtility.UrlEncode.
         /// This avoids the over head of converting it to a string and back to a byte[].
         /// </summary>
-        private static unsafe string OptimizedConvertToBase64string(byte[] hashPayLoad)
+        private static unsafe string OptimizedConvertToBase64string(byte[] hashPayLoad, bool urlEncode)
         {
             // Create a large enough buffer that URL encode can use it.
             // Increase the buffer by 3x so it can be used for the URL encoding
@@ -741,7 +778,9 @@ namespace Microsoft.Azure.Cosmos
                     throw new ArgumentException($"Authorization key payload is invalid. {status}");
                 }
 
-                return AuthorizationHelper.UrlEncodeBase64SpanInPlace(encodingBuffer, bytesWritten);
+                return urlEncode 
+                    ? AuthorizationHelper.UrlEncodeBase64SpanInPlace(encodingBuffer, bytesWritten)
+                    : Encoding.UTF8.GetString(encodingBuffer.Slice(0, bytesWritten));
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Authorization/AuthorizationHelperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Authorization/AuthorizationHelperTests.cs
@@ -1,0 +1,42 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Authorization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Documents.Collections;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using static Microsoft.Azure.Cosmos.AuthorizationHelper;
+
+    [TestClass]
+    public class AuthorizationHelperTests
+    {
+        [TestMethod]
+        public void TestGenerateAuthorizationTokenWithHashCoreDoesNotEncodeUrl()
+        {
+            Mock<INameValueCollection> mockHeaders = new Mock<INameValueCollection>();
+            mockHeaders.SetupGet(h => h["x-ms-date"]).Returns(DateTime.UtcNow.ToString("r", CultureInfo.InvariantCulture));
+            Mock<IComputeHash> hashHelperMock = new Mock<IComputeHash>();
+            hashHelperMock.Setup(
+                ch => ch.ComputeHash(It.IsAny<ArraySegment<byte>>()))
+                .Returns(new byte[] { 2, 4, 6, 8, 10, 12, 14, 16, 18, 20 });
+
+            string token = AuthorizationHelper.GenerateAuthorizationTokenWithHashCore(
+                verb: "testVerb",
+                resourceId: "dbs/V4lVAA==/colls/V4lVAMl0wuQ=/",
+                resourceType: "colls",
+                headers: mockHeaders.Object,
+                stringHMACSHA256Helper: hashHelperMock.Object,
+                out _);
+
+            // Encoding.UTF8 string representation of the key byte array. (if it were URL encoded, it would end with "3d%3d" instead of "==").
+            Assert.AreEqual("AgQGCAoMDhASFA==", token);
+        }
+    }
+}


### PR DESCRIPTION
Removing URL encoding for Authorization Token Helper used by compute