### PR TITLE
[Internal] Benchmark: Fixes RPs in summary to only be success operations

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/Summary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/Summary.cs
@@ -4,8 +4,6 @@
 namespace CosmosBenchmark
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
 
     internal struct Summary
     {
@@ -25,9 +23,8 @@ namespace CosmosBenchmark
 
         public double Rps()
         {
-            long total = this.successfulOpsCount + this.failedOpsCount;
             return Math.Round(
-                    Math.Min(total / this.elapsedMs * Summary.MsPerSecond, total),
+                    Math.Min(this.successfulOpsCount / this.elapsedMs * Summary.MsPerSecond, this.successfulOpsCount),
                     2);
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

The RPS in the summary should only include success operations. There was a bug that caused failures on the client side which cause the RPs to increase significantly, but most of them were client side failures.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber