### PR TITLE
[Internal] Change Feed: Adds emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -653,7 +653,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         /// <summary>
         /// This test validates Incremental Change Feed by inserting and deleting documents and verifying nothing reported
         /// </summary>
-        [Ignore]
         [TestMethod]
         public async Task ChangeFeedIteratorCore_DeleteAfterCreate()
         {
@@ -673,8 +672,15 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             FeedIterator<ToDoActivityWithMetadata> changefeedIterator = container.GetChangeFeedIterator<ToDoActivityWithMetadata>(
                 ChangeFeedStartFrom.Beginning(),
                 ChangeFeedMode.Incremental);
-            CosmosException cosmosException = await Assert.ThrowsExceptionAsync<CosmosException>(() => changefeedIterator.ReadNextAsync());
-            Assert.AreEqual(HttpStatusCode.NotModified, cosmosException.StatusCode, "Incremental Change Feed does not present intermediate results and should return nothing.");
+            while (changefeedIterator.HasMoreResults)
+            {
+                FeedResponse<ToDoActivityWithMetadata> feedResponse = await changefeedIterator.ReadNextAsync(this.cancellationToken);
+                Assert.AreEqual(HttpStatusCode.NotModified, feedResponse.StatusCode, "Incremental Change Feed does not present intermediate results and should return nothing.");
+                if (feedResponse.StatusCode == HttpStatusCode.NotModified)
+                {
+                    break;
+                }
+            }
         }
 
         /// <summary>
@@ -821,7 +827,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         /// <summary>
         /// This test validates error with Full Fidelity Change Feed and start from beginning.
         /// </summary>
-        [Ignore]
         [TestMethod]
         public async Task ChangeFeedIteratorCore_WithFullFidelityReadFromBeginning()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -820,7 +820,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
         /// <summary>
         /// This test validates error with Full Fidelity Change Feed and start from beginning.
-        /// </summary
+        /// </summary>
         [Ignore]
         [TestMethod]
         public async Task ChangeFeedIteratorCore_WithFullFidelityReadFromBeginning()


### PR DESCRIPTION
# [Internal] Change Feed: Adds emulator tests

## Description
Add tests for emulator change feed fix. 

1. Validates Incremental Change Feed by inserting and deleting documents and verifying nothing reported
2. Validates error message with Full Fidelity Change Feed and start from beginning.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #2194