### PR TITLE
ChangeFeedProcessor: Adds optimization to use cached partition key ranges

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Bootstrapping/PartitionSynchronizerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Bootstrapping/PartitionSynchronizerCore.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping
                 this.containerRid, 
                 FeedRangeEpk.FullRange.Range, 
                 NoOpTrace.Singleton, 
-                forceRefresh: true);
+                forceRefresh: false);
             DefaultTrace.TraceInformation("Source collection: '{0}', {1} partition(s)", this.container.LinkUri, ranges.Count);
             await this.CreateLeasesAsync(ranges).ConfigureAwait(false);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSynchronizerCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSynchronizerCoreTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<string>(),
                 It.Is<Documents.Routing.Range<string>>(r => r.Min == range.Min && r.Max == range.Max),
                 It.IsAny<ITrace>(),
-                It.Is<bool>(b => b == true)))
+                true))
                 .ReturnsAsync(resultingRanges);
 
             Mock<DocumentServiceLeaseManager> leaseManager = new Mock<DocumentServiceLeaseManager>();
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<string>(),
                 It.Is<Documents.Routing.Range<string>>(r => r.Min == range.Min && r.Max == range.Max),
                 It.IsAny<ITrace>(),
-                It.Is<bool>(b => b == true)))
+                true))
                 .ReturnsAsync(resultingRanges);
 
             Mock<DocumentServiceLeaseManager> leaseManager = new Mock<DocumentServiceLeaseManager>();
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<string>(),
                 It.IsAny<Documents.Routing.Range<string>>(),
                 It.IsAny<ITrace>(),
-                It.Is<bool>(b => b == true)))
+                false))
                 .ReturnsAsync(resultingRanges);
 
             Mock<DocumentServiceLeaseManager> leaseManager = new Mock<DocumentServiceLeaseManager>();
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<string>(),
                 It.IsAny<Documents.Routing.Range<string>>(),
                 It.IsAny<ITrace>(),
-                It.Is<bool>(b => b == true)))
+                false))
                 .ReturnsAsync(resultingRanges);
 
             Mock<DocumentServiceLeaseManager> leaseManager = new Mock<DocumentServiceLeaseManager>();
@@ -385,7 +385,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<string>(),
                 It.IsAny<Documents.Routing.Range<string>>(),
                 It.IsAny<ITrace>(),
-                It.Is<bool>(b => b == true)))
+                false))
                 .ReturnsAsync(resultingRanges);
 
             Mock<DocumentServiceLeaseManager> leaseManager = new Mock<DocumentServiceLeaseManager>();


### PR DESCRIPTION
# Pull Request Template

## Description

The current logic forces a cache refresh for each change feed processor. This adds additional overhead and latency. It now uses the cached value to avoid the gateway network calls. Changefeed already handles split logic if the cache is stale.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber