### PR TITLE
UserAgent: Adds flag to user agent to show if region failover is configured

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -828,19 +828,40 @@ namespace Microsoft.Azure.Cosmos
                 features |= CosmosClientOptionsFeatures.HttpClientFactory;
             }
 
+            string featureString = null;
             if (features != CosmosClientOptionsFeatures.NoFeatures)
             {
-                string featureString = Convert.ToString((int)features, 2).PadLeft(8, '0');
-                if (!string.IsNullOrEmpty(featureString))
-                {
-                    userAgent.SetFeatures(featureString);
-                }
+                featureString = Convert.ToString((int)features, 2).PadLeft(8, '0');
             }
+
+            string regionConfiguration = this.GetRegionConfiguration();
+            userAgent.SetFeatures(featureString, regionConfiguration);
 
             if (!string.IsNullOrEmpty(this.ApplicationName))
             {
                 userAgent.Suffix = this.ApplicationName;
             }
+        }
+
+        /// <summary>
+        /// This generates a key that added to the user agent to make it 
+        /// possible to determine if the SDK has region failover enabled.
+        /// </summary>
+        /// <returns>Format Reg-{L (Limit to single region)}-S(application region)|L(List of regions)|N(None, user did not configure it)</returns>
+        private string GetRegionConfiguration()
+        {
+            string regionConfig = this.LimitToEndpoint ? "L" : string.Empty;
+            if (!string.IsNullOrEmpty(this.ApplicationRegion))
+            {
+                return regionConfig + "S";
+            }
+
+            if (this.ApplicationPreferredRegions != null)
+            {
+                return regionConfig + "L";
+            }
+
+            return regionConfig + "N";
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -847,10 +847,10 @@ namespace Microsoft.Azure.Cosmos
         /// This generates a key that added to the user agent to make it 
         /// possible to determine if the SDK has region failover enabled.
         /// </summary>
-        /// <returns>Format Reg-{L (Limit to single region)}-S(application region)|L(List of regions)|N(None, user did not configure it)</returns>
+        /// <returns>Format Reg-{D (Disabled discovery)}-S(application region)|L(List of preferred regions)|N(None, user did not configure it)</returns>
         private string GetRegionConfiguration()
         {
-            string regionConfig = this.LimitToEndpoint ? "L" : string.Empty;
+            string regionConfig = this.LimitToEndpoint ? "D" : string.Empty;
             if (!string.IsNullOrEmpty(this.ApplicationRegion))
             {
                 return regionConfig + "S";

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -31,10 +31,14 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal void SetFeatures(string features)
+        internal void SetFeatures(
+            string features,
+            string regionConfiguration)
         {
             // Regenerate base user agent to account for features
-            this.cosmosBaseUserAgent = this.CreateBaseUserAgentString(features);
+            this.cosmosBaseUserAgent = this.CreateBaseUserAgentString(
+                features: features,
+                regionConfiguration: regionConfiguration);
             this.Suffix = string.Empty;
         }
 
@@ -55,7 +59,9 @@ namespace Microsoft.Azure.Cosmos
             runtimeFramework = environmentInformation.RuntimeFramework;
         }
 
-        private string CreateBaseUserAgentString(string features = null)
+        private string CreateBaseUserAgentString(
+            string features = null,
+            string regionConfiguration = null)
         {
             this.GetEnvironmentInformation(
                 out string clientVersion,
@@ -73,6 +79,11 @@ namespace Microsoft.Azure.Cosmos
             // Regex replaces all special characters with empty space except . - | since they do not cause format exception for the user agent string.
             // Do not change the cosmos-netstandard-sdk as it is required for reporting
             string baseUserAgent = $"cosmos-netstandard-sdk/{clientVersion}" + Regex.Replace($"|{directVersion}|{clientId}|{processArchitecture}|{operatingSystem}|{runtimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
+
+            if (!string.IsNullOrEmpty(regionConfiguration))
+            {
+                baseUserAgent += $"{regionConfiguration}|";
+            }
 
             if (!string.IsNullOrEmpty(features))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -115,10 +115,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             {
-                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
-                cosmosClientOptions.LimitToEndpoint = true;
-                // L - Limit endpoint, N - None. The user did not configure anything
-                string userAgentContentToValidate = "|LN|";
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
+                {
+                    LimitToEndpoint = true
+                };
+                // D - Disabled endpoint discovery, N - None. The user did not configure anything
+                string userAgentContentToValidate = "|DN|";
                 await this.ValidateUserAgentStringAsync(
                     cosmosClientOptions,
                     userAgentContentToValidate,
@@ -127,9 +129,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             {
-                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
-                cosmosClientOptions.LimitToEndpoint = false;
-                cosmosClientOptions.ApplicationRegion = Regions.EastUS;
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
+                {
+                    ApplicationRegion = Regions.EastUS
+                };
 
                 // S - Single application region is set
                 string userAgentContentToValidate = "|S|";
@@ -141,13 +144,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             {
-                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions();
-                cosmosClientOptions.LimitToEndpoint = false;
-                cosmosClientOptions.ApplicationRegion = null;
-                cosmosClientOptions.ApplicationPreferredRegions = new List<string>()
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
                 {
-                    Regions.EastUS,
-                    Regions.WestUS
+                    LimitToEndpoint = false,
+                    ApplicationRegion = null,
+                    ApplicationPreferredRegions = new List<string>()
+                    {
+                        Regions.EastUS,
+                        Regions.WestUS
+                    }
                 };
 
                 // L - List of region is set


### PR DESCRIPTION
# Pull Request Template

## Description

Do to recent outages and customer issues a flag is being added to the user agent to show if a client is properly configure to failover to new region in the case of a region outage.

D - Endpoint discovery disabled
S - Single application region is configured
L - List of regions specified
N - No regions specified

Default:
`cosmos-netstandard-sdk/3.18.0|3.19.1|02|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|N|`

Endpoint discovery disabled with no region specified
`cosmos-netstandard-sdk/3.18.0|3.19.1|05|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|DN|`

Endpoint discovery disabled with application region set
`cosmos-netstandard-sdk/3.18.0|3.19.1|05|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|DS|`

Endpoint discovery enabled with application region set
`cosmos-netstandard-sdk/3.18.0|3.19.1|05|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|S|`

Endpoint discovery enabled with preferred region list set
`cosmos-netstandard-sdk/3.18.0|3.19.1|05|X64|Microsoft Windows 10.0.19043 |.NET Core 4.6.30015.01|L|`

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber