### PR TITLE
Change Feed: Fixes unknown exceptions handling

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -259,6 +259,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     trace,
                     out CosmosException cosmosException))
                 {
+                    this.hasMoreResults = false;
                     throw enumerator.Current.Exception;
                 }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     trace,
                     out CosmosException cosmosException))
                 {
+                    this.hasMoreResults = false;
                     throw createException;
                 }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/CrossPartitionChangeFeedAsyncEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/CrossPartitionChangeFeedAsyncEnumeratorTests.cs
@@ -378,7 +378,7 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
                 It.IsAny<CancellationToken>()), Times.Never);
         }
 
-        [DataTestMethod]
+        [TestMethod]
         public async Task ShouldReturnTryCatchOnException()
         {
             ReadOnlyMemory<FeedRangeState<ChangeFeedState>> rangeStates = new FeedRangeState<ChangeFeedState>[]{

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
@@ -202,6 +202,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                             state: feedRangeState.State)));
             }
 
+            if (this.ShouldThrowException(out Exception exception))
+            {
+                //throw exception;
+                return Task.FromResult(TryCatch<ChangeFeedPage>.FromException(exception));
+            }
+
             return this.documentContainer.MonadicChangeFeedAsync(
                 feedRangeState,
                 changeFeedPaginationOptions,
@@ -253,17 +259,29 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             && this.failureConfigs.InjectEmptyPages
             && ((this.random.Next() % 2) == 0);
 
+        private bool ShouldThrowException(out Exception exception)
+        {
+            exception = this.failureConfigs.ThrowException;
+            return this.failureConfigs != null && this.failureConfigs.ThrowException != null;
+}
+
         public sealed class FailureConfigs
         {
-            public FailureConfigs(bool inject429s, bool injectEmptyPages)
+            public FailureConfigs(
+                bool inject429s, 
+                bool injectEmptyPages,
+                Exception throwException = null)
             {
                 this.Inject429s = inject429s;
                 this.InjectEmptyPages = injectEmptyPages;
+                this.ThrowException = throwException;
             }
 
             public bool Inject429s { get; }
 
             public bool InjectEmptyPages { get; }
+
+            public Exception ThrowException { get; }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/FlakyDocumentContainer.cs
@@ -204,8 +204,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
             if (this.ShouldThrowException(out Exception exception))
             {
-                //throw exception;
-                return Task.FromResult(TryCatch<ChangeFeedPage>.FromException(exception));
+                throw exception;
+            }
+
+            if (this.ShouldReturnFailure(out Exception failure))
+            {
+                return Task.FromResult(TryCatch<ChangeFeedPage>.FromException(failure));
             }
 
             return this.documentContainer.MonadicChangeFeedAsync(
@@ -263,18 +267,26 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         {
             exception = this.failureConfigs.ThrowException;
             return this.failureConfigs != null && this.failureConfigs.ThrowException != null;
-}
+        }
+
+        private bool ShouldReturnFailure(out Exception exception)
+        {
+            exception = this.failureConfigs.ReturnFailure;
+            return this.failureConfigs != null && this.failureConfigs.ReturnFailure != null;
+        }
 
         public sealed class FailureConfigs
         {
             public FailureConfigs(
                 bool inject429s, 
                 bool injectEmptyPages,
-                Exception throwException = null)
+                Exception throwException = null,
+                Exception returnFailure = null)
             {
                 this.Inject429s = inject429s;
                 this.InjectEmptyPages = injectEmptyPages;
                 this.ThrowException = throwException;
+                this.ReturnFailure = returnFailure;
             }
 
             public bool Inject429s { get; }
@@ -282,6 +294,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             public bool InjectEmptyPages { get; }
 
             public Exception ThrowException { get; }
+
+            public Exception ReturnFailure { get; }
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

The pagination library uses a nesting approach to tackle the different scenarios: Read Feed, Query, and Change Feed.

Iterators like the `ChangeFeedIterator` leverage a specialized Enumerator (`CrossPartitionChangeFeedAsyncEnumerator`) on top `CrossPartitionRangePageAsyncEnumerator` which maintains a queue of `PartitionRangePageAsyncEnumerator` which then leverage `NetworkAttachedDocumentContainer`.

```
         ChangeFeedIterator
                         |
                         |
CrossPartitionChangeFeedAsyncEnumerator
                         |
                         |
CrossPartitionRangePageAsyncEnumerator
                         |
                         |
PartitionRangePageAsyncEnumerator
                         |
                         |
NetworkAttachedDocumentContainer
                         |
                         |
CosmosClientContext pipeline
```

All the AsyncEnumerators use `TryCatch` monads under the assumption that the lowest level (DocumentContainer) will never throw an unhandled exception but there is no safeguard. Any code issue or unknown condition that bubbles an exception accidentally can happen.

The `CrossPartitionRangePageAsyncEnumerator` works by maintaining a `Queue` of `PartitionRangePageAsyncEnumerator` and it Dequeues them, process them, and then re-queues them for a later iteration execution.

The problem is that, if the lower level `NetworkAttachedDocumentContainer` throws an unhandled exception, since there are no try/catch explicit mechanics, this happens between the `CrossPartitionRangePageAsyncEnumerator` dequeueing the `PartitionRangePageAsyncEnumerator` and re-queueing it again.

In a normal flow:

1. User calls ReadNext on the iterator
2. CrossPartitionRangePageAsyncEnumerator dequeues PartitionRangePageAsyncEnumerator
3. PartitionRangePageAsyncEnumerator executes and fetches result
4. CrossPartitionRangePageAsyncEnumerator  re-queues PartitionRangePageAsyncEnumerator

But if an exception happens on step 3, there is no re-queueing, it leaves the Enumerator in a non-recoverable state with an empty Queue. 
If the Iterator still has the `HasMoreResults` flag as true and the user calls `ReadNext` again, they get the error in the related Issue.

### What are the particular fixes

1. On an unknown type of exception, ChangeFeedIterator will have HasMoreResults = false, which exists a user loop (previously it would not change this, causing users automatically looping and calling ReadNext again).
2. Add explicit try/catch handling on the base `PartitionRangePageAsyncEnumerator` which will help all Enumerator implementations in case of unhandled exceptions from the `NetworkAttachedDocumentContainer`

Added new tests to validate and define expectations of `HasMoreResults` on the different cases:

* Non-Retriable CosmosException
* Retriable CosmosException
* Unknown exception, like TaskCanceledException
* Unhandled exception in the DocumentContainer or lower levels

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #2473