### PR TITLE
Change Feed Estimator: Fixes exception propagation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorCore.cs
@@ -6,21 +6,25 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using Microsoft.Azure.Cosmos.ChangeFeed;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
 
     internal sealed class ChangeFeedEstimatorCore : ChangeFeedEstimator
     {
         private readonly string processorName;
         private readonly ContainerInternal monitoredContainer;
         private readonly ContainerInternal leaseContainer;
+        private readonly DocumentServiceLeaseContainer documentServiceLeaseContainer;
 
         public ChangeFeedEstimatorCore(
             string processorName,
             ContainerInternal monitoredContainer,
-            ContainerInternal leaseContainer)
+            ContainerInternal leaseContainer,
+            DocumentServiceLeaseContainer documentServiceLeaseContainer)
         {
             this.processorName = processorName ?? throw new ArgumentNullException(nameof(processorName));
             this.leaseContainer = leaseContainer ?? throw new ArgumentNullException(nameof(leaseContainer));
             this.monitoredContainer = monitoredContainer ?? throw new ArgumentNullException(nameof(monitoredContainer));
+            this.documentServiceLeaseContainer = documentServiceLeaseContainer;
         }
 
         public override FeedIterator<ChangeFeedProcessorState> GetCurrentStateIterator(ChangeFeedEstimatorRequestOptions changeFeedEstimatorRequestOptions = null)
@@ -29,6 +33,7 @@ namespace Microsoft.Azure.Cosmos
                 this.processorName,
                 this.monitoredContainer,
                 this.leaseContainer,
+                this.documentServiceLeaseContainer,
                 changeFeedEstimatorRequestOptions);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedEstimatorIterator.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
     using System.Globalization;
     using System.Linq;
     using System.Net;
-    using System.Security.Permissions;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
@@ -45,11 +44,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             string processorName,
             ContainerInternal monitoredContainer,
             ContainerInternal leaseContainer,
+            DocumentServiceLeaseContainer documentServiceLeaseContainer,
             ChangeFeedEstimatorRequestOptions changeFeedEstimatorRequestOptions)
             : this(
                   processorName,
                   monitoredContainer,
                   leaseContainer,
+                  documentServiceLeaseContainer,
                   changeFeedEstimatorRequestOptions,
                   (DocumentServiceLease lease, string continuationToken, bool startFromBeginning) => ChangeFeedPartitionKeyResultSetIteratorCore.Create(
                           lease: lease,
@@ -74,16 +75,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                   processorName: string.Empty,
                   monitoredContainer: monitoredContainer,
                   leaseContainer: leaseContainer,
+                  documentServiceLeaseContainer: documentServiceLeaseContainer,
                   changeFeedEstimatorRequestOptions: changeFeedEstimatorRequestOptions,
                   monitoredContainerFeedCreator: monitoredContainerFeedCreator)
         {
-            this.documentServiceLeaseContainer = documentServiceLeaseContainer;
         }
 
         private ChangeFeedEstimatorIterator(
             string processorName,
             ContainerInternal monitoredContainer,
             ContainerInternal leaseContainer,
+            DocumentServiceLeaseContainer documentServiceLeaseContainer,
             ChangeFeedEstimatorRequestOptions changeFeedEstimatorRequestOptions,
             Func<DocumentServiceLease, string, bool, FeedIterator> monitoredContainerFeedCreator)
         {
@@ -102,6 +104,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             this.hasMoreResults = true;
 
             this.monitoredContainerFeedCreator = monitoredContainerFeedCreator;
+            this.documentServiceLeaseContainer = documentServiceLeaseContainer;
         }
 
         public override bool HasMoreResults => this.hasMoreResults;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorRunner.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorRunner.cs
@@ -57,9 +57,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 
         private async Task EstimateAsync(CancellationToken cancellationToken)
         {
-            long estimation = await this.GetEstimatedRemainingWorkAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                long estimation = await this.GetEstimatedRemainingWorkAsync(cancellationToken).ConfigureAwait(false);
                 await this.dispatchEstimation(estimation, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception userException)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorRunner.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedEstimatorRunner.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
         private readonly ChangeFeedEstimator remainingWorkEstimator;
         private readonly TimeSpan monitoringDelay;
         private readonly ChangesEstimationHandler dispatchEstimation;
-        private readonly Func<CancellationToken, Task> estimateAndDispatchAsync;
 
         public FeedEstimatorRunner(
             ChangesEstimationHandler dispatchEstimation,
@@ -28,7 +27,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             TimeSpan? estimationPeriod = null)
         {
             this.dispatchEstimation = dispatchEstimation;
-            this.estimateAndDispatchAsync = this.EstimateAsync;
             this.remainingWorkEstimator = remainingWorkEstimator;
             this.monitoringDelay = estimationPeriod ?? FeedEstimatorRunner.defaultMonitoringDelay;
         }
@@ -39,12 +37,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             {
                 try
                 {
-                    await this.estimateAndDispatchAsync(cancellationToken);
+                    await this.EstimateAsync(cancellationToken);
                 }
                 catch (TaskCanceledException canceledException)
                 {
                     if (cancellationToken.IsCancellationRequested)
+                    {
                         throw;
+                    }
 
                     Extensions.TraceException(new Exception("exception within estimator", canceledException));
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerBuilder.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Tracing;
 
     /// <summary>
     /// Provides flexible way to build lease manager constructor parameters.
@@ -20,8 +21,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             string leaseContainerPrefix,
             string instanceName)
         {
-            ContainerResponse cosmosContainerResponse = await leaseContainer.ReadContainerAsync().ConfigureAwait(false);
-            ContainerProperties containerProperties = cosmosContainerResponse.Resource;
+            ContainerProperties containerProperties = await leaseContainer.GetCachedContainerPropertiesAsync(forceRefresh: false, NoOpTrace.Singleton, cancellationToken: default);
 
             bool isPartitioned =
                 containerProperties.PartitionKey != null &&

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -632,7 +632,8 @@ namespace Microsoft.Azure.Cosmos
             return new ChangeFeedEstimatorCore(
                 processorName: processorName,
                 monitoredContainer: this,
-                leaseContainer: (ContainerInternal)leaseContainer);
+                leaseContainer: (ContainerInternal)leaseContainer,
+                documentServiceLeaseContainer: default);
         }
 
         public override TransactionalBatch CreateTransactionalBatch(PartitionKey partitionKey)


### PR DESCRIPTION
#1830 introduced a regression on the refactoring of the Change Feed Estimator push model, where cases where the monitored or lease container did not exist were not throwing on StartAsync but rather failed and were captured during the initialization task and only surfaced when trying to StopAsync.

This PR fixes the scenario by moving the initialization back to the StartAsync flow and before the runner task is initiated.

Also improving performance by using the Cached Container Properties when initializing the lease store manager, this way if a customer is sharing the Lease Container object across many estimators/processors, we don't do another request to fetch the Partition Key (since it cannot be changed at any point).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #2389