### PR TITLE
[Internal] CTL: Adds Change Feed Processor scenario

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -81,6 +81,9 @@ namespace CosmosCTL
         [Option("ctl_graphite_port", Required = false, HelpText = "Graphite port to report metrics")]
         public string GraphitePort { get; set; }
 
+        [Option("ctl_logging_context", Required = false, HelpText = "Defines a custom context to use on metrics")]
+        public string LogginContext { get; set; } = string.Empty;
+
         internal TimeSpan RunningTimeDurationAsTimespan { get; private set; } = TimeSpan.FromHours(10);
         internal TimeSpan DiagnosticsThresholdDurationAsTimespan { get; private set; } = TimeSpan.FromSeconds(60);
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -29,6 +29,9 @@ namespace CosmosCTL
         [Option("ctl_collection", Required = false, HelpText = "Collection name")]
         public string Collection { get; set; } = "CTLCollection";
 
+        [Option("ctl_collection_pk", Required = false, HelpText = "Collection partition key")]
+        public string CollectionPartitionKey { get; set; } = "pk";
+
         [Option("ctl_operation", Required = false, HelpText = "Workload type")]
         public WorkloadType WorkloadType { get; set; } = WorkloadType.ReadWriteQuery;
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -50,7 +50,7 @@ namespace CosmosCTL
         [Option("ctl_number_of_operations", Required = false, HelpText = "Number of documents to insert")]
         public long Operations { get; set; } = -1;
 
