### PR TITLE
Availability: Fixes account refresh logic on gateway outage

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos
                 retryDelay = TimeSpan.FromMilliseconds(ClientRetryPolicy.RetryIntervalInMS);
             }
 
-            await this.globalEndpointManager.RefreshLocationAsync();
+            await this.globalEndpointManager.RefreshLocationAsync(forceRefresh);
 
             int retryLocationIndex = this.failoverRetryCount; // Used to generate a round-robin effect
             if (retryOnPreferredLocations)

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos
                 retryDelay = TimeSpan.FromMilliseconds(ClientRetryPolicy.RetryIntervalInMS);
             }
 
-            await this.globalEndpointManager.RefreshLocationAsync(null, forceRefresh);
+            await this.globalEndpointManager.RefreshLocationAsync();
 
             int retryLocationIndex = this.failoverRetryCount; // Used to generate a round-robin effect
             if (retryOnPreferredLocations)

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6580,7 +6580,7 @@ namespace Microsoft.Azure.Cosmos
             AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
             this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && accountProperties.EnableMultipleWriteLocations;
 
-            await this.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(accountProperties);
+            this.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(accountProperties);
         }
 
         internal void CaptureSessionToken(DocumentServiceRequest request, DocumentServiceResponse response)

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6580,7 +6580,7 @@ namespace Microsoft.Azure.Cosmos
             AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
             this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && accountProperties.EnableMultipleWriteLocations;
 
