### PR TITLE
Preview ITrace: Fixes JsonTraceWriter to include address resolution and store response stats.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -207,7 +207,79 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 this.WriteJsonUriArray("RegionsContacted", clientSideRequestStatisticsTraceDatum.RegionsContacted);
                 this.WriteJsonUriArray("FailedReplicas", clientSideRequestStatisticsTraceDatum.FailedReplicas);
 
+                this.jsonWriter.WriteFieldName("AddressResolutionStatistics");
+                this.jsonWriter.WriteArrayStart();
+
+                foreach (ClientSideRequestStatisticsTraceDatum.AddressResolutionStatistics stat in clientSideRequestStatisticsTraceDatum.EndpointToAddressResolutionStatistics.Values)
+                {
+                    VisitAddressResolutionStatistics(stat, this.jsonWriter);
+                }
+
+                this.jsonWriter.WriteArrayEnd();
+
+                this.jsonWriter.WriteFieldName("StoreResponseStatistics");
+                this.jsonWriter.WriteArrayStart();
+
+                foreach (ClientSideRequestStatisticsTraceDatum.StoreResponseStatistics stat in clientSideRequestStatisticsTraceDatum.StoreResponseStatisticsList)
+                {
+                    VisitStoreResponseStatistics(stat, this.jsonWriter);
+                }
+
+                this.jsonWriter.WriteArrayEnd();
+
                 this.jsonWriter.WriteObjectEnd();
+            }
+
+            private static void VisitAddressResolutionStatistics(
+                ClientSideRequestStatisticsTraceDatum.AddressResolutionStatistics addressResolutionStatistics,
+                IJsonWriter jsonWriter)
+            {
+                jsonWriter.WriteObjectStart();
+
+                jsonWriter.WriteFieldName("StartTimeUTC");
+                jsonWriter.WriteStringValue(addressResolutionStatistics.StartTime.ToString("o", CultureInfo.InvariantCulture));
+
+                jsonWriter.WriteFieldName("EndTimeUTC");
+                if (addressResolutionStatistics.EndTime.HasValue)
+                {
+                    jsonWriter.WriteStringValue(addressResolutionStatistics.EndTime.Value.ToString("o", CultureInfo.InvariantCulture));
+                }
+                else
+                {
+                    jsonWriter.WriteStringValue("EndTime Never Set.");
+                }
+
+                jsonWriter.WriteFieldName("TargetEndpoint");
+                jsonWriter.WriteStringValue(addressResolutionStatistics.TargetEndpoint);
+
+                jsonWriter.WriteObjectEnd();
+            }
+
+            private static void VisitStoreResponseStatistics(
+                ClientSideRequestStatisticsTraceDatum.StoreResponseStatistics storeResponseStatistics,
+                IJsonWriter jsonWriter)
+            {
+                jsonWriter.WriteObjectStart();
+
+                jsonWriter.WriteFieldName("ResponseTimeUTC");
+                jsonWriter.WriteStringValue(storeResponseStatistics.RequestResponseTime.ToString("o", CultureInfo.InvariantCulture));
+
+                jsonWriter.WriteFieldName("ResourceType");
+                jsonWriter.WriteStringValue(storeResponseStatistics.RequestResourceType.ToString());
+
+                jsonWriter.WriteFieldName("OperationType");
+                jsonWriter.WriteStringValue(storeResponseStatistics.RequestOperationType.ToString());
+
+                jsonWriter.WriteFieldName("LocationEndpoint");
+                jsonWriter.WriteStringValue(storeResponseStatistics.LocationEndpoint.ToString());
+
+                if (storeResponseStatistics.StoreResult != null)
+                {
+                    jsonWriter.WriteFieldName("StoreResult");
+                    jsonWriter.WriteStringValue(storeResponseStatistics.StoreResult.ToString());
+                }
+
+                jsonWriter.WriteObjectEnd();
             }
 
             public void Visit(CpuHistoryTraceDatum cpuHistoryTraceDatum)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -249,6 +249,27 @@
       "FailedReplicas": [
         "http://someuri1.com/",
         "http://someuri2.com/"
+      ],
+      "AddressResolutionStatistics": [
+        {
+          "StartTimeUTC": "0001-01-01T00:00:00",
+          "EndTimeUTC": "9999-12-31T23:59:59.9999999",
+          "TargetEndpoint": "http://localhost.com"
+        },
+        {
+          "StartTimeUTC": "0001-01-01T00:00:00",
+          "EndTimeUTC": "9999-12-31T23:59:59.9999999",
+          "TargetEndpoint": "http://localhost.com"
+        }
+      ],
+      "StoreResponseStatistics": [
+        {
+          "ResponseTimeUTC": "9999-12-31T23:59:59.9999999",
+          "ResourceType": "Document",
+          "OperationType": "Query",
+          "LocationEndpoint": "http://someuri1.com/",
+          "StoreResult": "StorePhysicalAddress: http://storephysicaladdress.com/, LSN: 1337, GlobalCommittedLsn: 1234, PartitionKeyRangeId: 42, IsValid: True, StatusCode: 0, SubStatusCode: 0, RequestCharge: 3.14, ItemLSN: 15, SessionToken: 42, UsingLocalLSN: True, TransportException: null"
+        }
       ]
     }
   },


### PR DESCRIPTION
# Internal ITrace: Fixes JsonTraceWriter to include address resolution and store response stats.

## Description

Adding some missing json visitor code. 

Resolves https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2228