### PR TITLE
Query: Fixes Take operator from enumerating all pages.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
@@ -184,9 +184,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     throw new ArgumentNullException(nameof(trace));
                 }
 
-                if (!await this.inputStage.MoveNextAsync(trace))
+                if (this.returnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
                 {
                     this.Current = default;
+                    this.returnedFinalPage = true;
                     return false;
                 }
 
@@ -201,6 +202,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                 List<CosmosElement> takedDocuments = sourcePage.Documents.Take(this.takeCount).ToList();
                 this.takeCount -= takedDocuments.Count;
+                this.returnedFinalPage = this.takeCount <= 0;
 
                 QueryState state;
                 if ((sourcePage.State != null) && (sourcePage.DisallowContinuationTokenMessage == null))

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
@@ -184,10 +184,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     throw new ArgumentNullException(nameof(trace));
                 }
 
-                if (this.returnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
+                if (this.ReturnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
                 {
                     this.Current = default;
-                    this.returnedFinalPage = true;
+                    this.takeCount = 0;
                     return false;
                 }
 
@@ -202,7 +202,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                 List<CosmosElement> takedDocuments = sourcePage.Documents.Take(this.takeCount).ToList();
                 this.takeCount -= takedDocuments.Count;
-                this.returnedFinalPage = this.takeCount <= 0;
 
                 QueryState state;
                 if ((sourcePage.State != null) && (sourcePage.DisallowContinuationTokenMessage == null))

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
@@ -109,10 +109,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     throw new ArgumentNullException(nameof(trace));
                 }
 
-                if (this.returnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
+                if (this.ReturnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
                 {
                     this.Current = default;
-                    this.returnedFinalPage = true;
+                    this.takeCount = 0;
                     return false;
                 }
 
@@ -127,7 +127,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                 List<CosmosElement> takedDocuments = sourcePage.Documents.Take(this.takeCount).ToList();
                 this.takeCount -= takedDocuments.Count;
-                this.returnedFinalPage = this.takeCount <= 0;
 
                 QueryState queryState;
                 if (sourcePage.State != null)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Compute.cs
@@ -109,9 +109,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                     throw new ArgumentNullException(nameof(trace));
                 }
 
-                if (!await this.inputStage.MoveNextAsync(trace))
+                if (this.returnedFinalPage || !await this.inputStage.MoveNextAsync(trace))
                 {
                     this.Current = default;
+                    this.returnedFinalPage = true;
                     return false;
                 }
 
@@ -126,6 +127,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                 List<CosmosElement> takedDocuments = sourcePage.Documents.Take(this.takeCount).ToList();
                 this.takeCount -= takedDocuments.Count;
+                this.returnedFinalPage = this.takeCount <= 0;
 
                 QueryState queryState;
                 if (sourcePage.State != null)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     {
         private int takeCount;
 
+        private bool returnedFinalPage;
+
         protected TakeQueryPipelineStage(
             IQueryPipelineStage source,
             CancellationToken cancellationToken,
@@ -20,6 +22,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
             : base(source, cancellationToken)
         {
             this.takeCount = takeCount;
+            this.returnedFinalPage = this.takeCount <= 0;
         }
 
         public static TryCatch<IQueryPipelineStage> MonadicCreateLimitStage(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     {
         private int takeCount;
 
-        private bool returnedFinalPage;
+        private bool ReturnedFinalPage => this.takeCount <= 0;
 
         protected TakeQueryPipelineStage(
             IQueryPipelineStage source,
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
             : base(source, cancellationToken)
         {
             this.takeCount = takeCount;
-            this.returnedFinalPage = this.takeCount <= 0;
         }
 
         public static TryCatch<IQueryPipelineStage> MonadicCreateLimitStage(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     internal sealed class MockQueryPipelineStage : QueryPipelineStageBase
     {
         private readonly IReadOnlyList<IReadOnlyList<CosmosElement>> pages;
-        private long pageIndex;
+
+        public long PageIndex { get; private set; }
 
         public MockQueryPipelineStage(IReadOnlyList<IReadOnlyList<CosmosElement>> pages)
             : base(EmptyQueryPipelineStage.Singleton, cancellationToken: default)
@@ -36,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             if (continuationToken != null)
             {
                 CosmosNumber index = continuationToken as CosmosNumber;
-                stage.pageIndex = Number64.ToLong(index.Value);
+                stage.PageIndex = Number64.ToLong(index.Value);
             }
 
             return stage;
@@ -44,14 +45,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 
         public override ValueTask<bool> MoveNextAsync(ITrace trace)
         {
-            if (this.pageIndex == this.pages.Count)
+            if (this.PageIndex == this.pages.Count)
             {
                 this.Current = default;
                 return new ValueTask<bool>(false);
             }
 
-            IReadOnlyList<CosmosElement> documents = this.pages[(int)this.pageIndex++];
-            QueryState state = this.pageIndex == this.pages.Count ? null : new QueryState(CosmosNumber64.Create(this.pageIndex));
+            IReadOnlyList<CosmosElement> documents = this.pages[(int)this.PageIndex++];
+            QueryState state = this.PageIndex == this.pages.Count ? null : new QueryState(CosmosNumber64.Create(this.PageIndex));
             QueryPage page = new QueryPage(
                 documents: documents,
                 requestCharge: default,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/TakeQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/TakeQueryPipelineStageTests.cs
@@ -10,6 +10,7 @@
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using PageList = System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<Microsoft.Azure.Cosmos.CosmosElements.CosmosElement>>;
 
     [TestClass]
     public sealed class TakeQueryPipelineStageTests
@@ -18,7 +19,7 @@
         public async Task SanityTests()
         {
             long[] values = new long[] { 42, 1337 };
-            IReadOnlyList<IReadOnlyList<CosmosElement>> pages = values
+            PageList pages = values
                 .Select(value => new List<CosmosElement>()
                 {
                     CosmosElement.Parse($"{{\"item\": {value}}}")
@@ -27,7 +28,7 @@
 
             foreach (int takeCount in new int[] { 0, 1, values.Length, 2 * values.Length })
             {
-                List<CosmosElement> elements = await TakeQueryPipelineStageTests.CreateAndDrainAsync(
+                (List<CosmosElement> elements, _) = await TakeQueryPipelineStageTests.CreateAndDrainAsync(
                     pages: pages,
                     executionEnvironment: ExecutionEnvironment.Compute,
                     takeCount: takeCount,
@@ -37,13 +38,53 @@
             }
         }
 
-        private static async Task<List<CosmosElement>> CreateAndDrainAsync(
+        static IReadOnlyList<(PageList, int, long)> TestCases()
+        {
+            // List<(pages, takeCount, pageIndex)>
+            List<(PageList, int, long)> result = new List<(PageList, int, long)>();
+
+            long[] values = new long[] { 0, 1, 13, 42, 1337, 1337, 42, 1, 2, 3 };
+            PageList pages = Enumerable
+                .Range(0, 10)
+                .Select(_ =>
+                    values
+                    .Select(value => CosmosElement.Parse($"{{\"item\": {value}}}"))
+                    .ToList())
+                .ToList();
+
+            foreach (int takeCount in new[] { 1, 3, 6, 10, 15, 20, 23, 32, 41, 56, 81, 97, 100 })
+            {
+                long pageIndex = takeCount < values.Length ? 1 : Convert.ToInt64(Math.Ceiling((decimal)takeCount / values.Length));
+                result.Add((pages, takeCount, pageIndex));
+            }
+
+            return result;
+        }
+
+
+        [TestMethod]
+        public async Task BasicTests()
+        {
+            foreach((PageList pages, int takeCount, long expectedPageIndex) in TestCases())
+            {
+                (List<CosmosElement> elements, long pageIndex) = await TakeQueryPipelineStageTests.CreateAndDrainAsync(
+                    pages: pages,
+                    executionEnvironment: ExecutionEnvironment.Compute,
+                    takeCount: takeCount,
+                    continuationToken: null);
+
+                Assert.AreEqual(expectedPageIndex, pageIndex);
+                Assert.AreEqual(Math.Min(takeCount, pages.Select(x => x.Count).Sum()), elements.Count);
+            }
+        }
+
+        private static async Task<(List<CosmosElement>, long)> CreateAndDrainAsync(
             IReadOnlyList<IReadOnlyList<CosmosElement>> pages,
             ExecutionEnvironment executionEnvironment,
             int takeCount,
             CosmosElement continuationToken)
         {
-            IQueryPipelineStage source = new MockQueryPipelineStage(pages);
+            MockQueryPipelineStage source = new MockQueryPipelineStage(pages);
 
             TryCatch<IQueryPipelineStage> tryCreateSkipQueryPipelineStage = TakeQueryPipelineStage.MonadicCreateLimitStage(
                 executionEnvironment: executionEnvironment,
@@ -63,7 +104,7 @@
                 elements.AddRange(page.Result.Documents);
             }
 
-            return elements;
+            return (elements, source.PageIndex);
         }
     }
 }


### PR DESCRIPTION
## Description

Currently, the TakeQueryPipelineStage drains the entire query pipeline instead of stopping eagerly. We fix this so that we only drain as many records as have been requested by the user.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #1979 
To automatically close an issue: closes #IssueNumber