### PR TITLE
Performance: Adds an optimization to disable Nagle Algorithm for HttpRequest on NetFx

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Cosmos
         private ServicePointAccessor(ServicePoint servicePoint)
         {
             this.servicePoint = servicePoint ?? throw new ArgumentNullException(nameof(servicePoint));
+            this.TryDisableUseNagleAlgorithm();
         }
 
         internal static ServicePointAccessor FindServicePoint(Uri endpoint)
@@ -33,6 +34,22 @@ namespace Microsoft.Azure.Cosmos
         {
             get => this.servicePoint.ConnectionLimit;
             set => this.TrySetConnectionLimit(value);
+        }
+
+        /// <summary>
+        /// Disable Nagle for HTTP requests.
+        /// This improves latency/throughput for Gateway operations on.net Framework
+        /// </summary>
+        private void TryDisableUseNagleAlgorithm()
+        {
+            try
+            {
+                this.servicePoint.UseNagleAlgorithm = false;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                DefaultTrace.TraceWarning("ServicePoint.set_UseNagleAlgorithm - Platform does not support feature.");
+            }
         }
 
         private void TrySetConnectionLimit(int connectionLimit)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ServicePointAccessorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ServicePointAccessorTests.cs
@@ -23,5 +23,14 @@ namespace Microsoft.Azure.Cosmos.Tests
             ServicePoint servicePoint = ServicePointManager.FindServicePoint(ServicePointAccessorTests.uri);
             Assert.AreEqual(limit, servicePoint.ConnectionLimit);
         }
+
+        [TestMethod]
+        public void ServicePointAccessor_DisableNagle()
+        {
+            ServicePointAccessor accessor = ServicePointAccessor.FindServicePoint(ServicePointAccessorTests.uri);
+            Assert.IsNotNull(accessor);
+            ServicePoint servicePoint = ServicePointManager.FindServicePoint(ServicePointAccessorTests.uri);
+            Assert.IsFalse(servicePoint.UseNagleAlgorithm);
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Disable Nagle for HTTP gateway mode requests;
this improves latency/throughput for Gatewaymode customers on .net Framework.
This is already the default on .net core so they should be no-op for those customers.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber