### PR TITLE
Benchmark: Adds the ability to configure MaxRequestsPerTcpConnection and MaxTcpConnectionsPerEndpoint

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -57,6 +57,12 @@ namespace CosmosBenchmark
         [Option("pl", Required = false, HelpText = "Degree of parallism")]
         public int DegreeOfParallelism { get; set; } = -1;
 
+        [Option("tcp", Required = false, HelpText = "MaxRequestsPerTcpConnection")]
+        public int? MaxRequestsPerTcpConnection { get; set; } = null;
+
+        [Option(Required = false, HelpText = "MaxTcpConnectionsPerEndpoint")]
+        public int? MaxTcpConnectionsPerEndpoint { get; set; } = null;
+
         [Option(Required = false, HelpText = "Item template")]
         public string ItemTemplateFile { get; set; } = "Player.json";
 
@@ -157,7 +163,9 @@ namespace CosmosBenchmark
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
                 ApplicationName = BenchmarkConfig.UserAgentSuffix,
-                MaxRetryAttemptsOnRateLimitedRequests = 0
+                MaxRetryAttemptsOnRateLimitedRequests = 0,
+                MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
+                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
             };
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))
@@ -185,6 +193,8 @@ namespace CosmosBenchmark
                             {
                                 ConnectionMode = Microsoft.Azure.Documents.Client.ConnectionMode.Direct,
                                 ConnectionProtocol = Protocol.Tcp,
+                                MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
+                                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
                                 UserAgentSuffix = BenchmarkConfig.UserAgentSuffix,
                                 RetryOptions = new RetryOptions()
                                 {


### PR DESCRIPTION
# Pull Request Template

## Description

Recent benchmarking is showing issues that are likely caused by the default MaxRequestsPerTcpConnection. This setting allows us to override and test different configuration.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber