### PR TITLE
[Internal] CTL: Fixes retry configuration

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -110,8 +110,7 @@ namespace CosmosCTL
         {
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
-                ApplicationName = CTLConfig.UserAgentSuffix,
-                MaxRetryAttemptsOnRateLimitedRequests = 0
+                ApplicationName = CTLConfig.UserAgentSuffix
             };
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
@@ -48,6 +48,8 @@ namespace CosmosCTL
                         cosmosClient: client,
                         logger: logger);
 
+                    logger.LogInformation("Initialization completed.");
+
                     List<Task> tasks = new List<Task>
                     {
                         scenario.RunAsync(

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
@@ -97,7 +97,7 @@ namespace CosmosCTL
                     {
                         if (lease.LeaseToken != null)
                         {
-                            logger.LogInformation($"Lease for range {lease.LeaseToken}");
+                            logger.LogInformation($"Lease for range {lease.LeaseToken} - {lease.FeedRange.EffectiveRange.Min} - {lease.FeedRange.EffectiveRange.Max}");
                             ranges.Add(lease.FeedRange.EffectiveRange);
                             leaseTotal++;
                         }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedProcessorScenario.cs
@@ -61,7 +61,7 @@ namespace CosmosCTL
             GaugeOptions leaseGauge = new GaugeOptions { Name = "#Leases created", Context = loggingContextIdentifier };
 
             string leaseContainerId = Guid.NewGuid().ToString();
-            Container leaseContainer = await cosmosClient.GetDatabase(config.Database).CreateContainerAsync(leaseContainerId, "/id", config.Throughput);
+            Container leaseContainer = await cosmosClient.GetDatabase(config.Database).CreateContainerAsync(leaseContainerId, "/id");
             logger.LogInformation("Created lease container {0}", leaseContainerId);
 
             try


### PR DESCRIPTION
CTL default configuration was throwing on throttled requests with no retries.

On CFP scenarios, the Lease Container initialization when the number of partitions is really high, could generate 429s on the lease collection with the default provisioned RU.

This PR also adds some extra logging that help to debug scenarios and tell apart where a particular issue might have occurred.