### PR TITLE
[Internal] ChangeFeed: Adds Support to Pass Custom Headers for ChangeFeed Queries

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerable.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
 
             return new ChangeFeedCrossFeedRangeAsyncEnumerator(
                 innerEnumerator, 
-                this.changeFeedRequestOptions?.JsonSerializationFormatOptions);
+                this.changeFeedRequestOptions);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedCrossFeedRangeAsyncEnumerator.cs
@@ -15,14 +15,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     internal sealed class ChangeFeedCrossFeedRangeAsyncEnumerator : IAsyncEnumerator<TryCatch<ChangeFeedPage>>
     {
         private readonly CrossPartitionChangeFeedAsyncEnumerator enumerator;
-        private readonly JsonSerializationFormatOptions jsonSerializationFormatOptions;
+        private readonly ChangeFeedRequestOptions changeFeedRequestOptions;
 
         public ChangeFeedCrossFeedRangeAsyncEnumerator(
             CrossPartitionChangeFeedAsyncEnumerator enumerator,
-            JsonSerializationFormatOptions jsonSerializationFormatOptions)
+            ChangeFeedRequestOptions changeFeedRequestOptions)
         {
             this.enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
-            this.jsonSerializationFormatOptions = jsonSerializationFormatOptions;
+            this.changeFeedRequestOptions = changeFeedRequestOptions;
         }
 
         public TryCatch<ChangeFeedPage> Current { get; private set; }
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 Pagination.ChangeFeedSuccessPage successPage => ChangeFeedPage.CreatePageWithChanges(
                     RestFeedResponseParser.ParseRestFeedResponse(
                         successPage.Content,
-                        this.jsonSerializationFormatOptions),
+                        this.changeFeedRequestOptions?.JsonSerializationFormatOptions),
                     successPage.RequestCharge,
                     successPage.ActivityId,
                     state),

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedPartitionRangePageAsyncEnumerator.cs
@@ -16,24 +16,21 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     internal sealed class ChangeFeedPartitionRangePageAsyncEnumerator : PartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState>
     {
         private readonly IChangeFeedDataSource changeFeedDataSource;
-        private readonly int pageSize;
+        private readonly ChangeFeedRequestOptions changeFeedRequestOptions;
         private readonly ChangeFeedMode changeFeedMode;
-        private readonly JsonSerializationFormat? jsonSerializationFormat;
 
         public ChangeFeedPartitionRangePageAsyncEnumerator(
             IChangeFeedDataSource changeFeedDataSource,
             FeedRangeInternal range,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             ChangeFeedState state,
             CancellationToken cancellationToken)
             : base(range, cancellationToken, state)
         {
             this.changeFeedDataSource = changeFeedDataSource ?? throw new ArgumentNullException(nameof(changeFeedDataSource));
             this.changeFeedMode = changeFeedMode ?? throw new ArgumentNullException(nameof(changeFeedMode));
-            this.pageSize = pageSize;
-            this.jsonSerializationFormat = jsonSerializationFormat;
+            this.changeFeedRequestOptions = changeFeedRequestOptions;
         }
 
         public override ValueTask DisposeAsync() => default;
@@ -43,9 +40,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             CancellationToken cancellationToken) => this.changeFeedDataSource.MonadicChangeFeedAsync(
             this.State,
             this.Range,
-            this.pageSize,
+            this.changeFeedRequestOptions,
             this.changeFeedMode,
-            this.jsonSerializationFormat,
             trace,
             cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -151,9 +151,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                 documentContainer,
                 CrossPartitionChangeFeedAsyncEnumerator.MakeCreateFunction(
                     documentContainer,
-                    changeFeedRequestOptions.PageSizeHint.GetValueOrDefault(int.MaxValue),
+                    changeFeedRequestOptions,
                     changeFeedMode,
-                    changeFeedRequestOptions?.JsonSerializationFormatOptions?.JsonSerializationFormat,
                     cancellationToken),
                 comparer: default /* this uses a regular queue instead of prioirty queue */,
                 maxConcurrency: default,
@@ -169,15 +168,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 
         private static CreatePartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState> MakeCreateFunction(
             IChangeFeedDataSource changeFeedDataSource,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             CancellationToken cancellationToken) => (FeedRangeInternal range, ChangeFeedState state) => new ChangeFeedPartitionRangePageAsyncEnumerator(
                 changeFeedDataSource,
                 range,
-                pageSize,
+                changeFeedRequestOptions,
                 changeFeedMode,
-                jsonSerializationFormat,
                 state,
                 cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedDataSource.cs
@@ -15,9 +15,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         Task<ChangeFeedPage> ChangeFeedAsync(
             ChangeFeedState state,
             FeedRangeInternal feedRange,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IMonadicChangeFeedDataSource.cs
@@ -15,9 +15,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         Task<TryCatch<ChangeFeedPage>> MonadicChangeFeedAsync(
             ChangeFeedState state,
             FeedRangeInternal feedRange,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken);
     }

--- a/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/DocumentContainer.cs
@@ -197,17 +197,15 @@ namespace Microsoft.Azure.Cosmos.Pagination
         public Task<ChangeFeedPage> ChangeFeedAsync(
             ChangeFeedState state,
             FeedRangeInternal feedRange,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken) => TryCatch<ChangeFeedPage>.UnsafeGetResultAsync(
                 this.MonadicChangeFeedAsync(
                     state,
                     feedRange,
-                    pageSize,
+                    changeFeedRequestOptions,
                     changeFeedMode,
-                    jsonSerializationFormat,
                     trace,
                     cancellationToken), 
                 cancellationToken);
@@ -215,16 +213,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
         public Task<TryCatch<ChangeFeedPage>> MonadicChangeFeedAsync(
             ChangeFeedState state,
             FeedRangeInternal feedRange,
-            int pageSize,
+            ChangeFeedRequestOptions changeFeedRequestOptions,
             ChangeFeedMode changeFeedMode,
-            JsonSerializationFormat? jsonSerializationFormat,
             ITrace trace,
             CancellationToken cancellationToken) => this.monadicDocumentContainer.MonadicChangeFeedAsync(
                 state,
                 feedRange,
-                pageSize,
+                changeFeedRequestOptions,
                 changeFeedMode,
-                jsonSerializationFormat,
                 trace,
                 cancellationToken);
 


### PR DESCRIPTION
- This is needed for the Cassandra API to function correctly as we rely on passing down the BinaryPassThrough header for HybridRow Full-FidelitySupport, as well as the SchemaOwnerId, SchemaHash, & SchemaId Headers for data correctness.

- [] Bug fix (non-breaking change which fixes an issue)