### PR TITLE
Direct: Adds direct version 3.19 which includes improvements and fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.17.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.18.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.18.0</DirectVersion>
+		<DirectVersion>3.19.0</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV13</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6507,7 +6507,8 @@ namespace Microsoft.Azure.Cosmos
                     enableCpuMonitor: this.enableCpuMonitor,
                     retryWithConfiguration: this.ConnectionPolicy.RetryOptions?.GetRetryWithConfiguration(),
                     enableTcpConnectionEndpointRediscovery: this.ConnectionPolicy.EnableTcpConnectionEndpointRediscovery,
-                    addressResolver: this.AddressResolver);
+                    addressResolver: this.AddressResolver,
+                    rntbdMaxConcurrentOpeningConnectionCount: this.rntbdMaxConcurrentOpeningConnectionCount);
 
                 if (this.transportClientHandlerFactory != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -96,6 +96,8 @@ namespace Microsoft.Azure.Cosmos
         private const string RntbdReceiveHangDetectionTimeConfig = "CosmosDbTcpReceiveHangDetectionTimeSeconds";
         private const string RntbdSendHangDetectionTimeConfig = "CosmosDbTcpSendHangDetectionTimeSeconds";
         private const string EnableCpuMonitorConfig = "CosmosDbEnableCpuMonitor";
+        // Env variable
+        private const string RntbdMaxConcurrentOpeningConnectionCountConfig = "AZURE_COSMOS_TCP_MAX_CONCURRENT_OPENING_CONNECTION_COUNT";
 
         private const int MaxConcurrentConnectionOpenRequestsPerProcessor = 25;
         private const int DefaultMaxRequestsPerRntbdChannel = 30;
@@ -128,6 +130,7 @@ namespace Microsoft.Azure.Cosmos
         private int rntbdReceiveHangDetectionTimeSeconds = DefaultRntbdReceiveHangDetectionTimeSeconds;
         private int rntbdSendHangDetectionTimeSeconds = DefaultRntbdSendHangDetectionTimeSeconds;
         private bool enableCpuMonitor = DefaultEnableCpuMonitor;
+        private int rntbdMaxConcurrentOpeningConnectionCount = 5;
 
         //Consistency
         private Documents.ConsistencyLevel? desiredConsistencyLevel;
@@ -818,8 +821,22 @@ namespace Microsoft.Azure.Cosmos
                 }
 #if NETSTANDARD20
             }
-#endif   
 #endif
+#endif
+
+            string rntbdMaxConcurrentOpeningConnectionCountOverrideString = Environment.GetEnvironmentVariable(RntbdMaxConcurrentOpeningConnectionCountConfig);
+            if (!string.IsNullOrEmpty(rntbdMaxConcurrentOpeningConnectionCountOverrideString))
+            {
+                if (Int32.TryParse(rntbdMaxConcurrentOpeningConnectionCountOverrideString, out int rntbdMaxConcurrentOpeningConnectionCountOverrideInt))
+                {
+                    if (rntbdMaxConcurrentOpeningConnectionCountOverrideInt <= 0)
+                    {
+                        throw new ArgumentException("RntbdMaxConcurrentOpeningConnectionCountConfig should be larger than 0");
+                    }
+
+                    this.rntbdMaxConcurrentOpeningConnectionCount = rntbdMaxConcurrentOpeningConnectionCountOverrideInt;
+                }
+            }
 
             // ConnectionPolicy always overrides appconfig
             if (connectionPolicy != null)

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             }
             else
             {
-                //Debug.Fail("DocumentServiceRequest start time not recorded");
+                Debug.Fail("DocumentServiceRequest start time not recorded");
             }
 
             DateTime responseTime = DateTime.UtcNow;

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             }
             else
             {
-                Debug.Fail("DocumentServiceRequest start time not recorded");
+                //Debug.Fail("DocumentServiceRequest start time not recorded");
             }
 
             DateTime responseTime = DateTime.UtcNow;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -266,9 +266,9 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    It.IsAny<Uri>(),
+                    It.IsAny<TransportAddressUri>(),
                     It.Is<DocumentServiceRequest>(e => this.IsValidDsr(e))))
-                    .Returns((Uri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));
+                    .Returns((TransportAddressUri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));
 
             return mockTransportClient.Object;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -266,6 +266,12 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
+                    It.IsAny<Uri>(),
+                    It.Is<DocumentServiceRequest>(e => this.IsValidDsr(e))))
+                    .Returns((Uri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));
+
+            mockTransportClient.Setup(
+                client => client.InvokeResourceOperationAsync(
                     It.IsAny<TransportAddressUri>(),
                     It.Is<DocumentServiceRequest>(e => this.IsValidDsr(e))))
                     .Returns((TransportAddressUri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -266,12 +266,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    It.IsAny<Uri>(),
-                    It.Is<DocumentServiceRequest>(e => this.IsValidDsr(e))))
-                    .Returns((Uri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));
-
-            mockTransportClient.Setup(
-                client => client.InvokeResourceOperationAsync(
                     It.IsAny<TransportAddressUri>(),
                     It.Is<DocumentServiceRequest>(e => this.IsValidDsr(e))))
                     .Returns((TransportAddressUri uri, DocumentServiceRequest documentServiceRequest) => Task.FromResult(MockRequestHelper.GetStoreResponse(documentServiceRequest)));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    It.IsAny<Uri>(), It.IsAny<DocumentServiceRequest>()))
+                    It.IsAny<TransportAddressUri>(), It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(sendDirectFunc);
 
             AddressInformation[] addressInformation = GetMockAddressInformation();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ExceptionlessTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 });
             }
 
-            StoreResponse sendDirectFunc(Uri uri, DocumentServiceRequest request)
+            StoreResponse sendDirectFunc(TransportAddressUri uri, DocumentServiceRequest request)
             {
                 return new StoreResponse()
                 {
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         private static ServerStoreModel MockServerStoreModel(
             object sessionContainer, 
-            Func<Uri, DocumentServiceRequest, StoreResponse> sendDirectFunc)
+            Func<TransportAddressUri, DocumentServiceRequest, StoreResponse> sendDirectFunc)
         {
             Mock<TransportClient> mockTransportClient = new Mock<TransportClient>();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos
                 };
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    It.IsAny<Uri>(),
+                    It.IsAny<TransportAddressUri>(),
                     It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(mockStoreResponse);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RequestEventHandlerTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos
             TransportClient mockTransportClient = this.GetMockTransportClient();
             ISessionContainer sessionContainer = new SessionContainer(string.Empty);
 
-            StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer);
+            StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, new AddressEnumerator(), sessionContainer);
 
             Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
             mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
@@ -448,7 +448,7 @@ namespace Microsoft.Azure.Cosmos
                     PhysicalUri =
                     "rntbd://dummytenant.documents.azure.com:14003/apps/APPGUID/services/SERVICEGUID/partitions/PARTITIONGUID/replicas/"
                     + i.ToString("G", CultureInfo.CurrentCulture) + (i == 0 ? "p" : "s") + "/",
-                    IsPrimary = i == 0 ? true : false,
+                    IsPrimary = i == 0,
                     Protocol = Protocol.Tcp,
                     IsPublic = true
                 };
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryTransportAddressUriAsync(entity, false /*forceAddressRefresh*/).Result.Uri;
 
             // check if the address return from Address Selector matches the original address info
             Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
@@ -538,6 +538,7 @@ namespace Microsoft.Azure.Cosmos
             StoreReader storeReader =
                 new StoreReader(mockTransportClient,
                     addressSelector,
+                    new AddressEnumerator(),
                     sessionContainer);
 
             // reads always go to read quorum (2) replicas
@@ -595,7 +596,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryTransportAddressUriAsync(entity, false /*forceAddressRefresh*/).Result.Uri;
 
             // check if the address return from Address Selector matches the original address info
             Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
@@ -613,7 +614,7 @@ namespace Microsoft.Azure.Cosmos
             for (int i = 0; i < addressInformation.Length; i++)
             {
                 TransportClient mockTransportClient = this.GetMockTransportClientForGlobalStrongWrites(addressInformation, i, false, false, false);
-                StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, sessionContainer);
+                StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, new AddressEnumerator(), sessionContainer);
                 ConsistencyWriter consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false);
                 StoreResponse response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(30)), false).Result;
                 Assert.AreEqual(100, response.LSN);
@@ -687,7 +688,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(addressInfo[0] == addressInformation[0]);
 
             AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
-            Uri primaryAddress = addressSelector.ResolvePrimaryUriAsync(entity, false /*forceAddressRefresh*/).Result;
+            Uri primaryAddress = addressSelector.ResolvePrimaryTransportAddressUriAsync(entity, false /*forceAddressRefresh*/).Result.Uri;
 
             // check if the address return from Address Selector matches the original address info
             Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
@@ -704,6 +705,7 @@ namespace Microsoft.Azure.Cosmos
                 StoreReader storeReader =
                     new StoreReader(mockTransportClient,
                         addressSelector,
+                        new AddressEnumerator(),
                         sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
@@ -746,6 +748,7 @@ namespace Microsoft.Azure.Cosmos
                 StoreReader storeReader =
                     new StoreReader(mockTransportClient,
                         addressSelector,
+                        new AddressEnumerator(),
                         sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
@@ -797,6 +800,7 @@ namespace Microsoft.Azure.Cosmos
                 StoreReader storeReader =
                 new StoreReader(mockTransportClient,
                     addressSelector,
+                    new AddressEnumerator(),
                     sessionContainer);
 
                 Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Specialized;
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
@@ -13,7 +12,6 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
-    using Microsoft.Azure.Documents.Collections;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -100,12 +98,12 @@ namespace Microsoft.Azure.Cosmos
             // setup mock transport client
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[0].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(mockStoreResponse);
 
             TransportClient mockTransportClientObject = mockTransportClient.Object;
             // get response from mock object
-            StoreResponse response = mockTransportClientObject.InvokeResourceOperationAsync(new Uri(addressInformation[0].PhysicalUri), entity).Result;
+            StoreResponse response = mockTransportClientObject.InvokeResourceOperationAsync(new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), entity).Result;
 
             // validate that the LSN matches
             Assert.IsTrue(response.LSN == 50);
@@ -142,13 +140,13 @@ namespace Microsoft.Azure.Cosmos
             // setup mock transport client for the first replica
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[0].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(mockStoreResponseFast);
 
             // setup mock transport client with a sequence of outputs
             mockTransportClient.SetupSequence(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[1].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[1].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponseFast))   // initial read response
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponseFast))   // barrier retry, count 1
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponseFast))   // barrier retry, count 2
@@ -178,7 +176,7 @@ namespace Microsoft.Azure.Cosmos
             // 2nd time: returns InvalidPartitionException
             mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[2].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[2].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(queueOfResponses.Dequeue());
 
             TransportClient mockTransportClientObject = mockTransportClient.Object;
