### PR TITLE
CosmosObjectDisposedException: Adds new exception to include traces and additional info

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -100,6 +100,7 @@ namespace Microsoft.Azure.Cosmos
         private bool isDisposed = false;
 
         internal static int numberOfClientsCreated;
+        internal DateTime? DisposedDateTimeUtc { get; private set; } = null;
 
         static CosmosClient()
         {
@@ -506,7 +507,10 @@ namespace Microsoft.Azure.Cosmos
         /// </returns>
         public virtual Task<AccountProperties> ReadAccountAsync()
         {
-            return ((IDocumentClientInternal)this.DocumentClient).GetDatabaseAccountInternalAsync(this.Endpoint);
+            return this.ClientContext.OperationHelperAsync(
+                nameof(CreateDatabaseAsync),
+                null,
+                (trace) => ((IDocumentClientInternal)this.DocumentClient).GetDatabaseAccountInternalAsync(this.Endpoint));
         }
 
         /// <summary>
@@ -1262,20 +1266,14 @@ namespace Microsoft.Azure.Cosmos
         {
             if (!this.isDisposed)
             {
+                this.DisposedDateTimeUtc = DateTime.UtcNow;
+
                 if (disposing)
                 {
                     this.ClientContext.Dispose();
                 }
 
                 this.isDisposed = true;
-            }
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (this.isDisposed)
-            {
-                throw new ObjectDisposedException($"Accessing {nameof(CosmosClient)} after it is disposed is invalid.");
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -433,6 +433,13 @@ namespace Microsoft.Azure.Cosmos
                 {
                     throw new CosmosOperationCanceledException(oe, trace);
                 }
+                catch (ObjectDisposedException objectDisposed) when (!(objectDisposed is CosmosObjectDisposedException))
+                {
+                    throw new CosmosObjectDisposedException(
+                        objectDisposed, 
+                        this.client, 
+                        trace);
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
@@ -1,0 +1,90 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections;
+    using System.Globalization;
+    using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Tracing;
+
+    /// <summary>
+    /// The exception is a wrapper for ObjectDisposedExceptions. This wrapper
+    /// adds a way to access the CosmosDiagnostics and appends additional information
+    /// to the message for easier troubleshooting.
+    /// </summary>
+    public class CosmosObjectDisposedException : ObjectDisposedException
+    {
+        private readonly ObjectDisposedException originalException;
+        private readonly CosmosClient cosmosClient;
+
+        /// <summary>
+        /// Create an instance of CosmosObjectDisposedException
+        /// </summary>
+        internal CosmosObjectDisposedException(
+            ObjectDisposedException originalException,
+            CosmosClient cosmosClient,
+            ITrace trace) 
+            : base(originalException.ObjectName)
+        {
+            this.cosmosClient = cosmosClient ?? throw new ArgumentNullException(nameof(CosmosClient));
+            this.originalException = originalException ?? throw new ArgumentNullException(nameof(originalException));
+
+            string disposedMessage = this.cosmosClient.DisposedDateTimeUtc.HasValue
+                ? $" Disposed at: {this.cosmosClient.DisposedDateTimeUtc.Value.ToString("o", CultureInfo.InvariantCulture)}"
+                : " NOT disposed";
+
+            this.Message = $"{originalException.Message} CosmosClient Endpoint: {this.cosmosClient.Endpoint}; Created at: {this.cosmosClient.ClientConfigurationTraceDatum.ClientCreatedDateTimeUtc.ToString("o", CultureInfo.InvariantCulture)}; " +
+                $"{disposedMessage}; UserAgent: {this.cosmosClient.ClientConfigurationTraceDatum.UserAgentContainer.UserAgent};";
+
+            if (trace == null)
+            {
+                throw new ArgumentNullException(nameof(trace));
+            }
+
+            this.Diagnostics = new CosmosTraceDiagnostics(trace);
+        }
+
+        /// <inheritdoc/>
+        public override string Source
+        {
+            get => this.originalException.Source;
+            set => this.originalException.Source = value;
+        }
+
+        /// <inheritdoc/>
+        public override string Message { get; }
+
+        /// <inheritdoc/>
+        public override string StackTrace => this.originalException.StackTrace;
+
+        /// <inheritdoc/>
+        public override IDictionary Data => this.originalException.Data;
+
+        /// <summary>
+        /// Gets the diagnostics for the request
+        /// </summary>
+        public CosmosDiagnostics Diagnostics { get; }
+
+        /// <inheritdoc/>
+        public override string HelpLink
+        {
+            get => this.originalException.HelpLink;
+            set => this.originalException.HelpLink = value;
+        }
+
+        /// <inheritdoc/>
+        public override Exception GetBaseException()
+        {
+            return this.originalException.GetBaseException();
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"{this.originalException} {Environment.NewLine}CosmosDiagnostics: {this.Diagnostics}";
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{this.originalException} {Environment.NewLine}CosmosDiagnostics: {this.Diagnostics}";
+            return $"{this.Message} {Environment.NewLine}CosmosDiagnostics: {this.Diagnostics} StackTrace: {this.StackTrace}";
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -67,6 +67,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                     Assert.IsNotNull(diagnostics);
                     Assert.IsFalse(diagnostics.Contains("NoOp"));
                     Assert.IsTrue(diagnostics.Contains("Client Configuration"));
+                    string exceptionString = e.ToString();
+                    Assert.IsTrue(exceptionString.Contains(diagnostics));
+                    Assert.IsTrue(exceptionString.Contains(e.Message));
+                    Assert.IsTrue(exceptionString.Contains(e.StackTrace));
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This is adding a new CosmosObjectDisposedException which includes the traces and adds additional info like when the client was disposed of.

Examples Message:
```
Cannot access a disposed object.
Object name: 'Accessing CosmosClient after it is disposed is invalid.'. CosmosClient Endpoint: https://localtestcosmos.documents.azure.com/; Created at: 2021-05-14T13:44:54.1044250Z;  Disposed at: 2021-05-14T13:44:55.1164461Z; UserAgent: cosmos-netstandard-sdk/3.18.0|3.19.1|01|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|;
```

Example ToString()
```
Cannot access a disposed object.
Object name: 'Accessing CosmosClient after it is disposed is invalid.'. CosmosClient Endpoint: https://localtestcosmos.documents.azure.com/; Created at: 2021-05-14T13:44:54.1044250Z;  Disposed at: 2021-05-14T13:44:55.1164461Z; UserAgent: cosmos-netstandard-sdk/3.18.0|3.19.1|01|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|; 
CosmosDiagnostics: {"name":"ReadItemAsync","id":"4595c19f-527c-4a72-9212-4b601b1c90c2","caller info":{"member":"OperationHelperWithRootTraceAsync","file":"ClientContextCore.cs","line":219},"start time":"01:45:08:337","duration in milliseconds":170.58,"data":{"Client Configuration":{"Client Created Time Utc":"2021-05-14T13:44:54.1044250Z","NumberOfClientsCreated":1,"User Agent":"cosmos-netstandard-sdk/3.18.0|3.19.1|01|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|","ConnectionConfig":{"gw":"(cps:50, urto:10, p:False, httpf: False)","rntbd":"(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: False, pr: ReuseUnicastPort)","other":"(ed:False, be:False)"},"ConsistencyConfig":"(consistency: Strong, prgns:[])"}}} StackTrace:    at Microsoft.Azure.Cosmos.ClientContextCore.ThrowIfDisposed() in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\ClientContextCore.cs:line 519
   at Microsoft.Azure.Cosmos.ClientContextCore.ProcessResourceOperationStreamAsync(String resourceUri, ResourceType resourceType, OperationType operationType, RequestOptions requestOptions, ContainerInternal cosmosContainerCore, Nullable`1 partitionKey, String itemId, Stream streamPayload, Action`1 requestEnricher, ITrace trace, CancellationToken cancellationToken) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\ClientContextCore.cs:line 269
   at Microsoft.Azure.Cosmos.ContainerCore.ProcessItemStreamAsync(Nullable`1 partitionKey, String itemId, Stream streamPayload, OperationType operationType, ItemRequestOptions requestOptions, ITrace trace, CancellationToken cancellationToken) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\Container\ContainerCore.Items.cs:line 1011
   at Microsoft.Azure.Cosmos.ContainerCore.ReadItemAsync[T](String id, PartitionKey partitionKey, ITrace trace, ItemRequestOptions requestOptions, CancellationToken cancellationToken) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\Container\ContainerCore.Items.cs:line 118
   at Microsoft.Azure.Cosmos.ClientContextCore.RunWithDiagnosticsHelperAsync[TResult](ITrace trace, Func`2 task) in C:\azure-cosmos-dotnet-v3\Microsoft.Azure.Cosmos\src\Resource\ClientContextCore.cs:line 430
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber