### PR TITLE
Spatial: Fixes deserialization when Json does not represent a Spatial type

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Spatial/Converters/GeometryJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/Spatial/Converters/GeometryJsonConverter.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Azure.Cosmos.Spatial.Converters
             }
 
             JToken typeToken = token["type"];
-            if (typeToken.Type != JTokenType.String)
+            if (typeToken == null 
+                || typeToken.Type != JTokenType.String)
             {
                 throw new JsonSerializationException(RMResources.SpatialInvalidGeometryType);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Spatial/CommonSerializationTest.cs
@@ -30,6 +30,17 @@ namespace Microsoft.Azure.Cosmos.Test.Spatial
         }
 
         /// <summary>
+        /// Tests that no type throws exception.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(JsonSerializationException))]
+        public void TestNoType()
+        {
+            string json = @"{""notatype"":""nothingrelevant""}";
+            Point point = JsonConvert.DeserializeObject<Point>(json);
+        }
+
+        /// <summary>
         /// Tests that coordinates cannot be null.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

When deserializing a Spatial type, if the raw Json was valid but did not contain a `type` property, a `NullReferenceException` was being thrown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #2304