### PR TITLE
Client Encryption: Adds integration with latest CosmosDb Preview Package - 3.18.0-preview.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<ClientPreviewVersion>3.18.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
 		<DirectVersion>3.17.2</DirectVersion>
-		<EncryptionVersion>1.0.0-previewV12</EncryptionVersion>
+		<EncryptionVersion>1.0.0-previewV13</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview1</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
 		<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>

--- a/Microsoft.Azure.Cosmos.Encryption/changelog.md
+++ b/Microsoft.Azure.Cosmos.Encryption/changelog.md
@@ -3,6 +3,11 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### <a name="1.0.0-previewV13"/> [1.0.0-previewV13](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-previewV13) - 2021-03-26
+
+#### Added 
+- [#2340](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2340) Adds integration with latest CosmosDb Preview Package - 3.18.0-preview.
+
 ### <a name="1.0.0-previewV12"/> [1.0.0-previewV12](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/1.0.0-previewV12) - 2021-03-15
 
 #### Added 

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionContainer.cs
@@ -873,5 +873,25 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                     changeFeedRequestOptions),
                 this.ResponseFactory);
         }
+
+        public override Task<ItemResponse<T>> PatchItemAsync<T>(
+            string id,
+            PartitionKey partitionKey,
+            IReadOnlyList<PatchOperation> patchOperations,
+            PatchItemRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ResponseMessage> PatchItemStreamAsync(
+            string id,
+            PartitionKey partitionKey,
+            IReadOnlyList<PatchOperation> patchOperations,
+            PatchItemRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionTransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionTransactionalBatch.cs
@@ -252,5 +252,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 response,
                 this.cosmosSerializer);
         }
+
+        public override TransactionalBatch PatchItem(
+            string id,
+            IReadOnlyList<PatchOperation> patchOperations,
+            TransactionalBatchPatchItemRequestOptions requestOptions = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -741,5 +741,25 @@ namespace Microsoft.Azure.Cosmos.Encryption
                     changeFeedRequestOptions),
                 this.ResponseFactory);
         }
+
+        public override Task<ItemResponse<T>> PatchItemAsync<T>(
+            string id,
+            PartitionKey partitionKey,
+            IReadOnlyList<PatchOperation> patchOperations,
+            PatchItemRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<ResponseMessage> PatchItemStreamAsync(
+            string id,
+            PartitionKey partitionKey,
+            IReadOnlyList<PatchOperation> patchOperations,
+            PatchItemRequestOptions requestOptions = null,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
@@ -202,5 +202,13 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 response,
                 this.cosmosSerializer);
         }
+
+        public override TransactionalBatch PatchItem(
+            string id,
+            IReadOnlyList<PatchOperation> patchOperations,
+            TransactionalBatchPatchItemRequestOptions requestOptions = null)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
      <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.3" />
-     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.17.0-preview1" />
+     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0-preview" />
      <PackageReference Include="Azure.Core" Version="1.3.0" />
      <PackageReference Include="Azure.Identity" Version="1.1.1" />
      <PackageReference Include="Microsoft.Data.Encryption.Cryptography" Version="0.1.0-pre" />


### PR DESCRIPTION
## Description

1. This PR will upgrade the dependent CosmosDB Preview Package to 3.18.0-preview.
2. Updates the Encryption preview release version to 1.0.0-previewV13 and the change log.

Note:
PatchItemAsync<T>(...) and  PatchItemStreamAsync(...)  for Container and TransactionalBatch operations introduced as part of 3.18.0-preview is not supported by the Encryption Package and will throw NotImplementedException.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [] This change requires a documentation update

