### PR TITLE
Connection: Fixes NullReference on connection disposing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.17.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.18.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.19.0</DirectVersion>
+		<DirectVersion>3.19.1</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV13</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.17.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.18.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.19.1</DirectVersion>
+		<DirectVersion>3.19.0</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV13</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>


### PR DESCRIPTION
Fixes NRE happening on Connection closing/disposing.

Reference stack:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Azure.Documents.Rntbd.Connection.Dispose()
   at Microsoft.Azure.Documents.Rntbd.Dispatcher.CloseConnection()
   at Microsoft.Azure.Documents.Rntbd.Dispatcher.Dispose()
   at Microsoft.Azure.Documents.Rntbd.Channel.System.IDisposable.Dispose()
   at Microsoft.Azure.Documents.Rntbd.LoadBalancingPartition.RequestAsync(DocumentServiceRequest request, TransportAddressUri physicalAddress, ResourceOperation resourceOperation, Guid activityId)
   at Microsoft.Azure.Documents.Rntbd.TransportClient.InvokeStoreAsync(TransportAddressUri physicalAddress, ResourceOperation resourceOperation, DocumentServiceRequest request)
```