### PR TITLE
Client Encryption : Adds support to Migrate Data Encryption Key via Rewrap from Legacy Algorithm to MDE Algorithm

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainer.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         /// </summary>
         /// <param name="id">Unique identifier of the data encryption key.</param>
         /// <param name="newWrapMetadata">The metadata using which the data encryption key needs to now be wrapped.</param>
+        /// <param name="encryptionAlgorithm"> Encryption algorithm that will be used along with this data encryption key to encrypt/decrypt data.</param>
         /// <param name="requestOptions">(Optional) The options for the request.</param>
         /// <param name="cancellationToken">(Optional) Token representing request cancellation.</param>
         /// <returns>An awaitable response which wraps a <see cref="DataEncryptionKeyProperties"/> containing details of the data encryption key that was re-wrapped.</returns>
@@ -103,6 +104,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         public abstract Task<ItemResponse<DataEncryptionKeyProperties>> RewrapDataEncryptionKeyAsync(
             string id,
             EncryptionKeyWrapMetadata newWrapMetadata,
+            string encryptionAlgorithm = null,
             ItemRequestOptions requestOptions = null,
             CancellationToken cancellationToken = default(CancellationToken));
 

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerCore.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerCore.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
             }
             else if (string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized))
             {
-                (wrappedDek, updatedMetadata) = this.GenerateAndWrapPdekForMdeEncAlgo(encryptionKeyWrapMetadata);
+                (wrappedDek, updatedMetadata) = this.GenerateAndWrapPdekForMdeEncAlgo(id, encryptionKeyWrapMetadata);
             }
 
             DataEncryptionKeyProperties dekProperties = new DataEncryptionKeyProperties(
@@ -122,6 +122,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         public override async Task<ItemResponse<DataEncryptionKeyProperties>> RewrapDataEncryptionKeyAsync(
            string id,
            EncryptionKeyWrapMetadata newWrapMetadata,
+           string encryptionAlgorithm = null,
            ItemRequestOptions requestOptions = null,
            CancellationToken cancellationToken = default)
         {
@@ -156,6 +157,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                     cancellationToken);
 
                 rawkey = encryptionKeyUnwrapResult.DataEncryptionKey;
+            }
+
+            if (!string.IsNullOrEmpty(encryptionAlgorithm))
+            {
+                dekProperties.EncryptionAlgorithm = encryptionAlgorithm;
             }
 
             (byte[] wrappedDek, EncryptionKeyWrapMetadata updatedMetadata, InMemoryRawDek updatedRawDek) = await this.WrapAsync(
@@ -210,13 +216,14 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 return await this.RewrapDataEncryptionKeyAsync(
                     id,
                     newWrapMetadata,
+                    encryptionAlgorithm,
                     requestOptions,
                     cancellationToken);
             }
 
             this.DekProvider.DekCache.SetDekProperties(id, response.Resource);
 
-            if (string.Equals(dekProperties.EncryptionAlgorithm, CosmosEncryptionAlgorithm.AEAes256CbcHmacSha256Randomized))
+            if (string.Equals(newDekProperties.EncryptionAlgorithm, CosmosEncryptionAlgorithm.AEAes256CbcHmacSha256Randomized))
             {
                 this.DekProvider.DekCache.SetRawDek(id, updatedRawDek);
             }
@@ -283,7 +290,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
             // Init PlainDataEncryptionKey and then Init MDE Algorithm using PlaintextDataEncryptionKey.
             // PlaintextDataEncryptionKey derives DataEncryptionkey to Init a Raw Root Key received via Legacy WrapProvider Unwrap result.
             PlaintextDataEncryptionKey plaintextDataEncryptionKey = new PlaintextDataEncryptionKey(
-                dekProperties.EncryptionKeyWrapMetadata.GetName(dekProperties.EncryptionKeyWrapMetadata),
+                dekProperties.Id,
                 unwrapResult.DataEncryptionKey);
 
             return new MdeEncryptionAlgorithm(
@@ -365,16 +372,24 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
             CancellationToken cancellationToken)
         {
             EncryptionKeyWrapResult keyWrapResponse = null;
+
             using (diagnosticsContext.CreateScope("WrapDataEncryptionKey"))
             {
-                keyWrapResponse = string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.AEAes256CbcHmacSha256Randomized) && this.DekProvider.EncryptionKeyWrapProvider != null
-                    ? await this.DekProvider.EncryptionKeyWrapProvider.WrapKeyAsync(key, metadata, cancellationToken)
-                    : string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized) && this.DekProvider.MdeKeyWrapProvider != null
-                        ? await this.DekProvider.MdeKeyWrapProvider.WrapKeyAsync(key, metadata, cancellationToken)
-                        : throw new ArgumentException(string.Format(
+                if (string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.AEAes256CbcHmacSha256Randomized) && this.DekProvider.EncryptionKeyWrapProvider != null)
+                {
+                    keyWrapResponse = await this.DekProvider.EncryptionKeyWrapProvider.WrapKeyAsync(key, metadata, cancellationToken);
+                }
+                else if (string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized) && this.DekProvider.MdeKeyWrapProvider != null)
+                {
+                    keyWrapResponse = await this.DekProvider.MdeKeyWrapProvider.WrapKeyAsync(key, metadata, cancellationToken);
+                }
+                else
+                {
+                    throw new ArgumentException(string.Format(
                             "Unsupported encryption algorithm {0}." +
                             " Please initialize the Encryptor or CosmosDataEncryptionKeyProvider with an implementation of the EncryptionKeyStoreProvider / EncryptionKeyWrapProvider.",
                             encryptionAlgorithm));
+                }
             }
 
             // Verify
@@ -462,7 +477,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 cancellationToken);
         }
 
