### PR TITLE
[Preview] ContainerRequestOptions: Adds PopulateAnalyticalMigrationProgress for Synapse link migration preview

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6825,6 +6825,11 @@ namespace Microsoft.Azure.Cosmos
                 headers.Set(HttpConstants.HttpHeaders.PopulateQuotaInfo, bool.TrueString);
             }
 
+            //if (options.PopulateAnalyticalMigrationProgress)
+            //{
+            //    headers.Set(HttpConstants.HttpHeaders.PopulateAnalyticalMigrationProgress, bool.TrueString);
+            //}
+
             if (options.PopulateRestoreStatus)
             {
                 headers.Set(HttpConstants.HttpHeaders.PopulateRestoreStatus, bool.TrueString);

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6825,11 +6825,6 @@ namespace Microsoft.Azure.Cosmos
                 headers.Set(HttpConstants.HttpHeaders.PopulateQuotaInfo, bool.TrueString);
             }
 
-            //if (options.PopulateAnalyticalMigrationProgress)
-            //{
-            //    headers.Set(HttpConstants.HttpHeaders.PopulateAnalyticalMigrationProgress, bool.TrueString);
-            //}
-
             if (options.PopulateRestoreStatus)
             {
                 headers.Set(HttpConstants.HttpHeaders.PopulateRestoreStatus, bool.TrueString);

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
@@ -12,28 +12,30 @@ namespace Microsoft.Azure.Cosmos
     public class ContainerRequestOptions : RequestOptions
     {
         /// <summary>
-        ///  Gets or sets the <see cref="PopulateQuotaInfo"/> for document collection read requests in the Azure Cosmos DB service.
+        ///  Gets or sets the <see cref="PopulateQuotaInfo"/> for container read requests in the Azure Cosmos DB service.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// PopulateQuotaInfo is used to enable/disable getting document collection quota related stats for document collection read requests.
+        /// PopulateQuotaInfo is used to enable/disable getting container quota related stats for container read requests.
         /// </para>
         /// </remarks>
         public bool PopulateQuotaInfo { get; set; }
 
         /// <summary>
-        ///  Gets or sets the <see cref="PopulateAnalyticalMigrationProgress"/> for document collection read requests in the Azure Cosmos DB service.
+        ///  Gets or sets the <see cref="PopulateAnalyticalMigrationProgress"/> for container read requests in the Azure Cosmos DB service.
         /// </summary>
         /// <remarks>
         /// <para>
-        /// PopulateAnalyticalMigrationProgress is used to enable/disable getting analytical migration progress for document collection read requests.
+        /// PopulateAnalyticalMigrationProgress is used to enable/disable getting analytical migration progress for container read requests.
+        /// The response header "x-ms-cosmos-analytical-migration-progress" will contain an integer representing the percentage progress of analytical migration. 
+        /// The response header will be between 0 and 99 for containers that are undergoing analytical migration, 100 for containers that have finished migration, and -1 otherwise.
         /// </para>
         /// </remarks>
 #if PREVIEW
         public
 #else
         internal
-        #endif
+#endif
         bool PopulateAnalyticalMigrationProgress { get; set; }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
@@ -29,12 +29,12 @@ namespace Microsoft.Azure.Cosmos
         /// PopulateAnalyticalMigrationProgress is used to enable/disable getting analytical migration progress for document collection read requests.
         /// </para>
         /// </remarks>
-        #if PREVIEW
-            public
-        #else
-            internal
+#if PREVIEW
+        public
+#else
+        internal
         #endif
-            bool PopulateAnalyticalMigrationProgress { get; set; }
+        bool PopulateAnalyticalMigrationProgress { get; set; }
 
         /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/ContainerRequestOptions.cs
@@ -22,6 +22,21 @@ namespace Microsoft.Azure.Cosmos
         public bool PopulateQuotaInfo { get; set; }
 
         /// <summary>
+        ///  Gets or sets the <see cref="PopulateAnalyticalMigrationProgress"/> for document collection read requests in the Azure Cosmos DB service.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// PopulateAnalyticalMigrationProgress is used to enable/disable getting analytical migration progress for document collection read requests.
+        /// </para>
+        /// </remarks>
+        #if PREVIEW
+            public
+        #else
+            internal
+        #endif
+            bool PopulateAnalyticalMigrationProgress { get; set; }
+
+        /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties
         /// </summary>
         /// <param name="request">The <see cref="RequestMessage"/></param>
@@ -30,6 +45,11 @@ namespace Microsoft.Azure.Cosmos
             if (this.PopulateQuotaInfo)
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.PopulateQuotaInfo, bool.TrueString);
+            }
+
+            if (this.PopulateAnalyticalMigrationProgress)
+            {
+                request.Headers.Add(HttpConstants.HttpHeaders.PopulateAnalyticalMigrationProgress, bool.TrueString);
             }
 
             base.PopulateRequestOptions(request);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -93,30 +93,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task PopulateAnalyticalMigrationTest()
-        {
-            ContainerProperties cp = new ContainerProperties()
-            {
-                Id = "NonMigrationContainer",
-                PartitionKeyPath = "/pk"
-            };
-
-            ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
-            Container container = response;
-
-            // Progress should be -1, as there is no migration involved.
-            ContainerRequestOptions requestOptions = new ContainerRequestOptions
-            {
-                PopulateAnalyticalMigrationProgress = true
-            };
-
-            ContainerResponse readResponse = await container.ReadContainerAsync(requestOptions);
-            string analyticalMigrationProgress = readResponse.Headers["x-ms-cosmos-analytical-migration-progress"];
-            Assert.IsNotNull(analyticalMigrationProgress);
-            Assert.AreEqual(-1, int.Parse(analyticalMigrationProgress));
-        }
-
-        [TestMethod]
         public async Task ContainerContractTest()
         {
             ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
@@ -1550,6 +1526,32 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 Assert.IsTrue(ex.Message.Contains("Paths which are part of the partition key may not be included in the ClientEncryptionPolicy."));
             }
+        }
+
+
+        [Ignore] // Lack of emulator support
+        [TestMethod]
+        public async Task PopulateAnalyticalMigrationTest()
+        {
+            ContainerProperties cp = new ContainerProperties()
+            {
+                Id = "NonMigrationContainer",
+                PartitionKeyPath = "/pk"
+            };
+
+            ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
+            Container container = response;
+
+            // Progress should be -1, as there is no migration involved.
+            ContainerRequestOptions requestOptions = new ContainerRequestOptions
+            {
+                PopulateAnalyticalMigrationProgress = true
+            };
+
+            ContainerResponse readResponse = await container.ReadContainerAsync(requestOptions);
+            string analyticalMigrationProgress = readResponse.Headers["x-ms-cosmos-analytical-migration-progress"];
+            Assert.IsNotNull(analyticalMigrationProgress);
+            Assert.AreEqual(-1, int.Parse(analyticalMigrationProgress));
         }
 
         private void ValidateCreateContainerResponseContract(ContainerResponse containerResponse)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -93,6 +93,35 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task PopulateAnalyticalMigrationTest()
