### PR TITLE
Benchmark: Adds MaxTcpConnectionsPerEndpoint and MaxRequestsPerTcpConnection to Summary output

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -57,6 +57,12 @@ namespace CosmosBenchmark
         [Option("pl", Required = false, HelpText = "Degree of parallism")]
         public int DegreeOfParallelism { get; set; } = -1;
 
+        [Option("tcp", Required = false, HelpText = "MaxRequestsPerTcpConnection")]
+        public int? MaxRequestsPerTcpConnection { get; set; } = null;
+
+        [Option(Required = false, HelpText = "MaxTcpConnectionsPerEndpoint")]
+        public int? MaxTcpConnectionsPerEndpoint { get; set; } = null;
+
         [Option(Required = false, HelpText = "Item template")]
         public string ItemTemplateFile { get; set; } = "Player.json";
 
@@ -157,7 +163,9 @@ namespace CosmosBenchmark
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
                 ApplicationName = BenchmarkConfig.UserAgentSuffix,
-                MaxRetryAttemptsOnRateLimitedRequests = 0
+                MaxRetryAttemptsOnRateLimitedRequests = 0,
+                MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
+                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
             };
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))
@@ -185,6 +193,8 @@ namespace CosmosBenchmark
                             {
                                 ConnectionMode = Microsoft.Azure.Documents.Client.ConnectionMode.Direct,
                                 ConnectionProtocol = Protocol.Tcp,
+                                MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
+                                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
                                 UserAgentSuffix = BenchmarkConfig.UserAgentSuffix,
                                 RetryOptions = new RetryOptions()
                                 {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs
@@ -159,6 +159,8 @@ namespace CosmosBenchmark
                 runSummary.Container = config.Container;
                 runSummary.AccountName = config.EndPoint;
                 runSummary.pk = config.ResultsPartitionKeyValue;
+                runSummary.MaxTcpConnectionsPerEndpoint = config.MaxTcpConnectionsPerEndpoint;
+                runSummary.MaxRequestsPerTcpConnection = config.MaxRequestsPerTcpConnection;
 
                 string consistencyLevel = config.ConsistencyLevel;
                 if (string.IsNullOrWhiteSpace(consistencyLevel))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -30,7 +30,8 @@ namespace CosmosBenchmark
 
         public int Concurrency { get; set; }
         public int TotalOps { get; set; }
-
+        public int? MaxRequestsPerTcpConnection { get; set; }
+        public int? MaxTcpConnectionsPerEndpoint { get; set; }
         [JsonProperty]
         public static string MachineName { get; set; } = Environment.MachineName;
         [JsonProperty]


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the MaxTcpConnectionsPerEndpoint and MaxRequestsPerTcpConnection to summary output so different value are recorded. This will allow reports to compare the impact of the different values changing.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber