### PR TITLE
QueryRequestOption: Adds optimization to avoid duplicating QueryRequestOption

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -266,6 +266,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     serviceRequest.UseGatewayMode = this.UseGatewayMode.Value;
                 }
+
                 serviceRequest.RequestContext.ClientRequestStatistics = new CosmosClientSideRequestStatistics(this.DiagnosticsContext);
                 serviceRequest.UseStatusCodeForFailures = true;
                 serviceRequest.UseStatusCodeFor429 = true;

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -267,6 +267,13 @@ namespace Microsoft.Azure.Cosmos
                     serviceRequest.UseGatewayMode = this.UseGatewayMode.Value;
                 }
 
+                if (this.RequestOptions?.Properties != null &&
+                   this.RequestOptions.Properties.TryGetValue("x-ms-cosmos-default-replica-index", out object defaultReplicaIndexHeader) &&
+                   int.TryParse(defaultReplicaIndexHeader.ToString(), out int defaultReplicaIndex))
+                {
+                    serviceRequest.DefaultReplicaIndex = (uint)defaultReplicaIndex;
+                }
+
                 serviceRequest.RequestContext.ClientRequestStatistics = new CosmosClientSideRequestStatistics(this.DiagnosticsContext);
                 serviceRequest.UseStatusCodeForFailures = true;
                 serviceRequest.UseStatusCodeFor429 = true;

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -266,7 +266,6 @@ namespace Microsoft.Azure.Cosmos
                 {
                     serviceRequest.UseGatewayMode = this.UseGatewayMode.Value;
                 }
-              
                 serviceRequest.RequestContext.ClientRequestStatistics = new CosmosClientSideRequestStatistics(this.DiagnosticsContext);
                 serviceRequest.UseStatusCodeForFailures = true;
                 serviceRequest.UseStatusCodeFor429 = true;

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -266,14 +266,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     serviceRequest.UseGatewayMode = this.UseGatewayMode.Value;
                 }
-
-                if (this.RequestOptions?.Properties != null &&
-                   this.RequestOptions.Properties.TryGetValue("x-ms-cosmos-default-replica-index", out object defaultReplicaIndexHeader) &&
-                   int.TryParse(defaultReplicaIndexHeader.ToString(), out int defaultReplicaIndex))
-                {
-                    serviceRequest.DefaultReplicaIndex = (uint)defaultReplicaIndex;
-                }
-
+              
                 serviceRequest.RequestContext.ClientRequestStatistics = new CosmosClientSideRequestStatistics(this.DiagnosticsContext);
                 serviceRequest.UseStatusCodeForFailures = true;
                 serviceRequest.UseStatusCodeFor429 = true;

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 throw new ArgumentNullException(nameof(trace));
             }
 
-            QueryRequestOptions queryRequestOptions = this.queryRequestOptions == null ? new QueryRequestOptions() : this.queryRequestOptions.Clone();
+            QueryRequestOptions queryRequestOptions = this.queryRequestOptions == null ? new QueryRequestOptions() : this.queryRequestOptions;
             TryCatch<QueryPage> monadicQueryPage = await this.cosmosQueryClient.ExecuteItemQueryAsync(
                 this.resourceLink,
                 this.resourceType,

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -235,30 +235,6 @@ namespace Microsoft.Azure.Cosmos
             base.PopulateRequestOptions(request);
         }
 
-        internal virtual QueryRequestOptions Clone()
-        {
-            QueryRequestOptions queryRequestOptions = new QueryRequestOptions
-            {
-                IfMatchEtag = this.IfMatchEtag,
-                IfNoneMatchEtag = this.IfNoneMatchEtag,
-                MaxItemCount = this.MaxItemCount,
-                ResponseContinuationTokenLimitInKb = this.ResponseContinuationTokenLimitInKb,
-                EnableScanInQuery = this.EnableScanInQuery,
-                EnableLowPrecisionOrderBy = this.EnableLowPrecisionOrderBy,
-                MaxBufferedItemCount = this.MaxBufferedItemCount,
-                SessionToken = this.SessionToken,
-                ConsistencyLevel = this.ConsistencyLevel,
-                MaxConcurrency = this.MaxConcurrency,
-                PartitionKey = this.PartitionKey,
-                CosmosSerializationFormatOptions = this.CosmosSerializationFormatOptions,
-                Properties = this.Properties,
-                IsEffectivePartitionKeyRouting = this.IsEffectivePartitionKeyRouting,
-                CosmosElementContinuationToken = this.CosmosElementContinuationToken,
-            };
-
-            return queryRequestOptions;
-        }
-
         internal static void FillContinuationToken(
             RequestMessage request,
             string continuationToken)

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Cosmos
             base.PopulateRequestOptions(request);
         }
 
-        internal QueryRequestOptions Clone()
+        internal virtual QueryRequestOptions Clone()
         {
             QueryRequestOptions queryRequestOptions = new QueryRequestOptions
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             CosmosElement continuationToken = null;
             do
             {
-                QueryRequestOptions computeRequestOptions = queryRequestOptions.Clone();
+                QueryRequestOptions computeRequestOptions = queryRequestOptions;
                 computeRequestOptions.ExecutionEnvironment = ExecutionEnvironment.Compute;
                 computeRequestOptions.CosmosElementContinuationToken = continuationToken;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -544,7 +544,25 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             CosmosElement continuationToken = null;
             do
             {
-                QueryRequestOptions computeRequestOptions = queryRequestOptions;
+                QueryRequestOptions computeRequestOptions = new QueryRequestOptions
+                {
+                    IfMatchEtag = queryRequestOptions.IfMatchEtag,
+                    IfNoneMatchEtag = queryRequestOptions.IfNoneMatchEtag,
+                    MaxItemCount = queryRequestOptions.MaxItemCount,
+                    ResponseContinuationTokenLimitInKb = queryRequestOptions.ResponseContinuationTokenLimitInKb,
+                    EnableScanInQuery = queryRequestOptions.EnableScanInQuery,
+                    EnableLowPrecisionOrderBy = queryRequestOptions.EnableLowPrecisionOrderBy,
+                    MaxBufferedItemCount = queryRequestOptions.MaxBufferedItemCount,
+                    SessionToken = queryRequestOptions.SessionToken,
+                    ConsistencyLevel = queryRequestOptions.ConsistencyLevel,
+                    MaxConcurrency = queryRequestOptions.MaxConcurrency,
+                    PartitionKey = queryRequestOptions.PartitionKey,
+                    CosmosSerializationFormatOptions = queryRequestOptions.CosmosSerializationFormatOptions,
+                    Properties = queryRequestOptions.Properties,
+                    IsEffectivePartitionKeyRouting = queryRequestOptions.IsEffectivePartitionKeyRouting,
+                    CosmosElementContinuationToken = queryRequestOptions.CosmosElementContinuationToken,
+                };
+
                 computeRequestOptions.ExecutionEnvironment = ExecutionEnvironment.Compute;
                 computeRequestOptions.CosmosElementContinuationToken = continuationToken;
 


### PR DESCRIPTION
# Pull Request Template

## Description

QueryRequestOption is cloned while executing the request. This limits the applications to extend QueryRequestOptions to populate extra headers

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- 
## Closing issues

To automatically close an issue: closes #IssueNumber