+        {
+            ContainerProperties cp = new ContainerProperties()
+            {
+                Id = "NonMigrationContainer",
+                PartitionKeyPath = "/pk",
+                IndexingPolicy = new Cosmos.IndexingPolicy()
+                {
+                    Automatic = false,
+                },
+                AnalyticalStoreTimeToLiveInSeconds = 10
+            };
+
+            ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);
+            Container container = response;
+
+            // Progress should be -1, as there is no migration involved.
+            ContainerRequestOptions requestOptions = new ContainerRequestOptions
+            {
+                PopulateAnalyticalMigrationProgress = true
+            };
+
+            ContainerResponse readResponse = await container.ReadContainerAsync(requestOptions);
+            string analyticalMigrationProgress = readResponse.Headers["x-ms-cosmos-analytical-migration-progress"];
+            Assert.IsNotNull(analyticalMigrationProgress);
+            Assert.AreEqual(-1, int.Parse(analyticalMigrationProgress));
+        }
+
+        [TestMethod]
         public async Task ContainerContractTest()
         {
             ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -98,12 +98,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ContainerProperties cp = new ContainerProperties()
             {
                 Id = "NonMigrationContainer",
-                PartitionKeyPath = "/pk",
-                IndexingPolicy = new Cosmos.IndexingPolicy()
-                {
-                    Automatic = false,
-                },
-                AnalyticalStoreTimeToLiveInSeconds = 10
+                PartitionKeyPath = "/pk"
             };
 
             ContainerResponse response = await this.cosmosDatabase.CreateContainerAsync(cp);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
@@ -1436,7 +1436,7 @@
             │       └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
                 └── [9F-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,BF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-                    └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds 
+                    └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
 ]]></Text>
       <Json><![CDATA[{
   "name": "Trace For Baseline Testing",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -980,6 +980,31 @@
       },
       "NestedTypes": {}
     },
+    "Microsoft.Azure.Cosmos.ContainerRequestOptions;Microsoft.Azure.Cosmos.RequestOptions;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Boolean get_PopulateAnalyticalMigrationProgress()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Boolean get_PopulateAnalyticalMigrationProgress();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Boolean PopulateAnalyticalMigrationProgress": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Boolean PopulateAnalyticalMigrationProgress;CanRead:True;CanWrite:True;Boolean get_PopulateAnalyticalMigrationProgress();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_PopulateAnalyticalMigrationProgress(Boolean);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_PopulateAnalyticalMigrationProgress(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_PopulateAnalyticalMigrationProgress(Boolean);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
     "Microsoft.Azure.Cosmos.CosmosClient;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
@@ -1597,6 +1622,31 @@
               "Type": "Method",
               "Attributes": [],
               "MethodInfo": "Void set_PageSizeHint(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+            }
+          },
+          "NestedTypes": {}
+        },
+        "Microsoft.Azure.Cosmos.ContainerRequestOptions;Microsoft.Azure.Cosmos.RequestOptions;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+          "Subclasses": {},
+          "Members": {
+            "Boolean get_PopulateAnalyticalMigrationProgress()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Boolean get_PopulateAnalyticalMigrationProgress();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+            },
+            "Boolean PopulateAnalyticalMigrationProgress": {
+              "Type": "Property",
+              "Attributes": [],
+              "MethodInfo": "Boolean PopulateAnalyticalMigrationProgress;CanRead:True;CanWrite:True;Boolean get_PopulateAnalyticalMigrationProgress();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_PopulateAnalyticalMigrationProgress(Boolean);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+            },
+            "Void set_PopulateAnalyticalMigrationProgress(Boolean)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+              "Type": "Method",
+              "Attributes": [
+                "CompilerGeneratedAttribute"
+              ],
+              "MethodInfo": "Void set_PopulateAnalyticalMigrationProgress(Boolean);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             }
           },
           "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientResourceUnitTests.cs
@@ -132,6 +132,25 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             Assert.IsNotNull(container.BatchExecutor);
         }
 
+        [TestMethod]
+        public void ValidateSetContainerRequestOptions()
+        {
+            ContainerRequestOptions options = new ContainerRequestOptions
+            {
+                PopulateAnalyticalMigrationProgress = true,
+                PopulateQuotaInfo = true
+            };
+
+            RequestMessage httpRequest = new RequestMessage(
+                HttpMethod.Post,
+                new Uri("/dbs/testdb/colls/testcontainer/docs/testId", UriKind.Relative));
+
+            options.PopulateRequestOptions(httpRequest);
+
+            Assert.IsTrue(httpRequest.Headers.TryGetValue(HttpConstants.HttpHeaders.PopulateAnalyticalMigrationProgress, out string populateAnalyticalMigrationProgress));
+            Assert.IsTrue(httpRequest.Headers.TryGetValue(HttpConstants.HttpHeaders.PopulateQuotaInfo, out string populateQuotaInfo));
+        }
+
         private CosmosClientContext CreateMockClientContext(bool allowBulkExecution = false)
         {
             Mock<CosmosClient> mockClient = new Mock<CosmosClient>();


### PR DESCRIPTION
# Pull Request Template

## Description

Added PopulateAnalyticalMigrationProgress to ContainerRequestOptions, which populates the HTTP header "x-ms-cosmos-populate-analytical-migration-progress". When this header is provided on collection reads, the response header "x-ms-cosmos-analytical-migration-progress" will contain an integer representing the percentage progress of analytical store migration (Synapse link migration). This header will be -1 for containers that haven't used analytical store migration and 100 for containers that are ready to be queried by Synapse link connectors (Spark/SQL OD).

Example of the API in use on a collection that is undergoing analytical store migration:
```
ContainerResponse containerResponse = await client.GetContainer("db1", "coll1").
    ReadContainerAsync(new ContainerRequestOptions
    { PopulateAnalyticalMigrationProgress = true });

return int.Parse(containerResponse.Headers["x-ms-cosmos-analytical-migration-progress"]);
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update