### PR TITLE
[Internal] Client encryption: Fixes encryption emulator test case given stronger pipeline validations

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -367,36 +367,6 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
         }
 
         [TestMethod]
-        public async Task EncryptionFailsWithUnknownClientEncryptionKey()
-        {
-            ClientEncryptionIncludedPath unknownKeyConfigured = new ClientEncryptionIncludedPath()
-            {
-                Path = "/",
-                ClientEncryptionKeyId = "unknownKey",
-                EncryptionType = "Deterministic",
-                EncryptionAlgorithm = "AEAD_AES_256_CBC_HMAC_SHA256",
-            };
-
-            Collection<ClientEncryptionIncludedPath> paths = new Collection<ClientEncryptionIncludedPath>  { unknownKeyConfigured };
-            ClientEncryptionPolicy clientEncryptionPolicyId = new ClientEncryptionPolicy(paths);            
-
-            ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/PK") { ClientEncryptionPolicy = clientEncryptionPolicyId };
-
-            Container encryptionContainer = await database.CreateContainerAsync(containerProperties, 400);           
-
-            try
-            {
-                await encryptionContainer.InitializeEncryptionAsync();
-                await MdeEncryptionTests.MdeCreateItemAsync(encryptionContainer);
-                Assert.Fail("Expected item creation should fail since client encryption policy is configured with unknown key.");
-            }
-            catch (Exception ex)
-            {
-                Assert.IsTrue(ex is InvalidOperationException);
-            }
-        }
-
-        [TestMethod]
         public async Task ClientEncryptionPolicyTests()
         {
             string containerId = "containerWithUnsuportedPolicy1";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -1373,6 +1373,34 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(readResponse.Resource.ClientEncryptionPolicy);
         }
 
+
+        [TestMethod]
+        public async Task ContainerCreationFailsWithUnknownClientEncryptionKey()
+        {
+            ClientEncryptionIncludedPath unknownKeyConfigured = new ClientEncryptionIncludedPath()
+            {
+                Path = "/",
+                ClientEncryptionKeyId = "unknownKey",
+                EncryptionType = "Deterministic",
+                EncryptionAlgorithm = "AEAD_AES_256_CBC_HMAC_SHA256",
+            };
+
+            Collection<ClientEncryptionIncludedPath> clientEncryptionPaths = new Collection<ClientEncryptionIncludedPath> { unknownKeyConfigured };
+            ContainerProperties containerProperties = new ContainerProperties(Guid.NewGuid().ToString(), "/PK")
+            {
+                ClientEncryptionPolicy = new ClientEncryptionPolicy(clientEncryptionPaths)
+            };
+
+            try
+            {
+                Container encryptionContainer = await this.cosmosDatabase.CreateContainerAsync(containerProperties, 400);
+                Assert.Fail("Expected container creation should fail since client encryption policy is configured with unknown key.");
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.BadRequest)
+            {
+            }
+        }
+
         [TestMethod]
         public void ClientEncryptionPolicyFailureTest()
         {


### PR DESCRIPTION
## Description

Fixes test case which was trying to use a client encryption policy with a CEK that was not created, but which was failing earlier due to service side validations for the same at container creation time.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