-        [Option("ctl_max_running_time_duration", Required = false, HelpText = "Running time.")]
+        [Option("ctl_max_running_time_duration", Required = false, HelpText = "Running time in PT format, for example, PT10H.")]
         public string RunningTimeDuration
         {
             get => this.RunningTimeDurationAsTimespan.ToString();
@@ -61,7 +61,7 @@ namespace CosmosCTL
         [Option("ctl_number_Of_collection", Required = false, HelpText = "Number of collections to use")]
         public int CollectionCount { get; set; } = 4;
 
-        [Option("ctl_diagnostics_threshold_duration", Required = false, HelpText = "Threshold to log diagnostics")]
+        [Option("ctl_diagnostics_threshold_duration", Required = false, HelpText = "Threshold to log diagnostics in PT format, for example, PT60S.")]
         public string DiagnosticsThresholdDuration
         {
             get => this.DiagnosticsThresholdDurationAsTimespan.ToString();

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
@@ -169,6 +169,7 @@ namespace CosmosCTL
             return workloadType switch
             {
                 WorkloadType.ReadWriteQuery => new ReadWriteQueryScenario(),
+                WorkloadType.ChangeFeedProcessor => new ChangeFeedProcessorScenario(),
                 _ => throw new NotImplementedException($"No mapping for {workloadType}"),
             };
         }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
@@ -1,0 +1,284 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace CosmosCTL
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using App.Metrics;
+    using App.Metrics.Counter;
+    using App.Metrics.Gauge;
+    using App.Metrics.Timer;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal class ChangeFeedProcessorScenario : ICTLScenario
+    {
+        private static readonly int DefaultDocumentFieldCount = 5;
+        private static readonly int DefaultDataFieldSize = 20;
+        private static readonly string DataFieldValue = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, DefaultDataFieldSize);
+
+        private readonly Random random = new Random();
+
+        private InitializationResult initializationResult;
+
+        public async Task InitializeAsync(
+            CTLConfig config,
+            CosmosClient cosmosClient,
+            ILogger logger)
+        {
+            this.initializationResult = await CreateDatabaseAndContainerAsync(config, cosmosClient);
+            if (this.initializationResult.CreatedDatabase)
+            {
+                logger.LogInformation("Created database for execution");
+            }
+
+            if (this.initializationResult.CreatedContainer)
+            {
+                logger.LogInformation("Created collection for execution");
+            }
+
+            if (config.Operations > 0)
+            {
+                logger.LogInformation("Pre-populating {0} documents", config.Operations);
+                await PopulateDocumentsAsync(config, cosmosClient, logger);
+            }
+        }
+
+        public async Task RunAsync(
+            CTLConfig config,
+            CosmosClient cosmosClient,
+            ILogger logger,
+            IMetrics metrics,
+            string loggingContextIdentifier,
+            CancellationToken cancellationToken)
+        {
+            logger.LogInformation("Initializing counters and metrics.");
+            CounterOptions documentCounter = new CounterOptions { Name = "#Documents received", Context = loggingContextIdentifier };
+            GaugeOptions leaseGauge = new GaugeOptions { Name = "#Leases created", Context = loggingContextIdentifier };
+
+            Container leaseContainer = await cosmosClient.GetDatabase(config.Database).CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
+
+            try
+            {
+                ChangeFeedProcessor changeFeedProcessor = cosmosClient.GetContainer(config.Database, config.Collection)
+                    .GetChangeFeedProcessorBuilder<SimpleItem>("ctlProcessor", 
+                    (IReadOnlyCollection<SimpleItem> docs, CancellationToken token) =>
+                        {
+                            metrics.Measure.Counter.Increment(documentCounter, docs.Count);
+                            return Task.CompletedTask;
+                        })
+                    .WithLeaseContainer(leaseContainer)
+                    .WithInstanceName(Guid.NewGuid().ToString())
+                    .WithStartTime(DateTime.MinValue.ToUniversalTime())
+                    .Build();
+
+                await changeFeedProcessor.StartAsync();
+                logger.LogInformation("Started change feed processor");
+
+                await Task.Delay(config.RunningTimeDurationAsTimespan, cancellationToken);
+
+                logger.LogInformation("Stopping change feed processor");
+                await changeFeedProcessor.StopAsync();
+
+                // List leases
+                using FeedIterator<LeaseSchema> leaseIterator = leaseContainer.GetItemQueryIterator<LeaseSchema>();
+                int leaseTotal = 0;
+                List<FeedRange> ranges = new List<FeedRange>();
+                while (leaseIterator.HasMoreResults)
+                {
+                    FeedResponse<LeaseSchema> response = await leaseIterator.ReadNextAsync();
+                    foreach (LeaseSchema lease in response)
+                    {
+                        logger.LogInformation($"Lease for range {lease.LeaseToken}");
+                        ranges.Add(lease.FeedRange.EffectiveRange);
+                    }
+
+                    leaseTotal += response.Count;
+                }
+
+                string previousMin = "";
+                foreach(FeedRange sortedRange in ranges.OrderBy(range => range.Min))
+                {
+                    if (previousMin != sortedRange.Min)
+                    {
+                        logger.LogError($"Expected a sorted range with Min <{previousMin}> but encountered range <{sortedRange.Min}>:<{sortedRange.Max}>");
+                    }
+
+                    previousMin = sortedRange.Max;
+                }
+
+                metrics.Measure.Gauge.SetValue(leaseGauge, leaseTotal);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failure during Change Feed Processor initialization");
+            }
+            finally
+            {
+                await leaseContainer.DeleteContainerAsync();
+                if (this.initializationResult.CreatedDatabase)
+                {
+                    await cosmosClient.GetDatabase(config.Database).DeleteAsync();
+                }
+
+                if (this.initializationResult.CreatedContainer)
+                {
+                    await cosmosClient.GetContainer(config.Database, config.Collection).DeleteContainerAsync();
+                }
+            }
+        }
+
+        private static async Task<InitializationResult> CreateDatabaseAndContainerAsync(
+            CTLConfig config,
+            CosmosClient cosmosClient)
+        {
+            InitializationResult result = new InitializationResult()
+            {
+                CreatedDatabase = false,
+                CreatedContainer = false
+            };
+
+            Database database;
+            try
+            {
+                database = await cosmosClient.GetDatabase(config.Database).ReadAsync();
+            }
+            catch (CosmosException exception) when (exception.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                DatabaseResponse databaseResponse = await cosmosClient.CreateDatabaseAsync(config.Database, config.Throughput);
+                result.CreatedDatabase = true;
+                database = databaseResponse.Database;
+            }
+
+            Container container;
+            try
+            {
+                container = await database.GetContainer(config.Collection).ReadContainerAsync();
+            }
+            catch (CosmosException exception) when (exception.StatusCode == System.Net.HttpStatusCode.NotFound)
+            {
+                await database.CreateContainerAsync(config.Collection, $"/{config.CollectionPartitionKey}");
+                result.CreatedContainer = true;
+            }
+
+            return result;
+        }
+
+        private static async Task PopulateDocumentsAsync(
+            CTLConfig config,
+            CosmosClient cosmosClient,
+            ILogger logger)
+        {
+            long successes = 0;
+            long failures = 0;
+            Container container = cosmosClient.GetContainer(config.Database, config.Collection);
+            ConcurrentBag<Dictionary<string, string>> createdDocumentsInContainer = new ConcurrentBag<Dictionary<string, string>>();
+            IEnumerable<Dictionary<string, string>> documentsToCreate = GenerateDocuments(config.Operations, config.CollectionPartitionKey);
+            await Utils.ForEachAsync(documentsToCreate, (Dictionary<string, string> doc)
+                => container.CreateItemAsync(doc).ContinueWith(task =>
+                {
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        createdDocumentsInContainer.Add(doc);
+                        Interlocked.Increment(ref successes);
+                    }
+                    else
+                    {
+                        AggregateException innerExceptions = task.Exception.Flatten();
+                        if (innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
+                        {
+                            logger.LogError(cosmosException, "Failure pre-populating container {0}", container.Id);
+                        }
+
+                        Interlocked.Increment(ref failures);
+                    }
+                }), 100);
+
+            if (successes > 0)
+            {
+                logger.LogInformation("Completed pre-populating {0} documents in container {1}.", successes, container.Id);
+            }
+
+            if (failures > 0)
+            {
+                logger.LogWarning("Failed pre-populating {0} documents in container {1}.", failures, container.Id);
+            }
+        }
+
+        private static IEnumerable<Dictionary<string, string>> GenerateDocuments(
+            long documentsToCreate,
+            string partitionKeyPropertyName)
+        {
+            List<Dictionary<string, string>> createdDocuments = new List<Dictionary<string, string>>((int)documentsToCreate);
+            for (long i = 0; i < documentsToCreate; i++)
+            {
+                createdDocuments.Add(GenerateDocument(partitionKeyPropertyName));
+            }
+
+            return createdDocuments;
+        }
+
+        private static Dictionary<string, string> GenerateDocument(string partitionKeyPropertyName)
+        {
+            Dictionary<string, string> document = new Dictionary<string, string>();
+            string newGuid = Guid.NewGuid().ToString();
+            document["id"] = newGuid;
+            document[partitionKeyPropertyName] = newGuid;
+            for (int j = 0; j < DefaultDocumentFieldCount; j++)
+            {
+                document["dataField" + j] = DataFieldValue;
+            }
+
+            return document;
+        }
+
+        private struct InitializationResult
+        {
+            public bool CreatedDatabase;
+            public bool CreatedContainer;
+        }
+
+        private class SimpleItem
+        {
+            [JsonProperty("id")]
+            public string Id { get; set; }
+        }
+
+        internal class LeaseSchema
+        {
+            [JsonProperty("id")]
+            public string LeaseId { get; set; }
+
+            [JsonProperty("LeaseToken")]
+            public string LeaseToken { get; set; }
+
+            [JsonProperty("FeedRange")]
+            public Range FeedRange { get; set; }
+
+        }
+
+        internal class Range
+        {
+            [JsonProperty("Range")]
+            public FeedRange EffectiveRange { get; set; }
+        }
+
+        internal class FeedRange
+        {
+            [JsonProperty("min")]
+            public string Min { get; set; }
+
+            [JsonProperty("max")]
+            public string Max { get; set; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
@@ -98,11 +98,13 @@ namespace CosmosCTL
                     FeedResponse<LeaseSchema> response = await leaseIterator.ReadNextAsync();
                     foreach (LeaseSchema lease in response)
                     {
-                        logger.LogInformation($"Lease for range {lease.LeaseToken}");
-                        ranges.Add(lease.FeedRange.EffectiveRange);
+                        if (lease.LeaseToken != null)
+                        {
+                            logger.LogInformation($"Lease for range {lease.LeaseToken}");
+                            ranges.Add(lease.FeedRange.EffectiveRange);
+                            leaseTotal++;
+                        }
                     }
-
-                    leaseTotal += response.Count;
                 }
 
                 string previousMin = "";

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ICTLScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ICTLScenario.cs
@@ -13,6 +13,9 @@ namespace CosmosCTL
 
     internal interface ICTLScenario
     {
+        /// <summary>
+        /// Initialization tasks that will not be measured nor produce metrics.
+        /// Such as container creation if needed.
         public Task InitializeAsync(
             CTLConfig config,
             CosmosClient cosmosClient,
@@ -23,6 +26,7 @@ namespace CosmosCTL
             CosmosClient cosmosClient,
             ILogger logger,
             IMetrics metrics,
+            string loggingContextIdentifier,
             CancellationToken cancellationToken);
     }
 }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -386,7 +386,7 @@ namespace CosmosCTL
 
             for (int i = 1; i <= collectionCount; i++)
             {
-                string containerName = $"{config.Collection}_{i}";
+                string containerName = collectionCount == 1? config.Collection : $"{config.Collection}_{i}";
                 Container container;
                 try
                 {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -62,11 +62,19 @@ namespace CosmosCTL
             CosmosClient cosmosClient,
             ILogger logger, 
             IMetrics metrics,
+            string loggingContextIdentifier,
             CancellationToken cancellationToken)
         {
             try
             {
-                await this.ExecuteOperationsAsync(config, logger, metrics, this.initializationResult, this.readWriteQueryPercentage, cancellationToken);
+                await this.ExecuteOperationsAsync(
+                    config, 
+                    logger, 
+                    metrics, 
+                    loggingContextIdentifier, 
+                    this.initializationResult, 
+                    this.readWriteQueryPercentage, 
+                    cancellationToken);
             }
             catch (Exception unhandledException)
             {
@@ -92,17 +100,18 @@ namespace CosmosCTL
             CTLConfig config,
             ILogger logger,
             IMetrics metrics,
+            string loggingContextIdentifier,
             InitializationResult initializationResult,
             ReadWriteQueryPercentage readWriteQueryPercentage,
             CancellationToken cancellationToken)
         {
             logger.LogInformation("Initializing counters and metrics.");
-            CounterOptions readSuccessMeter = new CounterOptions { Name = "#Read Successful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
-            CounterOptions readFailureMeter = new CounterOptions { Name = "#Read Unsuccessful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
-            CounterOptions writeSuccessMeter = new CounterOptions { Name = "#Write Successful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
-            CounterOptions writeFailureMeter = new CounterOptions { Name = "#Write Unsuccessful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
-            CounterOptions querySuccessMeter = new CounterOptions { Name = "#Query Successful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
-            CounterOptions queryFailureMeter = new CounterOptions { Name = "#Query Unsuccessful Operations", Context = nameof(WorkloadType.ReadWriteQuery) };
+            CounterOptions readSuccessMeter = new CounterOptions { Name = "#Read Successful Operations", Context = loggingContextIdentifier };
+            CounterOptions readFailureMeter = new CounterOptions { Name = "#Read Unsuccessful Operations", Context = loggingContextIdentifier };
+            CounterOptions writeSuccessMeter = new CounterOptions { Name = "#Write Successful Operations", Context = loggingContextIdentifier };
+            CounterOptions writeFailureMeter = new CounterOptions { Name = "#Write Unsuccessful Operations", Context = loggingContextIdentifier };
+            CounterOptions querySuccessMeter = new CounterOptions { Name = "#Query Successful Operations", Context = loggingContextIdentifier };
+            CounterOptions queryFailureMeter = new CounterOptions { Name = "#Query Unsuccessful Operations", Context = loggingContextIdentifier };
 
             TimerOptions readLatencyTimer = new TimerOptions
             {
@@ -110,7 +119,7 @@ namespace CosmosCTL
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
-                Context = nameof(WorkloadType.ReadWriteQuery),
+                Context = loggingContextIdentifier,
                 Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
             };
 
@@ -120,7 +129,7 @@ namespace CosmosCTL
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
-                Context = nameof(WorkloadType.ReadWriteQuery),
+                Context = loggingContextIdentifier,
                 Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
             };
 
@@ -130,7 +139,7 @@ namespace CosmosCTL
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
-                Context = nameof(WorkloadType.ReadWriteQuery),
+                Context = loggingContextIdentifier,
                 Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
             };
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/WorkloadType.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/WorkloadType.cs
@@ -4,12 +4,9 @@
 
 namespace CosmosCTL
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Text;
-
     public enum WorkloadType
     {
-        ReadWriteQuery
+        ReadWriteQuery,
+        ChangeFeedProcessor
     }
 }


### PR DESCRIPTION
This PR extends CTL scenarios by adding a scenario for Change Feed Processor. The scenario can optionally initialize by creating a document load or take a pre-existing collection. It will start CFP from the beginning and generate metrics of the received documents during the running time.

After the running time is done, it will emit metrics for the existing leases and verify that all the effective ranges are covered (no gaps), this will help to verify split or merge mechanics.

The PR additionally adds Instance gauges (CPU and Memory) to be emitted during the run.

Example of gauges for the instance metrics:

```
"gauges": [
       {
          "value": 0.03890632844138315,
          "name": "Priviledged CPU",
          "tags": {},
          "unit": "percent"
        },
        {
          "value": 200855552,
          "name": "Process Working Set",
          "tags": {},
          "unit": "B"
        },
        {
          "value": 0.19453164220691574,
          "name": "Total CPU",
          "tags": {},
          "unit": "percent"
        },
        {
          "value": 0.1556253137655326,
          "name": "User CPU",
          "tags": {},
          "unit": "percent"
        }
      ],
```