### PR TITLE
Documentation: Fixes ConnectionMode intellisense

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionMode.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionMode.cs
@@ -9,6 +9,13 @@ namespace Microsoft.Azure.Cosmos
     /// <remarks>
     /// Direct and Gateway connectivity modes are supported. Direct is the default. 
     /// </remarks>
+    /// <example>
+    /// <code language="c#">
+    /// <![CDATA[
+    /// CosmosClient client = new CosmosClient(connectionString, new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway });
+    /// ]]>
+    /// </code>
+    /// </example>
     /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/sql-sdk-connection-modes"/>
     public enum ConnectionMode
     {

--- a/Microsoft.Azure.Cosmos/src/ConnectionMode.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionMode.cs
@@ -7,16 +7,9 @@ namespace Microsoft.Azure.Cosmos
     /// Represents the connection mode to be used by the client when connecting to the Azure Cosmos DB service.
     /// </summary>
     /// <remarks>
-    /// Direct and Gateway connectivity modes are supported. Gateway is the default. 
+    /// Direct and Gateway connectivity modes are supported. Direct is the default. 
     /// </remarks>
-    /// <example>
-    /// <code language="c#">
-    /// <![CDATA[
-    /// DocumentClient client = new DocumentClient(endpointUri, masterKey, new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct });
-    /// ]]>
-    /// </code>
-    /// </example>
-    /// <seealso cref="ConnectionPolicy"/>
+    /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/sql-sdk-connection-modes"/>
     public enum ConnectionMode
     {
         /// <summary>


### PR DESCRIPTION
Our intellisense docs were incorrectly stating that Gateway was the default, and referencing internal classes and old samples.