### PR TITLE
[Internal] Emulator Tests: Refactors the ToDoActivity object to use pk instead of status

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient(useGateway: true);
             DatabaseResponse db = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition();
-            partitionKeyDefinition.Paths.Add("/Status");
+            partitionKeyDefinition.Paths.Add("/pk");
             this.cosmosContainer = (ContainerInlineCore)await db.Database.CreateContainerAsync(new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition }, 10000);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient(useGateway: true);
             DatabaseResponse db = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition();
-            partitionKeyDefinition.Paths.Add("/pk");
+            partitionKeyDefinition.Paths.Add("/Status");
             this.cosmosContainer = (ContainerInlineCore)await db.Database.CreateContainerAsync(new ContainerProperties() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition }, 10000);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchTestBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchTestBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .GetAwaiter().GetResult().Database;
 
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition();
-            partitionKeyDefinition.Paths.Add("/Status");
+            partitionKeyDefinition.Paths.Add("/pk");
 
             BatchTestBase.LowThroughputJsonContainer = BatchTestBase.Database.CreateContainerAsync(
                 new ContainerProperties()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchTestBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchTestBase.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .GetAwaiter().GetResult().Database;
 
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition();
-            partitionKeyDefinition.Paths.Add("/pk");
+            partitionKeyDefinition.Paths.Add("/Status");
 
             BatchTestBase.LowThroughputJsonContainer = BatchTestBase.Database.CreateContainerAsync(
                 new ContainerProperties()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
-                MyDocument document = TestCommon.SerializerCore.FromStream<MyDocument>(result.Content);
+                ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
             }
         }
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task CreateItemAsync_WithBulk()
         {
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
                 tasks.Add(ExecuteCreateAsync(this.container, CreateItem(i.ToString())));
@@ -73,8 +73,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = tasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = tasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
-                MyDocument document = TestCommon.SerializerCore.FromStream<MyDocument>(result.Content);
+                ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
             }
         }
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task UpsertItem_WithBulk()
         {
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
                 tasks.Add(ExecuteUpsertAsync(this.container, CreateItem(i.ToString())));
@@ -138,8 +138,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = tasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = tasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
@@ -149,12 +149,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task DeleteItemStream_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
             }
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<Task<ResponseMessage>> deleteTasks = new List<Task<ResponseMessage>>();
             // Delete the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 deleteTasks.Add(ExecuteDeleteStreamAsync(this.container, createdDocument));
             }
@@ -182,21 +182,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task DeleteItem_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
 
-            List<Task<ItemResponse<MyDocument>>> deleteTasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> deleteTasks = new List<Task<ItemResponse<ToDoActivity>>>();
             // Delete the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 deleteTasks.Add(ExecuteDeleteAsync(this.container, createdDocument));
             }
@@ -204,8 +204,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Task.WhenAll(deleteTasks);
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = deleteTasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = deleteTasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
@@ -215,12 +215,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ReadItemStream_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
             }
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<Task<ResponseMessage>> readTasks = new List<Task<ResponseMessage>>();
             // Read the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 readTasks.Add(ExecuteReadStreamAsync(this.container, createdDocument));
             }
@@ -248,21 +248,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ReadItem_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
 
-            List<Task<ItemResponse<MyDocument>>> readTasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> readTasks = new List<Task<ItemResponse<ToDoActivity>>>();
             // Read the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 readTasks.Add(ExecuteReadAsync(this.container, createdDocument));
             }
@@ -270,8 +270,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Task.WhenAll(readTasks);
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = readTasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = readTasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
@@ -281,12 +281,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ReplaceItemStream_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
             }
@@ -295,7 +295,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<Task<ResponseMessage>> replaceTasks = new List<Task<ResponseMessage>>();
             // Replace the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 replaceTasks.Add(ExecuteReplaceStreamAsync(this.container, createdDocument));
             }
@@ -314,21 +314,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ReplaceItem_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
 
-            List<Task<ItemResponse<MyDocument>>> replaceTasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> replaceTasks = new List<Task<ItemResponse<ToDoActivity>>>();
             // Replace the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 replaceTasks.Add(ExecuteReplaceAsync(this.container, createdDocument));
             }
@@ -336,8 +336,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Task.WhenAll(replaceTasks);
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = replaceTasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = replaceTasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
@@ -347,12 +347,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task PatchItemStream_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
             }
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             List<Task<ResponseMessage>> PatchTasks = new List<Task<ResponseMessage>>();
             // Patch the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 PatchTasks.Add(ExecutePatchStreamAsync((ContainerInternal)this.container, createdDocument, patch));
             }
@@ -384,12 +384,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task PatchItem_WithBulk()
         {
-            List<MyDocument> createdDocuments = new List<MyDocument>();
+            List<ToDoActivity> createdDocuments = new List<ToDoActivity>();
             // Create the items
-            List<Task<ItemResponse<MyDocument>>> tasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                MyDocument createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
                 tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
             }
@@ -400,9 +400,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 PatchOperation.Add("/description", "patched")
             };
-            List<Task<ItemResponse<MyDocument>>> patchTasks = new List<Task<ItemResponse<MyDocument>>>();
+            List<Task<ItemResponse<ToDoActivity>>> patchTasks = new List<Task<ItemResponse<ToDoActivity>>>();
             // Patch the items
-            foreach (MyDocument createdDocument in createdDocuments)
+            foreach (ToDoActivity createdDocument in createdDocuments)
             {
                 patchTasks.Add(ExecutePatchAsync((ContainerInternal)this.container, createdDocument, patch));
             }
@@ -410,12 +410,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Task.WhenAll(patchTasks);
             for (int i = 0; i < 100; i++)
             {
-                Task<ItemResponse<MyDocument>> task = patchTasks[i];
-                ItemResponse<MyDocument> result = await task;
+                Task<ItemResponse<ToDoActivity>> task = patchTasks[i];
+                ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-                Assert.AreEqual("patched", result.Resource.Description);
+                Assert.AreEqual("patched", result.Resource.description);
             }
         }
 
@@ -439,9 +439,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 3; i++)
             {
-                MyDocument item = CreateItem(i.ToString());
+                ToDoActivity item = CreateItem(i.ToString());
 
-                if (i == 1) { item.Description = new string('x', appxItemSize); }
+                if (i == 1) { item.description = new string('x', appxItemSize); }
                 tasks.Add(ExecuteCreateStreamAsync(this.container, item));
             }
 
@@ -464,9 +464,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecuteCreateAsync(Container container, MyDocument item)
+        private static Task<ItemResponse<ToDoActivity>> ExecuteCreateAsync(Container container, ToDoActivity item)
         {
-            return container.CreateItemAsync<MyDocument>(item, new PartitionKey(item.Status));
+            return container.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.pk));
         }
 
         private static Task<ItemResponse<JObject>> ExecuteCreateAsync(Container container, JObject item)
@@ -474,79 +474,71 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             return container.CreateItemAsync<JObject>(item);
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecuteUpsertAsync(Container container, MyDocument item)
+        private static Task<ItemResponse<ToDoActivity>> ExecuteUpsertAsync(Container container, ToDoActivity item)
         {
-            return container.UpsertItemAsync<MyDocument>(item, new PartitionKey(item.Status));
+            return container.UpsertItemAsync<ToDoActivity>(item, new PartitionKey(item.pk));
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecuteReplaceAsync(Container container, MyDocument item)
+        private static Task<ItemResponse<ToDoActivity>> ExecuteReplaceAsync(Container container, ToDoActivity item)
         {
-            return container.ReplaceItemAsync<MyDocument>(item, item.id, new PartitionKey(item.Status));
+            return container.ReplaceItemAsync<ToDoActivity>(item, item.id, new PartitionKey(item.pk));
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecutePatchAsync(ContainerInternal container, MyDocument item, List<PatchOperation> patch)
+        private static Task<ItemResponse<ToDoActivity>> ExecutePatchAsync(ContainerInternal container, ToDoActivity item, List<PatchOperation> patch)
         {
-            return container.PatchItemAsync<MyDocument>(item.id, new PartitionKey(item.Status), patch);
+            return container.PatchItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk), patch);
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecuteDeleteAsync(Container container, MyDocument item)
+        private static Task<ItemResponse<ToDoActivity>> ExecuteDeleteAsync(Container container, ToDoActivity item)
         {
-            return container.DeleteItemAsync<MyDocument>(item.id, new PartitionKey(item.Status));
+            return container.DeleteItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk));
         }
 
-        private static Task<ItemResponse<MyDocument>> ExecuteReadAsync(Container container, MyDocument item)
+        private static Task<ItemResponse<ToDoActivity>> ExecuteReadAsync(Container container, ToDoActivity item)
         {
-            return container.ReadItemAsync<MyDocument>(item.id, new PartitionKey(item.Status));
+            return container.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk));
         }
 
-        private static Task<ResponseMessage> ExecuteCreateStreamAsync(Container container, MyDocument item)
+        private static Task<ResponseMessage> ExecuteCreateStreamAsync(Container container, ToDoActivity item)
         {
-            return container.CreateItemStreamAsync(TestCommon.SerializerCore.ToStream(item), new PartitionKey(item.Status));
+            return container.CreateItemStreamAsync(TestCommon.SerializerCore.ToStream(item), new PartitionKey(item.pk));
         }
 
-        private static Task<ResponseMessage> ExecuteUpsertStreamAsync(Container container, MyDocument item)
+        private static Task<ResponseMessage> ExecuteUpsertStreamAsync(Container container, ToDoActivity item)
         {
-            return container.UpsertItemStreamAsync(TestCommon.SerializerCore.ToStream(item), new PartitionKey(item.Status));
+            return container.UpsertItemStreamAsync(TestCommon.SerializerCore.ToStream(item), new PartitionKey(item.pk));
         }
 
-        private static Task<ResponseMessage> ExecuteReplaceStreamAsync(Container container, MyDocument item)
+        private static Task<ResponseMessage> ExecuteReplaceStreamAsync(Container container, ToDoActivity item)
         {
-            return container.ReplaceItemStreamAsync(TestCommon.SerializerCore.ToStream(item), item.id, new PartitionKey(item.Status));
+            return container.ReplaceItemStreamAsync(TestCommon.SerializerCore.ToStream(item), item.id, new PartitionKey(item.pk));
         }
 
-        private static Task<ResponseMessage> ExecutePatchStreamAsync(ContainerInternal container, MyDocument item, List<PatchOperation> patch)
+        private static Task<ResponseMessage> ExecutePatchStreamAsync(ContainerInternal container, ToDoActivity item, List<PatchOperation> patch)
         {
-            return container.PatchItemStreamAsync(item.id, new PartitionKey(item.Status), patch);
+            return container.PatchItemStreamAsync(item.id, new PartitionKey(item.pk), patch);
         }
 
-        private static Task<ResponseMessage> ExecuteDeleteStreamAsync(Container container, MyDocument item)
+        private static Task<ResponseMessage> ExecuteDeleteStreamAsync(Container container, ToDoActivity item)
         {
-            return container.DeleteItemStreamAsync(item.id, new PartitionKey(item.Status));
+            return container.DeleteItemStreamAsync(item.id, new PartitionKey(item.pk));
         }
 
-        private static Task<ResponseMessage> ExecuteReadStreamAsync(Container container, MyDocument item)
+        private static Task<ResponseMessage> ExecuteReadStreamAsync(Container container, ToDoActivity item)
         {
-            return container.ReadItemStreamAsync(item.id, new PartitionKey(item.Status));
+            return container.ReadItemStreamAsync(item.id, new PartitionKey(item.pk));
         }
 
-        private static MyDocument CreateItem(string id) => new MyDocument() { id = id, Status = id };
+        private static ToDoActivity CreateItem(string id)
+        {
+            return new ToDoActivity() { id = id, pk = id };
+        }
 
         private static JObject CreateJObjectWithoutPK(string id)
         {
             JObject document = new JObject();
             document["id"] = id;
             return document;
-        }
-
-        private class MyDocument
-        {
-            public string id { get; set; }
-
-            public string Status { get; set; }
-
-            public string Description { get; set; }
-
-            public bool Updated { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DatabaseResponse response = await client.CreateDatabaseIfNotExistsAsync(Guid.NewGuid().ToString());
             this.database = response.Database;
 
-            ContainerResponse containerResponse = await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/Status", 10000);
+            ContainerResponse containerResponse = await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk", 10000);
             this.container = containerResponse;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
@@ -179,17 +179,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead1));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead1));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead2));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead2));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: otherPK));
             }
 
             // Create one start state for each logical partition key.
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
                 for (int j = 0; j < perPKItemCount; j++)
                 {
-                    ToDoActivity temp = this.CreateRandomToDoActivity(pk);
+                    ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity(pk: pk);
 
                     createdList.Add(temp);
 
@@ -365,32 +365,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             }
 
             return createdList;
-        }
-
-        private ToDoActivity CreateRandomToDoActivity(string pk = null)
-        {
-            if (string.IsNullOrEmpty(pk))
-            {
-                pk = "TBD" + Guid.NewGuid().ToString();
-            }
-
-            return new ToDoActivity()
-            {
-                id = Guid.NewGuid().ToString(),
-                description = "CreateRandomToDoActivity",
-                status = pk,
-                taskNum = 42,
-                cost = double.MaxValue
-            };
-        }
-
-        public class ToDoActivity
-        {
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/ChangeFeedAsyncEnumerableTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 20000,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts/ContractTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Contracts
         [TestMethod]
         public async Task ItemStreamContractVerifier()
         {
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             Container container = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Contracts
         public async Task ChangeFeed_FeedRange_FromV0Token()
         {
             ContainerResponse largerContainer = await this.database.CreateContainerAsync(
-               new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: "/status"),
+               new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: "/pk"),
                throughput: 20000,
                cancellationToken: this.cancellationToken);
 
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Contracts
         public async Task Query_FeedRange_FromV2SDK()
         {
             ContainerResponse largerContainer = await this.database.CreateContainerAsync(
-               new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: "/status"),
+               new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: "/pk"),
                throughput: 20000,
                cancellationToken: this.cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContentResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContentResponseTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             this.container = await this.database.CreateContainerAsync(
                      id: "ItemNoResponseTest",
-                     partitionKeyPath: "/status");
+                     partitionKeyPath: "/pk");
             this.containerInternal = (ContainerInternal)this.container;
         }
 
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.Created, itemResponse.StatusCode);
             ValidateWrite(itemResponse);
 
-            itemResponse = await this.container.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.status), requestOptions: requestOptions);
+            itemResponse = await this.container.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk), requestOptions: requestOptions);
             Assert.AreEqual(HttpStatusCode.OK, itemResponse.StatusCode);
             ValidateRead(itemResponse);
 
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             itemResponse = await this.container.ReplaceItemAsync<ToDoActivity>(
                 item,
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions);
             Assert.AreEqual(HttpStatusCode.OK, itemResponse.StatusCode);
             ValidateWrite(itemResponse);
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             itemResponse = await this.containerInternal.PatchItemAsync<ToDoActivity>(
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 patchOperations: patch,
                 requestOptions: requestOptions);
             Assert.AreEqual(HttpStatusCode.OK, itemResponse.StatusCode);
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             itemResponse = await this.container.DeleteItemAsync<ToDoActivity>(
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions);
             Assert.AreEqual(HttpStatusCode.NoContent, itemResponse.StatusCode);
             this.ValidateItemNoContentResponse(itemResponse);
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity item = ToDoActivity.CreateRandomToDoActivity();
             using (ResponseMessage responseMessage = await this.container.CreateItemStreamAsync(
                 TestCommon.SerializerCore.ToStream(item),
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions))
             {
                 Assert.AreEqual(HttpStatusCode.Created, responseMessage.StatusCode);
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using (ResponseMessage responseMessage = await this.container.ReadItemStreamAsync(
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions))
             {
                 Assert.AreEqual(HttpStatusCode.OK, responseMessage.StatusCode);
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             item.cost = 424242.42;
             using (ResponseMessage responseMessage = await this.container.UpsertItemStreamAsync(
                 TestCommon.SerializerCore.ToStream(item),
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions))
             {
                 Assert.AreEqual(HttpStatusCode.OK, responseMessage.StatusCode);
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (ResponseMessage responseMessage = await this.container.ReplaceItemStreamAsync(
                 TestCommon.SerializerCore.ToStream(item),
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions))
             {
                 Assert.AreEqual(HttpStatusCode.OK, responseMessage.StatusCode);
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             using (ResponseMessage responseMessage = await this.containerInternal.PatchItemStreamAsync(
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 patchOperations: patch,
                 requestOptions: requestOptions))
             {
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using (ResponseMessage responseMessage = await this.container.DeleteItemStreamAsync(
                 item.id,
-                new PartitionKey(item.status),
+                new PartitionKey(item.pk),
                 requestOptions: requestOptions))
             {
                 Assert.AreEqual(HttpStatusCode.NoContent, responseMessage.StatusCode);
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             foreach (ToDoActivity item in items)
             {
-                bulkOperations.Add(bulkContainerInternal.PatchItemAsync<ToDoActivity>(item.id, new PartitionKey(item.status), patch, requestOptions: requestOptions));
+                bulkOperations.Add(bulkContainerInternal.PatchItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk), patch, requestOptions: requestOptions));
             }
 
             foreach (Task<ItemResponse<ToDoActivity>> result in bulkOperations)
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             bulkOperations = new List<Task<ItemResponse<ToDoActivity>>>();
             foreach (ToDoActivity item in items)
             {
-                bulkOperations.Add(bulkContainer.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.status), requestOptions: requestOptions));
+                bulkOperations.Add(bulkContainer.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk), requestOptions: requestOptions));
             }
 
             foreach (Task<ItemResponse<ToDoActivity>> result in bulkOperations)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDiagnosticsTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ItemResponse<ToDoActivity> readResponse = await this.Container.ReadItemAsync<ToDoActivity>(
                 id: testItem.id,
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 requestOptions);
 
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<ToDoActivity> replaceResponse = await this.Container.ReplaceItemAsync<ToDoActivity>(
                 item: testItem,
                 id: testItem.id,
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 requestOptions: requestOptions);
 
             Assert.AreEqual(replaceResponse.Resource.description, "NewDescription");
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             ItemResponse<ToDoActivity> patchResponse = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 patchOperations: patch,
                 requestOptions: requestOptions);
 
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 disableDiagnostics);
 
             ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 id: testItem.id,
                 requestOptions: requestOptions);
 
@@ -358,7 +358,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             //Checking point operation diagnostics on stream operations
             ResponseMessage createStreamResponse = await this.Container.CreateItemStreamAsync(
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 streamPayload: TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem),
                 requestOptions: requestOptions);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ResponseMessage readStreamResponse = await this.Container.ReadItemStreamAsync(
                 id: testItem.id,
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 requestOptions: requestOptions);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
                 readStreamResponse.Diagnostics,
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ResponseMessage replaceStreamResponse = await this.Container.ReplaceItemStreamAsync(
                streamPayload: TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem),
                id: testItem.id,
-               partitionKey: new PartitionKey(testItem.status),
+               partitionKey: new PartitionKey(testItem.pk),
                requestOptions: requestOptions);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
                 replaceStreamResponse.Diagnostics,
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ResponseMessage patchStreamResponse = await containerInternal.PatchItemStreamAsync(
                id: testItem.id,
-               partitionKey: new PartitionKey(testItem.status),
+               partitionKey: new PartitionKey(testItem.pk),
                patchOperations: patch,
                requestOptions: requestOptions);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ResponseMessage deleteStreamResponse = await this.Container.DeleteItemStreamAsync(
                id: testItem.id,
-               partitionKey: new PartitionKey(testItem.status),
+               partitionKey: new PartitionKey(testItem.pk),
                requestOptions: requestOptions);
             CosmosDiagnosticsTests.VerifyPointDiagnostics(
                 deleteStreamResponse.Diagnostics,
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Ensure diagnostics are set even on failed operations
             testItem.description = new string('x', Microsoft.Azure.Documents.Constants.MaxResourceSizeInBytes + 1);
             ResponseMessage createTooBigStreamResponse = await this.Container.CreateItemStreamAsync(
-                partitionKey: new PartitionKey(testItem.status),
+                partitionKey: new PartitionKey(testItem.pk),
                 streamPayload: TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem),
                 requestOptions: requestOptions);
             Assert.IsFalse(createTooBigStreamResponse.IsSuccessStatusCode);
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
 
                 ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-                createItemsTasks.Add(container.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.status)));
+                createItemsTasks.Add(container.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.pk)));
             }
 
             await Task.WhenAll(createItemsTasks);
@@ -493,7 +493,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
 
                 ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-                createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.status)));
+                createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.pk)));
             }
 
             await Task.WhenAll(createItemsTasks);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .WithHttpClientFactory(() => new HttpClient(httpClientHandler))))
             {
                 Cosmos.Database database = await client.CreateDatabaseAsync(Guid.NewGuid().ToString());
-                ContainerInternal container = (ContainerInternal)await database.CreateContainerAsync(Guid.NewGuid().ToString(), "/status");
+                ContainerInternal container = (ContainerInternal)await database.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk");
 
                 Container gatewayQueryPlanContainer = new ContainerInlineCore(
                     client.ClientContext,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHandlersTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHeaderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosHeaderTests.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 database = await client.CreateDatabaseAsync(nameof(VerifyKnownHeaders) + Guid.NewGuid().ToString());
                 Container container = await database.CreateContainerAsync(
                 Guid.NewGuid().ToString(),
-                "/status");
+                "/pk");
 
                 ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
-                await container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.status));
-                await container.ReadItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.status));
-                await container.UpsertItemAsync<ToDoActivity>(toDoActivity, new PartitionKey(toDoActivity.status));
+                await container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.pk));
+                await container.ReadItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.pk));
+                await container.UpsertItemAsync<ToDoActivity>(toDoActivity, new PartitionKey(toDoActivity.pk));
                 toDoActivity.cost = 8923498;
-                await container.ReplaceItemAsync<ToDoActivity>(toDoActivity, toDoActivity.id, new PartitionKey(toDoActivity.status));
-                await container.DeleteItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.status));
+                await container.ReplaceItemAsync<ToDoActivity>(toDoActivity, toDoActivity.id, new PartitionKey(toDoActivity.pk));
+                await container.DeleteItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.pk));
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -181,10 +181,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string corruptedTokenSerialized = JsonConvert.SerializeObject(corruptedTokens);
 
             ContainerInternal itemsCore = this.Container;
-            FeedIterator setIteratorNew =
+            using FeedIterator setIteratorNew =
                 itemsCore.GetStandByFeedIterator(corruptedTokenSerialized);
 
-            ResponseMessage responseMessage = await setIteratorNew.ReadNextAsync(this.cancellationToken);
+            using ResponseMessage responseMessage = await setIteratorNew.ReadNextAsync(this.cancellationToken);
 
             Assert.Fail("Should have thrown.");
         }
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             await this.CreateRandomItems(this.Container, 2, randomPartitionKey: true);
             ContainerInternal itemsCore = this.Container;
-            FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new StandByFeedIteratorRequestOptions() { StartTime = DateTime.MinValue });
+            using FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new StandByFeedIteratorRequestOptions() { StartTime = DateTime.MinValue });
 
             while (feedIterator.HasMoreResults)
             {
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 StandByFeedIteratorRequestOptions requestOptions = new StandByFeedIteratorRequestOptions() { StartTime = DateTime.MinValue };
 
-                FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(continuationToken, requestOptions: requestOptions);
+                using FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(continuationToken, requestOptions: requestOptions);
                 using (ResponseMessage responseMessage =
                     await feedIterator.ReadNextAsync(this.cancellationToken))
                 {
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<CompositeContinuationToken> previousToken = null;
             await this.CreateRandomItems(this.LargerContainer, expected, randomPartitionKey: true);
             ContainerInternal itemsCore = this.LargerContainer;
-            FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new StandByFeedIteratorRequestOptions() { StartTime = DateTime.MinValue });
+            using FeedIterator feedIterator = itemsCore.GetStandByFeedIterator(maxItemCount: 1, requestOptions: new StandByFeedIteratorRequestOptions() { StartTime = DateTime.MinValue });
             while (true)
             {
                 using (ResponseMessage responseMessage =
@@ -408,7 +408,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 id = Guid.NewGuid().ToString(),
                 description = "CreateRandomToDoActivity",
-                status = pk,
+                pk = pk,
                 taskNum = 42,
                 cost = double.MaxValue
             };
@@ -475,15 +475,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 return Task.FromResult(new ResponseMessage(System.Net.HttpStatusCode.NotModified));
             }
-        }
-
-        public class ToDoActivity
-        {
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemChangeFeedTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -655,7 +655,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             NumberLinqItem parametrizedLinqItem = new NumberLinqItem
             {
                 id = id,
-                status = pk,
+                pk = pk,
                 stringValue = stringValue,
                 sbyteValue = sbyteValue,
                 byteValue = byteValue,
@@ -762,7 +762,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private class NumberLinqItem
         {
             public string id;
-            public string status;
+            public string pk;
             public string stringValue;
             public sbyte sbyteValue;
             public byte byteValue;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //LINQ query execution with correct partition key.
             linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(
                 allowSynchronousQueryExecution: true,
-                requestOptions: new QueryRequestOptions { ConsistencyLevel = Cosmos.ConsistencyLevel.Eventual, PartitionKey = new Cosmos.PartitionKey(itemList[1].status) });
+                requestOptions: new QueryRequestOptions { ConsistencyLevel = Cosmos.ConsistencyLevel.Eventual, PartitionKey = new Cosmos.PartitionKey(itemList[1].pk) });
             queriable = linqQueryable.Where(item => item.taskNum < 100);
             Assert.AreEqual(1, queriable.Count());
             Assert.AreEqual(itemList[1].id, queriable.ToList()[0].id);
@@ -365,10 +365,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
             toDoActivity.taskNum = 20;
             toDoActivity.id = "minTaskNum";
-            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.status));
+            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.pk));
             toDoActivity.taskNum = 100;
             toDoActivity.id = "maxTaskNum";
-            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.status));
+            await this.Container.CreateItemAsync(toDoActivity, new PartitionKey(toDoActivity.pk));
 
             Response<int> minTaskNum = await linqQueryable.Select(item => item.taskNum).MinAsync();
             Assert.AreEqual(20, minTaskNum);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1089,7 +1089,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IList<ToDoActivity> findItems = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 1, perPKItemCount: 10, randomPartitionKey: false);
 
             string findPkValue = findItems.First().pk;
-            QueryDefinition sql = new QueryDefinition("SELECT * FROM toDoActivity t where t.status = @pkValue").WithParameter("@pkValue", findPkValue);
+            QueryDefinition sql = new QueryDefinition("SELECT * FROM toDoActivity t where t.pk = @pkValue").WithParameter("@pkValue", findPkValue);
 
 
             double totalRequstCharge = 0;
@@ -1145,7 +1145,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // BadReqeust bcoz collection is regular and not binary 
             Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
 
-            await this.Container.CreateItemAsync<dynamic>(new { id = Guid.NewGuid().ToString(), status = "test" });
+            await this.Container.CreateItemAsync<dynamic>(new { id = Guid.NewGuid().ToString(), pk = "test" });
             epk = new PartitionKey("test")
                            .InternalKey
                            .GetEffectivePartitionKeyString(this.containerSettings.PartitionKey);
@@ -1300,7 +1300,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ToDoActivity toDoActivity = deleteList.First();
             QueryDefinition sql = new QueryDefinition(
-                "select * from toDoActivity t where t.status = @pk")
+                "select * from toDoActivity t where t.pk = @pk")
                 .WithParameter("@pk", toDoActivity.pk);
 
             // Test max size at 1
@@ -1826,7 +1826,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 //Quering items on fixed container with non-none PK.
                 using (FeedIterator<dynamic> feedIterator = fixedContainer.GetItemQueryIterator<dynamic>(
                     sql,
-                    requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = new Cosmos.PartitionKey(itemWithPK.status) }))
+                    requestOptions: new QueryRequestOptions() { MaxItemCount = 10, PartitionKey = new Cosmos.PartitionKey(itemWithPK.partitionKey) }))
                 {
                     while (feedIterator.HasMoreResults)
                     {
@@ -1845,7 +1845,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 //Deleting item from fixed container with non-none PK.
                 ItemResponse<ToDoActivityAfterMigration> deleteResponseWithPk = await fixedContainer.DeleteItemAsync<ToDoActivityAfterMigration>(
-                 partitionKey: new Cosmos.PartitionKey(itemWithPK.status),
+                 partitionKey: new Cosmos.PartitionKey(itemWithPK.partitionKey),
                  id: itemWithPK.id);
 
                 Assert.IsNull(deleteResponseWithPk.Resource);
@@ -1910,7 +1910,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         // Re-Insert into container with a partition key
                         ToDoActivityAfterMigration itemWithPK = new ToDoActivityAfterMigration
-                        { id = activity.id, cost = activity.cost, description = activity.description, status = "TestPK", taskNum = activity.taskNum };
+                        { id = activity.id, cost = activity.cost, description = activity.description, partitionKey = "TestPK", taskNum = activity.taskNum };
                         ItemResponse<ToDoActivityAfterMigration> createResponseWithPk = await fixedContainer.CreateItemAsync<ToDoActivityAfterMigration>(
                          item: itemWithPK);
                         Assert.AreEqual(HttpStatusCode.Created, createResponseWithPk.StatusCode);
@@ -2385,7 +2385,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             public double cost { get; set; }
             public string description { get; set; }
             [JsonProperty(PropertyName = "_partitionKey")]
-            public string status { get; set; }
+            public string partitionKey { get; set; }
         }
 
         private ToDoActivityAfterMigration CreateRandomToDoActivityAfterMigration(string pk = null, string id = null)
@@ -2402,7 +2402,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 id = id,
                 description = "CreateRandomToDoActivity",
-                status = pk,
+                partitionKey = pk,
                 taskNum = 42,
                 cost = double.MaxValue
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
                 this.containerSettings,
@@ -73,11 +73,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
             testItem.id = "Invalid#/\\?Id";
-            await this.Container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.status));
+            await this.Container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
 
             try
             {
-                await this.Container.ReadItemAsync<JObject>(testItem.id, new Cosmos.PartitionKey(testItem.status));
+                await this.Container.ReadItemAsync<JObject>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
                 Assert.Fail("Read item should fail because id has invalid characters");
             }
             catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.NotFound)
@@ -127,10 +127,24 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync<ToDoActivity>(item: testItem);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Resource);
+            Assert.IsNotNull(response.Diagnostics);
+            Assert.IsTrue(!string.IsNullOrEmpty(response.Diagnostics.ToString()));
+            Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+
+            response = await this.Container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.Resource);
+            Assert.IsNotNull(response.Diagnostics);
+            Assert.IsTrue(!string.IsNullOrEmpty(response.Diagnostics.ToString()));
+            Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+
             Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.MaxResourceQuota));
             Assert.IsNotNull(response.Headers.GetHeaderValue<string>(Documents.HttpConstants.HttpHeaders.CurrentResourceQuotaUsage));
-            ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id);
+            ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id);
             Assert.IsNotNull(deleteResponse);
+            Assert.IsNotNull(response.Diagnostics);
+            Assert.IsTrue(!string.IsNullOrEmpty(response.Diagnostics.ToString()));
+            Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
         }
 
         [TestMethod]
@@ -142,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             httpHandler.RequestCallBack = (request, cancellation) =>
             {
-                if(request.Method == HttpMethod.Get &&
+                if (request.Method == HttpMethod.Get &&
                     request.RequestUri.AbsolutePath == "//addresses/")
                 {
                     HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.Forbidden);
@@ -157,14 +171,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 return null;
             };
-            
+
             try
             {
                 ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
                 await client.GetContainer(this.database.Id, this.Container.Id).CreateItemAsync<ToDoActivity>(item: testItem);
                 Assert.Fail("Request should throw exception.");
             }
-            catch(CosmosException ce) when (ce.StatusCode == HttpStatusCode.Forbidden)
+            catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.Forbidden)
             {
                 Assert.AreEqual(999999, ce.SubStatusCode);
                 string exception = ce.ToString();
@@ -188,7 +202,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task MemoryStreamBufferIsAccessibleOnResponse()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.SerializerCore.ToStream(testItem), partitionKey: new Cosmos.PartitionKey(testItem.status));
+            ResponseMessage response = await this.Container.CreateItemStreamAsync(streamPayload: TestCommon.SerializerCore.ToStream(testItem), partitionKey: new Cosmos.PartitionKey(testItem.pk));
             Assert.IsNotNull(response);
             Assert.IsTrue((response.Content as MemoryStream).TryGetBuffer(out _));
             FeedIterator feedIteratorQuery = this.Container.GetItemQueryStreamIterator(queryText: "SELECT * FROM c");
@@ -201,7 +215,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             FeedIterator feedIterator = this.Container.GetItemQueryStreamIterator(requestOptions: new QueryRequestOptions()
             {
-                PartitionKey = new Cosmos.PartitionKey(testItem.status)
+                PartitionKey = new Cosmos.PartitionKey(testItem.pk)
             });
 
             while (feedIterator.HasMoreResults)
@@ -225,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             { }
 
             // Both items have null description
-            dynamic testItem = new { id = id1, status = pk, description = (string)null};
+            dynamic testItem = new { id = id1, status = pk, description = (string)null };
             dynamic testItem2 = new { id = id2, status = pk, description = (string)null };
 
             // Create a client that ignore null
@@ -458,22 +472,40 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
-                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), streamPayload: stream))
+                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
                     Assert.IsTrue(response.Headers.RequestCharge > 0);
                     Assert.IsNotNull(response.Headers.ActivityId);
                     Assert.IsNotNull(response.Headers.ETag);
+                    Assert.IsNotNull(response.Diagnostics);
+                    Assert.IsTrue(!string.IsNullOrEmpty(response.Diagnostics.ToString()));
+                    Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
                 }
             }
 
-            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id))
+            using (ResponseMessage response = await this.Container.ReadItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
+            {
+                Assert.IsNotNull(response);
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+                Assert.IsTrue(response.Headers.RequestCharge > 0);
+                Assert.IsNotNull(response.Headers.ActivityId);
+                Assert.IsNotNull(response.Headers.ETag);
+                Assert.IsNotNull(response.Diagnostics);
+                Assert.IsTrue(!string.IsNullOrEmpty(response.Diagnostics.ToString()));
+                Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+            }
+
+            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
             {
                 Assert.IsNotNull(deleteResponse);
                 Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
                 Assert.IsTrue(deleteResponse.Headers.RequestCharge > 0);
                 Assert.IsNotNull(deleteResponse.Headers.ActivityId);
+                Assert.IsNotNull(deleteResponse.Diagnostics);
+                Assert.IsTrue(!string.IsNullOrEmpty(deleteResponse.Diagnostics.ToString()));
+                Assert.IsTrue(deleteResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
             }
         }
 
@@ -484,7 +516,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
                 //Create the object
-                using (ResponseMessage response = await this.Container.UpsertItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), streamPayload: stream))
+                using (ResponseMessage response = await this.Container.UpsertItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
@@ -499,13 +531,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             testItem.taskNum = 9001;
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
-                using (ResponseMessage response = await this.Container.UpsertItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), streamPayload: stream))
+                using (ResponseMessage response = await this.Container.UpsertItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 }
             }
-            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id))
+            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
             {
                 Assert.IsNotNull(deleteResponse);
                 Assert.AreEqual(deleteResponse.StatusCode, HttpStatusCode.NoContent);
@@ -520,7 +552,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 //Replace a non-existing item. It should fail, and not throw an exception.
                 using (ResponseMessage response = await this.Container.ReplaceItemStreamAsync(
-                    partitionKey: new Cosmos.PartitionKey(testItem.status),
+                    partitionKey: new Cosmos.PartitionKey(testItem.pk),
                     id: testItem.id,
                     streamPayload: stream))
                 {
@@ -533,7 +565,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
                 //Create the item
-                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), streamPayload: stream))
+                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
@@ -544,13 +576,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             testItem.taskNum = 9001;
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
-                using (ResponseMessage response = await this.Container.ReplaceItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id, streamPayload: stream))
+                using (ResponseMessage response = await this.Container.ReplaceItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id, streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 }
 
