### PR TITLE
Permission: Fixes documentation on resource token range limits

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Permission/Permission.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Permission/Permission.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Reads a <see cref="PermissionProperties"/> from the Azure Cosmos service as an asynchronous operation. Each read will return a new ResourceToken with its respective expiration. 
         /// </summary>
-        /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 seconds, to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
+        /// <param name="tokenExpiryInSeconds">(Optional) The expiry time for resource token in seconds. This value can range from 10 minutes (or 600 seconds), to 24 hours (or 86,400 seconds). The default value for this is 1 hour (or 3,600 seconds). This does not change the default value for future tokens.</param>
         /// <param name="requestOptions">(Optional) The options for the permission request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>


### PR DESCRIPTION
# Pull Request Template

## Description
ResourceToken has a minimum expiry period of 10 minutes (or 600 seconds). In the current code documentation, it is captured as 10 seconds, which is not in parity with CosmosDB limits. Aim of the change, is to update the correct range in code documentation.

Supporting detail for 10 minutes:
1. https://github.com/Azure/azure-sdk-for-js/issues/10077
2. https://docs.microsoft.com/en-us/azure/cosmos-db/concepts-limits#per-request-limits
## Type of change
- [Non Breaking] Documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber