### PR TITLE
Internal Json: Fixes double API of GetUtf8StringValue and GetStringValue

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/IJsonReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/IJsonReader.cs
@@ -50,12 +50,6 @@ namespace Microsoft.Azure.Cosmos.Json
         UtfAnyString GetStringValue();
 
         /// <summary>
-        /// Gets the next JSON token from the JsonReader as a UTF-8 string.
-        /// </summary>
-        /// <returns>The next JSON token from the JsonReader as a UTF-8 string.</returns>
-        Utf8String GetUtf8StringValue();
-
-        /// <summary>
         /// Tries to get the buffered UTF-8 string value.
         /// </summary>
         /// <param name="value">The buffered UTF-8 string value if found.</param>

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/NewtonsoftToCosmosDBReader.cs
@@ -85,11 +85,6 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
             return this.reader.Value.ToString();
         }
 
-        public override Utf8String GetUtf8StringValue()
-        {
-            return Utf8String.TranscodeUtf16(this.GetStringValue());
-        }
-
         public override uint GetUInt32Value()
         {
             return (uint)this.reader.Value;

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonBinaryReader.cs
@@ -332,21 +332,6 @@ namespace Microsoft.Azure.Cosmos.Json
             }
 
             /// <inheritdoc />
-            public override Utf8String GetUtf8StringValue()
-            {
-                if (!(
-                    (this.JsonObjectState.CurrentTokenType == JsonTokenType.String) ||
-                    (this.JsonObjectState.CurrentTokenType == JsonTokenType.FieldName)))
-                {
-                    throw new JsonInvalidTokenException();
-                }
-
-                return JsonBinaryEncoding.GetUtf8StringValue(
-                    this.rootBuffer,
-                    this.jsonBinaryBuffer.GetBufferedRawJsonToken(this.currentTokenPosition));
-            }
-
-            /// <inheritdoc />
             public override bool TryGetBufferedStringValue(out Utf8Memory bufferedUtf8StringValue)
             {
                 if (!(

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.JsonTextReader.cs
@@ -300,17 +300,6 @@ namespace Microsoft.Azure.Cosmos.Json
             }
 
             /// <inheritdoc />
-            public override Utf8String GetUtf8StringValue()
-            {
-                if (this.TryGetBufferedStringValue(out Utf8Memory memory))
-                {
-                    return Utf8String.UnsafeFromUtf8BytesNoValidation(memory.Memory);
-                }
-
-                return Utf8String.TranscodeUtf16(this.GetStringValue());
-            }
-
-            /// <inheritdoc />
             public override bool TryGetBufferedStringValue(out Utf8Memory value)
             {
                 if (this.token.JsonTextTokenType.HasFlag(JsonTextTokenType.EscapedFlag))

--- a/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonReader.cs
@@ -4,8 +4,6 @@
 namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
-    using System.Globalization;
-    using Microsoft.Azure.Cosmos.Core;
     using Microsoft.Azure.Cosmos.Core.Utf8;
 
     /// <summary>
@@ -97,9 +95,6 @@ namespace Microsoft.Azure.Cosmos.Json
 
         /// <inheritdoc />
         public abstract UtfAnyString GetStringValue();
-
-        /// <inheritdoc />
-        public abstract Utf8String GetUtf8StringValue();
 
         /// <inheritdoc />
         public abstract bool TryGetBufferedStringValue(out Utf8Memory value);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonReaderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonReaderTests.cs
@@ -3319,9 +3319,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
         private void VerifyStringOrFieldNameHelper(IJsonReader jsonReader, string expectedString)
         {
             string actualString = jsonReader.GetStringValue();
-            Utf8String actualUtf8StringValue = jsonReader.GetUtf8StringValue();
             Assert.AreEqual(expectedString, actualString);
-            Assert.AreEqual(expectedString, actualUtf8StringValue.ToString());
             if (jsonReader is ITypedJsonReader typedJsonReader)
             {
                 Utf8Span actualUtf8SpanValue = typedJsonReader.GetUtf8SpanValue();


### PR DESCRIPTION
# Internal Json: Fixes double API of GetUtf8StringValue and GetStringValue

## Description

Removes `GetUtf8StringValue`, since users should just go through `GetStringValue` from `IJsonReader`. The reasoning is, because `GetStringValue` returns `UtfAnyString`, which is as good as `string` and `utf8String`. It will also defer the actual transcoding. 