### PR TITLE
Change Feed Processor: Fixes initialization when client is set with EnableContentResponseOnWrite

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -90,6 +90,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
             string itemId,
             ItemRequestOptions cosmosItemRequestOptions = null)
         {
+            cosmosItemRequestOptions ??= new ItemRequestOptions();
+            cosmosItemRequestOptions.EnableContentResponseOnWrite = false;
             using (ResponseMessage response = await container.DeleteItemStreamAsync(itemId, partitionKey, cosmosItemRequestOptions).ConfigureAwait(false))
             {
                 return response.IsSuccessStatusCode;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -14,6 +14,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
 
     internal static class CosmosContainerExtensions
     {
+        private static readonly ItemRequestOptions itemRequestOptionsWithResponseEnabled = new ItemRequestOptions()
+        {
+            EnableContentResponseOnWrite = true
+        };
+
         public static readonly CosmosSerializerCore DefaultJsonSerializer = new CosmosSerializerCore();
 
         public static async Task<T> TryGetItemAsync<T>(
@@ -38,7 +43,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
         {
             using (Stream itemStream = CosmosContainerExtensions.DefaultJsonSerializer.ToStream<T>(item))
             {
-                using (ResponseMessage response = await container.CreateItemStreamAsync(itemStream, partitionKey).ConfigureAwait(false))
+                using (ResponseMessage response = await container.CreateItemStreamAsync(itemStream, partitionKey, itemRequestOptionsWithResponseEnabled).ConfigureAwait(false))
                 {
                     if (response.StatusCode == HttpStatusCode.Conflict)
                     {
@@ -66,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
         {
             using (Stream itemStream = CosmosContainerExtensions.DefaultJsonSerializer.ToStream<T>(item))
             {
+                itemRequestOptions.EnableContentResponseOnWrite = true;
                 using (ResponseMessage response = await container.ReplaceItemStreamAsync(itemStream, itemId, partitionKey, itemRequestOptions).ConfigureAwait(false))
                 {
                     response.EnsureSuccessStatusCode();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
         public async Task ChangeFeedTestInit()
         {
-            await base.TestInit();
+            await base.TestInit(customizeClientBuilder: (builder) => builder.WithContentResponseOnWrite(false));
             string PartitionKey = "/id";
 
             ContainerResponse response = await this.database.CreateContainerAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/BaseCosmosClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/BaseCosmosClientHelper.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Fluent;
 
     public abstract class BaseCosmosClientHelper
     {
@@ -15,12 +16,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         protected CancellationTokenSource cancellationTokenSource = null;
         protected CancellationToken cancellationToken;
 
-        public async Task TestInit(bool validateSinglePartitionKeyRangeCacheCall = false)
+        public async Task TestInit(
+            bool validateSinglePartitionKeyRangeCacheCall = false,
+            Action<CosmosClientBuilder> customizeClientBuilder = null)
         {
             this.cancellationTokenSource = new CancellationTokenSource();
             this.cancellationToken = this.cancellationTokenSource.Token;
 
-            this.cosmosClient = TestCommon.CreateCosmosClient(validatePartitionKeyRangeCalls: validateSinglePartitionKeyRangeCacheCall);
+            this.cosmosClient = TestCommon.CreateCosmosClient(validatePartitionKeyRangeCalls: validateSinglePartitionKeyRangeCacheCall, customizeClientBuilder: customizeClientBuilder);
             this.database = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString(),
                 cancellationToken: this.cancellationToken);
         }


### PR DESCRIPTION
When `EnableContentResponseOnWrite` is configured at the client level, it affects all operations. 

Change Feed Processor uses point create/replace to interact with the leases. 

When setting `EnableContentResponseOnWrite` to `false` at the client level, all lease interactions were failing.

This PR changes the interactions so we just use the input (body) for the write operation in the `ItemResponse` because really that is the same as what we would've gotten from the response if it had body, and applies the optimization to always mark `EnableContentResponseOnWrite` as `false` at the request level. So even if the customer is not setting the client-level flag, lease store interactions are optimized.

It also adjusts the Change Feed tests to execute with this client-level setting as `false` so it's validated in on all the existing coverage.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)