-                using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id))
+                using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
                 {
                     Assert.IsNotNull(deleteResponse);
                     Assert.AreEqual(deleteResponse.StatusCode, HttpStatusCode.NoContent);
@@ -631,7 +663,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
 
             ContainerInternal containerInternal = (ContainerInternal)this.Container;
-            ItemResponse<dynamic>  itemResponse = await this.Container.CreateItemAsync<dynamic>(testItem1);
+            ItemResponse<dynamic> itemResponse = await this.Container.CreateItemAsync<dynamic>(testItem1);
             ItemResponse<dynamic> itemResponse2 = await this.Container.CreateItemAsync<dynamic>(testItem2);
             ItemResponse<dynamic> itemResponse3 = await this.Container.CreateItemAsync<dynamic>(testItem3);
             Cosmos.PartitionKey partitionKey1 = new Cosmos.PartitionKey(pKString);
@@ -843,7 +875,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IList<ToDoActivity> deleteList = deleteList = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 3, perPKItemCount: perPKItemCount, randomPartitionKey: true);
             ToDoActivity find = deleteList.First();
 
-            QueryDefinition sql = new QueryDefinition("select * from r where r.status = @status").WithParameter("@status", find.status);
+            QueryDefinition sql = new QueryDefinition("select * from r where r.status = @status").WithParameter("@status", find.pk);
 
             int iterationCount = 0;
             int totalReadItem = 0;
@@ -860,7 +892,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         MaxItemCount = maxItemCount,
                         MaxConcurrency = 1,
-                        PartitionKey = new Cosmos.PartitionKey(find.status),
+                        PartitionKey = new Cosmos.PartitionKey(find.pk),
                     });
 
                 ResponseMessage response = await feedIterator.ReadNextAsync();
@@ -878,7 +910,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         .ToArray();
 
                     ToDoActivity[] expectedTodoActivities = deleteList
-                            .Where(e => e.status == find.status)
+                            .Where(e => e.pk == find.pk)
                             .Where(e => readTodoActivities.Any(e1 => e1.id == e.id))
                             .OrderBy(e => e.id)
                             .ToArray();
@@ -1056,7 +1088,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Create 10 items with same pk value
             IList<ToDoActivity> findItems = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 1, perPKItemCount: 10, randomPartitionKey: false);
 
-            string findPkValue = findItems.First().status;
+            string findPkValue = findItems.First().pk;
             QueryDefinition sql = new QueryDefinition("SELECT * FROM toDoActivity t where t.status = @pkValue").WithParameter("@pkValue", findPkValue);
 
 
@@ -1081,7 +1113,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             Assert.AreEqual(findItems.Count, foundItems.Count);
-            Assert.IsFalse(foundItems.Any(x => !string.Equals(x.status, findPkValue)), "All the found items should have the same PK value");
+            Assert.IsFalse(foundItems.Any(x => !string.Equals(x.pk, findPkValue)), "All the found items should have the same PK value");
             Assert.IsTrue(totalRequstCharge > 0);
         }
 
@@ -1269,7 +1301,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity toDoActivity = deleteList.First();
             QueryDefinition sql = new QueryDefinition(
                 "select * from toDoActivity t where t.status = @status")
-                .WithParameter("@status", toDoActivity.status);
+                .WithParameter("@status", toDoActivity.pk);
 
             // Test max size at 1
             FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
@@ -1277,7 +1309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 requestOptions: new QueryRequestOptions()
                 {
                     MaxItemCount = 1,
-                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.status),
+                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.pk),
                 });
 
             while (feedIterator.HasMoreResults)
@@ -1292,7 +1324,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 requestOptions: new QueryRequestOptions()
                 {
                     MaxItemCount = 2,
-                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.status),
+                    PartitionKey = new Cosmos.PartitionKey(toDoActivity.pk),
                 });
 
             while (setIteratorMax2.HasMoreResults)
@@ -1315,11 +1347,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 using (FeedIterator<dynamic> resultSet = this.Container.GetItemQueryIterator<dynamic>(
                     queryText: "SELECT r.id FROM root r WHERE r._ts > 0",
-                    requestOptions: new QueryRequestOptions() 
-                    { 
-                        ResponseContinuationTokenLimitInKb = 0, 
-                        MaxItemCount = 10, 
-                        MaxConcurrency = 1 
+                    requestOptions: new QueryRequestOptions()
+                    {
+                        ResponseContinuationTokenLimitInKb = 0,
+                        MaxItemCount = 10,
+                        MaxConcurrency = 1
                     }))
                 {
                     await resultSet.ReadNextAsync();
@@ -1360,7 +1392,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using (ResponseMessage responseMessage = await this.Container.UpsertItemStreamAsync(
                     streamPayload: TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem),
-                    partitionKey: new Cosmos.PartitionKey(testItem.status),
+                    partitionKey: new Cosmos.PartitionKey(testItem.pk),
                     requestOptions: itemRequestOptions))
             {
                 Assert.IsNotNull(responseMessage);
@@ -1391,7 +1423,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id);
+                ItemResponse<ToDoActivity> deleteResponse = await this.Container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id);
                 Assert.IsNotNull(deleteResponse);
             }
         }
@@ -1412,8 +1444,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(testItem.id, response.Resource.id);
             Assert.AreNotEqual(originalId, response.Resource.id);
 
-            string originalStatus = testItem.status;
-            testItem.status = Guid.NewGuid().ToString();
+            string originalStatus = testItem.pk;
+            testItem.pk = Guid.NewGuid().ToString();
 
             try
             {
@@ -1445,7 +1477,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 await containerInternal.PatchItemAsync<ToDoActivity>(
                     id: Guid.NewGuid().ToString(),
-                    partitionKey: new Cosmos.PartitionKey(testItem.status),
+                    partitionKey: new Cosmos.PartitionKey(testItem.pk),
                     patchOperations: patchOperations);
 
                 Assert.Fail("Patch operation should fail if the item doesn't exist.");
@@ -1453,7 +1485,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             catch (CosmosException ex)
             {
                 Assert.AreEqual(HttpStatusCode.NotFound, ex.StatusCode);
-                Assert.IsTrue(ex.Message.Contains("Resource Not Found"));                
+                Assert.IsTrue(ex.Message.Contains("Resource Not Found"));
             }
 
             // adding a child when parent / ancestor does not exist - 400 BadRequest response
@@ -1461,7 +1493,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 await containerInternal.PatchItemAsync<ToDoActivity>(
                     id: testItem.id,
-                    partitionKey: new Cosmos.PartitionKey(testItem.status),
+                    partitionKey: new Cosmos.PartitionKey(testItem.pk),
                     patchOperations: patchOperations);
 
                 Assert.Fail("Patch operation should fail for malformed PatchSpecification.");
@@ -1482,7 +1514,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 await containerInternal.PatchItemAsync<ToDoActivity>(
                     id: testItem.id,
-                    partitionKey: new Cosmos.PartitionKey(testItem.status),
+                    partitionKey: new Cosmos.PartitionKey(testItem.pk),
                     patchOperations: patchOperations,
                     requestOptions);
 
@@ -1506,10 +1538,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             int newTaskNum = originalTaskNum + 1;
             //Int16 one = 1;
 
-            Assert.IsNull(testItem.children[1].status);
+            Assert.IsNull(testItem.children[1].pk);
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
-            {   
+            {
                 PatchOperation.Add("/children/1/status", "patched"),
                 PatchOperation.Remove("/description"),
                 PatchOperation.Replace("/taskNum", newTaskNum),
@@ -1524,7 +1556,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ItemResponse<ToDoActivity> response = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 patchOperations: patchOperations,
                 requestOptions);
 
@@ -1534,11 +1566,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // read resource to validate the patch operation
             response = await containerInternal.ReadItemAsync<ToDoActivity>(
                 testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status));
+                partitionKey: new Cosmos.PartitionKey(testItem.pk));
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
-            Assert.AreEqual("patched", response.Resource.children[1].status);
+            Assert.AreEqual("patched", response.Resource.children[1].pk);
             Assert.IsNull(response.Resource.description);
             Assert.AreEqual(newTaskNum, response.Resource.taskNum);
 
@@ -1548,7 +1580,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // with content response
             response = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 patchOperations: patchOperations);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -1571,7 +1603,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             // Patch a non-existing item. It should fail, and not throw an exception.
             using (ResponseMessage response = await containerInternal.PatchItemStreamAsync(
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 id: testItem.id,
                 patchOperations: patchOperations))
             {
@@ -1583,7 +1615,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
                 // Create the item
-                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), streamPayload: stream))
+                using (ResponseMessage response = await this.Container.CreateItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), streamPayload: stream))
                 {
                     Assert.IsNotNull(response);
                     Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
@@ -1591,22 +1623,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             // Patch
-            using (ResponseMessage response = await containerInternal.PatchItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id, patchOperations: patchOperations))
+            using (ResponseMessage response = await containerInternal.PatchItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id, patchOperations: patchOperations))
             {
                 Assert.IsNotNull(response);
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             }
 
             // Read and validate
-            ItemResponse<ToDoActivity> itemResponse = await this.Container.ReadItemAsync<ToDoActivity>(testItem.id, partitionKey: new Cosmos.PartitionKey(testItem.status));
+            ItemResponse<ToDoActivity> itemResponse = await this.Container.ReadItemAsync<ToDoActivity>(testItem.id, partitionKey: new Cosmos.PartitionKey(testItem.pk));
             Assert.AreEqual(HttpStatusCode.OK, itemResponse.StatusCode);
             Assert.IsNotNull(itemResponse.Resource);
-            Assert.AreEqual("patched", itemResponse.Resource.children[1].status);
+            Assert.AreEqual("patched", itemResponse.Resource.children[1].pk);
             Assert.IsNull(itemResponse.Resource.description);
-            Assert.AreEqual(testItem.taskNum+1, itemResponse.Resource.taskNum);
+            Assert.AreEqual(testItem.taskNum + 1, itemResponse.Resource.taskNum);
 
             // Delete
-            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id))
+            using (ResponseMessage deleteResponse = await this.Container.DeleteItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
             {
                 Assert.IsNotNull(deleteResponse);
                 Assert.AreEqual(deleteResponse.StatusCode, HttpStatusCode.NoContent);
@@ -1627,7 +1659,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             int originalTaskNum = testItem.taskNum;
             int newTaskNum = originalTaskNum + 1;
 
-            Assert.IsNull(testItem.children[1].status);
+            Assert.IsNull(testItem.children[1].pk);
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
@@ -1638,12 +1670,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ItemResponse<ToDoActivity> response = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 patchOperations: patchOperations);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
-            Assert.AreEqual("patched", response.Resource.children[1].status);
+            Assert.AreEqual("patched", response.Resource.children[1].pk);
             Assert.IsNull(response.Resource.description);
             Assert.AreEqual(newTaskNum, response.Resource.taskNum);
         }
@@ -1679,7 +1711,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ItemResponse<dynamic> response = await containerInternal.PatchItemAsync<dynamic>(
                 id: testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status),
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
                 patchOperations: patchOperations,
                 requestOptions);
 
@@ -1692,7 +1724,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // regular container
             response = await this.Container.ReadItemAsync<dynamic>(
                 testItem.id,
-                partitionKey: new Cosmos.PartitionKey(testItem.status));
+                partitionKey: new Cosmos.PartitionKey(testItem.pk));
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
@@ -1737,7 +1769,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(itemWithoutPK.id, createResponseWithoutPk.Resource.id);
 
                 //Updating item on fixed container with CosmosContainerSettings.NonePartitionKeyValue.
-                itemWithoutPK.status = "updatedStatus";
+                itemWithoutPK.pk = "updatedStatus";
                 ItemResponse<ToDoActivity> updateResponseWithoutPk = await fixedContainer.ReplaceItemAsync<ToDoActivity>(
                  id: itemWithoutPK.id,
                  item: itemWithoutPK,
@@ -1934,7 +1966,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             CosmosClient client = TestCommon.CreateCosmosClient();
             Cosmos.Database db = await client.CreateDatabaseIfNotExistsAsync("LoadTest");
-            Container container = await db.CreateContainerIfNotExistsAsync("LoadContainer", "/status");
+            Container container = await db.CreateContainerIfNotExistsAsync("LoadContainer", "/pk");
 
             try
             {
@@ -1943,7 +1975,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity();
                     createItems[i] = container.CreateItemStreamAsync(
-                        partitionKey: new Cosmos.PartitionKey(temp.status),
+                        partitionKey: new Cosmos.PartitionKey(temp.pk),
                         streamPayload: TestCommon.SerializerCore.ToStream<ToDoActivity>(temp));
                 }
 
@@ -1980,12 +2012,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity("TBD");
 
-            ItemResponse<ToDoActivity> responseAstype = await this.Container.CreateItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(temp.status), item: temp);
+            ItemResponse<ToDoActivity> responseAstype = await this.Container.CreateItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(temp.pk), item: temp);
 
             string sessionToken = responseAstype.Headers.Session;
             Assert.IsNotNull(sessionToken);
 
-            ResponseMessage readResponse = await this.Container.ReadItemStreamAsync(temp.id, new Cosmos.PartitionKey(temp.status), new ItemRequestOptions() { SessionToken = sessionToken });
+            ResponseMessage readResponse = await this.Container.ReadItemStreamAsync(temp.id, new Cosmos.PartitionKey(temp.pk), new ItemRequestOptions() { SessionToken = sessionToken });
 
             Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
             Assert.IsNotNull(readResponse.Headers.Session);
@@ -1997,19 +2029,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             CosmosClient cosmosClient = TestCommon.CreateCosmosClient(new CosmosClientOptions() { ConsistencyLevel = Cosmos.ConsistencyLevel.Session });
             DatabaseResponse database = await cosmosClient.CreateDatabaseIfNotExistsAsync("NoSession");
-            Container container = await database.Database.CreateContainerIfNotExistsAsync("NoSession", "/status");
+            Container container = await database.Database.CreateContainerIfNotExistsAsync("NoSession", "/pk");
 
             try
             {
                 ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity("TBD");
 
-                ItemResponse<ToDoActivity> responseAstype = await container.CreateItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(temp.status), item: temp);
+                ItemResponse<ToDoActivity> responseAstype = await container.CreateItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(temp.pk), item: temp);
 
                 string invalidSessionToken = this.GetDifferentLSNToken(responseAstype.Headers.Session, 2000);
 
                 try
                 {
-                    ItemResponse<ToDoActivity> readResponse = await container.ReadItemAsync<ToDoActivity>(temp.id, new Cosmos.PartitionKey(temp.status), new ItemRequestOptions() { SessionToken = invalidSessionToken });
+                    ItemResponse<ToDoActivity> readResponse = await container.ReadItemAsync<ToDoActivity>(temp.id, new Cosmos.PartitionKey(temp.pk), new ItemRequestOptions() { SessionToken = invalidSessionToken });
                     Assert.Fail("Should had thrown ReadSessionNotAvailable");
                 }
                 catch (CosmosException cosmosException)
@@ -2108,10 +2140,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 ToDoActivity t = new ToDoActivity
                 {
-                    status = "AutoID"
+                    pk = "AutoID"
                 };
                 ItemResponse<ToDoActivity> responseAstype = await this.Container.CreateItemAsync<ToDoActivity>(
-                    partitionKey: new Cosmos.PartitionKey(t.status), item: t);
+                    partitionKey: new Cosmos.PartitionKey(t.pk), item: t);
 
                 Assert.Fail("Unexpected ID auto-generation");
             }
@@ -2125,14 +2157,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ToDoActivity itemWithoutId = new ToDoActivity
             {
-                status = "AutoID"
+                pk = "AutoID"
             };
 
             ToDoActivity createdItem = await this.AutoGenerateIdPatternTest<ToDoActivity>(
-                new Cosmos.PartitionKey(itemWithoutId.status), itemWithoutId);
+                new Cosmos.PartitionKey(itemWithoutId.pk), itemWithoutId);
 
             Assert.IsNotNull(createdItem.id);
-            Assert.AreEqual(itemWithoutId.status, createdItem.status);
+            Assert.AreEqual(itemWithoutId.pk, createdItem.pk);
         }
 
         [TestMethod]
@@ -2174,7 +2206,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
 
             ItemResponse<ToDoActivity> responseAstype = await container.CreateItemAsync<ToDoActivity>(
-                partitionKey: new Cosmos.PartitionKey(temp.status),
+                partitionKey: new Cosmos.PartitionKey(temp.pk),
                 item: temp,
                 requestOptions: ro);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -707,7 +707,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 id = "ItemCustomSerialzierTest1",
                 cost = (double?)null,
                 totalCost = 98.2789,
-                status = "MyCustomStatus",
+                pk = "MyCustomStatus",
                 taskNum = 4909,
                 createdDateTime = createDateTime,
                 statusCode = HttpStatusCode.Accepted,
@@ -720,7 +720,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 id = "ItemCustomSerialzierTest2",
                 cost = (double?)null,
                 totalCost = 98.2789,
-                status = "MyCustomStatus",
+                pk = "MyCustomStatus",
                 taskNum = 4909,
                 createdDateTime = createDateTime,
                 statusCode = HttpStatusCode.Accepted,
