### PR TITLE
[Internal] CTL: Adds yml automation for daily image build

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,5 +1,6 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-COPY . /usr/app/.
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
+COPY /CTL/. /usr/app/.
+COPY run_ctl.sh /usr/app
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,7 +1,7 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
-COPY ../../../. /usr/src/.
-RUN dotnet publish usr/src/CosmosCTL.csproj -c Release -o /usr/app/
-COPY run_ctl.sh /usr/app
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+COPY . /usr/src/.
+RUN dotnet publish usr/src/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o /usr/app/
+COPY Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh /usr/app
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,7 +1,4 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
-COPY . /usr/src/.
-RUN dotnet publish usr/src/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o /usr/app/
-COPY Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh /usr/app
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/runtime:3.1
-COPY artifacts/. /usr/app/.
+COPY artifacts/CTL/. /usr/app/.
 COPY run_ctl.sh /usr/app/.
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
-COPY /CTL/. /usr/app/.
+COPY CTL/. /usr/app/.
 COPY run_ctl.sh /usr/app
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,5 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
-COPY CTL/. /usr/app/.
+COPY artifacts/. /usr/app/.
 COPY run_ctl.sh /usr/app
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,5 +1,6 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
-COPY . /usr/app/.
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1
+COPY artifacts/. /usr/app/.
+COPY run_ctl.sh /usr/app/.
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,4 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+COPY . /usr/app/.
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile
@@ -1,6 +1,5 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
-COPY artifacts/. /usr/app/.
-COPY run_ctl.sh /usr/app
+COPY . /usr/app/.
 WORKDIR /usr/app
 RUN chmod +x run_ctl.sh
 CMD /bin/sh ./run_ctl.sh

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -50,7 +50,7 @@ jobs:
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
-        docker tag cosmos-dotnet-ctl:$(DefaultTag) $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+        docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload:$(DefaultTag)
         Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
         docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -41,6 +41,7 @@ jobs:
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl
+        ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -38,12 +38,8 @@ jobs:
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
         arguments: '-c Release'
+        outputDir: '$(Agent.TempDirectory)/ctl'
         nugetConfigPath: NuGet.config
-    - task: CopyFiles@2
-      displayName: 'Copy publish files'
-      inputs:
-        SourceFolder: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/bin/Release/netcoreapp3.1/publish'
-        TargetFolder: $(Agent.TempDirectory)/ctl
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -11,8 +11,6 @@ jobs:
         value: 'cosmosdotnetsdkctl'
       - name: ContainerRegistryUrl
         value: 'cosmosdotnetsdkctl.azurecr.io'
-      - name: DefaultTag
-        value: 'default'
 
     pool:
       vmImage: $(VmImage)

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -50,7 +50,7 @@ jobs:
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
-        docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload:$(DefaultTag)
-        Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload:$(DefaultTag)"
+        docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)
+        Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)"
         docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -22,13 +22,13 @@ jobs:
       displayName: 'Copy docker config files'
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile'
-        TargetFolder: $(Agent.TempDirectory)/ctl
+        TargetFolder: $(Agent.TempDirectory)/CTL
         flattenFolders: true
     - task: CopyFiles@2
       displayName: 'Copy shell files'
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh'
-        TargetFolder: $(Agent.TempDirectory)/ctl
+        TargetFolder: $(Agent.TempDirectory)/CTL
         flattenFolders: true
     - task: DotNetCoreCLI@2
       displayName: Build CTL project
@@ -37,10 +37,11 @@ jobs:
         command: 'publish'
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        arguments: '-c Release -o $(Agent.TempDirectory)/ctl'
+        arguments: '-c Release -o $(Agent.TempDirectory)'
         nugetConfigPath: NuGet.config
     - pwsh: |
-        cd $(Agent.TempDirectory)/ctl
+        cd $(Agent.TempDirectory)/CTL
+        ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -51,6 +51,6 @@ jobs:
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
         docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload:$(DefaultTag)
-        Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
+        Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload:$(DefaultTag)"
         docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -12,7 +12,7 @@ jobs:
       - name: ContainerRegistryUrl
         value: 'cosmosdotnetsdkctl.azurecr.io'
       - name: DefaultTag
-        value: 'latest'
+        value: 'default'
 
     pool:
       vmImage: $(VmImage)

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -38,8 +38,12 @@ jobs:
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
         arguments: '-c Release'
-        outputDir: $(Agent.TempDirectory)/ctl
         nugetConfigPath: NuGet.config
+    - task: CopyFiles@2
+      displayName: 'Copy publish files'
+      inputs:
+        SourceFolder: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/bin/Release/netcoreapp3.1/publish'
+        TargetFolder: $(Agent.TempDirectory)/ctl
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -42,10 +42,7 @@ jobs:
         arguments: '-c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
-        cd $(Agent.TempDirectory)/ctl/artifacts/CTL
-        ls
         cd $(Agent.TempDirectory)/ctl
-        ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -34,8 +34,10 @@ jobs:
       displayName: Build CTL project
       condition: succeeded()
       inputs:
-        command: custom
-        custom: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl'
+        command: 'publish'
+        publishWebProjects: false
+        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
+        arguments: '-c Release -o $(Agent.TempDirectory)/ctl'
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -2,7 +2,7 @@ variables:
   VmImage: 'ubuntu-18.04'
 
 jobs:
-  - job: Build and publish Docker image
+  - job: BuildDockerImage
     timeoutInMinutes: 20
     variables:
       - name: ContainerRegistryName

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -37,7 +37,7 @@ jobs:
         command: 'publish'
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        arguments: '-c Release -o $(Agent.TempDirectory)/ctl'
+        arguments: '-c Release -o $(Agent.TempDirectory)/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -40,6 +40,8 @@ jobs:
         arguments: '-c Release -o $(Agent.TempDirectory)/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
+        cd $(Agent.TempDirectory)/artifacts
+        ls
         cd $(Agent.TempDirectory)/ctl
         ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -11,6 +11,8 @@ jobs:
         value: 'cosmosdotnetsdkctl'
       - name: ContainerRegistryUrl
         value: 'cosmosdotnetsdkctl.azurecr.io'
+      - name: DefaultTag
+        value: 'latest'
 
     pool:
       vmImage: $(VmImage)
@@ -48,7 +50,7 @@ jobs:
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
-        docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+        docker tag cosmos-dotnet-ctl:$(DefaultTag) $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
         Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
         docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -34,12 +34,9 @@ jobs:
       displayName: Build CTL project
       condition: succeeded()
       inputs:
-        command: publish  
-        configuration: Release
+        command: custom
+        custom: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl'
         nugetConfigPath: NuGet.config
-        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        versioningScheme: OFF
-        outputDir: $(Agent.TempDirectory)/ctl
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -37,8 +37,7 @@ jobs:
         command: 'publish'
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        arguments: '-c Release'
-        outputDir: '$(Agent.TempDirectory)/ctl'
+        arguments: '-c Release -o $(Agent.TempDirectory)/ctl'
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
     # Below will build the image and push it to azure container registry
     - pwsh: |
+        cd Microsoft.Azure.Cosmos.Samples/Tools/CTL
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -49,8 +49,8 @@ jobs:
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
-        Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag"
+        Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)"
         docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)
         Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)"
-        docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag
+        docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -35,7 +35,7 @@ jobs:
       condition: succeeded()
       inputs:
         command: 'custom'
-        projects: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl/artifacts'
+        custom: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -24,7 +24,7 @@ jobs:
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
-        docker tag java-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+        docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
         Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
         docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -49,8 +49,8 @@ jobs:
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
-        Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
+        Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag"
         docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)
         Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag)"