@@ -253,12 +251,12 @@ namespace Microsoft.Azure.Cosmos
                 // setup mock transport client for the first replica
                 mockTransportClient.Setup(
                     client => client.InvokeResourceOperationAsync(
-                        new Uri(addressInformation[0].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .ReturnsAsync(mockStoreResponse5);
 
                 mockTransportClient.SetupSequence(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[1].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[1].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1))
@@ -268,7 +266,7 @@ namespace Microsoft.Azure.Cosmos
 
                 mockTransportClient.SetupSequence(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[2].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[2].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse2))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse2))
                     .Returns(Task.FromResult<StoreResponse>(mockStoreResponse2))
@@ -282,19 +280,19 @@ namespace Microsoft.Azure.Cosmos
                 // setup mock transport client for the first replica
                 mockTransportClient.Setup(
                     client => client.InvokeResourceOperationAsync(
-                        new Uri(addressInformation[0].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .ReturnsAsync(mockStoreResponse2);
 
                 // setup mock transport client with a sequence of outputs
                 mockTransportClient.Setup(
                     client => client.InvokeResourceOperationAsync(
-                        new Uri(addressInformation[1].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        new TransportAddressUri(new Uri(addressInformation[1].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .ReturnsAsync(mockStoreResponse1);
 
                 // setup mock transport client with a sequence of outputs
                 mockTransportClient.Setup(
                     client => client.InvokeResourceOperationAsync(
-                        new Uri(addressInformation[2].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        new TransportAddressUri(new Uri(addressInformation[2].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .ReturnsAsync(mockStoreResponse2);
             }
             else if (result == ReadQuorumResultKind.QuorumNotSelected)
@@ -302,17 +300,17 @@ namespace Microsoft.Azure.Cosmos
                 // setup mock transport client for the first replica
                 mockTransportClient.Setup(
                     client => client.InvokeResourceOperationAsync(
-                        new Uri(addressInformation[0].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .ReturnsAsync(mockStoreResponse5);
 
                 mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[1].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[1].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .ReturnsAsync(mockStoreResponse5);
 
                 mockTransportClient.Setup(
                 client => client.InvokeResourceOperationAsync(
-                    new Uri(addressInformation[2].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                    new TransportAddressUri(new Uri(addressInformation[2].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                     .Throws(new GoneException("test"));
             }
 
@@ -414,13 +412,13 @@ namespace Microsoft.Azure.Cosmos
                 if (i == indexOfCaughtUpReplica)
                 {
                     mockTransportClient.SetupSequence(
-                        client => client.InvokeResourceOperationAsync(new Uri(addressInformation[i].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        client => client.InvokeResourceOperationAsync(new TransportAddressUri(new Uri(addressInformation[i].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .Returns(Task.FromResult<StoreResponse>(finalResponse));
                 }
                 else
                 {
                     mockTransportClient.Setup(
-                        client => client.InvokeResourceOperationAsync(new Uri(addressInformation[i].PhysicalUri), It.IsAny<DocumentServiceRequest>()))
+                        client => client.InvokeResourceOperationAsync(new TransportAddressUri(new Uri(addressInformation[i].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
                         .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1));
                 }
             }
@@ -521,7 +519,7 @@ namespace Microsoft.Azure.Cosmos
             TransportClient mockTransportClient = this.GetMockTransportClientDuringUpgrade(addressInformation);
 
             // get response from mock object
-            StoreResponse response = mockTransportClient.InvokeResourceOperationAsync(new Uri(addressInformation[0].PhysicalUri), entity).Result;
+            StoreResponse response = mockTransportClient.InvokeResourceOperationAsync(new TransportAddressUri(new Uri(addressInformation[0].PhysicalUri)), entity).Result;
 
             // validate that the LSN matches
             Assert.IsTrue(response.LSN == 50);


### PR DESCRIPTION
1. Bump direct version from 3.18.0 to 3.19.0
2. wire up new API change for StoreReader and StoreReaderTest
3. wire up new API change for adding rntbdMaxConcurrentOpeningConnectionCount

Adds:
* Improved allocations on Direct/TCP

Fixes:
* Fixed race condition in direct + tcp mode causing SDK generated internal server errors and invalid operation exceptions 
* Fixed race condition in direct + tcp mode causing unnecessary connections to be created by concurrent requests 

closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2370