-        private (byte[], EncryptionKeyWrapMetadata) GenerateAndWrapPdekForMdeEncAlgo(EncryptionKeyWrapMetadata encryptionKeyWrapMetadata)
+        private (byte[], EncryptionKeyWrapMetadata) GenerateAndWrapPdekForMdeEncAlgo(string id, EncryptionKeyWrapMetadata encryptionKeyWrapMetadata)
         {
             if (this.DekProvider.MdeKeyWrapProvider == null)
             {
@@ -476,7 +491,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 this.DekProvider.MdeKeyWrapProvider.EncryptionKeyStoreProvider);
 
             ProtectedDataEncryptionKey protectedDataEncryptionKey = new ProtectedDataEncryptionKey(
-                encryptionKeyWrapMetadata.Name,
+                id,
                 keyEncryptionKey);
 
             byte[] wrappedDek = protectedDataEncryptionKey.EncryptedValue;

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerCore.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerCore.cs
@@ -161,6 +161,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
 
             if (!string.IsNullOrEmpty(encryptionAlgorithm))
             {
+                if (string.Equals(dekProperties.EncryptionAlgorithm, CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized)
+                    && string.Equals(encryptionAlgorithm, CosmosEncryptionAlgorithm.AEAes256CbcHmacSha256Randomized))
+                {
+                    throw new InvalidOperationException($"Rewrap operation with EncryptionAlgorithm '{encryptionAlgorithm}' is not supported on Data Encryption Keys" +
+                        $" which are configured with '{CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized}'. ");
+                }
+
                 dekProperties.EncryptionAlgorithm = encryptionAlgorithm;
             }
 

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerInlineCore.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/DataEncryptionKeyContainerInlineCore.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         public override Task<ItemResponse<DataEncryptionKeyProperties>> RewrapDataEncryptionKeyAsync(
            string id,
            EncryptionKeyWrapMetadata newWrapMetadata,
+           string encryptionAlgorithm = null,
            ItemRequestOptions requestOptions = null,
            CancellationToken cancellationToken = default)
         {
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
             }
 
             return TaskHelper.RunInlineIfNeededAsync(() =>
-                this.dataEncryptionKeyContainerCore.RewrapDataEncryptionKeyAsync(id, newWrapMetadata, requestOptions, cancellationToken));
+                this.dataEncryptionKeyContainerCore.RewrapDataEncryptionKeyAsync(id, newWrapMetadata, encryptionAlgorithm, requestOptions, cancellationToken));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionProcessor.cs
@@ -489,7 +489,9 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         private static (TypeMarker, byte[]) Serialize(JToken propertyValue)
         {
             SqlSerializerFactory sqlSerializerFactory = new SqlSerializerFactory();
-            SqlNvarcharSerializer sqlNvarcharSerializer = new SqlNvarcharSerializer(-1);
+
+            // UTF-8 encoding.
+            SqlVarcharSerializer sqlVarcharSerializer = new SqlVarcharSerializer(size: -1, codePageCharacterEncoding: 65001);
 
             switch (propertyValue.Type)
             {
@@ -506,11 +508,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 case JTokenType.Integer:
                     return (TypeMarker.Long, sqlSerializerFactory.GetDefaultSerializer<long>().Serialize(propertyValue.ToObject<long>()));
                 case JTokenType.String:
-                    return (TypeMarker.String, sqlNvarcharSerializer.Serialize(propertyValue.ToObject<string>()));
+                    return (TypeMarker.String, sqlVarcharSerializer.Serialize(propertyValue.ToObject<string>()));
                 case JTokenType.Array:
-                    return (TypeMarker.Array, sqlNvarcharSerializer.Serialize(propertyValue.ToString()));
+                    return (TypeMarker.Array, sqlVarcharSerializer.Serialize(propertyValue.ToString()));
                 case JTokenType.Object:
-                    return (TypeMarker.Object, sqlNvarcharSerializer.Serialize(propertyValue.ToString()));
+                    return (TypeMarker.Object, sqlVarcharSerializer.Serialize(propertyValue.ToString()));
                 default:
                     throw new InvalidOperationException($" Invalid or Unsupported Data Type Passed : {propertyValue.Type}");
             }
@@ -524,6 +526,9 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         {
             SqlSerializerFactory sqlSerializerFactory = new SqlSerializerFactory();
 
+            // UTF-8 encoding.
+            SqlVarcharSerializer sqlVarcharSerializer = new SqlVarcharSerializer(size: -1, codePageCharacterEncoding: 65001);
+
             switch (typeMarker)
             {
                 case TypeMarker.Boolean:
@@ -536,13 +541,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                     jObject.Add(key, sqlSerializerFactory.GetDefaultSerializer<long>().Deserialize(serializedBytes));
                     break;
                 case TypeMarker.String:
-                    jObject.Add(key, sqlSerializerFactory.GetDefaultSerializer<string>().Deserialize(serializedBytes));
+                    jObject.Add(key, sqlVarcharSerializer.Deserialize(serializedBytes));
                     break;
                 case TypeMarker.Array:
-                    jObject.Add(key, JsonConvert.DeserializeObject<JArray>(sqlSerializerFactory.GetDefaultSerializer<string>().Deserialize(serializedBytes)));
+                    jObject.Add(key, JsonConvert.DeserializeObject<JArray>(sqlVarcharSerializer.Deserialize(serializedBytes)));
                     break;
                 case TypeMarker.Object:
-                    jObject.Add(key, JsonConvert.DeserializeObject<JObject>(sqlSerializerFactory.GetDefaultSerializer<string>().Deserialize(serializedBytes)));
+                    jObject.Add(key, JsonConvert.DeserializeObject<JObject>(sqlVarcharSerializer.Deserialize(serializedBytes)));
                     break;
                 default:
                     Debug.Fail(string.Format("Unexpected type marker {0}", typeMarker));

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionProcessor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                         string propertyName = pathToEncrypt.Substring(1);
                         if (!itemJObj.TryGetValue(propertyName, out JToken propertyValue))
                         {
-                            throw new ArgumentException($"{nameof(encryptionOptions.PathsToEncrypt)} includes a path: '{pathToEncrypt}' which was not found.");
+                            continue;
                         }
 
                         if (propertyValue.Type == JTokenType.Null)
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                         string propertyName = pathToEncrypt.Substring(1);
                         if (!itemJObj.TryGetValue(propertyName, out JToken propertyValue))
                         {
-                            throw new ArgumentException($"{nameof(encryptionOptions.PathsToEncrypt)} includes a path: '{pathToEncrypt}' which was not found.");
+                            continue;
                         }
 
                         toEncryptJObj.Add(propertyName, propertyValue.Value<JToken>());
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 string propertyName = path.Substring(1);
                 if (!document.TryGetValue(propertyName, out JToken propertyValue))
                 {
-                    throw new InvalidOperationException($"{nameof(encryptionProperties.EncryptedPaths)} includes a path: '{path}' which was not found.");
+                    continue;
                 }
 
                 byte[] cipherTextWithTypeMarker = propertyValue.ToObject<byte[]>();

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -271,22 +271,22 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized);
 
             Assert.AreEqual(HttpStatusCode.OK, dekResponse.StatusCode);
-            
-            dekProperties = MdeEncryptionTests.VerifyDekResponse(
+
+            dataEncryptionKeyProperties = MdeEncryptionTests.VerifyDekResponse(
                 dekResponse,
                 dekId);
 
-            Assert.AreEqual(CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized, dekProperties.EncryptionAlgorithm);
+            Assert.AreEqual(CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized, dataEncryptionKeyProperties.EncryptionAlgorithm);
 
             Assert.AreEqual(
                 MdeEncryptionTests.metadata2,
-                dekProperties.EncryptionKeyWrapMetadata);
+                dataEncryptionKeyProperties.EncryptionKeyWrapMetadata);
 
             // Use different DEK provider to avoid (unintentional) cache impact
             CosmosDataEncryptionKeyProvider dekProvider = new CosmosDataEncryptionKeyProvider(new TestEncryptionKeyStoreProvider());
             await dekProvider.InitializeAsync(MdeEncryptionTests.database, MdeEncryptionTests.keyContainer.Id);
             DataEncryptionKeyProperties readProperties = await dekProvider.DataEncryptionKeyContainer.ReadDataEncryptionKeyAsync(dekId);
-            Assert.AreEqual(dekProperties, readProperties);
+            Assert.AreEqual(dataEncryptionKeyProperties, readProperties);
 
             // validate key
             testDoc = await MdeEncryptionTests.CreateItemAsync(MdeEncryptionTests.encryptionContainer, dekId, TestDoc.PathsToEncrypt);

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Contracts/DotNetSDKEncryptionAPI.json
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Contracts/DotNetSDKEncryptionAPI.json
@@ -243,10 +243,10 @@
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[Microsoft.Azure.Cosmos.Encryption.Custom.DataEncryptionKeyProperties]] ReadDataEncryptionKeyAsync(System.String, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[Microsoft.Azure.Cosmos.Encryption.Custom.DataEncryptionKeyProperties]] RewrapDataEncryptionKeyAsync(System.String, Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[Microsoft.Azure.Cosmos.Encryption.Custom.DataEncryptionKeyProperties]] RewrapDataEncryptionKeyAsync(System.String, Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionKeyWrapMetadata, System.String, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[Microsoft.Azure.Cosmos.Encryption.Custom.DataEncryptionKeyProperties]] RewrapDataEncryptionKeyAsync(System.String, Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionKeyWrapMetadata, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.ItemResponse`1[Microsoft.Azure.Cosmos.Encryption.Custom.DataEncryptionKeyProperties]] RewrapDataEncryptionKeyAsync(System.String, Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionKeyWrapMetadata, System.String, Microsoft.Azure.Cosmos.ItemRequestOptions, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/MdeEncryptionProcessorTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/MdeEncryptionProcessorTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
 
             try
             {
-                Stream encryptedStream = await EncryptionProcessor.EncryptAsync(
+                await EncryptionProcessor.EncryptAsync(
                     testDoc.ToStream(),
                     MdeEncryptionProcessorTests.mockEncryptor.Object,
                     encryptionOptionsWithDuplicatePathToEncrypt,


### PR DESCRIPTION
## Description

This PR  brings in the following changes/Features. 

- Migrating Legacy Keys which are wrapped using Legacy Algorithm/Lib and configured to Encrypt data using legacy algorithm to MDE based algorithm/Lib by rewrapping and updating the Data Encryption Key properties.

- If EncryptionOption is configured with an Invalid path we now ignore this path and continue rather than throw an Exception.

- Serialization change from SqlNvarcharSerializer ( UTF-16 encoding ) to SqlVarcharSerializer ( with UTF-8 encoding ).

 

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
