### PR TITLE
CosmosDiagnostics: Fixes invalid nesting and handler names in ITrace

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -20,55 +20,56 @@ namespace Microsoft.Azure.Cosmos.Handlers
             RequestMessage request,
             CancellationToken cancellationToken)
         {
-            using (ITrace childTrace = request.Trace.StartChild("Send Async", TraceComponent.RequestHandler, TraceLevel.Info))
+            // Keep a reference to the current trace.
+            ITrace trace = request.Trace;
+            IDocumentClientRetryPolicy retryPolicyInstance = await this.GetRetryPolicyAsync(request);
+            request.OnBeforeSendRequestActions += retryPolicyInstance.OnBeforeSendRequest;
+
+            try
             {
-                request.Trace = childTrace;
-                IDocumentClientRetryPolicy retryPolicyInstance = await this.GetRetryPolicyAsync(request);
-                request.OnBeforeSendRequestActions += retryPolicyInstance.OnBeforeSendRequest;
-
-                try
-                {
-                    return await RetryHandler.ExecuteHttpRequestAsync(
-                        callbackMethod: (trace) => base.SendAsync(request, cancellationToken),
-                        callShouldRetry: (cosmosResponseMessage, trace, token) => retryPolicyInstance.ShouldRetryAsync(cosmosResponseMessage, cancellationToken),
-                        callShouldRetryException: (exception, trace, token) => retryPolicyInstance.ShouldRetryAsync(exception, cancellationToken),
-                        trace: request.Trace,
-                        cancellationToken: cancellationToken);
-                }
-                catch (DocumentClientException ex)
-                {
-                    return ex.ToCosmosResponseMessage(request);
-                }
-                catch (CosmosException ex)
-                {
-                    return ex.ToCosmosResponseMessage(request);
-                }
-                catch (AggregateException ex)
-                {
-                    // TODO: because the SDK underneath this path uses ContinueWith or task.Result we need to catch AggregateExceptions here
-                    // in order to ensure that underlying DocumentClientExceptions get propagated up correctly. Once all ContinueWith and .Result 
-                    // is removed this catch can be safely removed.
-                    AggregateException innerExceptions = ex.Flatten();
-                    Exception docClientException = innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is DocumentClientException);
-                    if (docClientException != null)
+                return await RetryHandler.ExecuteHttpRequestAsync(
+                    callbackMethod: () =>
                     {
-                        return ((DocumentClientException)docClientException).ToCosmosResponseMessage(request);
-                    }
-
-                    throw;
-                }
-                finally
+                        // Reset the trace back to the original to avoid nesting
+                        request.Trace = trace;
+                        return base.SendAsync(request, cancellationToken);
+                    },
+                    callShouldRetry: (cosmosResponseMessage, token) => retryPolicyInstance.ShouldRetryAsync(cosmosResponseMessage, cancellationToken),
+                    callShouldRetryException: (exception, token) => retryPolicyInstance.ShouldRetryAsync(exception, cancellationToken),
+                    cancellationToken: cancellationToken);
+            }
+            catch (DocumentClientException ex)
+            {
+                return ex.ToCosmosResponseMessage(request);
+            }
+            catch (CosmosException ex)
+            {
+                return ex.ToCosmosResponseMessage(request);
+            }
+            catch (AggregateException ex)
+            {
+                // TODO: because the SDK underneath this path uses ContinueWith or task.Result we need to catch AggregateExceptions here
+                // in order to ensure that underlying DocumentClientExceptions get propagated up correctly. Once all ContinueWith and .Result 
+                // is removed this catch can be safely removed.
+                AggregateException innerExceptions = ex.Flatten();
+                Exception docClientException = innerExceptions.InnerExceptions.FirstOrDefault(innerEx => innerEx is DocumentClientException);
+                if (docClientException != null)
                 {
-                    request.OnBeforeSendRequestActions -= retryPolicyInstance.OnBeforeSendRequest;
+                    return ((DocumentClientException)docClientException).ToCosmosResponseMessage(request);
                 }
-            } 
+
+                throw;
+            }
+            finally
+            {
+                request.OnBeforeSendRequestActions -= retryPolicyInstance.OnBeforeSendRequest;
+            }
         }
 
         private static async Task<ResponseMessage> ExecuteHttpRequestAsync(
-           Func<ITrace, Task<ResponseMessage>> callbackMethod,
-           Func<ResponseMessage, ITrace, CancellationToken, Task<ShouldRetryResult>> callShouldRetry,
-           Func<Exception, ITrace, CancellationToken, Task<ShouldRetryResult>> callShouldRetryException,
-           ITrace trace,
+           Func<Task<ResponseMessage>> callbackMethod,
+           Func<ResponseMessage, CancellationToken, Task<ShouldRetryResult>> callShouldRetry,
+           Func<Exception, CancellationToken, Task<ShouldRetryResult>> callShouldRetryException,
            CancellationToken cancellationToken)
         {
             while (true)
@@ -78,14 +79,13 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 try
                 {
-                    ResponseMessage cosmosResponseMessage = await callbackMethod(trace);
+                    ResponseMessage cosmosResponseMessage = await callbackMethod();
                     if (cosmosResponseMessage.IsSuccessStatusCode)
                     {
                         return cosmosResponseMessage;
                     }
 
-                    result = await callShouldRetry(cosmosResponseMessage, trace, cancellationToken);
-
+                    result = await callShouldRetry(cosmosResponseMessage, cancellationToken);
                     if (!result.ShouldRetry)
                     {
                         return cosmosResponseMessage;
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 catch (HttpRequestException httpRequestException)
                 {
-                    result = await callShouldRetryException(httpRequestException, trace, cancellationToken);
+                    result = await callShouldRetryException(httpRequestException, cancellationToken);
                     if (!result.ShouldRetry)
                     {
                         // Today we don't translate request exceptions into status codes since this was an error before

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
@@ -43,10 +43,10 @@
         ├── Create Batch Request(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── Execute Batch Request(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │                           (
             │                               [Client Side Request Stats]
@@ -123,7 +123,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -136,7 +136,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -149,7 +149,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -162,7 +162,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
@@ -47,12 +47,11 @@
             │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │                               (
-            │                                   [Client Side Request Stats]
-            │                                   Redacted To Not Change The Baselines From Run To Run
-            │                               )
+            │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │                           (
+            │                               [Client Side Request Stats]
+            │                               Redacted To Not Change The Baselines From Run To Run
+            │                           )
             └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -176,9 +175,9 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                   "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
+                                  "component": "Transport",
                                   "caller info": {
                                     "member": "MemberName",
                                     "file": "FilePath",
@@ -186,25 +185,10 @@
                                   },
                                   "start time": "12:00:00:000",
                                   "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": []
-                                    }
-                                  ]
+                                  "data": {
+                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                  },
+                                  "children": []
                                 }
                               ]
                             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -38,10 +38,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -55,10 +55,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -72,10 +72,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -89,10 +89,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -106,10 +106,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -123,10 +123,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -140,10 +140,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -157,10 +157,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -174,10 +174,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -191,10 +191,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -208,10 +208,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -225,10 +225,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -242,10 +242,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -259,10 +259,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -276,10 +276,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -293,10 +293,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -310,10 +310,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -327,10 +327,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -344,10 +344,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -361,10 +361,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -378,10 +378,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -395,10 +395,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -412,10 +412,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -429,10 +429,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -446,10 +446,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -463,10 +463,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -480,10 +480,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -497,10 +497,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -514,10 +514,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -531,10 +531,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -548,10 +548,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -565,10 +565,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -582,10 +582,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -599,10 +599,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -616,10 +616,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -633,10 +633,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -650,10 +650,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -667,10 +667,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -684,10 +684,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -701,10 +701,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -718,10 +718,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -735,10 +735,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -752,10 +752,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -769,10 +769,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -786,10 +786,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -803,10 +803,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -820,10 +820,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -837,10 +837,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -854,10 +854,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -871,10 +871,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -888,10 +888,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -905,10 +905,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -922,10 +922,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -939,10 +939,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -956,10 +956,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -973,10 +973,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -990,10 +990,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1007,10 +1007,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1024,10 +1024,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1041,10 +1041,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1058,10 +1058,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1075,10 +1075,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1092,10 +1092,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1109,10 +1109,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1126,10 +1126,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1143,10 +1143,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1160,10 +1160,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1177,10 +1177,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1194,10 +1194,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1211,10 +1211,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1228,10 +1228,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1245,10 +1245,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1262,10 +1262,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1279,10 +1279,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1296,10 +1296,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1313,10 +1313,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1330,10 +1330,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1347,10 +1347,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1364,10 +1364,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1381,10 +1381,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1398,10 +1398,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1415,10 +1415,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1432,10 +1432,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1449,10 +1449,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1466,10 +1466,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1483,10 +1483,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1500,10 +1500,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1517,10 +1517,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1534,10 +1534,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1551,10 +1551,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1568,10 +1568,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1585,10 +1585,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1602,10 +1602,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1619,10 +1619,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1636,10 +1636,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1653,10 +1653,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1670,10 +1670,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1687,10 +1687,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1704,10 +1704,10 @@
     │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           (
     │   │                               [Client Side Request Stats]
@@ -1721,10 +1721,10 @@
         │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           (
         │                               [Client Side Request Stats]
@@ -1788,7 +1788,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1801,7 +1801,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1814,7 +1814,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1827,7 +1827,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1924,7 +1924,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1937,7 +1937,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1950,7 +1950,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1963,7 +1963,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2060,7 +2060,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2073,7 +2073,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2086,7 +2086,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2099,7 +2099,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2196,7 +2196,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2209,7 +2209,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2222,7 +2222,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2235,7 +2235,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2332,7 +2332,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2345,7 +2345,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2358,7 +2358,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2371,7 +2371,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2468,7 +2468,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2481,7 +2481,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2494,7 +2494,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2507,7 +2507,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2604,7 +2604,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2617,7 +2617,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2630,7 +2630,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2643,7 +2643,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2740,7 +2740,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2753,7 +2753,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2766,7 +2766,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2779,7 +2779,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2876,7 +2876,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -2889,7 +2889,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -2902,7 +2902,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -2915,7 +2915,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3012,7 +3012,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3025,7 +3025,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3038,7 +3038,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3051,7 +3051,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3148,7 +3148,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3161,7 +3161,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3174,7 +3174,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3187,7 +3187,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3284,7 +3284,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3297,7 +3297,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3310,7 +3310,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3323,7 +3323,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3420,7 +3420,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3433,7 +3433,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3446,7 +3446,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3459,7 +3459,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3556,7 +3556,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3569,7 +3569,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3582,7 +3582,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3595,7 +3595,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3692,7 +3692,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3705,7 +3705,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3718,7 +3718,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3731,7 +3731,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3828,7 +3828,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3841,7 +3841,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3854,7 +3854,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -3867,7 +3867,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3964,7 +3964,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -3977,7 +3977,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -3990,7 +3990,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4003,7 +4003,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4100,7 +4100,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4113,7 +4113,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4126,7 +4126,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4139,7 +4139,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4236,7 +4236,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4249,7 +4249,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4262,7 +4262,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4275,7 +4275,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4372,7 +4372,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4385,7 +4385,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4398,7 +4398,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4411,7 +4411,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4508,7 +4508,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4521,7 +4521,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4534,7 +4534,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4547,7 +4547,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4644,7 +4644,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4657,7 +4657,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4670,7 +4670,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4683,7 +4683,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4780,7 +4780,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4793,7 +4793,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4806,7 +4806,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4819,7 +4819,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4916,7 +4916,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -4929,7 +4929,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -4942,7 +4942,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -4955,7 +4955,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5052,7 +5052,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5065,7 +5065,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5078,7 +5078,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5091,7 +5091,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5188,7 +5188,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5201,7 +5201,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5214,7 +5214,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5227,7 +5227,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5324,7 +5324,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5337,7 +5337,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5350,7 +5350,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5363,7 +5363,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5460,7 +5460,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5473,7 +5473,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5486,7 +5486,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5499,7 +5499,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5596,7 +5596,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5609,7 +5609,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5622,7 +5622,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5635,7 +5635,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5732,7 +5732,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5745,7 +5745,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5758,7 +5758,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5771,7 +5771,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5868,7 +5868,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -5881,7 +5881,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -5894,7 +5894,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -5907,7 +5907,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6004,7 +6004,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6017,7 +6017,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6030,7 +6030,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6043,7 +6043,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6140,7 +6140,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6153,7 +6153,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6166,7 +6166,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6179,7 +6179,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6276,7 +6276,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6289,7 +6289,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6302,7 +6302,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6315,7 +6315,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6412,7 +6412,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6425,7 +6425,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6438,7 +6438,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6451,7 +6451,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6548,7 +6548,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6561,7 +6561,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6574,7 +6574,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6587,7 +6587,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6684,7 +6684,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6697,7 +6697,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6710,7 +6710,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6723,7 +6723,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6820,7 +6820,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6833,7 +6833,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6846,7 +6846,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6859,7 +6859,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6956,7 +6956,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -6969,7 +6969,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -6982,7 +6982,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -6995,7 +6995,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7092,7 +7092,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7105,7 +7105,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7118,7 +7118,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7131,7 +7131,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7228,7 +7228,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7241,7 +7241,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7254,7 +7254,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7267,7 +7267,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7364,7 +7364,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7377,7 +7377,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7390,7 +7390,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7403,7 +7403,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7500,7 +7500,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7513,7 +7513,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7526,7 +7526,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7539,7 +7539,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7636,7 +7636,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7649,7 +7649,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7662,7 +7662,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7675,7 +7675,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7772,7 +7772,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7785,7 +7785,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7798,7 +7798,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7811,7 +7811,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -7908,7 +7908,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -7921,7 +7921,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -7934,7 +7934,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -7947,7 +7947,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8044,7 +8044,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8057,7 +8057,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8070,7 +8070,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8083,7 +8083,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8180,7 +8180,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8193,7 +8193,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8206,7 +8206,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8219,7 +8219,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8316,7 +8316,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8329,7 +8329,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8342,7 +8342,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8355,7 +8355,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8452,7 +8452,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8465,7 +8465,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8478,7 +8478,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8491,7 +8491,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8588,7 +8588,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8601,7 +8601,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8614,7 +8614,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8627,7 +8627,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8724,7 +8724,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8737,7 +8737,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8750,7 +8750,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8763,7 +8763,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8860,7 +8860,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -8873,7 +8873,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -8886,7 +8886,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -8899,7 +8899,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -8996,7 +8996,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9009,7 +9009,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9022,7 +9022,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9035,7 +9035,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9132,7 +9132,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9145,7 +9145,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9158,7 +9158,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9171,7 +9171,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9268,7 +9268,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9281,7 +9281,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9294,7 +9294,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9307,7 +9307,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9404,7 +9404,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9417,7 +9417,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9430,7 +9430,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9443,7 +9443,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9540,7 +9540,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9553,7 +9553,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9566,7 +9566,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9579,7 +9579,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9676,7 +9676,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9689,7 +9689,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9702,7 +9702,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9715,7 +9715,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9812,7 +9812,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9825,7 +9825,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9838,7 +9838,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9851,7 +9851,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -9948,7 +9948,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -9961,7 +9961,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -9974,7 +9974,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -9987,7 +9987,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10084,7 +10084,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10097,7 +10097,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10110,7 +10110,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10123,7 +10123,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10220,7 +10220,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10233,7 +10233,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10246,7 +10246,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10259,7 +10259,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10356,7 +10356,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10369,7 +10369,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10382,7 +10382,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10395,7 +10395,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10492,7 +10492,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10505,7 +10505,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10518,7 +10518,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10531,7 +10531,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10628,7 +10628,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10641,7 +10641,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10654,7 +10654,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10667,7 +10667,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10764,7 +10764,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10777,7 +10777,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10790,7 +10790,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10803,7 +10803,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -10900,7 +10900,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -10913,7 +10913,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -10926,7 +10926,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -10939,7 +10939,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11036,7 +11036,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11049,7 +11049,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11062,7 +11062,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11075,7 +11075,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11172,7 +11172,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11185,7 +11185,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11198,7 +11198,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11211,7 +11211,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11308,7 +11308,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11321,7 +11321,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11334,7 +11334,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11347,7 +11347,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11444,7 +11444,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11457,7 +11457,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11470,7 +11470,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11483,7 +11483,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11580,7 +11580,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11593,7 +11593,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11606,7 +11606,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11619,7 +11619,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11716,7 +11716,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11729,7 +11729,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11742,7 +11742,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11755,7 +11755,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11852,7 +11852,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -11865,7 +11865,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -11878,7 +11878,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -11891,7 +11891,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -11988,7 +11988,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12001,7 +12001,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12014,7 +12014,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12027,7 +12027,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12124,7 +12124,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12137,7 +12137,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12150,7 +12150,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12163,7 +12163,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12260,7 +12260,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12273,7 +12273,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12286,7 +12286,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12299,7 +12299,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12396,7 +12396,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12409,7 +12409,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12422,7 +12422,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12435,7 +12435,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12532,7 +12532,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12545,7 +12545,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12558,7 +12558,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12571,7 +12571,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12668,7 +12668,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12681,7 +12681,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12694,7 +12694,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12707,7 +12707,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12804,7 +12804,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12817,7 +12817,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12830,7 +12830,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12843,7 +12843,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -12940,7 +12940,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -12953,7 +12953,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -12966,7 +12966,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -12979,7 +12979,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13076,7 +13076,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13089,7 +13089,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13102,7 +13102,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13115,7 +13115,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13212,7 +13212,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13225,7 +13225,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13238,7 +13238,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13251,7 +13251,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13348,7 +13348,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13361,7 +13361,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13374,7 +13374,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13387,7 +13387,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13484,7 +13484,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13497,7 +13497,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13510,7 +13510,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13523,7 +13523,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13620,7 +13620,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13633,7 +13633,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13646,7 +13646,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13659,7 +13659,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13756,7 +13756,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13769,7 +13769,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13782,7 +13782,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13795,7 +13795,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -13892,7 +13892,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -13905,7 +13905,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -13918,7 +13918,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -13931,7 +13931,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14028,7 +14028,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14041,7 +14041,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14054,7 +14054,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14067,7 +14067,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14164,7 +14164,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14177,7 +14177,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14190,7 +14190,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14203,7 +14203,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14300,7 +14300,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14313,7 +14313,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14326,7 +14326,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14339,7 +14339,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14436,7 +14436,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14449,7 +14449,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14462,7 +14462,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14475,7 +14475,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14572,7 +14572,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14585,7 +14585,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14598,7 +14598,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14611,7 +14611,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14708,7 +14708,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14721,7 +14721,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14734,7 +14734,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14747,7 +14747,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14844,7 +14844,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14857,7 +14857,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -14870,7 +14870,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -14883,7 +14883,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -14980,7 +14980,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -14993,7 +14993,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -15006,7 +15006,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -15019,7 +15019,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -15116,7 +15116,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -15129,7 +15129,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -15142,7 +15142,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -15155,7 +15155,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -15252,7 +15252,7 @@
           "data": {},
           "children": [
             {
-              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -15265,7 +15265,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -15278,7 +15278,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -15291,7 +15291,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -42,12 +42,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -60,12 +59,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -78,12 +76,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -96,12 +93,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -114,12 +110,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -132,12 +127,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -150,12 +144,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -168,12 +161,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -186,12 +178,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -204,12 +195,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -222,12 +212,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -240,12 +229,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -258,12 +246,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -276,12 +263,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -294,12 +280,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -312,12 +297,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -330,12 +314,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -348,12 +331,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -366,12 +348,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -384,12 +365,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -402,12 +382,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -420,12 +399,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -438,12 +416,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -456,12 +433,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -474,12 +450,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -492,12 +467,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -510,12 +484,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -528,12 +501,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -546,12 +518,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -564,12 +535,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -582,12 +552,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -600,12 +569,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -618,12 +586,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -636,12 +603,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -654,12 +620,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -672,12 +637,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -690,12 +654,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -708,12 +671,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -726,12 +688,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -744,12 +705,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -762,12 +722,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -780,12 +739,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -798,12 +756,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -816,12 +773,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -834,12 +790,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -852,12 +807,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -870,12 +824,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -888,12 +841,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -906,12 +858,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -924,12 +875,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -942,12 +892,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -960,12 +909,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -978,12 +926,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -996,12 +943,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1014,12 +960,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1032,12 +977,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1050,12 +994,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1068,12 +1011,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1086,12 +1028,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1104,12 +1045,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1122,12 +1062,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1140,12 +1079,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1158,12 +1096,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1176,12 +1113,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1194,12 +1130,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1212,12 +1147,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1230,12 +1164,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1248,12 +1181,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1266,12 +1198,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1284,12 +1215,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1302,12 +1232,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1320,12 +1249,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1338,12 +1266,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1356,12 +1283,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1374,12 +1300,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1392,12 +1317,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1410,12 +1334,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1428,12 +1351,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1446,12 +1368,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1464,12 +1385,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1482,12 +1402,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1500,12 +1419,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1518,12 +1436,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1536,12 +1453,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1554,12 +1470,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1572,12 +1487,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1590,12 +1504,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1608,12 +1521,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1626,12 +1538,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1644,12 +1555,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1662,12 +1572,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1680,12 +1589,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1698,12 +1606,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1716,12 +1623,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1734,12 +1640,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1752,12 +1657,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1770,12 +1674,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1788,12 +1691,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1806,12 +1708,11 @@
     │   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               (
-    │   │                                   [Client Side Request Stats]
-    │   │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                               )
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
     │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
@@ -1824,12 +1725,11 @@
         │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               (
-        │                                   [Client Side Request Stats]
-        │                                   Redacted To Not Change The Baselines From Run To Run
-        │                               )
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1940,9 +1840,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -1950,25 +1850,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2091,9 +1976,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2101,25 +1986,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2242,9 +2112,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2252,25 +2122,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2393,9 +2248,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2403,25 +2258,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2544,9 +2384,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2554,25 +2394,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2695,9 +2520,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2705,25 +2530,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2846,9 +2656,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -2856,25 +2666,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -2997,9 +2792,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3007,25 +2802,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3148,9 +2928,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3158,25 +2938,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3299,9 +3064,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3309,25 +3074,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3450,9 +3200,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3460,25 +3210,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3601,9 +3336,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3611,25 +3346,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3752,9 +3472,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3762,25 +3482,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -3903,9 +3608,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -3913,25 +3618,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4054,9 +3744,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4064,25 +3754,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4205,9 +3880,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4215,25 +3890,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4356,9 +4016,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4366,25 +4026,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4507,9 +4152,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4517,25 +4162,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4658,9 +4288,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4668,25 +4298,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4809,9 +4424,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4819,25 +4434,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -4960,9 +4560,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -4970,25 +4570,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5111,9 +4696,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5121,25 +4706,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5262,9 +4832,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5272,25 +4842,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5413,9 +4968,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5423,25 +4978,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5564,9 +5104,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5574,25 +5114,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5715,9 +5240,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5725,25 +5250,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -5866,9 +5376,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -5876,25 +5386,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6017,9 +5512,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6027,25 +5522,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6168,9 +5648,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6178,25 +5658,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6319,9 +5784,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6329,25 +5794,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6470,9 +5920,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6480,25 +5930,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6621,9 +6056,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6631,25 +6066,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6772,9 +6192,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6782,25 +6202,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -6923,9 +6328,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -6933,25 +6338,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7074,9 +6464,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7084,25 +6474,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7225,9 +6600,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7235,25 +6610,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7376,9 +6736,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7386,25 +6746,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7527,9 +6872,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7537,25 +6882,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7678,9 +7008,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7688,25 +7018,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7829,9 +7144,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7839,25 +7154,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -7980,9 +7280,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -7990,25 +7290,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8131,9 +7416,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8141,25 +7426,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8282,9 +7552,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8292,25 +7562,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8433,9 +7688,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8443,25 +7698,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8584,9 +7824,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8594,25 +7834,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8735,9 +7960,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8745,25 +7970,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -8886,9 +8096,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -8896,25 +8106,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9037,9 +8232,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9047,25 +8242,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9188,9 +8368,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9198,25 +8378,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9339,9 +8504,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9349,25 +8514,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9490,9 +8640,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9500,25 +8650,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9641,9 +8776,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9651,25 +8786,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9792,9 +8912,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9802,25 +8922,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -9943,9 +9048,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -9953,25 +9058,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10094,9 +9184,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10104,25 +9194,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10245,9 +9320,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10255,25 +9330,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10396,9 +9456,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10406,25 +9466,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10547,9 +9592,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10557,25 +9602,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10698,9 +9728,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10708,25 +9738,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -10849,9 +9864,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -10859,25 +9874,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11000,9 +10000,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11010,25 +10010,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11151,9 +10136,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11161,25 +10146,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11302,9 +10272,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11312,25 +10282,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11453,9 +10408,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11463,25 +10418,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11604,9 +10544,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11614,25 +10554,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11755,9 +10680,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11765,25 +10690,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -11906,9 +10816,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -11916,25 +10826,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12057,9 +10952,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12067,25 +10962,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12208,9 +11088,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12218,25 +11098,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12359,9 +11224,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12369,25 +11234,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12510,9 +11360,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12520,25 +11370,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12661,9 +11496,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12671,25 +11506,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12812,9 +11632,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12822,25 +11642,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -12963,9 +11768,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -12973,25 +11778,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13114,9 +11904,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13124,25 +11914,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13265,9 +12040,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13275,25 +12050,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13416,9 +12176,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13426,25 +12186,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13567,9 +12312,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13577,25 +12322,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13718,9 +12448,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13728,25 +12458,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -13869,9 +12584,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -13879,25 +12594,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14020,9 +12720,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14030,25 +12730,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14171,9 +12856,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14181,25 +12866,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14322,9 +12992,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14332,25 +13002,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14473,9 +13128,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14483,25 +13138,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14624,9 +13264,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14634,25 +13274,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14775,9 +13400,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14785,25 +13410,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -14926,9 +13536,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -14936,25 +13546,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15077,9 +13672,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15087,25 +13682,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15228,9 +13808,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15238,25 +13818,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15379,9 +13944,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15389,25 +13954,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15530,9 +14080,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15540,25 +14090,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15681,9 +14216,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15691,25 +14226,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15832,9 +14352,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15842,25 +14362,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -15983,9 +14488,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -15993,25 +14498,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16134,9 +14624,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16144,25 +14634,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16285,9 +14760,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16295,25 +14770,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16436,9 +14896,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16446,25 +14906,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16587,9 +15032,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16597,25 +15042,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16738,9 +15168,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16748,25 +15178,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -16889,9 +15304,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -16899,25 +15314,10 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ChangeFeedAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ChangeFeedAsync.xml
@@ -53,10 +53,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -76,10 +76,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -99,10 +99,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -122,10 +122,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -145,10 +145,10 @@
         │   │           ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │           ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │           ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │           └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   │           └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   │               └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   │                   └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   │                       └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │                                   (
         │   │                                       [Client Side Request Stats]
@@ -161,10 +161,10 @@
         │       │           ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │           └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │           └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │               └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                   └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                       └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                                   (
         │       │                                       [Client Side Request Stats]
@@ -176,10 +176,10 @@
         │       │           ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │           └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │           └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │               └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                   └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                       └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                                   (
         │       │                                       [Client Side Request Stats]
@@ -191,10 +191,10 @@
         │       │           ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │           ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │           └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │           └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │               └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                   └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                       └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                                   (
         │       │                                       [Client Side Request Stats]
@@ -206,10 +206,10 @@
         │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                           (
         │                                               [Client Side Request Stats]
@@ -557,7 +557,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -570,7 +570,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -583,7 +583,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -596,7 +596,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -782,7 +782,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -795,7 +795,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -808,7 +808,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -821,7 +821,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1005,7 +1005,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1018,7 +1018,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1031,7 +1031,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1044,7 +1044,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1228,7 +1228,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1241,7 +1241,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1254,7 +1254,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1267,7 +1267,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1451,7 +1451,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1464,7 +1464,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1477,7 +1477,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1490,7 +1490,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1627,7 +1627,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1640,7 +1640,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1653,7 +1653,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1666,7 +1666,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1790,7 +1790,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1803,7 +1803,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1816,7 +1816,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1829,7 +1829,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1953,7 +1953,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1966,7 +1966,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1979,7 +1979,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1992,7 +1992,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2116,7 +2116,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2129,7 +2129,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2142,7 +2142,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2155,7 +2155,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2292,10 +2292,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -2316,10 +2316,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -2340,10 +2340,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -2364,10 +2364,10 @@
         │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                       (
         │                                           [Client Side Request Stats]
@@ -2716,7 +2716,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2729,7 +2729,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2742,7 +2742,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2755,7 +2755,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2955,7 +2955,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2968,7 +2968,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2981,7 +2981,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2994,7 +2994,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3192,7 +3192,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3205,7 +3205,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3218,7 +3218,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3231,7 +3231,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3429,7 +3429,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3442,7 +3442,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3455,7 +3455,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3468,7 +3468,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3616,10 +3616,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -3639,10 +3639,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -3662,10 +3662,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -3685,10 +3685,10 @@
         │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                       (
         │                                           [Client Side Request Stats]
@@ -4036,7 +4036,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4049,7 +4049,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4062,7 +4062,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4075,7 +4075,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -4261,7 +4261,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4274,7 +4274,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4287,7 +4287,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4300,7 +4300,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4484,7 +4484,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4497,7 +4497,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4510,7 +4510,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4523,7 +4523,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4707,7 +4707,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4720,7 +4720,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4733,7 +4733,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4746,7 +4746,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4882,10 +4882,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -4906,10 +4906,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -4930,10 +4930,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -4954,10 +4954,10 @@
         │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                       (
         │                                           [Client Side Request Stats]
@@ -5306,7 +5306,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -5319,7 +5319,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -5332,7 +5332,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -5345,7 +5345,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -5545,7 +5545,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5558,7 +5558,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -5571,7 +5571,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -5584,7 +5584,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -5782,7 +5782,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -5795,7 +5795,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -5808,7 +5808,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -5821,7 +5821,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -6019,7 +6019,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -6032,7 +6032,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -6045,7 +6045,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -6058,7 +6058,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ChangeFeedAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ChangeFeedAsync.xml
@@ -57,12 +57,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -81,12 +80,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -105,12 +103,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -129,12 +126,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -153,12 +149,11 @@
         │   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   │                                       (
-        │   │                                           [Client Side Request Stats]
-        │   │                                           Redacted To Not Change The Baselines From Run To Run
-        │   │                                       )
+        │   │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   │                                   (
+        │   │                                       [Client Side Request Stats]
+        │   │                                       Redacted To Not Change The Baselines From Run To Run
+        │   │                                   )
         │   └── Drain NotModified Pages(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │   └── [05C1CFFFFFFFF8,05C1DFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -170,12 +165,11 @@
         │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                                       (
-        │       │                                           [Client Side Request Stats]
-        │       │                                           Redacted To Not Change The Baselines From Run To Run
-        │       │                                       )
+        │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                                   (
+        │       │                                       [Client Side Request Stats]
+        │       │                                       Redacted To Not Change The Baselines From Run To Run
+        │       │                                   )
         │       ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │   └── [05C1DFFFFFFFF8,05C1E7FFFFFFFA) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │       └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -186,12 +180,11 @@
         │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                                       (
-        │       │                                           [Client Side Request Stats]
-        │       │                                           Redacted To Not Change The Baselines From Run To Run
-        │       │                                       )
+        │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                                   (
+        │       │                                       [Client Side Request Stats]
+        │       │                                       Redacted To Not Change The Baselines From Run To Run
+        │       │                                   )
         │       ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │   └── [05C1E7FFFFFFFA,FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │       └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -202,12 +195,11 @@
         │       │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       │                                       (
-        │       │                                           [Client Side Request Stats]
-        │       │                                           Redacted To Not Change The Baselines From Run To Run
-        │       │                                       )
+        │       │                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       │                                   (
+        │       │                                       [Client Side Request Stats]
+        │       │                                       Redacted To Not Change The Baselines From Run To Run
+        │       │                                   )
         │       └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │           └── [,05C1CFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -218,12 +210,11 @@
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                               (
-        │                                                   [Client Side Request Stats]
-        │                                                   Redacted To Not Change The Baselines From Run To Run
-        │                                               )
+        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                           (
+        │                                               [Client Side Request Stats]
+        │                                               Redacted To Not Change The Baselines From Run To Run
+        │                                           )
         ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
@@ -618,9 +609,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -628,25 +619,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -858,9 +834,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -868,25 +844,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1096,9 +1057,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -1106,25 +1067,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1334,9 +1280,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -1344,25 +1290,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1572,9 +1503,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -1582,25 +1513,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1763,9 +1679,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1773,25 +1689,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -1941,9 +1842,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1951,25 +1852,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2119,9 +2005,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2129,25 +2015,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2297,9 +2168,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2307,25 +2178,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2440,12 +2296,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2465,12 +2320,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2490,12 +2344,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2515,12 +2368,11 @@
         │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                           (
-        │                                               [Client Side Request Stats]
-        │                                               Redacted To Not Change The Baselines From Run To Run
-        │                                           )
+        │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                       (
+        │                                           [Client Side Request Stats]
+        │                                           Redacted To Not Change The Baselines From Run To Run
+        │                                       )
         ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2916,9 +2768,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2926,25 +2778,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3170,9 +3007,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3180,25 +3017,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3422,9 +3244,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3432,25 +3254,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3674,9 +3481,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3684,25 +3491,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3828,12 +3620,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3852,12 +3643,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3876,12 +3666,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Change Feed Iterator Read Next Async(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3900,12 +3689,11 @@
         │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                           (
-        │                                               [Client Side Request Stats]
-        │                                               Redacted To Not Change The Baselines From Run To Run
-        │                                           )
+        │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                       (
+        │                                           [Client Side Request Stats]
+        │                                           Redacted To Not Change The Baselines From Run To Run
+        │                                       )
         ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
@@ -4300,9 +4088,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4310,25 +4098,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -4540,9 +4313,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -4550,25 +4323,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -4778,9 +4536,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -4788,25 +4546,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -5016,9 +4759,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -5026,25 +4769,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -5158,12 +4886,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -5183,12 +4910,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -5208,12 +4934,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -5233,12 +4958,11 @@
         │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                           (
-        │                                               [Client Side Request Stats]
-        │                                               Redacted To Not Change The Baselines From Run To Run
-        │                                           )
+        │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                       (
+        │                                           [Client Side Request Stats]
+        │                                           Redacted To Not Change The Baselines From Run To Run
+        │                                       )
         ├── Get RID(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -5634,9 +5358,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -5644,25 +5368,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -5888,9 +5597,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -5898,25 +5607,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -6140,9 +5834,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -6150,25 +5844,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -6392,9 +6071,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -6402,25 +6081,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
@@ -20,12 +20,12 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            ├── Waiting for Initialization of client to complete(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Waiting for Initialization of client to complete(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.EmulatorTests.Tracing.EndToEndTraceWriterBaselineTests+RequestHandlerSleepHelper(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                             └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                     (
                                         [Client Side Request Stats]
@@ -63,7 +63,21 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Waiting for Initialization of client to complete",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "component": "Unknown",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "data": {},
+          "children": []
+        },
+        {
+          "name": "Microsoft.Azure.Cosmos.EmulatorTests.Tracing.EndToEndTraceWriterBaselineTests+RequestHandlerSleepHelper",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -76,21 +90,7 @@
           "data": {},
           "children": [
             {
-              "name": "Waiting for Initialization of client to complete",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "component": "Unknown",
-              "caller info": {
-                "member": "MemberName",
-                "file": "FilePath",
-                "line": 42
-              },
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "data": {},
-              "children": []
-            },
-            {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -103,7 +103,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -116,7 +116,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -129,7 +129,7 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -194,10 +194,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -235,7 +235,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -248,7 +248,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -261,7 +261,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -274,7 +274,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
@@ -4,10 +4,16 @@
       <Description>Custom Handler</Description>
       <Setup><![CDATA[
     TimeSpan delayTime = TimeSpan.FromSeconds(2);
+    RequestHandler requestHandler = new RequestHandlerSleepHelper(delayTime);
     CosmosClient cosmosClient = TestCommon.CreateCosmosClient(builder =>
-        builder.AddCustomHandlers(new RequestHandlerSleepHelper(delayTime)));
+        builder.AddCustomHandlers(requestHandler));
 
     DatabaseResponse databaseResponse = await cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
+    EndToEndTraceWriterBaselineTests.AssertCustomHandlerTime(
+        databaseResponse.Diagnostics.ToString(),
+        requestHandler.FullHandlerName,
+        delayTime);
+
     ITrace trace = ((CosmosTraceDiagnostics)databaseResponse.Diagnostics).Value;
     await databaseResponse.Database.DeleteAsync();
 ]]></Setup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.MiscellanousAsync.xml
@@ -26,14 +26,13 @@
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                        (
-                                            [Client Side Request Stats]
-                                            Redacted To Not Change The Baselines From Run To Run
-                                            [PointOperationStatisticsTraceDatum]
-                                            Redacted To Not Change The Baselines From Run To Run
-                                        )
+                            └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                    (
+                                        [Client Side Request Stats]
+                                        Redacted To Not Change The Baselines From Run To Run
+                                        [PointOperationStatisticsTraceDatum]
+                                        Redacted To Not Change The Baselines From Run To Run
+                                    )
 ]]></Text>
       <Json><![CDATA[{
   "name": "CreateDatabaseAsync",
@@ -143,9 +142,9 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request",
                               "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "RequestHandler",
+                              "component": "Transport",
                               "caller info": {
                                 "member": "MemberName",
                                 "file": "FilePath",
@@ -153,26 +152,11 @@
                               },
                               "start time": "12:00:00:000",
                               "duration in milliseconds": 0,
-                              "data": {},
-                              "children": [
-                                {
-                                  "name": "Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "Transport",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {
-                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                    "PointOperationStatisticsTraceDatum": "Redacted To Not Change The Baselines From Run To Run"
-                                  },
-                                  "children": []
-                                }
-                              ]
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                                "PointOperationStatisticsTraceDatum": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": []
                             }
                           ]
                         }
@@ -214,14 +198,13 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                        [PointOperationStatisticsTraceDatum]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                    [PointOperationStatisticsTraceDatum]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "CreateDatabaseAsync",
@@ -304,9 +287,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -314,26 +297,11 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                "PointOperationStatisticsTraceDatum": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "PointOperationStatisticsTraceDatum": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
@@ -40,18 +40,17 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               (
-    │                                   [Client Side Request Stats]
-    │                                   Redacted To Not Change The Baselines From Run To Run
-    │                                   [Point Operation Statistics]
-    │                                   Redacted To Not Change The Baselines From Run To Run
-    │                               )
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -111,7 +110,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -124,7 +123,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -137,7 +136,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -150,7 +149,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -163,9 +162,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -173,26 +172,11 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -272,46 +256,50 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Client Side Request Stats]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Client Side Request Stats]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           │   (
-    │                                           │       [Client Side Request Stats]
-    │                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                           │   )
-    │                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   │   (
-    │                                                   │       [Client Side Request Stats]
-    │                                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                                   │   )
-    │                                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                           │   (
-    │                                                           │       [Client Side Request Stats]
-    │                                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                                           │   )
-    │                                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                                       (
-    │                                                                           [Client Side Request Stats]
-    │                                                                           Redacted To Not Change The Baselines From Run To Run
-    │                                                                       )
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -371,7 +359,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -384,7 +372,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -397,7 +385,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -410,7 +398,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -423,9 +411,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -433,185 +421,240 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": [
-                                                {
-                                                  "name": "Send Async",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "RequestHandler",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {},
-                                                  "children": [
-                                                    {
-                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                      "component": "Transport",
-                                                      "caller info": {
-                                                        "member": "MemberName",
-                                                        "file": "FilePath",
-                                                        "line": 42
-                                                      },
-                                                      "start time": "12:00:00:000",
-                                                      "duration in milliseconds": 0,
-                                                      "data": {
-                                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                      },
-                                                      "children": [
-                                                        {
-                                                          "name": "Send Async",
-                                                          "id": "00000000-0000-0000-0000-000000000000",
-                                                          "component": "RequestHandler",
-                                                          "caller info": {
-                                                            "member": "MemberName",
-                                                            "file": "FilePath",
-                                                            "line": 42
-                                                          },
-                                                          "start time": "12:00:00:000",
-                                                          "duration in milliseconds": 0,
-                                                          "data": {},
-                                                          "children": [
-                                                            {
-                                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                              "id": "00000000-0000-0000-0000-000000000000",
-                                                              "component": "Transport",
-                                                              "caller info": {
-                                                                "member": "MemberName",
-                                                                "file": "FilePath",
-                                                                "line": 42
-                                                              },
-                                                              "start time": "12:00:00:000",
-                                                              "duration in milliseconds": 0,
-                                                              "data": {
-                                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                              },
-                                                              "children": [
-                                                                {
-                                                                  "name": "Send Async",
-                                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                                  "component": "RequestHandler",
-                                                                  "caller info": {
-                                                                    "member": "MemberName",
-                                                                    "file": "FilePath",
-                                                                    "line": 42
-                                                                  },
-                                                                  "start time": "12:00:00:000",
-                                                                  "duration in milliseconds": 0,
-                                                                  "data": {},
-                                                                  "children": [
-                                                                    {
-                                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                                      "component": "Transport",
-                                                                      "caller info": {
-                                                                        "member": "MemberName",
-                                                                        "file": "FilePath",
-                                                                        "line": 42
-                                                                      },
-                                                                      "start time": "12:00:00:000",
-                                                                      "duration in milliseconds": 0,
-                                                                      "data": {
-                                                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                                      },
-                                                                      "children": []
-                                                                    }
-                                                                  ]
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -720,26 +763,26 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Client Side Request Stats]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       (
-    │                                           [Client Side Request Stats]
-    │                                           Redacted To Not Change The Baselines From Run To Run
-    │                                           [Point Operation Statistics]
-    │                                           Redacted To Not Change The Baselines From Run To Run
-    │                                       )
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -799,7 +842,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -812,7 +855,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -825,7 +868,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -838,7 +881,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -851,9 +894,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -861,59 +904,58 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": []
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -1022,34 +1064,35 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Client Side Request Stats]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Client Side Request Stats]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │       [Point Operation Statistics]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Client Side Request Stats]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                                   [Point Operation Statistics]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1109,7 +1152,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -1122,7 +1165,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1135,7 +1178,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1148,7 +1191,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1161,9 +1204,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -1171,92 +1214,105 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -1365,50 +1421,53 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Client Side Request Stats]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Client Side Request Stats]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │       [Point Operation Statistics]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           │   (
-    │                                           │       [Client Side Request Stats]
-    │                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                           │       [Point Operation Statistics]
-    │                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                           │   )
-    │                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   │   (
-    │                                                   │       [Client Side Request Stats]
-    │                                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                                   │       [Point Operation Statistics]
-    │                                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                                   │   )
-    │                                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                               (
-    │                                                                   [Client Side Request Stats]
-    │                                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                                                   [Point Operation Statistics]
-    │                                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                                               )
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1468,7 +1527,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -1481,7 +1540,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1494,7 +1553,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1507,7 +1566,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1520,9 +1579,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -1530,158 +1589,199 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": [
-                                                {
-                                                  "name": "Send Async",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "RequestHandler",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {},
-                                                  "children": [
-                                                    {
-                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                      "component": "Transport",
-                                                      "caller info": {
-                                                        "member": "MemberName",
-                                                        "file": "FilePath",
-                                                        "line": 42
-                                                      },
-                                                      "start time": "12:00:00:000",
-                                                      "duration in milliseconds": 0,
-                                                      "data": {
-                                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                                      },
-                                                      "children": [
-                                                        {
-                                                          "name": "Send Async",
-                                                          "id": "00000000-0000-0000-0000-000000000000",
-                                                          "component": "RequestHandler",
-                                                          "caller info": {
-                                                            "member": "MemberName",
-                                                            "file": "FilePath",
-                                                            "line": 42
-                                                          },
-                                                          "start time": "12:00:00:000",
-                                                          "duration in milliseconds": 0,
-                                                          "data": {},
-                                                          "children": [
-                                                            {
-                                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                              "id": "00000000-0000-0000-0000-000000000000",
-                                                              "component": "Transport",
-                                                              "caller info": {
-                                                                "member": "MemberName",
-                                                                "file": "FilePath",
-                                                                "line": 42
-                                                              },
-                                                              "start time": "12:00:00:000",
-                                                              "duration in milliseconds": 0,
-                                                              "data": {
-                                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
-                                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                                              },
-                                                              "children": []
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
@@ -40,10 +40,10 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           (
     │                               [Point Operation Statistics]
@@ -108,7 +108,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -121,7 +121,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -134,7 +134,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -147,7 +147,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -253,40 +253,45 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Client Side Request Stats]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Client Side Request Stats]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Client Side Request Stats]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Client Side Request Stats]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Client Side Request Stats]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Client Side Request Stats]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           (
     │                               [Client Side Request Stats]
@@ -351,7 +356,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -364,7 +369,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -377,7 +382,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -390,7 +395,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -419,9 +424,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -450,9 +470,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -481,9 +516,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -512,9 +562,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -543,9 +608,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -680,16 +760,17 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           (
     │                               [Point Operation Statistics]
@@ -754,7 +835,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -767,7 +848,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -780,7 +861,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -793,7 +874,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -822,9 +903,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -959,22 +1055,24 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           (
     │                               [Point Operation Statistics]
@@ -1039,7 +1137,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -1052,7 +1150,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1065,7 +1163,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1078,7 +1176,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1107,9 +1205,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1138,9 +1251,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1275,34 +1403,38 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │               │           (
-    │               │               [Point Operation Statistics]
-    │               │               Redacted To Not Change The Baselines From Run To Run
-    │               │           )
-    │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           │               (
+    │           │                   [Point Operation Statistics]
+    │           │                   Redacted To Not Change The Baselines From Run To Run
+    │           │               )
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           (
     │                               [Point Operation Statistics]
@@ -1367,7 +1499,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -1380,7 +1512,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -1393,7 +1525,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -1406,7 +1538,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1435,9 +1567,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1466,9 +1613,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1497,9 +1659,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -1528,9 +1705,24 @@
                           "children": []
                         }
                       ]
-                    },
+                    }
+                  ]
+                },
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "component": "RequestHandler",
+                  "caller info": {
+                    "member": "MemberName",
+                    "file": "FilePath",
+                    "line": 42
+                  },
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {},
+                  "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
@@ -44,12 +44,11 @@
     │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               (
-    │                                   [Point Operation Statistics]
-    │                                   Redacted To Not Change The Baselines From Run To Run
-    │                               )
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -161,9 +160,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -171,25 +170,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -272,43 +256,42 @@
     │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Client Side Request Stats]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Client Side Request Stats]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Client Side Request Stats]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Client Side Request Stats]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Client Side Request Stats]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
     │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Client Side Request Stats]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Client Side Request Stats]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           │   (
-    │                                           │       [Client Side Request Stats]
-    │                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                           │   )
-    │                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   │   (
-    │                                                   │       [Client Side Request Stats]
-    │                                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                                   │   )
-    │                                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                           │   (
-    │                                                           │       [Client Side Request Stats]
-    │                                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                                           │   )
-    │                                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                                       (
-    │                                                                           [Client Side Request Stats]
-    │                                                                           Redacted To Not Change The Baselines From Run To Run
-    │                                                                       )
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -420,9 +403,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -430,185 +413,165 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": [
-                                                {
-                                                  "name": "Send Async",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "RequestHandler",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {},
-                                                  "children": [
-                                                    {
-                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                      "component": "Transport",
-                                                      "caller info": {
-                                                        "member": "MemberName",
-                                                        "file": "FilePath",
-                                                        "line": 42
-                                                      },
-                                                      "start time": "12:00:00:000",
-                                                      "duration in milliseconds": 0,
-                                                      "data": {
-                                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                      },
-                                                      "children": [
-                                                        {
-                                                          "name": "Send Async",
-                                                          "id": "00000000-0000-0000-0000-000000000000",
-                                                          "component": "RequestHandler",
-                                                          "caller info": {
-                                                            "member": "MemberName",
-                                                            "file": "FilePath",
-                                                            "line": 42
-                                                          },
-                                                          "start time": "12:00:00:000",
-                                                          "duration in milliseconds": 0,
-                                                          "data": {},
-                                                          "children": [
-                                                            {
-                                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                              "id": "00000000-0000-0000-0000-000000000000",
-                                                              "component": "Transport",
-                                                              "caller info": {
-                                                                "member": "MemberName",
-                                                                "file": "FilePath",
-                                                                "line": 42
-                                                              },
-                                                              "start time": "12:00:00:000",
-                                                              "duration in milliseconds": 0,
-                                                              "data": {
-                                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                              },
-                                                              "children": [
-                                                                {
-                                                                  "name": "Send Async",
-                                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                                  "component": "RequestHandler",
-                                                                  "caller info": {
-                                                                    "member": "MemberName",
-                                                                    "file": "FilePath",
-                                                                    "line": 42
-                                                                  },
-                                                                  "start time": "12:00:00:000",
-                                                                  "duration in milliseconds": 0,
-                                                                  "data": {},
-                                                                  "children": [
-                                                                    {
-                                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                                      "component": "Transport",
-                                                                      "caller info": {
-                                                                        "member": "MemberName",
-                                                                        "file": "FilePath",
-                                                                        "line": 42
-                                                                      },
-                                                                      "start time": "12:00:00:000",
-                                                                      "duration in milliseconds": 0,
-                                                                      "data": {
-                                                                        "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                                      },
-                                                                      "children": []
-                                                                    }
-                                                                  ]
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -720,19 +683,18 @@
     │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
     │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       (
-    │                                           [Point Operation Statistics]
-    │                                           Redacted To Not Change The Baselines From Run To Run
-    │                                       )
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -844,9 +806,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -854,57 +816,41 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": []
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -1016,25 +962,24 @@
     │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
     │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Point Operation Statistics]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Point Operation Statistics]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1146,9 +1091,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -1156,89 +1101,72 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -1350,37 +1278,36 @@
     │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
+    │               ├── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               │           (
+    │               │               [Point Operation Statistics]
+    │               │               Redacted To Not Change The Baselines From Run To Run
+    │               │           )
     │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           │   (
-    │                           │       [Point Operation Statistics]
-    │                           │       Redacted To Not Change The Baselines From Run To Run
-    │                           │   )
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   │   (
-    │                                   │       [Point Operation Statistics]
-    │                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                   │   )
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           │   (
-    │                                           │       [Point Operation Statistics]
-    │                                           │       Redacted To Not Change The Baselines From Run To Run
-    │                                           │   )
-    │                                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   │   (
-    │                                                   │       [Point Operation Statistics]
-    │                                                   │       Redacted To Not Change The Baselines From Run To Run
-    │                                                   │   )
-    │                                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                               (
-    │                                                                   [Point Operation Statistics]
-    │                                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                                               )
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
     └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1492,9 +1419,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -1502,153 +1429,134 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": [
-                                {
-                                  "name": "Send Async",
-                                  "id": "00000000-0000-0000-0000-000000000000",
-                                  "component": "RequestHandler",
-                                  "caller info": {
-                                    "member": "MemberName",
-                                    "file": "FilePath",
-                                    "line": 42
-                                  },
-                                  "start time": "12:00:00:000",
-                                  "duration in milliseconds": 0,
-                                  "data": {},
-                                  "children": [
-                                    {
-                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                      "id": "00000000-0000-0000-0000-000000000000",
-                                      "component": "Transport",
-                                      "caller info": {
-                                        "member": "MemberName",
-                                        "file": "FilePath",
-                                        "line": 42
-                                      },
-                                      "start time": "12:00:00:000",
-                                      "duration in milliseconds": 0,
-                                      "data": {
-                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                      },
-                                      "children": [
-                                        {
-                                          "name": "Send Async",
-                                          "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
-                                          "caller info": {
-                                            "member": "MemberName",
-                                            "file": "FilePath",
-                                            "line": 42
-                                          },
-                                          "start time": "12:00:00:000",
-                                          "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": [
-                                                {
-                                                  "name": "Send Async",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "RequestHandler",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {},
-                                                  "children": [
-                                                    {
-                                                      "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                      "id": "00000000-0000-0000-0000-000000000000",
-                                                      "component": "Transport",
-                                                      "caller info": {
-                                                        "member": "MemberName",
-                                                        "file": "FilePath",
-                                                        "line": 42
-                                                      },
-                                                      "start time": "12:00:00:000",
-                                                      "duration in milliseconds": 0,
-                                                      "data": {
-                                                        "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                                      },
-                                                      "children": [
-                                                        {
-                                                          "name": "Send Async",
-                                                          "id": "00000000-0000-0000-0000-000000000000",
-                                                          "component": "RequestHandler",
-                                                          "caller info": {
-                                                            "member": "MemberName",
-                                                            "file": "FilePath",
-                                                            "line": 42
-                                                          },
-                                                          "start time": "12:00:00:000",
-                                                          "duration in milliseconds": 0,
-                                                          "data": {},
-                                                          "children": [
-                                                            {
-                                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                              "id": "00000000-0000-0000-0000-000000000000",
-                                                              "component": "Transport",
-                                                              "caller info": {
-                                                                "member": "MemberName",
-                                                                "file": "FilePath",
-                                                                "line": 42
-                                                              },
-                                                              "start time": "12:00:00:000",
-                                                              "duration in milliseconds": 0,
-                                                              "data": {
-                                                                "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
-                                                              },
-                                                              "children": []
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Send Async",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "component": "RequestHandler",
+                      "caller info": {
+                        "member": "MemberName",
+                        "file": "FilePath",
+                        "line": 42
+                      },
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {},
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "component": "Transport",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
@@ -44,10 +44,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -71,10 +71,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -98,10 +98,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -125,10 +125,10 @@
                         │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │                           (
                         │                               [Client Side Request Stats]
@@ -375,7 +375,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -388,7 +388,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -401,7 +401,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -414,7 +414,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -601,7 +601,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -614,7 +614,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -627,7 +627,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -640,7 +640,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -827,7 +827,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -840,7 +840,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -853,7 +853,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -866,7 +866,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1053,7 +1053,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1066,7 +1066,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1079,7 +1079,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1092,7 +1092,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1203,10 +1203,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -1231,10 +1231,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -1259,10 +1259,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -1287,10 +1287,10 @@
         │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │                           (
         │               │                               [Client Side Request Stats]
@@ -1538,7 +1538,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1551,7 +1551,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1564,7 +1564,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1577,7 +1577,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1778,7 +1778,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1791,7 +1791,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1804,7 +1804,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1817,7 +1817,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2018,7 +2018,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2031,7 +2031,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2044,7 +2044,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2057,7 +2057,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2258,7 +2258,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2271,7 +2271,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2284,7 +2284,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2297,7 +2297,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2423,10 +2423,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -2450,10 +2450,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -2477,10 +2477,10 @@
     │                   │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │                           (
     │                   │                               [Client Side Request Stats]
@@ -2504,10 +2504,10 @@
                         │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │                           (
                         │                               [Client Side Request Stats]
@@ -2754,7 +2754,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2767,7 +2767,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2780,7 +2780,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2793,7 +2793,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2980,7 +2980,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2993,7 +2993,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3006,7 +3006,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3019,7 +3019,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -3206,7 +3206,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3219,7 +3219,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3232,7 +3232,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3245,7 +3245,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -3432,7 +3432,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3445,7 +3445,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3458,7 +3458,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3471,7 +3471,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -3583,10 +3583,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -3611,10 +3611,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -3639,10 +3639,10 @@
     │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │                           (
     │   │               │                               [Client Side Request Stats]
@@ -3667,10 +3667,10 @@
         │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │                           (
         │               │                               [Client Side Request Stats]
@@ -3918,7 +3918,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3931,7 +3931,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3944,7 +3944,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3957,7 +3957,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -4158,7 +4158,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4171,7 +4171,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4184,7 +4184,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4197,7 +4197,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -4398,7 +4398,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4411,7 +4411,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4424,7 +4424,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4437,7 +4437,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -4638,7 +4638,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4651,7 +4651,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4664,7 +4664,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4677,7 +4677,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
@@ -48,12 +48,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -76,12 +75,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -104,12 +102,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
@@ -132,12 +129,11 @@
                         │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                               (
-                        │                                   [Client Side Request Stats]
-                        │                                   Redacted To Not Change The Baselines From Run To Run
-                        │                               )
+                        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │                           (
+                        │                               [Client Side Request Stats]
+                        │                               Redacted To Not Change The Baselines From Run To Run
+                        │                           )
                         └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -431,9 +427,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -441,25 +437,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -672,9 +653,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -682,25 +663,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -913,9 +879,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -923,25 +889,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -1154,9 +1105,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1164,25 +1115,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -1271,12 +1207,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1300,12 +1235,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1329,12 +1263,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1358,12 +1291,11 @@
         │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                               (
-        │               │                                   [Client Side Request Stats]
-        │               │                                   Redacted To Not Change The Baselines From Run To Run
-        │               │                               )
+        │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │                           (
+        │               │                               [Client Side Request Stats]
+        │               │                               Redacted To Not Change The Baselines From Run To Run
+        │               │                           )
         │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
@@ -1658,9 +1590,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1668,25 +1600,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -1913,9 +1830,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1923,25 +1840,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2168,9 +2070,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2178,25 +2080,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2423,9 +2310,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2433,25 +2320,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -2555,12 +2427,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -2583,12 +2454,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -2611,12 +2481,11 @@
     │                   │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   │                               (
-    │                   │                                   [Client Side Request Stats]
-    │                   │                                   Redacted To Not Change The Baselines From Run To Run
-    │                   │                               )
+    │                   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   │                           (
+    │                   │                               [Client Side Request Stats]
+    │                   │                               Redacted To Not Change The Baselines From Run To Run
+    │                   │                           )
     │                   └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
@@ -2639,12 +2508,11 @@
                         │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        │                               (
-                        │                                   [Client Side Request Stats]
-                        │                                   Redacted To Not Change The Baselines From Run To Run
-                        │                               )
+                        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        │                           (
+                        │                               [Client Side Request Stats]
+                        │                               Redacted To Not Change The Baselines From Run To Run
+                        │                           )
                         └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -2938,9 +2806,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2948,25 +2816,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3179,9 +3032,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -3189,25 +3042,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3420,9 +3258,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -3430,25 +3268,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3661,9 +3484,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -3671,25 +3494,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3779,12 +3587,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3808,12 +3615,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3837,12 +3643,11 @@
     │   │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               │                               (
-    │   │               │                                   [Client Side Request Stats]
-    │   │               │                                   Redacted To Not Change The Baselines From Run To Run
-    │   │               │                               )
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
     │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -3866,12 +3671,11 @@
         │               │       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               │               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               │                               (
-        │               │                                   [Client Side Request Stats]
-        │               │                                   Redacted To Not Change The Baselines From Run To Run
-        │               │                               )
+        │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               │                           (
+        │               │                               [Client Side Request Stats]
+        │               │                               Redacted To Not Change The Baselines From Run To Run
+        │               │                           )
         │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
@@ -4166,9 +3970,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4176,25 +3980,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -4421,9 +4210,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4431,25 +4220,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -4676,9 +4450,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4686,25 +4460,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -4931,9 +4690,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4941,25 +4700,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ReadFeedAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ReadFeedAsync.xml
@@ -51,12 +51,11 @@
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   (
-    │                                                       [Client Side Request Stats]
-    │                                                       Redacted To Not Change The Baselines From Run To Run
-    │                                                   )
+    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                               (
+    │                                                   [Client Side Request Stats]
+    │                                                   Redacted To Not Change The Baselines From Run To Run
+    │                                               )
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
     │   │       [Client Configuration]
@@ -73,12 +72,11 @@
     │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Client Side Request Stats]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                           (
+    │                                               [Client Side Request Stats]
+    │                                               Redacted To Not Change The Baselines From Run To Run
+    │                                           )
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
     │   │       [Client Configuration]
@@ -95,12 +93,11 @@
     │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Client Side Request Stats]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                           (
+    │                                               [Client Side Request Stats]
+    │                                               Redacted To Not Change The Baselines From Run To Run
+    │                                           )
     └── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
         │       [Client Configuration]
@@ -117,12 +114,11 @@
                             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                                    (
-                                                        [Client Side Request Stats]
-                                                        Redacted To Not Change The Baselines From Run To Run
-                                                    )
+                                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                                (
+                                                    [Client Side Request Stats]
+                                                    Redacted To Not Change The Baselines From Run To Run
+                                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "Trace Forest",
@@ -515,9 +511,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -525,25 +521,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -727,9 +708,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -737,25 +718,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -937,9 +903,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -947,25 +913,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1147,9 +1098,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -1157,25 +1108,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -1251,12 +1187,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1274,12 +1209,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -1297,12 +1231,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
@@ -1320,12 +1253,11 @@
         │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                           (
-        │                                               [Client Side Request Stats]
-        │                                               Redacted To Not Change The Baselines From Run To Run
-        │                                           )
+        │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                       (
+        │                                           [Client Side Request Stats]
+        │                                           Redacted To Not Change The Baselines From Run To Run
+        │                                       )
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -1719,9 +1651,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -1729,25 +1661,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -1945,9 +1862,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -1955,25 +1872,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -2169,9 +2071,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -2179,25 +2081,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -2393,9 +2280,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -2403,25 +2290,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -2512,12 +2384,11 @@
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                           └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                                   (
-    │                                                       [Client Side Request Stats]
-    │                                                       Redacted To Not Change The Baselines From Run To Run
-    │                                                   )
+    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                               (
+    │                                                   [Client Side Request Stats]
+    │                                                   Redacted To Not Change The Baselines From Run To Run
+    │                                               )
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
     │   │       [Client Configuration]
@@ -2534,12 +2405,11 @@
     │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Client Side Request Stats]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                           (
+    │                                               [Client Side Request Stats]
+    │                                               Redacted To Not Change The Baselines From Run To Run
+    │                                           )
     ├── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
     │   │       [Client Configuration]
@@ -2556,12 +2426,11 @@
     │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                               (
-    │                                                   [Client Side Request Stats]
-    │                                                   Redacted To Not Change The Baselines From Run To Run
-    │                                               )
+    │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                           (
+    │                                               [Client Side Request Stats]
+    │                                               Redacted To Not Change The Baselines From Run To Run
+    │                                           )
     └── FeedIterator Read Next Async(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
         │       [Client Configuration]
@@ -2578,12 +2447,11 @@
                             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                                    (
-                                                        [Client Side Request Stats]
-                                                        Redacted To Not Change The Baselines From Run To Run
-                                                    )
+                                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                                (
+                                                    [Client Side Request Stats]
+                                                    Redacted To Not Change The Baselines From Run To Run
+                                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "Trace Forest",
@@ -2976,9 +2844,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -2986,25 +2854,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -3188,9 +3041,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3198,25 +3051,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3398,9 +3236,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3408,25 +3246,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3608,9 +3431,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -3618,25 +3441,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -3713,12 +3521,11 @@
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                               (
-    │   │                                                   [Client Side Request Stats]
-    │   │                                                   Redacted To Not Change The Baselines From Run To Run
-    │   │                                               )
+    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                           (
+    │   │                                               [Client Side Request Stats]
+    │   │                                               Redacted To Not Change The Baselines From Run To Run
+    │   │                                           )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -3736,12 +3543,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
@@ -3759,12 +3565,11 @@
     │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                                           (
-    │   │                                               [Client Side Request Stats]
-    │   │                                               Redacted To Not Change The Baselines From Run To Run
-    │   │                                           )
+    │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                                       (
+    │   │                                           [Client Side Request Stats]
+    │   │                                           Redacted To Not Change The Baselines From Run To Run
+    │   │                                       )
     │   └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
@@ -3782,12 +3587,11 @@
         │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                                           (
-        │                                               [Client Side Request Stats]
-        │                                               Redacted To Not Change The Baselines From Run To Run
-        │                                           )
+        │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                                       (
+        │                                           [Client Side Request Stats]
+        │                                           Redacted To Not Change The Baselines From Run To Run
+        │                                       )
         └── POCO Materialization(00000000-0000-0000-0000-000000000000)  Poco-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
@@ -4181,9 +3985,9 @@
                                           "data": {},
                                           "children": [
                                             {
-                                              "name": "Send Async",
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                               "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "RequestHandler",
+                                              "component": "Transport",
                                               "caller info": {
                                                 "member": "MemberName",
                                                 "file": "FilePath",
@@ -4191,25 +3995,10 @@
                                               },
                                               "start time": "12:00:00:000",
                                               "duration in milliseconds": 0,
-                                              "data": {},
-                                              "children": [
-                                                {
-                                                  "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                                  "id": "00000000-0000-0000-0000-000000000000",
-                                                  "component": "Transport",
-                                                  "caller info": {
-                                                    "member": "MemberName",
-                                                    "file": "FilePath",
-                                                    "line": 42
-                                                  },
-                                                  "start time": "12:00:00:000",
-                                                  "duration in milliseconds": 0,
-                                                  "data": {
-                                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                                  },
-                                                  "children": []
-                                                }
-                                              ]
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              },
+                                              "children": []
                                             }
                                           ]
                                         }
@@ -4407,9 +4196,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -4417,25 +4206,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -4631,9 +4405,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -4641,25 +4415,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }
@@ -4855,9 +4614,9 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                           "id": "00000000-0000-0000-0000-000000000000",
-                                          "component": "RequestHandler",
+                                          "component": "Transport",
                                           "caller info": {
                                             "member": "MemberName",
                                             "file": "FilePath",
@@ -4865,25 +4624,10 @@
                                           },
                                           "start time": "12:00:00:000",
                                           "duration in milliseconds": 0,
-                                          "data": {},
-                                          "children": [
-                                            {
-                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                                              "id": "00000000-0000-0000-0000-000000000000",
-                                              "component": "Transport",
-                                              "caller info": {
-                                                "member": "MemberName",
-                                                "file": "FilePath",
-                                                "line": 42
-                                              },
-                                              "start time": "12:00:00:000",
-                                              "duration in milliseconds": 0,
-                                              "data": {
-                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                                              },
-                                              "children": []
-                                            }
-                                          ]
+                                          "data": {
+                                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                          },
+                                          "children": []
                                         }
                                       ]
                                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ReadFeedAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.ReadFeedAsync.xml
@@ -47,10 +47,10 @@
     │                       ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                       ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                       ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                               (
     │                                                   [Client Side Request Stats]
@@ -68,10 +68,10 @@
     │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                           (
     │                                               [Client Side Request Stats]
@@ -89,10 +89,10 @@
     │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                           (
     │                                               [Client Side Request Stats]
@@ -110,10 +110,10 @@
                         ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                                 (
                                                     [Client Side Request Stats]
@@ -459,7 +459,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -472,7 +472,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -485,7 +485,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -498,7 +498,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -656,7 +656,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -669,7 +669,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -682,7 +682,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -695,7 +695,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -851,7 +851,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -864,7 +864,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -877,7 +877,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -890,7 +890,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1046,7 +1046,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1059,7 +1059,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1072,7 +1072,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1085,7 +1085,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1183,10 +1183,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -1205,10 +1205,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -1227,10 +1227,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -1249,10 +1249,10 @@
         │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                       (
         │                                           [Client Side Request Stats]
@@ -1599,7 +1599,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1612,7 +1612,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1625,7 +1625,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -1638,7 +1638,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -1810,7 +1810,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -1823,7 +1823,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -1836,7 +1836,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -1849,7 +1849,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2019,7 +2019,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2032,7 +2032,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2045,7 +2045,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2058,7 +2058,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2228,7 +2228,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -2241,7 +2241,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2254,7 +2254,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2267,7 +2267,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2380,10 +2380,10 @@
     │                       ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                       ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                       ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                                   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                               (
     │                                                   [Client Side Request Stats]
@@ -2401,10 +2401,10 @@
     │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                           (
     │                                               [Client Side Request Stats]
@@ -2422,10 +2422,10 @@
     │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │                                           (
     │                                               [Client Side Request Stats]
@@ -2443,10 +2443,10 @@
                         ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                                 (
                                                     [Client Side Request Stats]
@@ -2792,7 +2792,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -2805,7 +2805,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -2818,7 +2818,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -2831,7 +2831,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -2989,7 +2989,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3002,7 +3002,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3015,7 +3015,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3028,7 +3028,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3184,7 +3184,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3197,7 +3197,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3210,7 +3210,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3223,7 +3223,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3379,7 +3379,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -3392,7 +3392,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3405,7 +3405,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3418,7 +3418,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3517,10 +3517,10 @@
     │   │                   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                               └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                           (
     │   │                                               [Client Side Request Stats]
@@ -3539,10 +3539,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -3561,10 +3561,10 @@
     │   │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │                                       (
     │   │                                           [Client Side Request Stats]
@@ -3583,10 +3583,10 @@
         │               ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                       └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                       └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                               └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                                       (
         │                                           [Client Side Request Stats]
@@ -3933,7 +3933,7 @@
                               "children": []
                             },
                             {
-                              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -3946,7 +3946,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -3959,7 +3959,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -3972,7 +3972,7 @@
                                       "data": {},
                                       "children": [
                                         {
-                                          "name": "Send Async",
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                           "id": "00000000-0000-0000-0000-000000000000",
                                           "component": "RequestHandler",
                                           "caller info": {
@@ -4144,7 +4144,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4157,7 +4157,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4170,7 +4170,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4183,7 +4183,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4353,7 +4353,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4366,7 +4366,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4379,7 +4379,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4392,7 +4392,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {
@@ -4562,7 +4562,7 @@
                           "children": []
                         },
                         {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                           "id": "00000000-0000-0000-0000-000000000000",
                           "component": "RequestHandler",
                           "caller info": {
@@ -4575,7 +4575,7 @@
                           "data": {},
                           "children": [
                             {
-                              "name": "Send Async",
+                              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                               "id": "00000000-0000-0000-0000-000000000000",
                               "component": "RequestHandler",
                               "caller info": {
@@ -4588,7 +4588,7 @@
                               "data": {},
                               "children": [
                                 {
-                                  "name": "Send Async",
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                   "id": "00000000-0000-0000-0000-000000000000",
                                   "component": "RequestHandler",
                                   "caller info": {
@@ -4601,7 +4601,7 @@
                                   "data": {},
                                   "children": [
                                     {
-                                      "name": "Send Async",
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                       "id": "00000000-0000-0000-0000-000000000000",
                                       "component": "RequestHandler",
                                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml
@@ -28,12 +28,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "CreateItemStreamAsync",
@@ -116,9 +115,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -126,25 +125,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -183,12 +167,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "ReadItemStreamAsync",
@@ -271,9 +254,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -281,25 +264,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -346,12 +314,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "ReplaceItemStreamAsync",
@@ -434,9 +401,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -444,25 +411,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -504,12 +456,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "DeleteItemStreamAsync",
@@ -592,9 +543,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -602,25 +553,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml
@@ -24,10 +24,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -63,7 +63,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -76,7 +76,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -89,7 +89,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -102,7 +102,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -163,10 +163,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -202,7 +202,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -215,7 +215,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -228,7 +228,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -241,7 +241,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -310,10 +310,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -349,7 +349,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -362,7 +362,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -375,7 +375,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -388,7 +388,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -452,10 +452,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -491,7 +491,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -504,7 +504,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -517,7 +517,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -530,7 +530,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml
@@ -24,10 +24,10 @@
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -91,7 +91,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -104,7 +104,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -117,7 +117,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -130,7 +130,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -191,10 +191,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -230,7 +230,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -243,7 +243,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -256,7 +256,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -269,7 +269,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -339,10 +339,10 @@
     │   )
     ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -392,7 +392,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -405,7 +405,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -418,7 +418,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -431,7 +431,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {
@@ -494,10 +494,10 @@
     │       Redacted To Not Change The Baselines From Run To Run
     │   )
     └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        └── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                    └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                         └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                                 (
                                     [Client Side Request Stats]
@@ -533,7 +533,7 @@
       "data": {},
       "children": [
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
           "id": "00000000-0000-0000-0000-000000000000",
           "component": "RequestHandler",
           "caller info": {
@@ -546,7 +546,7 @@
           "data": {},
           "children": [
             {
-              "name": "Send Async",
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
               "id": "00000000-0000-0000-0000-000000000000",
               "component": "RequestHandler",
               "caller info": {
@@ -559,7 +559,7 @@
               "data": {},
               "children": [
                 {
-                  "name": "Send Async",
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "component": "RequestHandler",
                   "caller info": {
@@ -572,7 +572,7 @@
                   "data": {},
                   "children": [
                     {
-                      "name": "Send Async",
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
                       "component": "RequestHandler",
                       "caller info": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml
@@ -28,12 +28,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "CreateItemAsync",
@@ -144,9 +143,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -154,25 +153,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -211,12 +195,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "ReadItemAsync",
@@ -299,9 +282,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -309,25 +292,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -375,12 +343,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "ReplaceItemAsync",
@@ -477,9 +444,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -487,25 +454,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }
@@ -546,12 +498,11 @@
             └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                     └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                        └── Send Async(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                            └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                                    (
-                                        [Client Side Request Stats]
-                                        Redacted To Not Change The Baselines From Run To Run
-                                    )
+                        └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+                                (
+                                    [Client Side Request Stats]
+                                    Redacted To Not Change The Baselines From Run To Run
+                                )
 ]]></Text>
       <Json><![CDATA[{
   "name": "DeleteItemAsync",
@@ -634,9 +585,9 @@
                       "data": {},
                       "children": [
                         {
-                          "name": "Send Async",
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                           "id": "00000000-0000-0000-0000-000000000000",
-                          "component": "RequestHandler",
+                          "component": "Transport",
                           "caller info": {
                             "member": "MemberName",
                             "file": "FilePath",
@@ -644,25 +595,10 @@
                           },
                           "start time": "12:00:00:000",
                           "duration in milliseconds": 0,
-                          "data": {},
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "component": "Transport",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              },
-                              "children": []
-                            }
-                          ]
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                          },
+                          "children": []
                         }
                       ]
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -960,7 +960,7 @@
             string text = TraceWriter.TraceToText(traceForBaselineTesting);
             string json = TraceWriter.TraceToJson(traceForBaselineTesting);
 
-            // AssertTraceProperites(input.Trace);
+            AssertTraceProperites(input.Trace);
 
             return new Output(text, JToken.Parse(json).ToString(Newtonsoft.Json.Formatting.Indented));
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -921,10 +921,16 @@
             {
                 startLineNumber = GetLineNumber();
                 TimeSpan delayTime = TimeSpan.FromSeconds(2);
+                RequestHandler requestHandler = new RequestHandlerSleepHelper(delayTime);
                 CosmosClient cosmosClient = TestCommon.CreateCosmosClient(builder =>
-                    builder.AddCustomHandlers(new RequestHandlerSleepHelper(delayTime)));
+                    builder.AddCustomHandlers(requestHandler));
 
                 DatabaseResponse databaseResponse = await cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
+                EndToEndTraceWriterBaselineTests.AssertCustomHandlerTime(
+                    databaseResponse.Diagnostics.ToString(),
+                    requestHandler.FullHandlerName,
+                    delayTime);
+
                 ITrace trace = ((CosmosTraceDiagnostics)databaseResponse.Diagnostics).Value;
                 await databaseResponse.Database.DeleteAsync();
                 endLineNumber = GetLineNumber();
@@ -982,6 +988,54 @@
 
             return convertedTrace;
         }
+
+        private static void AssertCustomHandlerTime(
+            string diagnostics, 
+            string handlerName,
+            TimeSpan delay)
+        {
+            JObject jObject = JObject.Parse(diagnostics);
+            JObject handlerChild = EndToEndTraceWriterBaselineTests.FindChild(
+                handlerName, 
+                jObject);
+            Assert.IsNotNull(handlerChild);
+            JToken delayToken = handlerChild["duration in milliseconds"];
+            Assert.IsNotNull(delayToken);
+            double itraceDelay = delayToken.ToObject<double>();
+            Assert.IsTrue(TimeSpan.FromMilliseconds(itraceDelay) > delay);
+        }
+
+        private static JObject FindChild(
+            string name,
+            JObject jObject)
+        {
+            if(jObject == null)
+            {
+                return null;
+            }
+
+            JToken nameToken = jObject["name"];
+            if(nameToken != null && nameToken.ToString() == name)
+            {
+                return jObject;
+            }
+
+            JArray jArray = jObject["children"]?.ToObject<JArray>();
+            if(jArray != null)
+            {
+                foreach(JObject child in jArray)
+                {
+                    JObject response = EndToEndTraceWriterBaselineTests.FindChild(name, child);
+                    if(response != null)
+                    {
+                        return response;
+                    }
+                }
+            }
+
+            return null;
+        }
+
 
         private static void AssertTraceProperites(ITrace trace)
         {


### PR DESCRIPTION
# Pull Request Template

## Description

1. Removes an unnecessary ITrace 
2. Fixes the nesting by resetting the request.Trace back to the original one the handler got. The previous logic left the request always at the child even after the child/transport handler before it was done. This caused the nesting to happen on the child trace rather than the correct parent trace.
3. Fixed the handler naming
4. Added tests to verify the handler name matches the latency

Regression introduced in 3.17.0 from PR #2097
## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #2354