### PR TITLE
Direct: Adds direct package 3.18.0 and backend latency to diagnostic

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.17.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.18.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.17.2</DirectVersion>
+		<DirectVersion>3.18.0</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV13</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -194,7 +194,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     itemLSN: 5,
                     sessionToken: null,
                     usingLocalLSN: true,
-                    activityId: Guid.NewGuid().ToString()));
+                    activityId: Guid.NewGuid().ToString(),
+                    backendRequestDurationInMs: "0"));
 
                 throw Documents.Rntbd.TransportExceptions.GetServiceUnavailableException(physicalAddress, Guid.NewGuid(),
                     transportException);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -200,8 +200,7 @@
   <Result>
     <Input>
       <Description>Client Side Request Stats</Description>
-      <Setup>
-                      <![CDATA[
+      <Setup><![CDATA[
         TraceForBaselineTesting rootTrace;
         using (rootTrace = TraceForBaselineTesting.GetRootTrace())
         {
@@ -363,8 +362,7 @@
   <Result>
     <Input>
       <Description>Client Side Request Stats Default</Description>
-      <Setup>
-                      <![CDATA[
+      <Setup><![CDATA[
         TraceForBaselineTesting rootTrace;
         using (rootTrace = TraceForBaselineTesting.GetRootTrace())
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -200,7 +200,8 @@
   <Result>
     <Input>
       <Description>Client Side Request Stats</Description>
-      <Setup><![CDATA[
+      <Setup>
+                      <![CDATA[
         TraceForBaselineTesting rootTrace;
         using (rootTrace = TraceForBaselineTesting.GetRootTrace())
         {
@@ -246,7 +247,8 @@
                     itemLSN: 15,
                     sessionToken: new SimpleSessionToken(42),
                     usingLocalLSN: true,
-                    activityId: Guid.Empty.ToString()),
+                    activityId: Guid.Empty.ToString(),
+                    backendRequestDurationInMs:"0"),
                 ResourceType.Document,
                 OperationType.Query,
                 uri1);
@@ -349,7 +351,7 @@
           "OperationType": "Query",
           "LocationEndpoint": "http://someuri1.com/",
           "ActivityId": "00000000-0000-0000-0000-000000000000",
-          "StoreResult": "StorePhysicalAddress: http://storephysicaladdress.com/, LSN: 1337, GlobalCommittedLsn: 1234, PartitionKeyRangeId: 42, IsValid: True, StatusCode: 0, SubStatusCode: 0, RequestCharge: 3.14, ItemLSN: 15, SessionToken: 42, UsingLocalLSN: True, TransportException: null"
+          "StoreResult": "StorePhysicalAddress: http://storephysicaladdress.com/, LSN: 1337, GlobalCommittedLsn: 1234, PartitionKeyRangeId: 42, IsValid: True, StatusCode: 0, SubStatusCode: 0, RequestCharge: 3.14, ItemLSN: 15, SessionToken: 42, UsingLocalLSN: True, TransportException: null, BELatencyMs: 0"
         }
       ]
     }
@@ -361,7 +363,8 @@
   <Result>
     <Input>
       <Description>Client Side Request Stats Default</Description>
-      <Setup><![CDATA[
+      <Setup>
+                      <![CDATA[
         TraceForBaselineTesting rootTrace;
         using (rootTrace = TraceForBaselineTesting.GetRootTrace())
         {
@@ -400,7 +403,8 @@
                     itemLSN: default,
                     sessionToken: default,
                     usingLocalLSN: default,
-                    activityId: default),
+                    activityId: default,
+                    backendRequestDurationInMs: default),
                 resourceType: default,
                 operationType: default,
                 locationEndpoint: default); ;
@@ -491,7 +495,7 @@
           "OperationType": "Create",
           "LocationEndpoint": null,
           "ActivityId": null,
-          "StoreResult": "StorePhysicalAddress: , LSN: 0, GlobalCommittedLsn: 0, PartitionKeyRangeId: , IsValid: False, StatusCode: 0, SubStatusCode: 0, RequestCharge: 0, ItemLSN: 0, SessionToken: , UsingLocalLSN: False, TransportException: null"
+          "StoreResult": "StorePhysicalAddress: , LSN: 0, GlobalCommittedLsn: 0, PartitionKeyRangeId: , IsValid: False, StatusCode: 0, SubStatusCode: 0, RequestCharge: 0, ItemLSN: 0, SessionToken: , UsingLocalLSN: False, TransportException: null, BELatencyMs:"
         }
       ]
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -397,7 +397,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                                 itemLSN: 15,
                                 sessionToken: new SimpleSessionToken(42),
                                 usingLocalLSN: true,
-                                activityId: Guid.Empty.ToString()),
+                                activityId: Guid.Empty.ToString(),
+                                backendRequestDurationInMs: "0"),
                             ResourceType.Document,
                             OperationType.Query,
                             uri1);
@@ -449,7 +450,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                                 itemLSN: default,
                                 sessionToken: default,
                                 usingLocalLSN: default,
-                                activityId: default),
+                                activityId: default,
+                                backendRequestDurationInMs: default),
                             resourceType: default,
                             operationType: default,
                             locationEndpoint: default); ;


### PR DESCRIPTION
Bumps dependency to 3.18.0