@@ -735,7 +735,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<QueryDefinition> queryDefinitions = new List<QueryDefinition>()
             {
-                new QueryDefinition("select * from t where t.pk = @pk" ).WithParameter("@pk", testItem1.status),
+                new QueryDefinition("select * from t where t.pk = @pk" ).WithParameter("@pk", testItem1.pk),
                 new QueryDefinition("select * from t where t.cost = @cost" ).WithParameter("@cost", testItem1.cost),
                 new QueryDefinition("select * from t where t.taskNum = @taskNum" ).WithParameter("@taskNum", testItem1.taskNum),
                 new QueryDefinition("select * from t where t.totalCost = @totalCost" ).WithParameter("@totalCost", testItem1.totalCost),
@@ -744,7 +744,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new QueryDefinition("select * from t where t.itemIds = @itemIds" ).WithParameter("@itemIds", testItem1.itemIds),
                 new QueryDefinition("select * from t where t.dictionary = @dictionary" ).WithParameter("@dictionary", testItem1.dictionary),
                 new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
-                    .WithParameter("@pk", testItem1.status)
+                    .WithParameter("@pk", testItem1.pk)
                     .WithParameter("@cost", testItem1.cost),
             };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -647,19 +647,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             dynamic testItem1 = new
             {
                 id = "item1",
-                status = pKString
+                pk = pKString
             };
 
             dynamic testItem2 = new
             {
                 id = "item2",
-                status = pKString
+                pk = pKString
             };
 
             dynamic testItem3 = new
             {
                 id = "item3",
-                status = pKString2
+                pk = pKString2
             };
 
             ContainerInternal containerInternal = (ContainerInternal)this.Container;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -110,12 +110,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     JObject item = await containerByRid.ReplaceItemAsync<JObject>(
                         item: itemWithInvalidId,
                         id: itemWithInvalidId["_rid"].ToString(),
-                        partitionKey: new Cosmos.PartitionKey(itemWithInvalidId["status"].ToString()));
+                        partitionKey: new Cosmos.PartitionKey(itemWithInvalidId["pk"].ToString()));
 
                     // Validate the new id can be read using the original name based contianer reference
                     await this.Container.ReadItemAsync<ToDoActivity>(
                        item["id"].ToString(),
-                       new Cosmos.PartitionKey(item["status"].ToString())); ;
+                       new Cosmos.PartitionKey(item["pk"].ToString())); ;
                 }
             }
         }
@@ -488,7 +488,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (ResponseMessage response = await this.Container.ReadItemStreamAsync(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id))
             {
                 Assert.IsNotNull(response);
-                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsTrue(response.Headers.RequestCharge > 0);
                 Assert.IsNotNull(response.Headers.ActivityId);
                 Assert.IsNotNull(response.Headers.ETag);
@@ -735,7 +735,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<QueryDefinition> queryDefinitions = new List<QueryDefinition>()
             {
-                new QueryDefinition("select * from t where t.status = @status" ).WithParameter("@status", testItem1.status),
+                new QueryDefinition("select * from t where t.pk = @pk" ).WithParameter("@pk", testItem1.status),
                 new QueryDefinition("select * from t where t.cost = @cost" ).WithParameter("@cost", testItem1.cost),
                 new QueryDefinition("select * from t where t.taskNum = @taskNum" ).WithParameter("@taskNum", testItem1.taskNum),
                 new QueryDefinition("select * from t where t.totalCost = @totalCost" ).WithParameter("@totalCost", testItem1.totalCost),
@@ -743,8 +743,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new QueryDefinition("select * from t where t.statusCode = @statusCode" ).WithParameter("@statusCode", testItem1.statusCode),
                 new QueryDefinition("select * from t where t.itemIds = @itemIds" ).WithParameter("@itemIds", testItem1.itemIds),
                 new QueryDefinition("select * from t where t.dictionary = @dictionary" ).WithParameter("@dictionary", testItem1.dictionary),
-                new QueryDefinition("select * from t where t.status = @status and t.cost = @cost" )
-                    .WithParameter("@status", testItem1.status)
+                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+                    .WithParameter("@pk", testItem1.status)
                     .WithParameter("@cost", testItem1.cost),
             };
 
@@ -875,7 +875,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IList<ToDoActivity> deleteList = deleteList = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 3, perPKItemCount: perPKItemCount, randomPartitionKey: true);
             ToDoActivity find = deleteList.First();
 
-            QueryDefinition sql = new QueryDefinition("select * from r where r.status = @status").WithParameter("@status", find.pk);
+            QueryDefinition sql = new QueryDefinition("select * from r where r.pk = @pk").WithParameter("@pk", find.pk);
 
             int iterationCount = 0;
             int totalReadItem = 0;
@@ -1300,8 +1300,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             ToDoActivity toDoActivity = deleteList.First();
             QueryDefinition sql = new QueryDefinition(
-                "select * from toDoActivity t where t.status = @status")
-                .WithParameter("@status", toDoActivity.pk);
+                "select * from toDoActivity t where t.status = @pk")
+                .WithParameter("@pk", toDoActivity.pk);
 
             // Test max size at 1
             FeedIterator<ToDoActivity> feedIterator = this.Container.GetItemQueryIterator<ToDoActivity>(
@@ -1542,7 +1542,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
-                PatchOperation.Add("/children/1/status", "patched"),
+                PatchOperation.Add("/children/1/pk", "patched"),
                 PatchOperation.Remove("/description"),
                 PatchOperation.Replace("/taskNum", newTaskNum),
                 //PatchOperation.Increment("/taskNum", one)
@@ -1596,7 +1596,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
-                PatchOperation.Add("/children/1/status", "patched"),
+                PatchOperation.Add("/children/1/pk", "patched"),
                 PatchOperation.Remove("/description"),
                 PatchOperation.Replace("/taskNum", testItem.taskNum+1)
             };
@@ -1663,7 +1663,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
-                PatchOperation.Add("/children/1/status", "patched"),
+                PatchOperation.Add("/children/1/pk", "patched"),
                 PatchOperation.Remove("/description"),
                 PatchOperation.Replace("/taskNum", newTaskNum)
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosJsonSerializerTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Mock<CosmosSerializer> mockJsonSerializer = new Mock<CosmosSerializer>();
 
             //The item object will be serialized with the custom json serializer.
-            ToDoActivity testItem = this.CreateRandomToDoActivity();
+            ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
             mockJsonSerializer.Setup(x => x.ToStream<ToDoActivity>(It.IsAny<ToDoActivity>()))
                 .Callback(() => toStreamCount++)
                 .Returns(TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem));
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(1, toStreamCount);
             Assert.AreEqual(1, fromStreamCount);
 
-            await mockContainer.DeleteItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.status));
+            await mockContainer.DeleteItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
         }
 
         /// <summary>
@@ -179,46 +179,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity document = new ToDoActivity()
             {
                 id = Guid.NewGuid().ToString(),
-                description = default(string),
-                status = "TBD",
+                description = default,
+                pk = "TBD",
                 taskNum = 42,
                 cost = double.MaxValue
             };
 
             await this.container.UpsertItemAsync(document);
 
-            ResponseMessage cosmosResponseMessage = await this.container.ReadItemStreamAsync(document.id, new PartitionKey(document.status));
+            ResponseMessage cosmosResponseMessage = await this.container.ReadItemStreamAsync(document.id, new PartitionKey(document.pk));
             StreamReader reader = new StreamReader(cosmosResponseMessage.Content);
             string text = reader.ReadToEnd();
 
             Assert.IsTrue(text.IndexOf(nameof(document.description)) > -1, "Stored item doesn't contains null attributes");
-        }
-
-        private ToDoActivity CreateRandomToDoActivity(string pk = null)
-        {
-            if (string.IsNullOrEmpty(pk))
-            {
-                pk = "TBD" + Guid.NewGuid().ToString();
-            }
-
-            return new ToDoActivity()
-            {
-                id = Guid.NewGuid().ToString(),
-                description = "CreateRandomToDoActivity",
-                status = pk,
-                taskNum = 42,
-                cost = double.MaxValue
-            };
-        }
-
-        public class ToDoActivity
-        {
-            [JsonProperty(PropertyName = "id")]
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosOperationCanceledExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosOperationCanceledExceptionTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 await container.CreateItemAsync<ToDoActivity>(
                     toDoActivity,
-                    new Cosmos.PartitionKey(toDoActivity.status),
+                    new Cosmos.PartitionKey(toDoActivity.pk),
                     cancellationToken: cancellationToken);
 
                 Assert.Fail("Should have thrown");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
     [SDK.EmulatorTests.TestClass]
     public class ChangeFeedIteratorCoreTests : BaseCosmosClientHelper
     {
-        private static readonly string PartitionKey = "/status";
+        private static readonly string PartitionKey = "/pk";
 
         [TestInitialize]
         public async Task TestInitialize()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -169,12 +169,12 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             ContainerInternal itemsCore = await this.InitializeContainerAsync();
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: otherPK));
             }
 
             ChangeFeedIteratorCore feedIterator = itemsCore.GetChangeFeedStreamIterator(
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     totalCount += response.Count;
                     foreach (ToDoActivity toDoActivity in response)
                     {
-                        Assert.AreEqual(pkToRead, toDoActivity.status);
+                        Assert.AreEqual(pkToRead, toDoActivity.pk);
                     }
                 }
             }
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             // Insert another batch of 25 and use the last FeedToken from the first cycle
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead));
             }
 
             ChangeFeedIteratorCore setIteratorNew = itemsCore.GetChangeFeedStreamIterator(
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     totalCount += response.Count;
                     foreach (ToDoActivity toDoActivity in response)
                     {
-                        Assert.AreEqual(pkToRead, toDoActivity.status);
+                        Assert.AreEqual(pkToRead, toDoActivity.pk);
                     }
                 }
             }
@@ -261,12 +261,12 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             ContainerInternal itemsCore = await this.InitializeContainerAsync();
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: otherPK));
             }
 
             FeedIterator<ToDoActivity> feedIterator = itemsCore.GetChangeFeedIterator<ToDoActivity>(
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     totalCount += feedResponse.Count;
                     foreach (ToDoActivity toDoActivity in feedResponse)
                     {
-                        Assert.AreEqual(pkToRead, toDoActivity.status);
+                        Assert.AreEqual(pkToRead, toDoActivity.pk);
                     }
 
                     continuation = feedResponse.ContinuationToken;
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             // Insert another batch of 25 and use the last FeedToken from the first cycle
             for (int i = 0; i < batchSize; i++)
             {
-                await itemsCore.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await itemsCore.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead));
             }
 
             FeedIterator<ToDoActivity> setIteratorNew = itemsCore.GetChangeFeedIterator<ToDoActivity>(
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     totalCount += feedResponse.Count;
                     foreach (ToDoActivity toDoActivity in feedResponse)
                     {
-                        Assert.AreEqual(pkToRead, toDoActivity.status);
+                        Assert.AreEqual(pkToRead, toDoActivity.pk);
                     }
                 }
                 catch (CosmosException cosmosException) when (cosmosException.StatusCode == HttpStatusCode.NotModified)
@@ -699,7 +699,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             IList<ToDoActivity> createdItems = await this.CreateRandomItems(container, totalDocuments, randomPartitionKey: true);
             foreach (ToDoActivity item in createdItems)
             {
-                await container.DeleteItemAsync<ToDoActivity>(item.id, new PartitionKey(item.status));
+                await container.DeleteItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk));
             }
 
             // Resume Change Feed and verify we pickup all the events
@@ -750,7 +750,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
                 for (int j = 0; j < perPKItemCount; j++)
                 {
-                    ToDoActivity temp = this.CreateRandomToDoActivity(pk);
+                    ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity(pk: pk);
 
                     createdList.Add(temp);
 
@@ -759,32 +759,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             }
 
             return createdList;
-        }
-
-        private ToDoActivity CreateRandomToDoActivity(string pk = null)
-        {
-            if (string.IsNullOrEmpty(pk))
-            {
-                pk = "TBD" + Guid.NewGuid().ToString();
-            }
-
-            return new ToDoActivity()
-            {
-                id = Guid.NewGuid().ToString(),
-                description = "CreateRandomToDoActivity",
-                status = pk,
-                taskNum = 42,
-                cost = double.MaxValue
-            };
-        }
-
-        public class ToDoActivity
-        {
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
 
         public class ToDoActivityWithMetadata : ToDoActivity

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/FeedRangeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/FeedRangeTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse largerContainer = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 20000,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
@@ -275,12 +275,12 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.LargerContainer.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead));
+                await this.LargerContainer.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.LargerContainer.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await this.LargerContainer.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: otherPK));
             }
 
             ContainerInternal itemsCore = this.LargerContainer;
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         totalCount += response.Count;
                         foreach (ToDoActivity toDoActivity in response)
                         {
-                            Assert.AreEqual(pkToRead, toDoActivity.status);
+                            Assert.AreEqual(pkToRead, toDoActivity.pk);
                         }
                     }
                 }
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     totalCount += response.Count;
                     foreach (ToDoActivity toDoActivity in response)
                     {
-                        Assert.AreEqual(pkToRead, toDoActivity.status);
+                        Assert.AreEqual(pkToRead, toDoActivity.pk);
                     }
 
                     continuationToken = responseMessage.ContinuationToken;
@@ -571,7 +571,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
                 for (int j = 0; j < perPKItemCount; j++)
                 {
-                    ToDoActivity temp = this.CreateRandomToDoActivity(pk);
+                    ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity(pk: pk);
 
                     createdList.Add(temp);
 
@@ -582,38 +582,12 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             return createdList;
         }
 
-        private ToDoActivity CreateRandomToDoActivity(string pk = null)
-        {
-            if (string.IsNullOrEmpty(pk))
-            {
-                pk = "TBD" + Guid.NewGuid().ToString();
-            }
-
-            return new ToDoActivity()
-            {
-                id = Guid.NewGuid().ToString(),
-                description = "CreateRandomToDoActivity",
-                status = pk,
-                taskNum = 42,
-                cost = double.MaxValue
-            };
-        }
-
         // Copy of Friends
         public enum BinaryScanDirection : byte
         {
             Invalid = 0x00,
             Forward = 0x01,
             Reverse = 0x02,
-        }
-
-        public class ToDoActivity
-        {
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -1391,7 +1391,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Container container = await database.CreateContainerAsync(id: "coll1", partitionKeyPath: "/doesnotexist");
                     ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
 
-                    ItemResponse<ToDoActivity> response = await container.CreateItemAsync(toDoActivity, partitionKey: new Cosmos.PartitionKey(toDoActivity.status));
+                    ItemResponse<ToDoActivity> response = await container.CreateItemAsync(toDoActivity, partitionKey: new Cosmos.PartitionKey(toDoActivity.pk));
                     Assert.Fail("Create item should fail with wrong partition key value");
                 }
                 catch (CosmosException ce)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ReadFeed/ReadFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ReadFeed/ReadFeedAsyncEnumerableTests.cs
@@ -140,17 +140,17 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead1));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead1));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(pkToRead2));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: pkToRead2));
             }
 
             for (int i = 0; i < batchSize; i++)
             {
-                await this.Container.CreateItemAsync(this.CreateRandomToDoActivity(otherPK));
+                await this.Container.CreateItemAsync(ToDoActivity.CreateRandomToDoActivity(pk: otherPK));
             }
 
             // Create one start state for each logical partition key.
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
 
                 for (int j = 0; j < perPKItemCount; j++)
                 {
-                    ToDoActivity temp = this.CreateRandomToDoActivity(pk);
+                    ToDoActivity temp = ToDoActivity.CreateRandomToDoActivity(pk: pk);
 
                     createdList.Add(temp);
 
@@ -299,32 +299,6 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
             }
 
             return createdList;
-        }
-
-        private ToDoActivity CreateRandomToDoActivity(string pk = null)
-        {
-            if (string.IsNullOrEmpty(pk))
-            {
-                pk = "TBD" + Guid.NewGuid().ToString();
-            }
-
-            return new ToDoActivity()
-            {
-                id = Guid.NewGuid().ToString(),
-                description = "CreateRandomToDoActivity",
-                status = pk,
-                taskNum = 42,
-                cost = double.MaxValue
-            };
-        }
-
-        public class ToDoActivity
-        {
-            public string id { get; set; }
-            public int taskNum { get; set; }
-            public double cost { get; set; }
-            public string description { get; set; }
-            public string status { get; set; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ReadFeed/ReadFeedAsyncEnumerableTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ReadFeed/ReadFeedAsyncEnumerableTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.ReadFeed
         public async Task TestInitialize()
         {
             await base.TestInit();
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 throughput: 20000,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
@@ -59,8 +59,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             databaseIterator.ReadNextAsync().GetAwaiter().GetResult();
                         }
 
-                        Container container = database.CreateContainerAsync(Guid.NewGuid().ToString(), "/status").GetAwaiter().GetResult();
-                        container = database.CreateContainerIfNotExistsAsync(container.Id, "/status").GetAwaiter().GetResult();
+                        Container container = database.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk").GetAwaiter().GetResult();
+                        container = database.CreateContainerIfNotExistsAsync(container.Id, "/pk").GetAwaiter().GetResult();
 
                         ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
                         ItemResponse<ToDoActivity> response = container.CreateItemAsync<ToDoActivity>(item: testItem).ConfigureAwait(false).GetAwaiter().GetResult();
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         double cost = container.GetItemLinqQueryable<ToDoActivity>(
                             allowSynchronousQueryExecution: true).Select(x => x.cost).Sum();
 
-                        ItemResponse<ToDoActivity> deleteResponse = container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.status), id: testItem.id).ConfigureAwait(false).GetAwaiter().GetResult();
+                        ItemResponse<ToDoActivity> deleteResponse = container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id).ConfigureAwait(false).GetAwaiter().GetResult();
                         Assert.IsNotNull(deleteResponse);
                     }
                 }, state: null);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.database = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString(),
                 cancellationToken: this.cancellationToken);
 
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 id = Guid.NewGuid().ToString(),
                 cost = 9001,
                 description = "trigger_test_item",
-                status = "Done",
+                pk = "Done",
                 taskNum = 1
             };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserDefinedFunctionsTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.cosmosClient = TestCommon.CreateCosmosClient(clientOptions);
             this.database = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString(),
                 cancellationToken: this.cancellationToken);
-            string PartitionKey = "/status";
+            string PartitionKey = "/pk";
             ContainerResponse response = await this.database.CreateContainerAsync(
                 new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey),
                 cancellationToken: this.cancellationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public int taskNum { get; set; }
         public double cost { get; set; }
         public string description { get; set; }
-        public string status { get; set; }
+        public string pk { get; set; }
         public string CamelCase { get; set; }
 
         public bool valid { get; set; }
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 && this.taskNum == input.taskNum
                 && this.cost == input.cost
                 && string.Equals(this.description, input.description)
-                && string.Equals(this.status, input.status);
+                && string.Equals(this.pk, input.pk);
         }
 
         public override int GetHashCode()
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 id = id,
                 description = "CreateRandomToDoActivity",
-                status = pk,
+                pk = pk,
                 taskNum = 42,
                 cost = double.MaxValue,
                 CamelCase = "camelCase",


### PR DESCRIPTION
# Pull Request Template

## Description

1. Removed multiple duplicate ToDoActivity objects so all test use same version.
2. ToDoActivity partition key from "status" to "pk" to make it clear that the value is the partition key.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber