### PR TITLE
[Internal] CTL: Fixes code duplication and unifies logic

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -5,10 +5,8 @@
 namespace CosmosCTL
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using App.Metrics;
@@ -19,10 +17,6 @@ namespace CosmosCTL
 
     internal class ReadWriteQueryScenario : ICTLScenario
     {
-        private static readonly int DefaultDocumentFieldCount = 5;
-        private static readonly int DefaultDataFieldSize = 20;
-        private static readonly string DataFieldValue = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, DefaultDataFieldSize);
-
         private readonly Random random = new Random();
 
         private ReadWriteQueryPercentage readWriteQueryPercentage;
@@ -52,7 +46,7 @@ namespace CosmosCTL
             }
 
             logger.LogInformation("Pre-populating {0} documents", config.PreCreatedDocuments);
-            this.createdDocuments = await PopulateDocumentsAsync(config, logger, this.initializationResult.Containers);
+            this.createdDocuments = await Utils.PopulateDocumentsAsync(config, logger, this.initializationResult.Containers);
         }
 
         public async Task RunAsync(
@@ -247,7 +241,7 @@ namespace CosmosCTL
             bool isContentResponseOnWriteEnabled)
         {
             Container container = containers[(int)operation % containers.Count];
-            Dictionary<string, string> document = GenerateDocument(partitionKeyAttributeName);
+            Dictionary<string, string> document = Utils.GenerateDocument(partitionKeyAttributeName);
             ItemRequestOptions itemRequestOptions = new ItemRequestOptions
             {
                 EnableContentResponseOnWrite = isContentResponseOnWriteEnabled
@@ -291,81 +285,6 @@ namespace CosmosCTL
             }
 
             return iterationCount < maxNumberOfOperations;
-        }
-
-        private static async Task<IReadOnlyDictionary<string, IReadOnlyList<Dictionary<string, string>>>> PopulateDocumentsAsync(
-            CTLConfig config,
-            ILogger logger,
-            IEnumerable<Container> containers)
-        {
-            Dictionary<string, IReadOnlyList<Dictionary<string, string>>> createdDocuments = new Dictionary<string, IReadOnlyList<Dictionary<string, string>>>();
-            foreach (Container container in containers)
-            {
-                long successes = 0;
-                long failures = 0;
-                ConcurrentBag<Dictionary<string, string>> createdDocumentsInContainer = new ConcurrentBag<Dictionary<string, string>>();
-                IEnumerable<Dictionary<string, string>> documentsToCreate = GenerateDocuments(config.PreCreatedDocuments, config.CollectionPartitionKey);
-                await Utils.ForEachAsync(documentsToCreate, (Dictionary<string, string> doc)
-                    => container.CreateItemAsync(doc).ContinueWith(task =>
-                    {
-                        if (task.IsCompletedSuccessfully)
-                        {
-                            createdDocumentsInContainer.Add(doc);
-                            Interlocked.Increment(ref successes);
-                        }
-                        else
-                        {
-                            AggregateException innerExceptions = task.Exception.Flatten();
-                            if (innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
-                            {
-                                logger.LogError(cosmosException, "Failure pre-populating container {0}", container.Id);
-                            }
-
-                            Interlocked.Increment(ref failures);
-                        }
-                    }), 100);
-
-                if (successes > 0)
-                {
-                    logger.LogInformation("Completed pre-populating {0} documents in container {1}.", successes, container.Id);
-                }
-
-                if (failures > 0)
-                {
-                    logger.LogWarning("Failed pre-populating {0} documents in container {1}.", failures, container.Id);
-                }
-
-                createdDocuments.Add(container.Id, createdDocumentsInContainer.ToList());
-            }
-
-            return createdDocuments;
-        }
-
-        private static IEnumerable<Dictionary<string, string>> GenerateDocuments(
-            long documentsToCreate,
-            string partitionKeyPropertyName)
-        {
-            List<Dictionary<string, string>> createdDocuments = new List<Dictionary<string, string>>();
-            for (long i = 0; i < documentsToCreate; i++)
-            {
-                createdDocuments.Add(GenerateDocument(partitionKeyPropertyName));
-            }
-
-            return createdDocuments;
-        }
-
-        private static Dictionary<string, string> GenerateDocument(string partitionKeyPropertyName)
-        {
-            Dictionary<string, string> document = new Dictionary<string, string>();
-            string newGuid = Guid.NewGuid().ToString();
-            document["id"] = newGuid;
-            document[partitionKeyPropertyName] = newGuid;
-            for (int j = 0; j < DefaultDocumentFieldCount; j++)
-            {
-                document["dataField" + j] = DataFieldValue;
-            }
-
-            return document;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Utils.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Utils.cs
@@ -10,9 +10,15 @@ namespace CosmosCTL
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Extensions.Logging;
 
     internal static class Utils
     {
+        private static readonly int DefaultDocumentFieldCount = 5;
+        private static readonly int DefaultDataFieldSize = 20;
+        private static readonly string DataFieldValue = Convert.ToBase64String(Guid.NewGuid().ToByteArray()).Substring(0, DefaultDataFieldSize);
+
         public static Task ForEachAsync<TSource>(
             this IEnumerable<TSource> source,
             Func<TSource, Task> worker,
@@ -39,6 +45,81 @@ namespace CosmosCTL
                                        }
                                    }
                                })));
+        }
+
+        public static async Task<IReadOnlyDictionary<string, IReadOnlyList<Dictionary<string, string>>>> PopulateDocumentsAsync(
+            CTLConfig config,
+            ILogger logger,
+            IEnumerable<Container> containers)
+        {
+            Dictionary<string, IReadOnlyList<Dictionary<string, string>>> createdDocuments = new Dictionary<string, IReadOnlyList<Dictionary<string, string>>>();
+            foreach (Container container in containers)
+            {
+                long successes = 0;
+                long failures = 0;
+                ConcurrentBag<Dictionary<string, string>> createdDocumentsInContainer = new ConcurrentBag<Dictionary<string, string>>();
+                IEnumerable<Dictionary<string, string>> documentsToCreate = GenerateDocuments(config.PreCreatedDocuments, config.CollectionPartitionKey);
+                await Utils.ForEachAsync(documentsToCreate, (Dictionary<string, string> doc)
+                    => container.CreateItemAsync(doc).ContinueWith(task =>
+                    {
+                        if (task.IsCompletedSuccessfully)
+                        {
+                            createdDocumentsInContainer.Add(doc);
+                            Interlocked.Increment(ref successes);
+                        }
+                        else
+                        {
+                            AggregateException innerExceptions = task.Exception.Flatten();
+                            if (innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
+                            {
+                                logger.LogError(cosmosException, "Failure pre-populating container {0}", container.Id);
+                            }
+
+                            Interlocked.Increment(ref failures);
+                        }
+                    }), config.Concurrency);
+
+                if (successes > 0)
+                {
+                    logger.LogInformation("Completed pre-populating {0} documents in container {1}.", successes, container.Id);
+                }
+
+                if (failures > 0)
+                {
+                    logger.LogWarning("Failed pre-populating {0} documents in container {1}.", failures, container.Id);
+                }
+
+                createdDocuments.Add(container.Id, createdDocumentsInContainer.ToList());
+            }
+
+            return createdDocuments;
+        }
+
+        public static IEnumerable<Dictionary<string, string>> GenerateDocuments(
+            long documentsToCreate,
+            string partitionKeyPropertyName)
+        {
+            List<Dictionary<string, string>> createdDocuments = new List<Dictionary<string, string>>();
+            for (long i = 0; i < documentsToCreate; i++)
+            {
+                createdDocuments.Add(GenerateDocument(partitionKeyPropertyName));
+            }
+
+            return createdDocuments;
+        }
+
+        public static Dictionary<string, string> GenerateDocument(string partitionKeyPropertyName)
+        {
+            Dictionary<string, string> document = new Dictionary<string, string>();
+            string newGuid = Guid.NewGuid().ToString();
+            document["id"] = newGuid;
+            document[partitionKeyPropertyName] = newGuid;
+            for (int j = 0; j < DefaultDocumentFieldCount; j++)
+            {
+                document["dataField" + j] = DataFieldValue;
+            }
+
+            return document;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/run_ctl.sh
@@ -128,7 +128,7 @@ else
 dotnetparameters="$dotnetparameters --ctl_logging_context $ctl_logging_context"
 fi
 
-if [ -z "ctl_precreated_documents" ]
+if [ -z "$ctl_precreated_documents" ]
 then
 dotnetparameters="$dotnetparameters"
 else


### PR DESCRIPTION
Moving duplicated code into a single utility to avoid scenarios potentially using different configurations to pre-populate containers.