-        docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+        docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/$(DefaultTag
       displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -34,16 +34,11 @@ jobs:
       displayName: Build CTL project
       condition: succeeded()
       inputs:
-        command: 'publish'
-        publishWebProjects: false
-        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        arguments: '-c Release -o $(Agent.TempDirectory)/artifacts'
+        command: 'custom'
+        projects: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
-        cd $(Agent.TempDirectory)/artifacts
-        ls
         cd $(Agent.TempDirectory)/ctl
-        ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -18,9 +18,8 @@ jobs:
     steps:
     # Below will build the image and push it to azure container registry
     - pwsh: |
-        cd Microsoft.Azure.Cosmos.Samples/Tools/CTL
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
-        docker build -t cosmos-dotnet-ctl -f Dockerfile .
+        docker build -t cosmos-dotnet-ctl -f Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -37,7 +37,7 @@ jobs:
         command: publish  
         configuration: Release
         nugetConfigPath: NuGet.config
-        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.sln'
+        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
         versioningScheme: OFF
         outputDir: $(Agent.TempDirectory)/ctl
     - pwsh: |

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -34,11 +34,15 @@ jobs:
       displayName: Build CTL project
       condition: succeeded()
       inputs:
-        command: 'custom'
-        custom: 'publish $(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj -c Release -o $(Agent.TempDirectory)/ctl/artifacts'
+        command: 'publish'
+        publishWebProjects: false
+        zipAfterPublish: false
+        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
+        arguments: '-c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
         cd $(Agent.TempDirectory)/ctl
+        ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -42,7 +42,7 @@ jobs:
         arguments: '-c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
-        cd $(Agent.TempDirectory)/ctl/artifacts
+        cd $(Agent.TempDirectory)/ctl/artifacts/CTL
         ls
         cd $(Agent.TempDirectory)/ctl
         ls

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -37,10 +37,13 @@ jobs:
         command: 'publish'
         publishWebProjects: false
         zipAfterPublish: false
+        modifyOutputPath: true
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
         arguments: '-c Release -o $(Agent.TempDirectory)/ctl/artifacts'
         nugetConfigPath: NuGet.config
     - pwsh: |
+        cd $(Agent.TempDirectory)/ctl/artifacts
+        ls
         cd $(Agent.TempDirectory)/ctl
         ls
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -16,11 +16,32 @@ jobs:
       vmImage: $(VmImage)
 
     steps:
-    # Below will build the image and push it to azure container registry
+    - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+      clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+    - task: CopyFiles@2
+      displayName: 'Copy docker config files'
+      inputs:
+        Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile'
+        TargetFolder: $(Agent.TempDirectory)/ctl
+    - task: CopyFiles@2
+      displayName: 'Copy shell files'
+      inputs:
+        Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh'
+        TargetFolder: $(Agent.TempDirectory)/ctl
+    - task: DotNetCoreCLI@2
+      displayName: Build CTL project
+      condition: succeeded()
+      inputs:
+        command: publish  
+        configuration: Release
+        nugetConfigPath: NuGet.config
+        projects: Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.sln
+        versioningScheme: OFF
+        outputDir: $(Agent.TempDirectory)/ctl
     - pwsh: |
-        cd Microsoft.Azure.Cosmos.Samples/Tools/CTL
+        cd $(Agent.TempDirectory)/ctl
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
-        docker build -t cosmos-dotnet-ctl -f Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile .
+        docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
         az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
         Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -23,11 +23,13 @@ jobs:
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile'
         TargetFolder: $(Agent.TempDirectory)/ctl
+        flattenFolders: true
     - task: CopyFiles@2
       displayName: 'Copy shell files'
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh'
         TargetFolder: $(Agent.TempDirectory)/ctl
+        flattenFolders: true
     - task: DotNetCoreCLI@2
       displayName: Build CTL project
       condition: succeeded()

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -35,7 +35,7 @@ jobs:
         command: publish  
         configuration: Release
         nugetConfigPath: NuGet.config
-        projects: Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.sln
+        projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.sln'
         versioningScheme: OFF
         outputDir: $(Agent.TempDirectory)/ctl
     - pwsh: |

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -1,0 +1,30 @@
+variables:
+  VmImage: 'ubuntu-18.04'
+
+jobs:
+  - job: Build and publish Docker image
+    timeoutInMinutes: 20
+    variables:
+      - name: ContainerRegistryName
+        value: 'cosmosdotnetsdkctl'
+      - name: ContainerRegistryUserName
+        value: 'cosmosdotnetsdkctl'
+      - name: ContainerRegistryUrl
+        value: 'cosmosdotnetsdkctl.azurecr.io'
+
+    pool:
+      vmImage: $(VmImage)
+
+    steps:
+    # Below will build the image and push it to azure container registry
+    - pwsh: |
+        cd Microsoft.Azure.Cosmos.Samples/Tools/CTL
+        Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
+        docker build -t cosmos-dotnet-ctl -f Dockerfile .
+        Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"
+        az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)
+        Write-Host "Executing docker tag cosmos-dotnet-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
+        docker tag java-ctl $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+        Write-Host "Executing docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload"
+        docker push $(ContainerRegistryUrl)/cosmos-dotnet-ctl/workload
+      displayName: 'Build and push docker image to registry'

--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -22,13 +22,13 @@ jobs:
       displayName: 'Copy docker config files'
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Dockerfile'
-        TargetFolder: $(Agent.TempDirectory)/CTL
+        TargetFolder: $(Agent.TempDirectory)/ctl
         flattenFolders: true
     - task: CopyFiles@2
       displayName: 'Copy shell files'
       inputs:
         Contents: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh'
-        TargetFolder: $(Agent.TempDirectory)/CTL
+        TargetFolder: $(Agent.TempDirectory)/ctl
         flattenFolders: true
     - task: DotNetCoreCLI@2
       displayName: Build CTL project
@@ -37,11 +37,11 @@ jobs:
         command: 'publish'
         publishWebProjects: false
         projects: '$(build.sourcesdirectory)/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj'
-        arguments: '-c Release -o $(Agent.TempDirectory)'
+        arguments: '-c Release'
+        outputDir: $(Agent.TempDirectory)/ctl
         nugetConfigPath: NuGet.config
     - pwsh: |
-        cd $(Agent.TempDirectory)/CTL
-        ls
+        cd $(Agent.TempDirectory)/ctl
         Write-Host "Executing docker build . -t cosmos-dotnet-ctl"
         docker build -t cosmos-dotnet-ctl -f Dockerfile .
         Write-Host "Executing az acr login --name $(ContainerRegistryName) -u $(ContainerRegistryUserName) -p $(dotnet-cosmos-container-registry-pwd)"

--- a/templates/build-ctl.yml
+++ b/templates/build-ctl.yml
@@ -2,9 +2,7 @@
 
 parameters:
   BuildConfiguration: ''
-  Arguments: ''
   VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
-  OS: 'Windows'
 
 jobs:
 - job:


### PR DESCRIPTION
This PR automates the generation of the Docker image for CTL runs using a YML Azure Pipelines job.

The Azure Pipelines job by default pushes the image to a default container in Azure Container Registry, but can be customized in case we want to push a new image for a particular test case (for example, testing if a particular set of changes would generate an image with any issues).