### PR TITLE
[Internal] QueryTests: Fixes maxPageSize and continuationTokenLimitInKb tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -95,17 +95,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 });
             }
 
-            // default page size, expect 100 documents
+            // Arbitrary count of elements up to int.MaxValue.
             DocumentFeedResponse<dynamic> result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
-            Assert.AreEqual(100, result.Count);
+            Assert.IsTrue(result.Count <= 200, $"{result.Count} elements returned. It is more than available on collection");
 
-            // dynamic page size (-1), expect all documents to be returned
+            // dynamic page size (-1), expect arbitrary count of elements up to int.MaxValue.
             result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = -1, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
-            Assert.AreEqual(200, result.Count);
+            Assert.IsTrue(result.Count <= 200, $"{result.Count} elements returned. It is more than available on collection");
 
             // page size 10
             result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = 10, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
-            Assert.AreEqual(10, result.Count);
+            Assert.IsTrue(result.Count <= 10, $"{result.Count} elements returned. It is more than MaxItemCount = 10");
 
             TestCommon.RetryRateLimiting<ResourceResponse<Database>>(() =>
             {
@@ -2216,12 +2216,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             feedOptions.ResponseContinuationTokenLimitInKb = 1;
             result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
             string continuation = result.ResponseContinuation;
-            Assert.IsTrue(!continuation.Contains("#FPC") && !continuation.Contains("#FPP"));
+            Assert.IsTrue(
+                continuation.StartsWith("CGW") || (!continuation.Contains("#FPC") && !continuation.Contains("#FPP")),
+                $"{continuation} neither constructed by Compute nor proper BE token");
 
             feedOptions.ResponseContinuationTokenLimitInKb = 2;
             result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
             continuation = result.ResponseContinuation;
-            Assert.IsTrue(continuation.Contains("#FPC") || continuation.Contains("#FPP"));
+            Assert.IsTrue(
+                continuation.StartsWith("CGW") || (continuation.Contains("#FPC") || continuation.Contains("#FPP")),
+                $"{continuation} neither constructed by Compute nor proper BE token");
         }
 
         private void TestQueryMetricsHeaders(Database database, bool partitionedCollection)


### PR DESCRIPTION
# Pull Request Template

## Description

Update existing maxPageSize and continuationTokenLimitInKb tests. MaxPageSize will have corrected expectations and continuationTokenLimitInKb will be aware of the Compute continuation tokens

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
