### PR TITLE
CosmosBenchmarks: Adds additional percentages to summary output

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/ParallelExecutionStrategy.cs
@@ -129,13 +129,16 @@ namespace CosmosBenchmark
                     runSummary.Top80PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.8 * summaryCounters.Length)).Average(), 0);
                     runSummary.Top90PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.9 * summaryCounters.Length)).Average(), 0);
                     runSummary.Top95PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.95 * summaryCounters.Length)).Average(), 0);
+                    runSummary.Top99PercentAverageRps = Math.Round(summaryCounters.Take((int)(0.99 * summaryCounters.Length)).Average(), 0);
                     runSummary.AverageRps = Math.Round(summaryCounters.Average(), 0);
 
                     runSummary.Top50PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(50);
                     runSummary.Top75PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(75);
                     runSummary.Top90PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(90);
                     runSummary.Top95PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(95);
+                    runSummary.Top98PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(98);
                     runSummary.Top99PercentLatencyInMs = TelemetrySpan.GetLatencyPercentile(99);
+                    runSummary.MaxLatencyInMs = TelemetrySpan.GetLatencyPercentile(100);
 
                     string summary = JsonConvert.SerializeObject(runSummary);
                     Utility.TeeTraceInformation(summary);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -57,12 +57,15 @@ namespace CosmosBenchmark
         public double Top80PercentAverageRps { get; set; }
         public double Top90PercentAverageRps { get; set; }
         public double Top95PercentAverageRps { get; set; }
+        public double Top99PercentAverageRps { get; set; }
 
         public double? Top50PercentLatencyInMs { get; set; }
         public double? Top75PercentLatencyInMs { get; set; }
         public double? Top90PercentLatencyInMs { get; set; }
         public double? Top95PercentLatencyInMs { get; set; }
+        public double? Top98PercentLatencyInMs { get; set; }
         public double? Top99PercentLatencyInMs { get; set; }
+        public double? MaxLatencyInMs { get; set; }
 
         public double AverageRps { get; set; }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This adds additional percentages to the summary output. This will help give better insights into the latency.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber