### PR TITLE
[Internal] Encryption project: Adds gates to prevent breaking changes

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -24,8 +24,15 @@
     <AdditionalFiles Include="..\..\Microsoft.Azure.Cosmos\src\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
 
+	<ItemGroup Condition=" '$(SdkProjectRef)' != 'True' ">
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0-preview" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(SdkProjectRef)' == 'True' ">
+		<ProjectReference Include="..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+	</ItemGroup>
+	
   <ItemGroup>
-     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.18.0-preview" />
      <PackageReference Include="Azure.Core" Version="1.3.0" />
      <PackageReference Include="Azure.Identity" Version="1.1.1" />
      <PackageReference Include="Microsoft.Data.Encryption.Cryptography" Version="0.2.0-pre" />

--- a/templates/build-preview.yml
+++ b/templates/build-preview.yml
@@ -28,6 +28,25 @@ jobs:
       versioningScheme: OFF
       
 - job:
+  displayName: Encryption Project Ref SDK Preview ${{ parameters.BuildConfiguration }} 
+  pool:
+    vmImage: ${{ parameters.VmImage }}
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption Project Ref
+    inputs: 
+      command: build  
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.sln 
+      arguments: -p:Optimize=true -p:IsPreview=true;SdkProjectRef=true
+      versioningScheme: OFF
+
+- job:
   displayName: Preview Tests ${{ parameters.BuildConfiguration }}
   pool:
     vmImage: ${{ parameters.VmImage }}


### PR DESCRIPTION
# Pull Request Template

## Description

This adds a gate to prevent SDK changes that break encryption project. This way it is always safe to do an encryption release.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber