### PR TITLE
Bulk: Fixes diagnostic traces by removing redundant info and adding correct retry context

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
@@ -113,11 +113,10 @@ namespace Microsoft.Azure.Cosmos
             BatchPartitionMetric partitionMetric,
             CancellationToken cancellationToken = default)
         {
-            await this.clientContext.OperationHelperAsync("Batch Dispatch Async",
-                        requestOptions: null,
-                        task: (trace) => this.DispatchHelperAsync(trace, partitionMetric, cancellationToken),
-                        traceComponent: TraceComponent.Batch,
-                        traceLevel: Tracing.TraceLevel.Info);
+            using (ITrace trace = Tracing.Trace.GetRootTrace("Batch Dispatch Async", TraceComponent.Batch, Tracing.TraceLevel.Info))
+            {
+                await this.DispatchHelperAsync(trace, partitionMetric, cancellationToken);
+            }
         }
 
         private async Task<object> DispatchHelperAsync(

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncBatcher.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Cosmos
                     // Any overflow goes to a new batch
                     foreach (ItemBatchOperation operation in pendingOperations)
                     {
-                        await this.retrier(operation, trace, cancellationToken);
+                        await this.retrier(operation, cancellationToken);
                     }
                 }
                 catch (Exception ex)
@@ -175,10 +175,10 @@ namespace Microsoft.Azure.Cosmos
 
                             if (!response.IsSuccessStatusCode)
                             {
-                                Documents.ShouldRetryResult shouldRetry = await itemBatchOperation.Context.ShouldRetryAsync(response, cancellationToken);
+                                ShouldRetryResult shouldRetry = await itemBatchOperation.Context.ShouldRetryAsync(response, cancellationToken);
                                 if (shouldRetry.ShouldRetry)
                                 {
-                                    await this.retrier(itemBatchOperation, trace, cancellationToken);
+                                    await this.retrier(itemBatchOperation, cancellationToken);
                                     continue;
                                 }
                             }
@@ -244,6 +244,5 @@ namespace Microsoft.Azure.Cosmos
     /// <returns>An instance of <see cref="PartitionKeyRangeBatchResponse"/>.</returns>
     internal delegate Task BatchAsyncBatcherRetryDelegate(
         ItemBatchOperation operation,
-        ITrace trace,
         CancellationToken cancellationToken);
 }

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos
             ItemBatchOperation operation,
             CancellationToken cancellationToken)
         {
-            using (ITrace trace = Tracing.Trace.GetRootTrace("Batch Retry Async", TraceComponent.Batch, Tracing.TraceLevel.Info))
+            using (ITrace trace = Tracing.Trace.GetRootTrace("Batch Retry Async", TraceComponent.Batch, Tracing.TraceLevel.Verbose))
             {
                 string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(operation, trace, cancellationToken).ConfigureAwait(false);
                 operation.Context.ReRouteOperation(resolvedPartitionKeyRangeId, trace);

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.Cosmos
 
         public virtual async Task<TransactionalBatchOperationResult> AddAsync(
             ItemBatchOperation operation,
+            ITrace trace,
             ItemRequestOptions itemRequestOptions = null,
             CancellationToken cancellationToken = default)
         {
@@ -82,9 +83,15 @@ namespace Microsoft.Azure.Cosmos
 
             await this.ValidateOperationAsync(operation, itemRequestOptions, cancellationToken);
 
-            string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(operation, NoOpTrace.Singleton, cancellationToken).ConfigureAwait(false);
+            string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(
+                operation, 
+                trace, 
+                cancellationToken).ConfigureAwait(false);
             BatchAsyncStreamer streamer = this.GetOrAddStreamerForPartitionKeyRange(resolvedPartitionKeyRangeId);
-            ItemBatchOperationContext context = new ItemBatchOperationContext(resolvedPartitionKeyRangeId, BatchAsyncContainerExecutor.GetRetryPolicy(this.cosmosContainer, operation.OperationType, this.retryOptions));
+            ItemBatchOperationContext context = new ItemBatchOperationContext(
+                resolvedPartitionKeyRangeId,
+                trace,
+                BatchAsyncContainerExecutor.GetRetryPolicy(this.cosmosContainer, operation.OperationType, this.retryOptions));
             operation.AttachContext(context);
             streamer.Add(operation);
             return await context.OperationTask;
@@ -178,16 +185,12 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task ReBatchAsync(
             ItemBatchOperation operation,
-            ITrace trace,
             CancellationToken cancellationToken)
         {
-            using (ITrace retryTrace = trace.StartChild("Batch Retry Async", TraceComponent.Batch, Tracing.TraceLevel.Info))
-            {
-                string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(operation, retryTrace, cancellationToken).ConfigureAwait(false);
-                operation.Context.ReRouteOperation(resolvedPartitionKeyRangeId);
-                BatchAsyncStreamer streamer = this.GetOrAddStreamerForPartitionKeyRange(resolvedPartitionKeyRangeId);
-                streamer.Add(operation);
-            }
+            string resolvedPartitionKeyRangeId = await this.ResolvePartitionKeyRangeIdAsync(operation, operation.Context.Trace, cancellationToken).ConfigureAwait(false);
+            operation.Context.ReRouteOperation(resolvedPartitionKeyRangeId);
+            BatchAsyncStreamer streamer = this.GetOrAddStreamerForPartitionKeyRange(resolvedPartitionKeyRangeId);
+            streamer.Add(operation);
         }
 
         private async Task<string> ResolvePartitionKeyRangeIdAsync(

--- a/Microsoft.Azure.Cosmos/src/Batch/ItemBatchOperationContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/ItemBatchOperationContext.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -27,11 +28,15 @@ namespace Microsoft.Azure.Cosmos
 
         public ItemBatchOperationContext(
             string partitionKeyRangeId,
+            ITrace trace,
             IDocumentClientRetryPolicy retryPolicy = null)
         {
             this.PartitionKeyRangeId = partitionKeyRangeId;
+            this.Trace = trace;
             this.retryPolicy = retryPolicy;
         }
+
+        public ITrace Trace { get; private set; }
 
         /// <summary>
         /// Based on the Retry Policy, if a failed response should retry.
@@ -40,6 +45,7 @@ namespace Microsoft.Azure.Cosmos
             TransactionalBatchOperationResult batchOperationResult,
             CancellationToken cancellationToken)
         {
+            // append Traces
             if (this.retryPolicy == null
                 || batchOperationResult.IsSuccessStatusCode)
             {
@@ -54,6 +60,7 @@ namespace Microsoft.Azure.Cosmos
             BatchAsyncBatcher completer,
             TransactionalBatchOperationResult result)
         {
+            // append traces
             if (this.AssertBatcher(completer))
             {
                 this.taskCompletionSource.SetResult(result);

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -286,6 +286,7 @@ namespace Microsoft.Azure.Cosmos
                     partitionKey: partitionKey.Value,
                     itemId: itemId,
                     streamPayload: streamPayload,
+                    trace: trace,
                     cancellationToken: cancellationToken);
             }
 
@@ -442,6 +443,7 @@ namespace Microsoft.Azure.Cosmos
             PartitionKey partitionKey,
             string itemId,
             Stream streamPayload,
+            ITrace trace,
             CancellationToken cancellationToken)
         {
             this.ThrowIfDisposed();
@@ -458,6 +460,7 @@ namespace Microsoft.Azure.Cosmos
 
             TransactionalBatchOperationResult batchOperationResult = await cosmosContainerCore.BatchExecutor.AddAsync(
                 itemBatchOperation,
+                trace,
                 itemRequestOptions,
                 cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Tracing/ITrace.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/ITrace.cs
@@ -113,5 +113,11 @@ namespace Microsoft.Azure.Cosmos.Tracing
         /// <param name="key">The key to associate the datum.</param>
         /// <param name="value">The datum itself.</param>
         void AddDatum(string key, object value);
+
+        /// <summary>
+        /// Adds a trace children that is already completed.
+        /// </summary>
+        /// <param name="trace">Existing trace.</param>
+        void AddChild(ITrace trace);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Tracing/NoOpTrace.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/NoOpTrace.cs
@@ -76,5 +76,10 @@ namespace Microsoft.Azure.Cosmos.Tracing
         {
             // NoOp
         }
+
+        public void AddChild(ITrace trace)
+        {
+            // NoOp
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Tracing/Trace.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/Trace.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
 
     internal sealed class Trace : ITrace
     {
-        private readonly List<Trace> children;
+        private readonly List<ITrace> children;
         private readonly Dictionary<string, object> data;
         private readonly Stopwatch stopwatch;
 
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
             this.Level = level;
             this.Component = component;
             this.Parent = parent;
-            this.children = new List<Trace>();
+            this.children = new List<ITrace>();
             this.data = new Dictionary<string, object>();
         }
 
@@ -89,12 +89,17 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 component: component,
                 parent: this);
 
+            this.AddChild(child);
+
+            return child;
+        }
+
+        public void AddChild(ITrace child)
+        {
             lock (this.children)
             {
                 this.children.Add(child);
             }
-
-            return child;
         }
 
         public static Trace GetRootTrace(string name)

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceJoiner.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceJoiner.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
             return traceForest;
         }
 
-        private sealed class TraceForest : ITrace
+        private class TraceForest : ITrace
         {
             private static readonly CallerInfo EmptyInfo = new CallerInfo(string.Empty, string.Empty, 0);
 
@@ -89,8 +89,13 @@ namespace Microsoft.Azure.Cosmos.Tracing
             public ITrace StartChild(string name, TraceComponent component, TraceLevel level, [CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             {
                 ITrace child = Trace.GetRootTrace(name, component, level, memberName, sourceFilePath, sourceLineNumber);
-                this.children.Add(child);
+                this.AddChild(child);
                 return child;
+            }
+
+            public void AddChild(ITrace trace)
+            {
+                this.children.Add(trace);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceJoiner.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceJoiner.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
             return traceForest;
         }
 
-        private class TraceForest : ITrace
+        private sealed class TraceForest : ITrace
         {
             private static readonly CallerInfo EmptyInfo = new CallerInfo(string.Empty, string.Empty, 0);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -7,7 +7,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 100; i++)
+    for (int i = 0; i < 20; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -25,1695 +25,18 @@
         traces.Add(trace);
     }
 
-    ITrace joinedTrace = TraceJoiner.JoinTraces(traces);
 ]]></Setup>
     </Input>
     <Output>
       <Text><![CDATA[.
 └── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   (
     │   │       [Client Configuration]
     │   │       Redacted To Not Change The Baselines From Run To Run
     │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │                           (
-    │   │                               [Client Side Request Stats]
-    │   │                               Redacted To Not Change The Baselines From Run To Run
-    │   │                           )
-    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
         │       [Client Configuration]
@@ -1744,6 +67,44 @@
   "duration in milliseconds": 0,
   "children": [
     {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    },
+    {
       "name": "Batch Dispatch Async",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
@@ -1824,6 +185,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -1916,6 +386,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2008,6 +587,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2100,6 +788,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2192,6 +989,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2284,6 +1190,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2386,9 +1401,80 @@
           "duration in milliseconds": 0
         }
       ]
-    },
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
     {
-      "name": "Batch Dispatch Async",
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -2402,7 +1488,7 @@
       },
       "children": [
         {
-          "name": "Using Wait",
+          "name": "ItemSerialize",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2413,7054 +1499,8 @@
           "duration in milliseconds": 0
         },
         {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
             "file": "FilePath",
@@ -9562,9 +1602,80 @@
           "duration in milliseconds": 0
         }
       ]
-    },
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
     {
-      "name": "Batch Dispatch Async",
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -9578,7 +1689,7 @@
       },
       "children": [
         {
-          "name": "Using Wait",
+          "name": "ItemSerialize",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -9587,63 +1698,9 @@
           },
           "start time": "12:00:00:000",
           "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
         },
         {
-          "name": "Create Trace",
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -9746,9 +1803,80 @@
           "duration in milliseconds": 0
         }
       ]
-    },
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
     {
-      "name": "Batch Dispatch Async",
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -9762,7 +1890,7 @@
       },
       "children": [
         {
-          "name": "Using Wait",
+          "name": "ItemSerialize",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -9771,63 +1899,9 @@
           },
           "start time": "12:00:00:000",
           "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
         },
         {
-          "name": "Create Trace",
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -9930,9 +2004,80 @@
           "duration in milliseconds": 0
         }
       ]
-    },
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
     {
-      "name": "Batch Dispatch Async",
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -9946,7 +2091,7 @@
       },
       "children": [
         {
-          "name": "Using Wait",
+          "name": "ItemSerialize",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -9955,63 +2100,9 @@
           },
           "start time": "12:00:00:000",
           "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
         },
         {
-          "name": "Create Trace",
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10104,6 +2195,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10193,9 +2393,118 @@
               ]
             }
           ]
+        },
+        {
+          "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
         },
         {
-          "name": "Create Trace",
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10288,6 +2597,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10380,6 +2798,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10472,6 +2999,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10564,6 +3200,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10656,6 +3401,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10748,6 +3602,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -10840,6 +3803,115 @@
         },
         {
           "name": "Create Trace",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Bulk Operation</Description>
+      <Setup><![CDATA[
+    string pkValue = "DiagnosticBulkTestPk";
+    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
+    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
+    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
+    for (int i = 0; i < 20; i++)
+    {
+        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
+        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+    }
+
+    await Task.WhenAll(createItemsTasks);
+
+    List<ITrace> traces = new List<ITrace>();
+    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    {
+        ItemResponse<ToDoActivity> itemResponse = await createTask;
+        Assert.IsNotNull(itemResponse);
+
+        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │                           (
+        │                               [Client Side Request Stats]
+        │                               Redacted To Not Change The Baselines From Run To Run
+        │                           )
+        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "CreateItemAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "ItemSerialize",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        },
+        {
+          "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -38,10 +38,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -114,9 +110,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -239,10 +232,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -315,9 +304,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -440,10 +426,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -516,9 +498,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -641,10 +620,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -717,9 +692,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -842,10 +814,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -918,9 +886,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -1043,10 +1008,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1119,9 +1080,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -1244,10 +1202,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1320,9 +1274,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -1445,10 +1396,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1521,9 +1468,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -1646,10 +1590,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1722,9 +1662,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -1847,10 +1784,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1923,9 +1856,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -2061,10 +1991,6 @@
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2101,10 +2027,6 @@
     ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2141,10 +2063,6 @@
     ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2181,10 +2099,6 @@
     ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2278,9 +2192,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -2484,9 +2395,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -2690,9 +2598,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",
@@ -2896,9 +2801,6 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
         {
           "name": "Using Wait",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -29,14 +29,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -52,7 +51,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -61,9 +60,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -71,34 +73,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -223,14 +209,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -246,7 +231,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -255,9 +240,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -265,34 +253,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -417,14 +389,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -440,7 +411,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -449,9 +420,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -459,34 +433,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -611,14 +569,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -634,7 +591,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -643,9 +600,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -653,34 +613,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -805,14 +749,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -828,7 +771,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -837,9 +780,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -847,34 +793,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -999,14 +929,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1022,7 +951,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -1031,9 +960,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -1041,34 +973,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -1193,14 +1109,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1216,7 +1131,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -1225,9 +1140,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -1235,34 +1153,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -1387,14 +1289,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1410,7 +1311,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -1419,9 +1320,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -1429,34 +1333,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -1581,14 +1469,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1604,7 +1491,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -1613,9 +1500,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -1623,34 +1513,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -1775,14 +1649,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1798,7 +1671,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -1807,9 +1680,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -1817,34 +1693,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",
@@ -1982,14 +1842,13 @@
     </Input>
     <Output>
       <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2134,7 +1993,7 @@
         └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
-  "name": "Trace Forest",
+  "name": "CreateItemAsync",
   "id": "00000000-0000-0000-0000-000000000000",
   "caller info": {
     "member": "MemberName",
@@ -2143,9 +2002,12 @@
   },
   "start time": "12:00:00:000",
   "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
   "children": [
     {
-      "name": "CreateItemAsync",
+      "name": "ItemSerialize",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -2153,34 +2015,18 @@
         "line": 42
       },
       "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
       },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
     },
     {
       "name": "Batch Dispatch Async",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BulkOperationsAsync.xml
@@ -7,7 +7,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -208,7 +208,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -409,7 +409,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -610,7 +610,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -811,7 +811,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -1012,7 +1012,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -1213,7 +1213,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -1414,7 +1414,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -1615,7 +1615,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -1816,7 +1816,7 @@
     CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
     Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
     List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    for (int i = 0; i < 10; i++)
     {
         ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
         createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -2011,30 +2011,43 @@
   </Result>
   <Result>
     <Input>
-      <Description>Bulk Operation</Description>
+      <Description>Bulk Operation With Throttle</Description>
       <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    string errorMessage = "Mock throttle exception" + Guid.NewGuid().ToString();
+    Guid exceptionActivityId = Guid.NewGuid();
+    // Set a small retry count to reduce test time
+    CosmosClient throttleClient = TestCommon.CreateCosmosClient(builder =>
+        builder.WithThrottlingRetryOptions(TimeSpan.FromSeconds(5), 3)
+        .WithBulkExecution(true)
+        .WithTransportClientHandlerFactory(transportClient => new TransportClientWrapper(
+               transportClient,
+               (uri, resourceOperation, request) => TransportClientHelper.ReturnThrottledStoreResponseOnItemOperation(
+                    uri,
+                    resourceOperation,
+                    request,
+                    exceptionActivityId,
+                    errorMessage)))
+        );
+
+    ItemRequestOptions requestOptions = new ItemRequestOptions();
+    Container containerWithThrottleException = throttleClient.GetContainer(
+        database.Id,
+        container.Id);
+
+    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+    ITrace trace = null;
+    try
     {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
+        ItemResponse<ToDoActivity> createResponse = await containerWithThrottleException.CreateItemAsync<ToDoActivity>(
+          item: testItem,
+          partitionKey: new PartitionKey(testItem.id),
+          requestOptions: requestOptions);
+        Assert.Fail("Should have thrown a throttling exception");
     }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
+    catch (CosmosException ce) when ((int)ce.StatusCode == (int)Documents.StatusCodes.TooManyRequests)
     {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
+        trace = ((CosmosTraceDiagnostics)ce.Diagnostics).Value;
     }
-
 ]]></Setup>
     </Input>
     <Output>
@@ -2047,6 +2060,126 @@
     │   │   )
     │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
+    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
+    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │           │               (
+    │   │           │                   [Client Side Request Stats]
+    │   │           │                   Redacted To Not Change The Baselines From Run To Run
+    │   │           │               )
+    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │                           (
+    │   │                               [Client Side Request Stats]
+    │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │                           )
+    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   (
         │       [Client Configuration]
@@ -2056,6 +2189,27 @@
         ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │               (
+        │           │                   [Client Side Request Stats]
+        │           │                   Redacted To Not Change The Baselines From Run To Run
+        │           │               )
+        │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │               (
+        │           │                   [Client Side Request Stats]
+        │           │                   Redacted To Not Change The Baselines From Run To Run
+        │           │               )
+        │           ├── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │   └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │       └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+        │           │               (
+        │           │                   [Client Side Request Stats]
+        │           │                   Redacted To Not Change The Baselines From Run To Run
+        │           │               )
         │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2186,6 +2340,96 @@
                           ]
                         }
                       ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2205,80 +2449,9 @@
           "duration in milliseconds": 0
         }
       ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    },
     {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
+      "name": "Batch Retry Async",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -2287,21 +2460,7 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
         {
           "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
@@ -2387,6 +2546,96 @@
                           ]
                         }
                       ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2406,80 +2655,9 @@
           "duration in milliseconds": 0
         }
       ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    },
     {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
+      "name": "Batch Retry Async",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -2488,21 +2666,7 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
         {
           "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
@@ -2588,6 +2752,96 @@
                           ]
                         }
                       ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "caller info": {
+                                "member": "MemberName",
+                                "file": "FilePath",
+                                "line": 42
+                              },
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                              }
+                            }
+                          ]
+                        }
+                      ]
                     }
                   ]
                 }
@@ -2607,80 +2861,9 @@
           "duration in milliseconds": 0
         }
       ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
+    },
     {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
+      "name": "Batch Retry Async",
       "id": "00000000-0000-0000-0000-000000000000",
       "caller info": {
         "member": "MemberName",
@@ -2689,21 +2872,7 @@
       },
       "start time": "12:00:00:000",
       "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
       "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
         {
           "name": "Get Collection Cache",
           "id": "00000000-0000-0000-0000-000000000000",
@@ -2789,178 +2958,7 @@
                           ]
                         }
                       ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
+                    },
                     {
                       "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
@@ -2990,178 +2988,7 @@
                           ]
                         }
                       ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
+                    },
                     {
                       "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",
@@ -3191,781 +3018,7 @@
                           ]
                         }
                       ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
-                    {
-                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
-                      "id": "00000000-0000-0000-0000-000000000000",
-                      "start time": "12:00:00:000",
-                      "duration in milliseconds": 0,
-                      "children": [
-                        {
-                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
-                          "id": "00000000-0000-0000-0000-000000000000",
-                          "start time": "12:00:00:000",
-                          "duration in milliseconds": 0,
-                          "children": [
-                            {
-                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
-                              "id": "00000000-0000-0000-0000-000000000000",
-                              "caller info": {
-                                "member": "MemberName",
-                                "file": "FilePath",
-                                "line": 42
-                              },
-                              "start time": "12:00:00:000",
-                              "duration in milliseconds": 0,
-                              "data": {
-                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
-                              }
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "name": "Create Trace",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    }
-  ]
-}]]></Json>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>Bulk Operation</Description>
-      <Setup><![CDATA[
-    string pkValue = "DiagnosticBulkTestPk";
-    CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
-    Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
-    List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-    for (int i = 0; i < 20; i++)
-    {
-        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
-        createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
-    }
-
-    await Task.WhenAll(createItemsTasks);
-
-    List<ITrace> traces = new List<ITrace>();
-    foreach (Task<ItemResponse<ToDoActivity>> createTask in createItemsTasks)
-    {
-        ItemResponse<ToDoActivity> itemResponse = await createTask;
-        Assert.IsNotNull(itemResponse);
-
-        ITrace trace = ((CosmosTraceDiagnostics)itemResponse.Diagnostics).Value;
-        traces.Add(trace);
-    }
-
-]]></Setup>
-    </Input>
-    <Output>
-      <Text><![CDATA[.
-└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    ├── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   │   (
-    │   │       [Client Configuration]
-    │   │       Redacted To Not Change The Baselines From Run To Run
-    │   │   )
-    │   ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   (
-        │       [Client Configuration]
-        │       Redacted To Not Change The Baselines From Run To Run
-        │   )
-        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-        │                           (
-        │                               [Client Side Request Stats]
-        │                               Redacted To Not Change The Baselines From Run To Run
-        │                           )
-        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-]]></Text>
-      <Json><![CDATA[{
-  "name": "Trace Forest",
-  "id": "00000000-0000-0000-0000-000000000000",
-  "caller info": {
-    "member": "MemberName",
-    "file": "FilePath",
-    "line": 42
-  },
-  "start time": "12:00:00:000",
-  "duration in milliseconds": 0,
-  "children": [
-    {
-      "name": "CreateItemAsync",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "ItemSerialize",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Get Collection Cache",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        }
-      ]
-    },
-    {
-      "name": "Batch Dispatch Async",
-      "id": "00000000-0000-0000-0000-000000000000",
-      "caller info": {
-        "member": "MemberName",
-        "file": "FilePath",
-        "line": 42
-      },
-      "start time": "12:00:00:000",
-      "duration in milliseconds": 0,
-      "data": {
-        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
-      },
-      "children": [
-        {
-          "name": "Using Wait",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "caller info": {
-            "member": "MemberName",
-            "file": "FilePath",
-            "line": 42
-          },
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0
-        },
-        {
-          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
-          "id": "00000000-0000-0000-0000-000000000000",
-          "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0,
-              "children": [
-                {
-                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
-                  "id": "00000000-0000-0000-0000-000000000000",
-                  "start time": "12:00:00:000",
-                  "duration in milliseconds": 0,
-                  "children": [
+                    },
                     {
                       "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                       "id": "00000000-0000-0000-0000-000000000000",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -47,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<TransactionalBatchOperationResult>> tasks = new List<Task<TransactionalBatchOperationResult>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(executor.AddAsync(CreateItem(i.ToString()), null, default(CancellationToken)));
+                tasks.Add(executor.AddAsync(CreateItem(i.ToString()), NoOpTrace.Singleton));
             }
 
             await Task.WhenAll(tasks);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -1249,7 +1249,7 @@
         private sealed class TraceForBaselineTesting : ITrace
         {
             public readonly Dictionary<string, object> data;
-            public readonly List<TraceForBaselineTesting> children;
+            public readonly List<ITrace> children;
 
             public TraceForBaselineTesting(
                 string name,
@@ -1261,7 +1261,7 @@
                 this.Level = level;
                 this.Component = component;
                 this.Parent = parent;
-                this.children = new List<TraceForBaselineTesting>();
+                this.children = new List<ITrace>();
                 this.data = new Dictionary<string, object>();
             }
 
@@ -1313,8 +1313,13 @@
             public ITrace StartChild(string name, TraceComponent component, TraceLevel level, [CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             {
                 TraceForBaselineTesting child = new TraceForBaselineTesting(name, level, component, parent: this);
-                this.children.Add(child);
+                this.AddChild(child);
                 return child;
+            }
+
+            public void AddChild(ITrace trace)
+            {
+                this.children.Add(trace);
             }
 
             public static TraceForBaselineTesting GetRootTrace()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -879,7 +879,7 @@
                 CosmosClient bulkClient = TestCommon.CreateCosmosClient(builder => builder.WithBulkExecution(true));
                 Container bulkContainer = bulkClient.GetContainer(database.Id, container.Id);
                 List<Task<ItemResponse<ToDoActivity>>> createItemsTasks = new List<Task<ItemResponse<ToDoActivity>>>();
-                for (int i = 0; i < 100; i++)
+                for (int i = 0; i < 20; i++)
                 {
                     ToDoActivity item = ToDoActivity.CreateRandomToDoActivity(pk: pkValue);
                     createItemsTasks.Add(bulkContainer.CreateItemAsync<ToDoActivity>(item, new PartitionKey(item.id)));
@@ -897,10 +897,12 @@
                     traces.Add(trace);
                 }
 
-                ITrace joinedTrace = TraceJoiner.JoinTraces(traces);
                 endLineNumber = GetLineNumber();
 
-                inputs.Add(new Input("Bulk Operation", joinedTrace, startLineNumber, endLineNumber));
+                foreach (ITrace trace in traces)
+                {
+                    inputs.Add(new Input("Bulk Operation", trace, startLineNumber, endLineNumber));
+                }
             }
             //----------------------------------------------------------------
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 resourceStream: new MemoryStream(new byte[] { 0x41, 0x42 }, index: 0, count: 2, writable: false, publiclyVisible: true));
             if (withContext)
             {
-                operation.AttachContext(new ItemBatchOperationContext(string.Empty));
+                operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
             }
 
             return operation;
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         private readonly BatchAsyncBatcherExecuteDelegate ExecutorWithFailure
             = (PartitionKeyRangeServerBatchRequest request, ITrace trace, CancellationToken cancellationToken) => throw expectedException;
 
-        private readonly BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, ITrace trace, CancellationToken cancellation) => Task.CompletedTask;
+        private readonly BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, CancellationToken cancellation) => Task.CompletedTask;
 
         [DataTestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
@@ -378,9 +378,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             BatchAsyncBatcher batchAsyncBatcher = new BatchAsyncBatcher(2, 1000, MockCosmosUtil.Serializer, this.ExecutorWithFailure, this.Retrier, BatchAsyncBatcherTests.MockClientContext());
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            ItemBatchOperationContext context1 = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext context1 = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation1.AttachContext(context1);
-            ItemBatchOperationContext context2 = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext context2 = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation2.AttachContext(context2);
             batchAsyncBatcher.TryAdd(operation1);
             batchAsyncBatcher.TryAdd(operation2);
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     partitionKey: new Cosmos.PartitionKey(i.ToString()),
                     id: i.ToString());
 
-                ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty);
+                ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
                 operation.AttachContext(context);
                 operations.Add(operation);
                 Assert.IsTrue(batchAsyncBatcher.TryAdd(operation));
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             for (int i = 0; i < 10; i++)
             {
                 ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, i, Cosmos.PartitionKey.Null, i.ToString());
-                ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty);
+                ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
                 operation.AttachContext(context);
                 operations.Add(operation);
                 Assert.IsTrue(batchAsyncBatcher.TryAdd(operation));
@@ -496,7 +496,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             BatchAsyncBatcher batchAsyncBatcher = new BatchAsyncBatcher(1, 1000, MockCosmosUtil.Serializer, this.Executor, this.Retrier, BatchAsyncBatcherTests.MockClientContext());
             ItemBatchOperation operation = this.CreateItemBatchOperation();
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation));
             await batchAsyncBatcher.DispatchAsync(metric);
             Assert.IsFalse(batchAsyncBatcher.TryAdd(this.CreateItemBatchOperation()));
@@ -517,8 +517,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy2));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
@@ -526,9 +526,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -546,8 +546,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy2));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
@@ -555,9 +555,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -575,8 +575,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy2));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
@@ -584,9 +584,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
 
         [TestMethod]
@@ -594,8 +594,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
             Mock<BatchAsyncBatcherExecuteDelegate> executeDelegate = new Mock<BatchAsyncBatcherExecuteDelegate>();
@@ -604,9 +604,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Never);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -624,8 +624,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy2));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
@@ -633,9 +633,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Never);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Once);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -653,8 +653,8 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
-            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy1));
-            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy2));
+            operation1.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy1));
+            operation2.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy2));
 
             Mock<BatchAsyncBatcherRetryDelegate> retryDelegate = new Mock<BatchAsyncBatcherRetryDelegate>();
 
@@ -662,9 +662,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation1));
             Assert.IsTrue(batchAsyncBatcher.TryAdd(operation2));
             await batchAsyncBatcher.DispatchAsync(metric);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never);
-            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never);
-            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation1), It.IsAny<CancellationToken>()), Times.Never);
+            retryDelegate.Verify(a => a(It.Is<ItemBatchOperation>(o => o == operation2), It.IsAny<CancellationToken>()), Times.Never);
+            retryDelegate.Verify(a => a(It.IsAny<ItemBatchOperation>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         private static ContainerInternal GetSplitEnabledContainer()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string.Empty);
             mockContainer.Setup(x => x.GetRoutingMapAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(routingMap));
             BatchAsyncContainerExecutor executor = new BatchAsyncContainerExecutor(mockContainer.Object, mockedContext.Object, 20, BatchAsyncContainerExecutorCache.DefaultMaxBulkRequestBodySizeInBytes);
-            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation);
+            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation, NoOpTrace.Singleton);
 
             Mock.Get(mockContainer.Object)
                 .Verify(x => x.GetCachedContainerPropertiesAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string.Empty);
             mockContainer.Setup(x => x.GetRoutingMapAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(routingMap));
             BatchAsyncContainerExecutor executor = new BatchAsyncContainerExecutor(mockContainer.Object, mockedContext.Object, 20, BatchAsyncContainerExecutorCache.DefaultMaxBulkRequestBodySizeInBytes);
-            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation);
+            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation, NoOpTrace.Singleton);
 
             Mock.Get(mockContainer.Object)
                 .Verify(x => x.GetCachedContainerPropertiesAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string.Empty);
             mockContainer.Setup(x => x.GetRoutingMapAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(routingMap));
             BatchAsyncContainerExecutor executor = new BatchAsyncContainerExecutor(mockContainer.Object, mockedContext.Object, 20, BatchAsyncContainerExecutorCache.DefaultMaxBulkRequestBodySizeInBytes);
-            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation);
+            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation, NoOpTrace.Singleton);
 
             Mock.Get(mockContainer.Object)
                 .Verify(x => x.GetCachedContainerPropertiesAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 string.Empty);
             mockContainer.Setup(x => x.GetRoutingMapAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(routingMap));
             BatchAsyncContainerExecutor executor = new BatchAsyncContainerExecutor(mockContainer.Object, mockedContext.Object, 20, BatchAsyncContainerExecutorCache.DefaultMaxBulkRequestBodySizeInBytes);
-            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation);
+            TransactionalBatchOperationResult result = await executor.AddAsync(itemBatchOperation, NoOpTrace.Singleton);
 
             Mock.Get(mockContainer.Object)
                 .Verify(x => x.GetCachedContainerPropertiesAsync(It.IsAny<bool>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Once);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -53,10 +53,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             batchAsyncOperationContext.Complete(null, result);
 
             Assert.AreEqual(result, await batchAsyncOperationContext.OperationTask);
-            Assert.AreEqual(3, result.Trace.Children.Count, "The final trace should have the initial trace, plus the retries, plus the final trace");
-            Assert.AreEqual(rootTrace, result.Trace.Children[0], "The first trace child should be the initial root");
-            Assert.AreEqual(retryTrace, result.Trace.Children[1], "The second trace child should be the one from the retry");
-            Assert.AreEqual(transportTrace, result.Trace.Children[2], "The third trace child should be the one from the final result");
+            Assert.AreEqual(2, result.Trace.Children.Count, "The final trace should have the initial trace, plus the retries, plus the final trace");
+            Assert.AreEqual(rootTrace, result.Trace, "The first trace child should be the initial root");
+            Assert.AreEqual(retryTrace, result.Trace.Children[0], "The second trace child should be the one from the retry");
+            Assert.AreEqual(transportTrace, result.Trace.Children[1], "The third trace child should be the one from the final result");
         }
 
         [TestMethod]
@@ -94,9 +94,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             batchAsyncOperationContext.Complete(null, result);
 
             Assert.AreEqual(result, await batchAsyncOperationContext.OperationTask);
-            Assert.AreEqual(2, result.Trace.Children.Count, "The final trace should have the initial trace, plus the final trace, since the result is not retried, it should not capture it");
-            Assert.AreEqual(rootTrace, result.Trace.Children[0], "The first trace child should be the initial root");
-            Assert.AreEqual(transportTrace, result.Trace.Children[1], "The second trace child should be the one from the final result");
+            Assert.AreEqual(1, result.Trace.Children.Count, "The final trace should have the initial trace, plus the final trace, since the result is not retried, it should not capture it");
+            Assert.AreEqual(rootTrace, result.Trace, "The first trace child should be the initial root");
+            Assert.AreEqual(transportTrace, result.Trace.Children[0], "The second trace child should be the one from the final result");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             string expectedPkRangeId = Guid.NewGuid().ToString();
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(expectedPkRangeId);
+            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(expectedPkRangeId, NoOpTrace.Singleton);
             operation.AttachContext(batchAsyncOperationContext);
 
             Assert.IsNotNull(batchAsyncOperationContext.OperationTask);
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void TaskIsCreatedOnInitialization()
         {
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation.AttachContext(batchAsyncOperationContext);
 
             Assert.IsNotNull(batchAsyncOperationContext.OperationTask);
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task TaskResultIsSetOnCompleteAsync()
         {
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation.AttachContext(batchAsyncOperationContext);
 
             TransactionalBatchOperationResult expected = new TransactionalBatchOperationResult(HttpStatusCode.OK);
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             Exception failure = new Exception("It failed");
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext batchAsyncOperationContext = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation.AttachContext(batchAsyncOperationContext);
 
             batchAsyncOperationContext.Fail(null, failure);
@@ -78,8 +78,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void CannotAttachMoreThanOnce()
         {
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty));
-            Assert.ThrowsException<InvalidOperationException>(() => operation.AttachContext(new ItemBatchOperationContext(string.Empty)));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
+            Assert.ThrowsException<InvalidOperationException>(() => operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton)));
         }
 
         [TestMethod]
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);
         }
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);
         }
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsFalse(shouldRetryResult.ShouldRetry);
         }
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new ResourceThrottleRetryPolicy(1));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
-            operation.AttachContext(new ItemBatchOperationContext(string.Empty, retryPolicy));
+            operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
             ShouldRetryResult shouldRetryResult = await operation.Context.ShouldRetryAsync(result, default);
             Assert.IsTrue(shouldRetryResult.ShouldRetry);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncStreamerTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         private readonly BatchAsyncBatcherExecuteDelegate ExecutorWithFailure = (PartitionKeyRangeServerBatchRequest request, ITrace trace, CancellationToken cancellationToken) => throw expectedException;
 
-        private readonly BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, ITrace trace, CancellationToken cancellation) => Task.CompletedTask;
+        private readonly BatchAsyncBatcherRetryDelegate Retrier = (ItemBatchOperation operation, CancellationToken cancellation) => Task.CompletedTask;
 
         [DataTestMethod]
         [ExpectedException(typeof(ArgumentOutOfRangeException))]
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         private static ItemBatchOperationContext AttachContext(ItemBatchOperation operation)
         {
-            ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty);
+            ItemBatchOperationContext context = new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton);
             operation.AttachContext(context);
             return context;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosItemUnitTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     partitionKey: partitionKey,
                     streamPayload: itemStream))
                 {
-                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
             }
         }
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     partitionKey: partitionKey,
                     streamPayload: itemStream))
                 {
-                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
             }
         }
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     id: testItem.id,
                     streamPayload: itemStream))
                 {
-                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
             }
         }
@@ -274,7 +274,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     partitionKey: partitionKey,
                     id: testItem.id))
                 {
-                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                    mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
                 }
             }
         }
@@ -296,7 +296,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 partitionKey: partitionKey,
                 id: testItem.id))
             {
-                mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 id: testItem.id,
                 patchOperations: patch))
             {
-                mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+                mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
             }
         }
 
@@ -342,7 +342,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ItemResponse<dynamic> response = await container.CreateItemAsync<dynamic>(
                 testItem,
                 partitionKey: partitionKey);
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ItemResponse<dynamic> response = await container.UpsertItemAsync<dynamic>(
                 testItem,
                 partitionKey: partitionKey);
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ItemResponse<dynamic> response = await container.ReplaceItemAsync<dynamic>(
                 testItem,
                 testItem.id);
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ItemResponse<dynamic> response = await container.ReadItemAsync<dynamic>(
                 id: testItem.id,
                 partitionKey: partitionKey);
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -415,7 +415,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 partitionKey: partitionKey,
                 id: testItem.id);
 
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -440,7 +440,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 partitionKey,
                 patch);
 
-            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
+            mockedExecutor.Verify(c => c.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [TestMethod]
@@ -928,7 +928,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Mock<BatchAsyncContainerExecutor> mockedExecutor = new Mock<BatchAsyncContainerExecutor>();
 
             mockedExecutor
-                .Setup(e => e.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
+                .Setup(e => e.AddAsync(It.IsAny<ItemBatchOperation>(), It.IsAny<ITrace>(), It.IsAny<ItemRequestOptions>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new TransactionalBatchOperationResult(HttpStatusCode.OK)
                 {
                 });

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceTests.cs
@@ -38,6 +38,23 @@
         }
 
         [TestMethod]
+        public void TestAddChild()
+        {
+            Trace oneChild = Trace.GetRootTrace(name: "OneChild");
+            Trace twoChild = Trace.GetRootTrace(name: "TwoChild");
+            Trace rootTrace;
+            using (rootTrace = Trace.GetRootTrace(name: "RootTrace"))
+            {
+                rootTrace.AddChild(oneChild);
+                rootTrace.AddChild(twoChild);
+            }
+
+            Assert.AreEqual(2, rootTrace.Children.Count);
+            Assert.AreEqual(oneChild, rootTrace.Children[0]);
+            Assert.AreEqual(twoChild, rootTrace.Children[1]);
+        }
+
+        [TestMethod]
         public void TestTraceChildren()
         {
             using (Trace rootTrace = Trace.GetRootTrace(name: "RootTrace", component: TraceComponent.Query, level: TraceLevel.Info))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -822,7 +822,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
         private sealed class TraceForBaselineTesting : ITrace
         {
             private readonly Dictionary<string, object> data;
-            private readonly List<TraceForBaselineTesting> children;
+            private readonly List<ITrace> children;
 
             public TraceForBaselineTesting(
                 string name,
@@ -834,7 +834,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                 this.Level = level;
                 this.Component = component;
                 this.Parent = parent;
-                this.children = new List<TraceForBaselineTesting>();
+                this.children = new List<ITrace>();
                 this.data = new Dictionary<string, object>();
             }
 
@@ -880,8 +880,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
             public ITrace StartChild(string name, TraceComponent component, TraceLevel level, [CallerMemberName] string memberName = "", [CallerFilePath] string sourceFilePath = "", [CallerLineNumber] int sourceLineNumber = 0)
             {
                 TraceForBaselineTesting child = new TraceForBaselineTesting(name, level, component, parent: this);
-                this.children.Add(child);
+                this.AddChild(child);
                 return child;
+            }
+
+            public void AddChild(ITrace trace)
+            {
+                this.children.Add(trace);
             }
 
             public static TraceForBaselineTesting GetRootTrace()


### PR DESCRIPTION
# Pull Request Template

## Description

After https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2097 the diagnostics for Bulk operations have been incomplete and missing retry information.

The first scenario (incomplete) is due to the root trace being created on the Context level not being properly wired down into the Bulk pipeline, so we were missing things like item serialization, or anything happening previous to the actual Network call.

For example, the current traces would show:

```
├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │   (
    │   │       [Client Configuration]
    │   │       Redacted To Not Change The Baselines From Run To Run
    │   │   )
    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                           (
    │   │                               [Client Side Request Stats]
    │   │                               Redacted To Not Change The Baselines From Run To Run
    │   │                           )
    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
```

It is losing any cache or serialization information. With this PR, we are wiring correctly the traces down:

```
└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   (
    │       [Client Configuration]
    │       Redacted To Not Change The Baselines From Run To Run
    │   )
    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │                           (
        │                               [Client Side Request Stats]
        │                               Redacted To Not Change The Baselines From Run To Run
        │                           )
        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
```

The other regression was regarding retries. When the operation had to be re-enqueued due to a retry scenario, a new Trace was created but it was not being leveraged anywhere, and the previous operation's diagnostics was lost.

In this scenario, if an operation is retrying due to throttles, the current implementation only exposes the diagnostics of the last Bulk execution:

```
└── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   (
    │       [Client Configuration]
    │       Redacted To Not Change The Baselines From Run To Run
    │   )
    ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds
    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │                           (
    │                               [Client Side Request Stats]
    │                               Redacted To Not Change The Baselines From Run To Run
    │                           )
    └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds 
```

With this PR, the diagnostics now contain the previous executions and the retry log lines:

```
└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   (
    │       [Client Configuration]
    │       Redacted To Not Change The Baselines From Run To Run
    │   )
    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                           (
    │   │                               [Client Side Request Stats]
    │   │                               Redacted To Not Change The Baselines From Run To Run
    │   │                           )
    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                           (
    │   │                               [Client Side Request Stats]
    │   │                               Redacted To Not Change The Baselines From Run To Run
    │   │                           )
    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   │                           (
    │   │                               [Client Side Request Stats]
    │   │                               Redacted To Not Change The Baselines From Run To Run
    │   │                           )
    │   └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    ├── Batch Retry Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
    └── Batch Dispatch Async(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        ├── Using Wait(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
        │                           (
        │                               [Client Side Request Stats]
        │                               Redacted To Not Change The Baselines From Run To Run
        │                           )
        └── Create Trace(00000000-0000-0000-0000-000000000000)  Batch-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
```

The PR completes the wiring and also adds baseline tests for retry scenarios. The existing baseline tests were reduced in size (we were capturing 100 operations and it made no sense to be that big).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Diagnostics example

```
{
    "name": "CreateItemAsync",
    "id": "3938c523-7555-4250-9864-1ddd64a7cbf3",
    "caller info": {
        "member": "OperationHelperWithRootTraceAsync",
        "file": "ClientContextCore.cs",
        "line": 219
    },
    "start time": "10:19:50:845",
    "duration in milliseconds": 1598.7744,
    "data": {
        "Client Configuration": {
            "Client Created Time Utc": "2021-05-11T22:19:47.7733878Z",
            "NumberOfClientsCreated": 1,
            "User Agent": "cosmos-netstandard-sdk/3.18.0|3.19.1|02|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.29916.01|F 00000001|",
            "ConnectionConfig": {
                "gw": "(cps:50, urto:10, p:False, httpf: False)",
                "rntbd": "(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: False, pr: ReuseUnicastPort)",
                "other": "(ed:False, be:True)"
            },
            "ConsistencyConfig": "(consistency: Strong, prgns:[])"
        }
    },
    "children": [
        {
            "name": "ItemSerialize",
            "id": "53e9ba0c-9606-4cb3-b05c-a7be99f9a6c8",
            "caller info": {
                "member": "ExtractPartitionKeyAndProcessItemStreamAsync",
                "file": "ContainerCore.Items.cs",
                "line": 931
            },
            "start time": "10:19:50:852",
            "duration in milliseconds": 5.5658
        },
        {
            "name": "Get Collection Cache",
            "id": "5f9bf6d0-ef95-447c-b63b-adef2871c4db",
            "caller info": {
                "member": "GetCollectionCacheAsync",
                "file": "DocumentClient.cs",
                "line": 546
            },
            "start time": "10:19:51:054",
            "duration in milliseconds": 0.0086
        },
        {
            "name": "Batch Dispatch Async",
            "id": "da76dc11-6062-4183-b2bf-4d589eefb391",
            "caller info": {
                "member": "DispatchAsync",
                "file": "BatchAsyncBatcher.cs",
                "line": 116
            },
            "start time": "10:19:51:595",
            "duration in milliseconds": 838.57120000000009,
            "children": [
                {
                    "name": "Using Wait",
                    "id": "05ccbc2a-0f65-40d9-82ec-2e0e0e310a7a",
                    "caller info": {
                        "member": "UsingWaitAsync",
                        "file": "Extensions.cs",
                        "line": 189
                    },
                    "start time": "10:19:51:920",
                    "duration in milliseconds": 0.0047
                },
                {
                    "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
                    "id": "54eafa7e-0ef8-40b2-bde2-d889152e0332",
                    "start time": "10:19:51:920",
                    "duration in milliseconds": 454.70410000000004,
                    "children": [
                        {
                            "name": "Get Collection Cache",
                            "id": "00498887-4221-4327-919c-54b1584c86c0",
                            "caller info": {
                                "member": "GetCollectionCacheAsync",
                                "file": "DocumentClient.cs",
                                "line": 546
                            },
                            "start time": "10:19:51:920",
                            "duration in milliseconds": 0.0012000000000000001
                        },
                        {
                            "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
                            "id": "5b1f5fe4-ac99-44d9-9890-582ddb0f6e56",
                            "start time": "10:19:51:928",
                            "duration in milliseconds": 446.72400000000005,
                            "data": {
                                "CPU Load History": {
                                    "CPU History": "(2021-05-11T22:19:48.3659150Z 100.000)"
                                }
                            },
                            "children": [
                                {
                                    "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
                                    "id": "91050636-fcc0-4940-a4c5-996773787874",
                                    "start time": "10:19:51:928",
                                    "duration in milliseconds": 446.7026,
                                    "children": [
                                        {
                                            "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
                                            "id": "6d550991-1e7b-4e9f-aaae-4ebad06d58e7",
                                            "start time": "10:19:51:928",
                                            "duration in milliseconds": 446.6286,
                                            "children": [
                                                {
                                                    "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
                                                    "id": "0dcb1ebb-c109-44fd-a036-3a2e3fa83aad",
                                                    "start time": "10:19:51:928",
                                                    "duration in milliseconds": 446.615,
                                                    "children": [
                                                        {
                                                            "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
                                                            "id": "ede921ac-9e36-4570-bddb-535206f87eb9",
                                                            "caller info": {
                                                                "member": "ProcessMessageAsync",
                                                                "file": "TransportHandler.cs",
                                                                "line": 109
                                                            },
                                                            "start time": "10:19:51:928",
                                                            "duration in milliseconds": 446.5049,
                                                            "data": {
                                                                "Client Side Request Stats": {
                                                                    "Id": "AggregatedClientSideRequestStatistics",
                                                                    "ContactedReplicas": [
                                                                        {
                                                                            "Count": 12,
                                                                            "Uri": "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer14/partitions/a4cb495a-38c8-11e6-8106-8cdcd42c33be/replicas/1p/"
                                                                        }
                                                                    ],
                                                                    "RegionsContacted": [
                                                                        "https://127.0.0.1:8081/"
                                                                    ],
                                                                    "FailedReplicas": [],
                                                                    "AddressResolutionStatistics": [
                                                                        {
                                                                            "StartTimeUTC": "2021-05-11T22:19:51.9859395Z",
                                                                            "EndTimeUTC": "2021-05-11T22:19:52.1712113Z",
                                                                            "TargetEndpoint": "https://127.0.0.1:8081//addresses/?$resolveFor=dbs%2fkjcOAA%3d%3d%2fcolls%2fkjcOAMVCXW8%3d%2fdocs&$filter=protocol eq rntbd&$partitionKeyRangeIds=0"
                                                                        }
                                                                    ],
                                                                    "StoreResponseStatistics": [
                                                                        {
                                                                            "ResponseTimeUTC": "2021-05-11T22:19:52.3498945Z",
                                                                            "ResourceType": "Document",
                                                                            "OperationType": "Batch",
                                                                            "LocationEndpoint": "https://127.0.0.1:8081/",
                                                                            "StoreResult": {
                                                                                "ActivityId": "7a60041d-372e-40a6-b106-7f10bd5d75ff",
                                                                                "StatusCode": "Ok",
                                                                                "SubStatusCode": "Unknown",
                                                                                "LSN": 2,
                                                                                "PartitionKeyRangeId": "0",
                                                                                "GlobalCommittedLSN": -1,
                                                                                "ItemLSN": -1,
                                                                                "UsingLocalLSN": false,
                                                                                "QuorumAckedLSN": 1,
                                                                                "SessionToken": "-1#2",
                                                                                "CurrentWriteQuorum": 1,
                                                                                "CurrentReplicaSetSize": 1,
                                                                                "NumberOfReadRegions": 0,
                                                                                "IsClientCpuOverloaded": false,
                                                                                "IsValid": true,
                                                                                "StorePhysicalAddress": "rntbd://127.0.0.1:10253/apps/DocDbApp/services/DocDbServer14/partitions/a4cb495a-38c8-11e6-8106-8cdcd42c33be/replicas/1p/",
                                                                                "RequestCharge": 386.29,
                                                                                "BELatencyInMs": "37.771",
                                                                                "TransportException": null
                                                                            }
                                                                        }
                                                                    ],
                                                                    "HttpResponseStats": [
                                                                        {
                                                                            "StartTimeUTC": "2021-05-11T22:19:52.1711325Z",
                                                                            "EndTimeUTC": "2021-05-11T22:19:52.1711329Z",
                                                                            "RequestUri": "https://127.0.0.1:8081//addresses/?$resolveFor=dbs%2fkjcOAA%3d%3d%2fcolls%2fkjcOAMVCXW8%3d%2fdocs&$filter=protocol eq rntbd&$partitionKeyRangeIds=0",
                                                                            "ResourceType": "Document",
                                                                            "HttpMethod": "GET",
                                                                            "ActivityId": "7a60041d-372e-40a6-b106-7f10bd5d75ff",
                                                                            "StatusCode": "OK"
                                                                        }
                                                                    ]
                                                                }
                                                            }
                                                        }
                                                    ]
                                                }
                                            ]
                                        }
                                    ]
                                }
                            ]
                        }
                    ]
                },
                {
                    "name": "Create Trace",
                    "id": "55329381-3913-4af3-a1ac-48682a21381a",
                    "caller info": {
                        "member": "FromResponseMessageAsync",
                        "file": "TransactionalBatchResponse.cs",
                        "line": 214
                    },
                    "start time": "10:19:52:375",
                    "duration in milliseconds": 51.1118
                }
            ]
        }
    ]
}
```