### PR TITLE
Query: Fixes NotImplementedException in OrderByCrossPartitionQueryPipelineStage

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -1166,6 +1166,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             private static class IsSystemFunctions
             {
+                public const string Defined = "IS_DEFINED";
                 public const string Undefined = "NOT IS_DEFINED";
                 public const string Null = "IS_NULL";
                 public const string Boolean = "IS_BOOLEAN";
@@ -1173,12 +1174,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 public const string String = "IS_STRING";
                 public const string Array = "IS_ARRAY";
                 public const string Object = "IS_OBJECT";
-            }
-
-            private static class ExtendedTypesIsSystemFunctions
-            {
-                public const string Undefined = "NOT IS_DEFINED";
-                public const string Defined = "IS_DEFINED";
             }
 
             private static readonly ReadOnlyMemory<string> SystemFunctionSortOrder = new string[]
@@ -1194,8 +1189,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             private static readonly ReadOnlyMemory<string> ExtendedTypesSystemFunctionSortOrder = new string[]
             {
-                ExtendedTypesIsSystemFunctions.Undefined,
-                ExtendedTypesIsSystemFunctions.Defined
+                IsSystemFunctions.Undefined,
+                IsSystemFunctions.Defined
             };
 
             private static class SortOrder

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -1175,6 +1175,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 public const string Object = "IS_OBJECT";
             }
 
+            private static class ExtendedTypesIsSystemFunctions
+            {
+                public const string Undefined = "not IS_DEFINED";
+                public const string Defined = "IS_DEFINED";
+            }
+
             private static readonly ReadOnlyMemory<string> SystemFunctionSortOrder = new string[]
             {
                 IsSystemFunctions.Undefined,
@@ -1184,6 +1190,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 IsSystemFunctions.String,
                 IsSystemFunctions.Array,
                 IsSystemFunctions.Object,
+            };
+
+            private static readonly ReadOnlyMemory<string> ExtendedTypesSystemFunctionSortOrder = new string[]
+            {
+                ExtendedTypesIsSystemFunctions.Undefined,
+                ExtendedTypesIsSystemFunctions.Defined
             };
 
             private static class SortOrder
@@ -1197,6 +1209,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 public const int Object = 6;
             }
 
+            private static class ExtendedTypesSortOrder
+            {
+                public const int Undefined = 0;
+                public const int Defined = 1;
+            }
+
             private CosmosElementToIsSystemFunctionsVisitor()
             {
             }
@@ -1208,7 +1226,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             public ReadOnlyMemory<string> Visit(CosmosBinary cosmosBinary, bool isAscending)
             {
-                throw new NotImplementedException();
+                return GetExtendedTypesIsDefinedFunctions(ExtendedTypesSortOrder.Defined, isAscending);
             }
 
             public ReadOnlyMemory<string> Visit(CosmosBoolean cosmosBoolean, bool isAscending)
@@ -1218,7 +1236,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             public ReadOnlyMemory<string> Visit(CosmosGuid cosmosGuid, bool isAscending)
             {
-                throw new NotImplementedException();
+                return GetExtendedTypesIsDefinedFunctions(ExtendedTypesSortOrder.Defined, isAscending);
             }
 
             public ReadOnlyMemory<string> Visit(CosmosNull cosmosNull, bool isAscending)
@@ -1249,6 +1267,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             private static ReadOnlyMemory<string> GetIsDefinedFunctions(int index, bool isAscending)
             {
                 return isAscending ? SystemFunctionSortOrder.Slice(index + 1) : SystemFunctionSortOrder.Slice(start: 0, index);
+            }
+
+            private static ReadOnlyMemory<string> GetExtendedTypesIsDefinedFunctions(int index, bool isAscending)
+            {
+                return isAscending ?
+                    ExtendedTypesSystemFunctionSortOrder.Slice(index + 1) :
+                    ExtendedTypesSystemFunctionSortOrder.Slice(start: 0, index);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -1166,7 +1166,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             private static class IsSystemFunctions
             {
-                public const string Undefined = "not IS_DEFINED";
+                public const string Undefined = "NOT IS_DEFINED";
                 public const string Null = "IS_NULL";
                 public const string Boolean = "IS_BOOLEAN";
                 public const string Number = "IS_NUMBER";
@@ -1177,7 +1177,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             private static class ExtendedTypesIsSystemFunctions
             {
-                public const string Undefined = "not IS_DEFINED";
+                public const string Undefined = "NOT IS_DEFINED";
                 public const string Defined = "IS_DEFINED";
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
@@ -28,6 +28,25 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     [TestClass]
     public class OrderByCrossPartitionQueryPipelineStageTests
     {
+        private static IReadOnlyList<(string serializedToken, CosmosElement element)> TokenTestData()
+        {
+            Guid guid = Guid.Parse("69D5AB17-C94A-4173-A278-B59D0D9C7C37");
+            byte[] randomBytes = guid.ToByteArray();
+            string hexString = PartitionKeyInternal.HexConvert.ToHex(randomBytes, 0, randomBytes.Length);
+
+            return new List<(string, CosmosElement)>
+            {
+                ("[42, 37]", CosmosArray.Parse("[42, 37]")),
+                ($@"{{C_Binary(""0x{hexString}"")}}", CosmosBinary.Create(new ReadOnlyMemory<byte>(randomBytes))),
+                ("false", CosmosBoolean.Create(false)),
+                ($@"{{C_Guid(""{guid}"")}}", CosmosGuid.Create(guid)),
+                ("null", CosmosNull.Create()),
+                ("1", CosmosInt64.Create(1)),
+                ("{\"foo\": false}", CosmosObject.Parse("{\"foo\": false}")),
+                ("asdf", CosmosString.Create("asdf"))
+            };
+        }
+
         [TestMethod]
         public void MonadicCreate_NullContinuationToken()
         {
@@ -119,21 +138,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         public void MonadicCreate_SingleOrderByContinuationToken()
         {
             Mock<IDocumentContainer> mockDocumentContainer = new Mock<IDocumentContainer>();
-            Guid guid = Guid.Parse("69D5AB17-C94A-4173-A278-B59D0D9C7C37");
-            byte[] randomBytes = guid.ToByteArray();
-            string hexString = PartitionKeyInternal.HexConvert.ToHex(randomBytes, 0, randomBytes.Length);
+            IReadOnlyList<(string serializedToken, CosmosElement element)> tokens = TokenTestData();
 
-            foreach ((string serializedToken, CosmosElement element) in new (string, CosmosElement)[]
-            {
-                ("[42, 37]", CosmosArray.Parse("[42, 37]")),
-                ($@"{{C_Binary(""0x{hexString}"")}}", CosmosBinary.Create(new ReadOnlyMemory<byte>(randomBytes))),
-                ("false", CosmosBoolean.Create(false)),
-                ($@"{{C_Guid(""{guid.ToString()}"")}}", CosmosGuid.Create(guid)),
-                ("null", CosmosNull.Create()),
-                ("1", CosmosInt64.Create(1)),
-                ("{\"foo\": false}", CosmosObject.Parse("{\"foo\": false}")),
-                ("asdf", CosmosString.Create("asdf"))
-            })
+            foreach ((string serializedToken, CosmosElement element) in tokens)
             {
                 ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
                     token: serializedToken,
@@ -165,58 +172,110 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         }));
                 Assert.IsTrue(monadicCreate.Succeeded);
             }
+
+            foreach ((string token1, CosmosElement element1) in tokens)
+            {
+                foreach ((string token2, CosmosElement element2) in tokens)
+                {
+                    ParallelContinuationToken parallelContinuationToken1 = new ParallelContinuationToken(
+                        token: $"[{token1}, {token2}]",
+                        range: new Documents.Routing.Range<string>("A", "B", true, false));
+
+                    OrderByContinuationToken orderByContinuationToken = new OrderByContinuationToken(
+                        parallelContinuationToken1,
+                        new List<OrderByItem>()
+                        {
+                            new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>(){ { "item1", element1 } })),
+                            new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>(){ { "item2", element2 } }))
+                        },
+                        rid: "rid",
+                        skipCount: 42,
+                        filter: "filter");
+
+                    TryCatch<IQueryPipelineStage> monadicCreate = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
+                        documentContainer: mockDocumentContainer.Object,
+                        sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c ORDER BY c.item1, c.item2"),
+                        targetRanges: new List<FeedRangeEpk>()
+                        {
+                            new FeedRangeEpk(new Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)),
+                            new FeedRangeEpk(new Range<string>(min: "B", max: "C", isMinInclusive: true, isMaxInclusive: false)),
+                        },
+                        partitionKey: null,
+                        orderByColumns: new List<OrderByColumn>()
+                        {
+                               new OrderByColumn("item1", SortOrder.Ascending),
+                               new OrderByColumn("item2", SortOrder.Ascending)
+                        },
+                        queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
+                        maxConcurrency: 10,
+                        cancellationToken: default,
+                        continuationToken: CosmosArray.Create(
+                            new List<CosmosElement>()
+                            {
+                                OrderByContinuationToken.ToCosmosElement(orderByContinuationToken)
+                            }));
+                    Assert.IsTrue(monadicCreate.Succeeded);
+                }
+            }
         }
 
         [TestMethod]
         public void MonadicCreate_MultipleOrderByContinuationToken()
         {
             Mock<IDocumentContainer> mockDocumentContainer = new Mock<IDocumentContainer>();
+            IReadOnlyList<(string serializedToken, CosmosElement element)> tokens = TokenTestData();
 
-            ParallelContinuationToken parallelContinuationToken1 = new ParallelContinuationToken(
-                token: "asdf",
-                range: new Documents.Routing.Range<string>("A", "B", true, false));
-
-            OrderByContinuationToken orderByContinuationToken1 = new OrderByContinuationToken(
-                parallelContinuationToken1,
-                new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", CosmosString.Create("asdf") } })) },
-                rid: "rid",
-                skipCount: 42,
-                filter: "filter");
-
-            ParallelContinuationToken parallelContinuationToken2 = new ParallelContinuationToken(
-                token: "asdf",
-                range: new Documents.Routing.Range<string>("B", "C", true, false));
-
-            OrderByContinuationToken orderByContinuationToken2 = new OrderByContinuationToken(
-                parallelContinuationToken2,
-                new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", CosmosString.Create("asdf") } })) },
-                rid: "rid",
-                skipCount: 42,
-                filter: "filter");
-
-            TryCatch<IQueryPipelineStage> monadicCreate = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
-                documentContainer: mockDocumentContainer.Object,
-                sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c ORDER BY c._ts"),
-                targetRanges: new List<FeedRangeEpk>()
+            foreach((string token1, CosmosElement element1) in tokens)
+            {
+                foreach ((string token2, CosmosElement element2) in tokens)
                 {
-                    new FeedRangeEpk(new Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)),
-                    new FeedRangeEpk(new Range<string>(min: "B", max: "C", isMinInclusive: true, isMaxInclusive: false)),
-                },
-                partitionKey: null,
-                orderByColumns: new List<OrderByColumn>()
-                {
-                    new OrderByColumn("_ts", SortOrder.Ascending)
-                },
-                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
-                maxConcurrency: 10,
-                cancellationToken: default,
-                continuationToken: CosmosArray.Create(
-                    new List<CosmosElement>()
-                    {
-                        OrderByContinuationToken.ToCosmosElement(orderByContinuationToken1),
-                        OrderByContinuationToken.ToCosmosElement(orderByContinuationToken2)
-                    }));
-            Assert.IsTrue(monadicCreate.Succeeded);
+                    ParallelContinuationToken parallelContinuationToken1 = new ParallelContinuationToken(
+                        token: token1,
+                        range: new Documents.Routing.Range<string>("A", "B", true, false));
+
+                    OrderByContinuationToken orderByContinuationToken1 = new OrderByContinuationToken(
+                        parallelContinuationToken1,
+                        new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", element1 } })) },
+                        rid: "rid",
+                        skipCount: 42,
+                        filter: "filter");
+
+                    ParallelContinuationToken parallelContinuationToken2 = new ParallelContinuationToken(
+                        token: token2,
+                        range: new Documents.Routing.Range<string>("B", "C", true, false));
+
+                    OrderByContinuationToken orderByContinuationToken2 = new OrderByContinuationToken(
+                        parallelContinuationToken2,
+                        new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", element2 } })) },
+                        rid: "rid",
+                        skipCount: 42,
+                        filter: "filter");
+
+                    TryCatch<IQueryPipelineStage> monadicCreate = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
+                        documentContainer: mockDocumentContainer.Object,
+                        sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c ORDER BY c.item"),
+                        targetRanges: new List<FeedRangeEpk>()
+                        {
+                            new FeedRangeEpk(new Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)),
+                            new FeedRangeEpk(new Range<string>(min: "B", max: "C", isMinInclusive: true, isMaxInclusive: false)),
+                        },
+                        partitionKey: null,
+                        orderByColumns: new List<OrderByColumn>()
+                        {
+                               new OrderByColumn("item", SortOrder.Ascending)
+                        },
+                        queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
+                        maxConcurrency: 10,
+                        cancellationToken: default,
+                        continuationToken: CosmosArray.Create(
+                            new List<CosmosElement>()
+                            {
+                                OrderByContinuationToken.ToCosmosElement(orderByContinuationToken1),
+                                OrderByContinuationToken.ToCosmosElement(orderByContinuationToken2)
+                            }));
+                    Assert.IsTrue(monadicCreate.Succeeded);
+                }
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
@@ -118,36 +119,52 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         public void MonadicCreate_SingleOrderByContinuationToken()
         {
             Mock<IDocumentContainer> mockDocumentContainer = new Mock<IDocumentContainer>();
+            Guid guid = Guid.Parse("69D5AB17-C94A-4173-A278-B59D0D9C7C37");
+            byte[] randomBytes = guid.ToByteArray();
+            string hexString = PartitionKeyInternal.HexConvert.ToHex(randomBytes, 0, randomBytes.Length);
 
-            ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
-                token: "asdf",
-                range: new Documents.Routing.Range<string>("A", "B", true, false));
+            foreach ((string serializedToken, CosmosElement element) in new (string, CosmosElement)[]
+            {
+                ("[42, 37]", CosmosArray.Parse("[42, 37]")),
+                ($@"{{C_Binary(""0x{hexString}"")}}", CosmosBinary.Create(new ReadOnlyMemory<byte>(randomBytes))),
+                ("false", CosmosBoolean.Create(false)),
+                ($@"{{C_Guid(""{guid.ToString()}"")}}", CosmosGuid.Create(guid)),
+                ("null", CosmosNull.Create()),
+                ("1", CosmosInt64.Create(1)),
+                ("{\"foo\": false}", CosmosObject.Parse("{\"foo\": false}")),
+                ("asdf", CosmosString.Create("asdf"))
+            })
+            {
+                ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
+                    token: serializedToken,
+                    range: new Documents.Routing.Range<string>("A", "B", true, false));
 
-            OrderByContinuationToken orderByContinuationToken = new OrderByContinuationToken(
-                parallelContinuationToken,
-                new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", CosmosString.Create("asdf") } })) },
-                rid: "rid",
-                skipCount: 42,
-                filter: "filter");
+                OrderByContinuationToken orderByContinuationToken = new OrderByContinuationToken(
+                    parallelContinuationToken,
+                    new List<OrderByItem>() { new OrderByItem(CosmosObject.Create(new Dictionary<string, CosmosElement>() { { "item", element} })) },
+                    rid: "rid",
+                    skipCount: 42,
+                    filter: "filter");
 
-            TryCatch<IQueryPipelineStage> monadicCreate = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
-                documentContainer: mockDocumentContainer.Object,
-                sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c ORDER BY c._ts"),
-                targetRanges: new List<FeedRangeEpk>() { new FeedRangeEpk(new Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)) },
-                partitionKey: null,
-                orderByColumns: new List<OrderByColumn>()
-                {
-                    new OrderByColumn("_ts", SortOrder.Ascending)
-                },
-                queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
-                maxConcurrency: 10,
-                cancellationToken: default,
-                continuationToken: CosmosArray.Create(
-                    new List<CosmosElement>()
+                TryCatch<IQueryPipelineStage> monadicCreate = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
+                    documentContainer: mockDocumentContainer.Object,
+                    sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c ORDER BY c.item"),
+                    targetRanges: new List<FeedRangeEpk>() { new FeedRangeEpk(new Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)) },
+                    partitionKey: null,
+                    orderByColumns: new List<OrderByColumn>()
                     {
+                    new OrderByColumn("item", SortOrder.Ascending)
+                    },
+                    queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
+                    maxConcurrency: 10,
+                    cancellationToken: default,
+                    continuationToken: CosmosArray.Create(
+                        new List<CosmosElement>()
+                        {
                         OrderByContinuationToken.ToCosmosElement(orderByContinuationToken)
-                    }));
-            Assert.IsTrue(monadicCreate.Succeeded);
+                        }));
+                Assert.IsTrue(monadicCreate.Succeeded);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Currently we throw a NotImplementedException in OrderByCrossPartitionQueryPipelineStage if the continuation token contains any of the extended types like CosmosBinary and CosmosGuid. This visitor that throws was added so that we correctly handle continuation from undefined values. This change will cause us to use a coarse grained IS_DEFINED filter if we encounter these extended types instead of throwing. Currently, the extended types are only used by Cassandra which is schematized, so this should not have a performance penalty. We can look into adding more system functions like IS_BINARY etc. if we decide to expose these types through the SQL api.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