-            await this.GlobalEndpointManager.RefreshLocationAsync(accountProperties);
+            await this.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(accountProperties);
         }
 
         internal void CaptureSessionToken(DocumentServiceRequest request, DocumentServiceResponse response)

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -466,7 +466,6 @@ namespace Microsoft.Azure.Cosmos.Routing
         {
             if (this.SkipRefresh(forceRefresh))
             {
-                Console.WriteLine("Skip Refreshing before lock");
                 return;
             }
             
@@ -475,14 +474,12 @@ namespace Microsoft.Azure.Cosmos.Routing
                 // Check again if should refresh after obtaining the lock
                 if (this.SkipRefresh(forceRefresh))
                 {
-                    Console.WriteLine("Skip Refreshing");
                     return;
                 }
 
                 // If the refresh is already in progress just return. No reason to do another refresh.
                 if (this.isAccountRefreshInProgress)
                 {
-                    Console.WriteLine("In progress Refreshing");
                     return;
                 }
 
@@ -491,7 +488,6 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             try
             {
-                Console.WriteLine("Refreshing");
 #nullable disable // Needed because AsyncCache does not have nullable enabled
                 AccountProperties accountProperties = await this.databaseAccountCache.GetAsync(
                     key: string.Empty,
@@ -511,7 +507,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 lock (this.isAccountRefreshInProgressLock)
                 {
-                    Console.WriteLine("Finished Refreshing");
                     this.isAccountRefreshInProgress = false;
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -519,7 +519,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         private bool SkipRefresh(bool forceRefresh)
         {
             TimeSpan timeSinceLastRefresh = DateTime.UtcNow - this.LastBackgroundRefreshUtc;
-            return (this.isAccountRefreshInProgress || this.MinTimeBetweenAccountRefresh < timeSinceLastRefresh)
+            return (this.isAccountRefreshInProgress || this.MinTimeBetweenAccountRefresh > timeSinceLastRefresh)
                 && !forceRefresh;
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        public async Task InitializeAccountPropertiesAndStartBackgroundRefreshAsync(AccountProperties databaseAccount)
+        public virtual async Task InitializeAccountPropertiesAndStartBackgroundRefreshAsync(AccountProperties databaseAccount)
         {
             if (this.cancellationTokenSource.IsCancellationRequested)
             {
@@ -382,7 +382,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        public async Task RefreshLocationAsync()
+        public virtual async Task RefreshLocationAsync()
         {
             if (this.cancellationTokenSource.IsCancellationRequested)
             {

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -71,19 +71,22 @@ namespace Microsoft.Azure.Cosmos.Routing
                         this.backgroundRefreshLocationTimeIntervalInMS = GlobalEndpointManager.DefaultBackgroundRefreshLocationTimeIntervalInMS;
                     }
                 }
-
-                string minimumIntervalForNonForceRefreshLocationInMSConfig = System.Configuration.ConfigurationManager.AppSettings[GlobalEndpointManager.MinimumIntervalForNonForceRefreshLocationInMS];
-                if (!string.IsNullOrEmpty(minimumIntervalForNonForceRefreshLocationInMSConfig))
-                {
-                    if (int.TryParse(minimumIntervalForNonForceRefreshLocationInMSConfig, out int minimumIntervalForNonForceRefreshLocationInMS))
-                    {
-                        this.MinTimeBetweenAccountRefresh = TimeSpan.FromMilliseconds(minimumIntervalForNonForceRefreshLocationInMS);
-                    }
-                }
 #if NETSTANDARD20
             }
 #endif  
 #endif
+            string minimumIntervalForNonForceRefreshLocationInMSConfig = Environment.GetEnvironmentVariable(GlobalEndpointManager.MinimumIntervalForNonForceRefreshLocationInMS);
+            if (!string.IsNullOrEmpty(minimumIntervalForNonForceRefreshLocationInMSConfig))
+            {
+                if (int.TryParse(minimumIntervalForNonForceRefreshLocationInMSConfig, out int minimumIntervalForNonForceRefreshLocationInMS))
+                {
+                    this.MinTimeBetweenAccountRefresh = TimeSpan.FromMilliseconds(minimumIntervalForNonForceRefreshLocationInMS);
+                }
+                else
+                {
+                    DefaultTrace.TraceError($"GlobalEndpointManager: Failed to parse {GlobalEndpointManager.MinimumIntervalForNonForceRefreshLocationInMS}; Value:{minimumIntervalForNonForceRefreshLocationInMSConfig}");
+                }
+            }
         }
 
         public ReadOnlyCollection<Uri> ReadEndpoints => this.locationCache.ReadEndpoints;

--- a/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
@@ -29,6 +29,6 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         Task InitializeAccountPropertiesAndStartBackgroundRefreshAsync(AccountProperties databaseAccount);
 
-        Task RefreshLocationAsync();
+        Task RefreshLocationAsync(bool forceRefresh = false);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         bool CanUseMultipleWriteLocations(DocumentServiceRequest request);
 
-        Task InitializeAccountPropertiesAndStartBackgroundRefreshAsync(AccountProperties databaseAccount);
+        void InitializeAccountPropertiesAndStartBackgroundRefresh(AccountProperties databaseAccount);
 
         Task RefreshLocationAsync(bool forceRefresh = false);
     }

--- a/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/IGlobalEndpointManager.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         bool CanUseMultipleWriteLocations(DocumentServiceRequest request);
 
-        Task RefreshLocationAsync(AccountProperties databaseAccount, bool forceRefresh = false);
+        Task InitializeAccountPropertiesAndStartBackgroundRefreshAsync(AccountProperties databaseAccount);
+
+        Task RefreshLocationAsync();
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Cosmos
                     "Should have surfaced OperationCanceledException because the token was canceled.");
 
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.MarkEndpointUnavailableForRead(It.IsAny<Uri>()), Times.Once, "Should had marked the endpoint unavailable");
-                ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(), Times.Once, "Should had refreshed the account information");
+                ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(false), Times.Once, "Should had refreshed the account information");
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Cosmos
                     "Should have surfaced OperationCanceledException because the token was canceled.");
 
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.MarkEndpointUnavailableForRead(It.IsAny<Uri>()), Times.Once, "Should had marked the endpoint unavailable");
-                ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(It.IsAny<AccountProperties>(), It.Is<bool>(refresh => refresh == false)), Times.Once, "Should had refreshed the account information");
+                ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(), Times.Once, "Should had refreshed the account information");
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos
             bool failedToResolve = false;
             bool didNotRetry = false;
 
-            const string failedToResolveMessage = "Fail to reach gateway endpoint https://veryrandomurl123456789.documents.azure.com/, ";
+            const string failedToResolveMessage = "GlobalEndpointManager: Fail to reach gateway endpoint https://veryrandomurl123456789.documents.azure.com/, ";
             string didNotRetryMessage = null;
 
             void TraceHandler(string message)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -359,6 +359,9 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ReadLocationRemoveAndAddMockTest()
         {
+            string originalConfigValue = System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"];
+            System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"] = "1000";
+
             // Setup dummpy read locations for the database account
             Collection<AccountRegion> readableLocations = new Collection<AccountRegion>();
 
@@ -410,6 +413,8 @@ namespace Microsoft.Azure.Cosmos
             //Sleep a bit for the refresh timer to kick in and rediscover location 1
             Thread.Sleep(2000);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
+
+            System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"] = originalConfigValue;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -359,8 +359,8 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ReadLocationRemoveAndAddMockTest()
         {
-            string originalConfigValue = System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"];
-            System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"] = "1000";
+            string originalConfigValue = Environment.GetEnvironmentVariable("MinimumIntervalForNonForceRefreshLocationInMS");
+            Environment.SetEnvironmentVariable("MinimumIntervalForNonForceRefreshLocationInMS", "1000");
 
             // Setup dummpy read locations for the database account
             Collection<AccountRegion> readableLocations = new Collection<AccountRegion>();
@@ -414,7 +414,7 @@ namespace Microsoft.Azure.Cosmos
             Thread.Sleep(2000);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
 
-            System.Configuration.ConfigurationManager.AppSettings["MinimumIntervalForNonForceRefreshLocationInMS"] = originalConfigValue;
+            Environment.SetEnvironmentVariable("MinimumIntervalForNonForceRefreshLocationInMS", "1000");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos
 
             GlobalEndpointManager globalEndpointManager = new GlobalEndpointManager(mockOwner.Object, connectionPolicy);
 
-            await globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount);
+            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(databaseAccount);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
 
             //Mark each of the read locations as unavailable and validate that the read endpoint switches to the next preferred region / default endpoint.
@@ -393,14 +393,14 @@ namespace Microsoft.Azure.Cosmos
 
             GlobalEndpointManager globalEndpointManager = new GlobalEndpointManager(mockOwner.Object, connectionPolicy);
 
-            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount).Wait();
+            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(databaseAccount);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
 
             //Remove location 1 from read locations and validate that the read endpoint switches to the next preferred location
             readableLocations.Remove(readLocation1);
             databaseAccount.ReadLocationsInternal = readableLocations;
 
-            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount).Wait();
+            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(databaseAccount);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation2.Endpoint));
 
             //Add location 1 back to read locations and validate that location 1 becomes the read endpoint again.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -61,21 +61,21 @@ namespace Microsoft.Azure.Cosmos
 
             GlobalEndpointManager globalEndpointManager = new GlobalEndpointManager(mockOwner.Object, connectionPolicy);
 
-            await globalEndpointManager.RefreshLocationAsync(databaseAccount);
+            await globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount);
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
 
             //Mark each of the read locations as unavailable and validate that the read endpoint switches to the next preferred region / default endpoint.
             globalEndpointManager.MarkEndpointUnavailableForRead(globalEndpointManager.ReadEndpoints[0]);
-            globalEndpointManager.RefreshLocationAsync(null).Wait();
+            globalEndpointManager.RefreshLocationAsync().Wait();
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation2.Endpoint));
 
             globalEndpointManager.MarkEndpointUnavailableForRead(globalEndpointManager.ReadEndpoints[0]);
-            await globalEndpointManager.RefreshLocationAsync(null);
+            await globalEndpointManager.RefreshLocationAsync();
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], globalEndpointManager.WriteEndpoints[0]);
 
             //Sleep a second for the unavailable endpoint entry to expire and background refresh timer to kick in
             Thread.Sleep(3000);
-            await globalEndpointManager.RefreshLocationAsync(null);
+            await globalEndpointManager.RefreshLocationAsync();
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
         }
 
@@ -393,14 +393,14 @@ namespace Microsoft.Azure.Cosmos
 
             GlobalEndpointManager globalEndpointManager = new GlobalEndpointManager(mockOwner.Object, connectionPolicy);
 
-            globalEndpointManager.RefreshLocationAsync(databaseAccount).Wait();
+            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount).Wait();
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation1.Endpoint));
 
             //Remove location 1 from read locations and validate that the read endpoint switches to the next preferred location
             readableLocations.Remove(readLocation1);
             databaseAccount.ReadLocationsInternal = readableLocations;
 
-            globalEndpointManager.RefreshLocationAsync(databaseAccount).Wait();
+            globalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(databaseAccount).Wait();
             Assert.AreEqual(globalEndpointManager.ReadEndpoints[0], new Uri(readLocation2.Endpoint));
 
             //Add location 1 back to read locations and validate that location 1 becomes the read endpoint again.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: enableEndpointDiscovery,
                 isPreferredLocationsListEmpty: isPreferredLocationsListEmpty);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: true, isMasterResourceType: false))
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 preferedRegionListOverride: preferredList);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: true, isMasterResourceType: false))
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 preferedRegionListOverride: preferredList);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: false, isMasterResourceType: false))
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: false, isMasterResourceType: false))
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             int expectedRetryCount = isReadRequest || enableMultipleWriteLocations ? 2 : 1;
@@ -571,7 +571,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 preferedRegionListOverride: preferredList,
                 enforceSingleMasterSingleWriteLocation: true);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: isReadRequest, isMasterResourceType: false))
@@ -680,7 +680,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 preferedRegionListOverride: preferredList,
                 enforceSingleMasterSingleWriteLocation: true);
 
-            await this.endpointManager.RefreshLocationAsync(this.databaseAccount);
+            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: isReadRequest, isMasterResourceType: false))
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
         private async Task ValidateGlobalEndpointLocationCacheRefreshAsync()
         {
-            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.RefreshLocationAsync(null)));
+            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(null)));
 
             await Task.WhenAll(refreshLocations);
 
@@ -992,7 +992,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             this.mockedClient.ResetCalls();
 
-            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.RefreshLocationAsync(null))))
+            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(null))))
             {
                 await task;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: enableEndpointDiscovery,
                 isPreferredLocationsListEmpty: isPreferredLocationsListEmpty);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: true, isMasterResourceType: false))
@@ -245,7 +245,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 preferedRegionListOverride: preferredList);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: true, isMasterResourceType: false))
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 preferedRegionListOverride: preferredList);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: false, isMasterResourceType: false))
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: false, isMasterResourceType: false))
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             int expectedRetryCount = isReadRequest || enableMultipleWriteLocations ? 2 : 1;
@@ -571,7 +571,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 preferedRegionListOverride: preferredList,
                 enforceSingleMasterSingleWriteLocation: true);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(true);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: isReadRequest, isMasterResourceType: false))
@@ -680,7 +680,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 preferedRegionListOverride: preferredList,
                 enforceSingleMasterSingleWriteLocation: true);
 
-            await this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(this.databaseAccount);
+            this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(this.databaseAccount);
             ClientRetryPolicy retryPolicy = this.CreateClientRetryPolicy(enableEndpointDiscovery);
 
             using (DocumentServiceRequest request = this.CreateRequest(isReadRequest: isReadRequest, isMasterResourceType: false))
@@ -984,7 +984,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
         private async Task ValidateGlobalEndpointLocationCacheRefreshAsync()
         {
-            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(null)));
+            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(null)));
 
             await Task.WhenAll(refreshLocations);
 
@@ -992,7 +992,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             this.mockedClient.ResetCalls();
 
-            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(null))))
+            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(null))))
             {
                 await task;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -528,24 +528,23 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
         }
 
         [TestMethod]
-        [Owner("atulk")]
-        public async Task ValidateAsync()
+        [DataRow(true, true, true)]
+        [DataRow(true, false, false)]
+        [DataRow(true, false, true)]
+        [DataRow(true, true, false)]
+        [DataRow(false, false, false)]
+        [DataRow(false, true, true)]
+        [DataRow(false, true, false)]
+        [DataRow(false, true, true)]
+        public async Task ValidateAsync(
+            bool useMultipleWriteEndpoints,
+            bool endpointDiscoveryEnabled,
+            bool isPreferredListEmpty)
         {
-            bool[] boolValues = new bool[] {true, false};
-
-            foreach (bool useMultipleWriteEndpoints in boolValues)
-            {
-                foreach (bool endpointDiscoveryEnabled in boolValues)
-                {
-                    foreach (bool isPreferredListEmpty in boolValues)
-                    {
-                        await this.ValidateLocationCacheAsync(
-                            useMultipleWriteEndpoints,
-                            endpointDiscoveryEnabled,
-                            isPreferredListEmpty);
-                    }
-                }
-            }
+            await this.ValidateLocationCacheAsync(
+                useMultipleWriteEndpoints,
+                endpointDiscoveryEnabled,
+                isPreferredListEmpty);
         }
 
         [TestMethod]
@@ -906,21 +905,21 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                                                   CultureInfo.InvariantCulture) * 1000 * 2;
                     await Task.Delay(delayInMilliSeconds);
 
-                    string config =  $"Delay{expirationTime};" + 
+                    string config = $"Delay{expirationTime};" +
                                      $"useMultipleWriteLocations:{useMultipleWriteLocations};" +
                                      $"endpointDiscoveryEnabled:{endpointDiscoveryEnabled};" +
                                      $"isPreferredListEmpty:{isPreferredListEmpty}";
 
                     CollectionAssert.AreEqual(
-                        currentWriteEndpoints, 
-                        this.cache.WriteEndpoints, 
+                        currentWriteEndpoints,
+                        this.cache.WriteEndpoints,
                         "Write Endpoints failed;" +
                             $"config:{config};" +
                             $"Current:{string.Join(",", currentWriteEndpoints)};" +
                             $"Cache:{string.Join(",", this.cache.WriteEndpoints)};");
 
                     CollectionAssert.AreEqual(
-                        currentReadEndpoints, 
+                        currentReadEndpoints,
                         this.cache.ReadEndpoints,
                         "Read Endpoints failed;" +
                             $"config:{config};" +
@@ -984,7 +983,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
         private async Task ValidateGlobalEndpointLocationCacheRefreshAsync()
         {
-            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(null)));
+            IEnumerable<Task> refreshLocations = Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.RefreshLocationAsync(false)));
 
             await Task.WhenAll(refreshLocations);
 
@@ -992,7 +991,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             this.mockedClient.ResetCalls();
 
-            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(null))))
+            foreach (Task task in Enumerable.Range(0, 10).Select(index => Task.Factory.StartNew(() => this.endpointManager.RefreshLocationAsync(false))))
             {
                 await task;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
@@ -375,29 +375,5 @@ namespace Microsoft.Azure.Cosmos.Tests
                 containerResourceId: containerResourceId,
                 primaryReplicaUri: out primaryRegionprimaryReplicaUri);
         }
-
-        private class ToDoActivity
-        {
-            [JsonProperty(propertyName:"id")]
-            public string Id { get; set; }
-            [JsonProperty(propertyName: "pk")]
-            public string Pk { get; set; }
-
-            public override bool Equals(object obj)
-            {
-                if (!(obj is ToDoActivity input))
-                {
-                    return false;
-                }
-
-                return string.Equals(this.Id, input.Id)
-                    && string.Equals(this.Pk, input.Pk);
-            }
-
-            public override int GetHashCode()
-            {
-                return base.GetHashCode();
-            }
-        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                {
                    // Simulate the legacy gateway being down. After 40 requests simulate the write region pointing to new location.
                    count++;
-                   if(count < 40)
+                   if(count < 2)
                    {
                        return Task.FromResult(MockSetupsHelper.CreateStrongAccount(accountName, writeRegion, readRegions));
                    }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
@@ -1,0 +1,209 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class RegionFailoverTests
+    {
+        [TestMethod]
+        public async Task TestHttpRequestExceptionScenarioAsync()
+        {
+            // testhost.dll.config sets it to 2 seconds which causes it to always expire before retrying. Remove the override.
+            System.Configuration.ConfigurationManager.AppSettings["UnavailableLocationsExpirationTimeInSeconds"] = "500";
+
+            string accountName = "testAccount";
+            string primaryRegionNameForUri = "eastus";
+            string secondaryRegionNameForUri = "westus";
+            string globalEndpoint = $"https://{accountName}.documents.azure.com:443/";
+            Uri globalEndpointUri = new Uri(globalEndpoint);
+            string primaryRegionEndpoint = $"https://{accountName}-{primaryRegionNameForUri}.documents.azure.com";
+            string secondaryRegionEndpiont = $"https://{accountName}-{secondaryRegionNameForUri}.documents.azure.com";
+            string databaseName = "testDb";
+            string containerName = "testContainer";
+            string containerRid = "ccZ1ANCszwk=";
+            ResourceId containerResourceId = ResourceId.Parse(containerRid);
+
+            List<AccountRegion> writeRegion = new List<AccountRegion>()
+            {
+                new AccountRegion()
+                {
+                    Name = "East US",
+                    Endpoint = $"{primaryRegionEndpoint}:443/"
+                }
+            };
+
+            List<AccountRegion> readRegions = new List<AccountRegion>()
+            {
+                new AccountRegion()
+                {
+                    Name = "East US",
+                    Endpoint = $"{primaryRegionEndpoint}:443/"
+                },
+                new AccountRegion()
+                {
+                    Name = "West US",
+                    Endpoint = $"{secondaryRegionEndpiont}:443/"
+                }
+            };
+
+            List<AccountRegion> writeRegionFailedOver = new List<AccountRegion>()
+            {
+                new AccountRegion()
+                {
+                    Name = "West US",
+                    Endpoint = $"{secondaryRegionEndpiont}:443/"
+                }
+            };
+
+            List<AccountRegion> readRegionsFailedOver = new List<AccountRegion>()
+            {
+
+                new AccountRegion()
+                {
+                    Name = "West US",
+                    Endpoint = $"{secondaryRegionEndpiont}:443/"
+                },
+                new AccountRegion()
+                {
+                    Name = "East US",
+                    Endpoint = $"{primaryRegionEndpoint}:443/"
+                },
+            };
+
+            // Create a mock http handler to inject gateway responses.
+            // MockBehavior.Strict ensures that only the mocked APIs get called
+            Mock<IHttpHandler> mockHttpHandler = new Mock<IHttpHandler>(MockBehavior.Strict);
+
+
+            mockHttpHandler.Setup(x => x.SendAsync(
+                It.Is<HttpRequestMessage>(m => m.RequestUri == globalEndpointUri || m.RequestUri.ToString().Contains(primaryRegionNameForUri)),
+                It.IsAny<CancellationToken>())).Throws(new HttpRequestException("Mock HttpRequestException to simulate region being down"));
+
+            int count = 0;
+            mockHttpHandler.Setup(x => x.SendAsync(
+               It.Is<HttpRequestMessage>(x => x.RequestUri ==  new Uri(secondaryRegionEndpiont)),
+               It.IsAny<CancellationToken>()))
+               .Returns<HttpRequestMessage, CancellationToken>((request, cancellationToken) =>
+               {
+                   // Simulate the legacy gateway being down. After 40 requests simulate the write region pointing to new location.
+                   count++;
+                   if(count < 40)
+                   {
+                       return Task.FromResult(MockSetupsHelper.CreateStrongAccount(accountName, writeRegion, readRegions));
+                   }
+                   else
+                   {
+                       return Task.FromResult(MockSetupsHelper.CreateStrongAccount(accountName, writeRegionFailedOver, readRegionsFailedOver));
+                   }
+                });
+
+
+            MockSetupsHelper.SetupContainerProperties(
+                mockHttpHandler: mockHttpHandler,
+                regionEndpoint: secondaryRegionEndpiont,
+                databaseName: databaseName,
+                containerName: containerName,
+                containerRid: containerRid);
+
+            MockSetupsHelper.SetupPartitionKeyRanges(
+                mockHttpHandler: mockHttpHandler,
+                regionEndpoint: secondaryRegionEndpiont,
+                containerResourceId: containerResourceId,
+                partitionKeyRangeIds: out IReadOnlyList<string> secondaryRegionPartitionKeyRangeIds);
+
+            MockSetupsHelper.SetupAddresses(
+                mockHttpHandler: mockHttpHandler,
+                partitionKeyRangeId: secondaryRegionPartitionKeyRangeIds.First(),
+                regionEndpoint: secondaryRegionEndpiont,
+                regionName: secondaryRegionNameForUri,
+                containerResourceId: containerResourceId,
+                primaryReplicaUri: out TransportAddressUri secondaryRegionprimaryReplicaUri);
+
+            Mock<TransportClient> mockTransport = new Mock<TransportClient>(MockBehavior.Strict);
+
+            MockSetupsHelper.SetupRequestTimeoutException(
+                mockTransport,
+                secondaryRegionprimaryReplicaUri);
+
+            // Partition key ranges are the same in both regions so the SDK
+            // does not need to go the secondary to get the partition key ranges.
+            // Only the addresses need to be mocked on the secondary
+            MockSetupsHelper.SetupAddresses(
+                mockHttpHandler: mockHttpHandler,
+                partitionKeyRangeId: secondaryRegionPartitionKeyRangeIds.First(),
+                regionEndpoint: secondaryRegionEndpiont,
+                regionName: secondaryRegionNameForUri,
+                containerResourceId: containerResourceId,
+                primaryReplicaUri: out TransportAddressUri secondaryRegionPrimaryReplicaUri);
+
+            MockSetupsHelper.SetupCreateItemResponse(
+                mockTransport,
+                secondaryRegionPrimaryReplicaUri);
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                EnablePartitionLevelFailover = true,
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Strong,
+                ApplicationPreferredRegions = new List<string>()
+                    {
+                        Regions.EastUS,
+                        Regions.WestUS
+                    },
+                HttpClientFactory = () => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object)),
+                TransportClientHandlerFactory = (original) => mockTransport.Object,
+            };
+
+            CosmosClient customClient = new CosmosClient(
+                globalEndpoint,
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
+                cosmosClientOptions);
+
+            Container container = customClient.GetContainer(databaseName, containerName);
+
+            ToDoActivity toDoActivity = new ToDoActivity()
+            {
+                Id = "TestItem",
+                Pk = "TestPk"
+            };
+
+            ItemResponse<ToDoActivity> response = await container.CreateItemAsync(toDoActivity, new Cosmos.PartitionKey(toDoActivity.Pk));
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            mockTransport.VerifyAll();
+            mockHttpHandler.VerifyAll();
+
+            // Clears all the setups. No network calls should be done on the next operation.
+            mockHttpHandler.Reset();
+            mockTransport.Reset();
+
+            MockSetupsHelper.SetupCreateItemResponse(
+                mockTransport,
+                secondaryRegionPrimaryReplicaUri);
+
+            ToDoActivity toDoActivity2 = new ToDoActivity()
+            {
+                Id = "TestItem2",
+                Pk = "TestPk"
+            };
+
+            response = await container.CreateItemAsync(toDoActivity2, new Cosmos.PartitionKey(toDoActivity2.Pk));
+            Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+
+            // Reset it back to the override to avoid impacting other tests.
+            System.Configuration.ConfigurationManager.AppSettings["UnavailableLocationsExpirationTimeInSeconds"] = "2";
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -260,7 +260,7 @@ JsonConvert.DeserializeObject<Dictionary<string, object>>("{\"maxSqlQueryInputLe
 
             this.MockGlobalEndpointManager = new Mock<GlobalEndpointManager>(this, new ConnectionPolicy());
             this.MockGlobalEndpointManager.Setup(gep => gep.ResolveServiceEndpoint(It.IsAny<DocumentServiceRequest>())).Returns(new Uri("http://localhost"));
-            this.MockGlobalEndpointManager.Setup(gep => gep.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(It.IsAny<AccountProperties>())).Returns(Task.CompletedTask);
+            this.MockGlobalEndpointManager.Setup(gep => gep.InitializeAccountPropertiesAndStartBackgroundRefresh(It.IsAny<AccountProperties>()));
             SessionContainer sessionContainer = new SessionContainer(this.ServiceEndpoint.Host);
             this.sessionContainer = sessionContainer;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -260,7 +260,7 @@ JsonConvert.DeserializeObject<Dictionary<string, object>>("{\"maxSqlQueryInputLe
 
             this.MockGlobalEndpointManager = new Mock<GlobalEndpointManager>(this, new ConnectionPolicy());
             this.MockGlobalEndpointManager.Setup(gep => gep.ResolveServiceEndpoint(It.IsAny<DocumentServiceRequest>())).Returns(new Uri("http://localhost"));
-            this.MockGlobalEndpointManager.Setup(gep => gep.RefreshLocationAsync(It.IsAny<AccountProperties>(), It.IsAny<bool>())).Returns(Task.CompletedTask);
+            this.MockGlobalEndpointManager.Setup(gep => gep.InitializeAccountPropertiesAndStartBackgroundRefreshAsync(It.IsAny<AccountProperties>())).Returns(Task.CompletedTask);
             SessionContainer sessionContainer = new SessionContainer(this.ServiceEndpoint.Host);
             this.sessionContainer = sessionContainer;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/ToDoActivity.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/ToDoActivity.cs
@@ -1,0 +1,32 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using Newtonsoft.Json;
+
+    public class ToDoActivity
+    {
+        [JsonProperty(propertyName: "id")]
+        public string Id { get; set; }
+        [JsonProperty(propertyName: "pk")]
+        public string Pk { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is ToDoActivity input))
+            {
+                return false;
+            }
+
+            return string.Equals(this.Id, input.Id)
+                && string.Equals(this.Pk, input.Pk);
+        }
+
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

The previous behavior would not refresh the account information if there was a gateway outage, and it would depend on the background refresh to update the information. The background refresh can take up to 5 minutes before detecting a change.

1. HttpRequestExceptions will trigger an account refresh every 15 seconds. A config was added to override the minimum time between refreshes.
2. Account refresh will be a no-op if a different thread is already updating the information
3. Updated the traces to include the name to make it easier to discover
4. GlobalEndpointManager is refactored to use 2 methods instead of different overloads on 1 method. This makes it clear that 1 method loads the account information and starts the background refresh. The other is forcing a refresh outside the background refresh.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber