### PR TITLE
Query: Fixes BadRequest with "Failed to parse ... as ResourceId" for gateway mode on splits

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -145,9 +145,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
             {
                 try
                 {
+                    ContainerProperties containerProperties = await this.container.GetCachedContainerPropertiesAsync(
+                        forceRefresh: true,
+                        trace: refreshTrace,
+                        cancellationToken: cancellationToken);
+
                     // We can refresh the cache by just getting all the ranges for this container using the force refresh flag
                     _ = await this.cosmosQueryClient.TryGetOverlappingRangesAsync(
-                        this.container.LinkUri,
+                        containerProperties.ResourceId,
                         FeedRangeEpk.FullRange.Range,
                         forceRefresh: true);
 

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -145,14 +145,14 @@ namespace Microsoft.Azure.Cosmos.Pagination
             {
                 try
                 {
-                    ContainerProperties containerProperties = await this.container.GetCachedContainerPropertiesAsync(
-                        forceRefresh: true,
+                    string resourceId = await this.container.GetCachedRIDAsync(
+                        forceRefresh: false,
                         trace: refreshTrace,
                         cancellationToken: cancellationToken);
 
                     // We can refresh the cache by just getting all the ranges for this container using the force refresh flag
                     _ = await this.cosmosQueryClient.TryGetOverlappingRangesAsync(
-                        containerProperties.ResourceId,
+                        resourceId,
                         FeedRangeEpk.FullRange.Range,
                         forceRefresh: true);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             Mock<CosmosClientContext> context = new Mock<CosmosClientContext>();
             Mock<ContainerInternal> container = new Mock<ContainerInternal>();
             container.Setup(c => c.ClientContext).Returns(context.Object);
-            container.Setup(c => c.GetCachedRIDAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>())).ReturnsAsync(resourceId);
+            container.Setup(c => c.GetCachedRIDAsync(false, It.IsAny<ITrace>(), It.IsAny<CancellationToken>())).ReturnsAsync(resourceId);
 
             Mock<CosmosQueryClient> client = new Mock<CosmosQueryClient>();
             NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
     using Microsoft.Azure.Cosmos.ChangeFeed;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -21,6 +22,28 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
     public class NetworkAttachedDocumentContainerTests
     {
         [TestMethod]
+        public async Task TestKeyRangeCacheRefresh()
+        {
+            const string resourceId = "resourceId";
+            Mock<CosmosClientContext> context = new Mock<CosmosClientContext>();
+            Mock<ContainerInternal> container = new Mock<ContainerInternal>();
+            container.Setup(c => c.ClientContext).Returns(context.Object);
+            container.Setup(c => c.GetCachedRIDAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>())).ReturnsAsync(resourceId);
+
+            Mock<CosmosQueryClient> client = new Mock<CosmosQueryClient>();
+            NetworkAttachedDocumentContainer networkAttachedDocumentContainer = new NetworkAttachedDocumentContainer(
+                container.Object,
+                client.Object);
+
+            TryCatch result = await networkAttachedDocumentContainer.MonadicRefreshProviderAsync(
+                trace: NoOpTrace.Singleton,
+                cancellationToken: default);
+
+            Assert.IsTrue(result.Succeeded);
+            client.Verify(c => c.TryGetOverlappingRangesAsync(resourceId, FeedRangeEpk.FullRange.Range, true));
+        }
+
+            [TestMethod]
         public async Task MonadicChangeFeedAsync_ChangeFeedMode_Incremental()
         {
             Mock<ContainerInternal> container = new Mock<ContainerInternal>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/NetworkAttachedDocumentContainerTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 cancellationToken: default);
 
             Assert.IsTrue(result.Succeeded);
-            client.Verify(c => c.TryGetOverlappingRangesAsync(resourceId, FeedRangeEpk.FullRange.Range, true));
+            client.Verify(c => c.TryGetOverlappingRangesAsync(resourceId, FeedRangeEpk.FullRange.Range, true), Times.Once);
         }
 
             [TestMethod]


### PR DESCRIPTION
## Description

The NetworkAttachedDocumentContainer is calling the PartitionKeyRangeCache refresh with the collection route instead of the collection ResourceId. This breaks cache refresh logic in Gateway mode.

Example of exception message:
BadRequest (400); Substatus: 0; ActivityId: 89fa45ee-30a5-44b4-92aa-a6b0872f9e85; Reason: (Failed to parse the value 'dbs/testdb/colls/testContainer' as ResourceId.

Introduced in 3.14.0 from PR #1812
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber