### PR TITLE
Change Feed: Fixes CancellationToken support on ChangeFeedIterator

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs
@@ -249,6 +249,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             }
 
             CrossPartitionChangeFeedAsyncEnumerator enumerator = monadicEnumerator.Result;
+            enumerator.SetCancellationToken(cancellationToken);
+
             try
             {
                 if (!await enumerator.MoveNextAsync(trace))

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     internal sealed class CrossPartitionChangeFeedAsyncEnumerator : IAsyncEnumerator<TryCatch<CrossFeedRangePage<ChangeFeedPage, ChangeFeedState>>>
     {
         private readonly CrossPartitionRangePageAsyncEnumerator<ChangeFeedPage, ChangeFeedState> crossPartitionEnumerator;
-        private readonly CancellationToken cancellationToken;
+        private CancellationToken cancellationToken;
         private TryCatch<CrossFeedRangePage<ChangeFeedPage, ChangeFeedState>>? bufferedException;
 
         private CrossPartitionChangeFeedAsyncEnumerator(
@@ -135,6 +135,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
 
         public void SetCancellationToken(CancellationToken cancellationToken)
         {
+            this.cancellationToken = cancellationToken;
             this.crossPartitionEnumerator.SetCancellationToken(cancellationToken);
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
             }
         }
 
+        public void SetCancellationToken(CancellationToken cancellationToken)
+        {
+            this.crossPartitionEnumerator.SetCancellationToken(cancellationToken);
+        }
+
         public static CrossPartitionChangeFeedAsyncEnumerator Create(
             IDocumentContainer documentContainer,
             CrossFeedRangeState<ChangeFeedState> state,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -775,6 +775,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                 await feedIterator.ReadNextAsync(cancellationTokenSource.Token);
                 Assert.AreEqual(cancellationTokenSource.Token, cancellationTokenHandler.LastUsedToken, "The token passed did not reach the pipeline");
                 Assert.Fail("Expected exception.");
+                cancellationTokenHandler.ResetToken();
             }
             catch (OperationCanceledException)
             {
@@ -839,6 +840,12 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         private class CancellationTokenRequestHandler : RequestHandler
         {
             public CancellationToken LastUsedToken { get; private set;  }
+
+            public void ResetToken()
+            {
+                this.LastUsedToken = default;
+            }
+
             public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
             {
                 this.LastUsedToken = cancellationToken;


### PR DESCRIPTION
## Description

After the refactoring in #1933, the user CancellationToken on ReadNexAsync is not flowing into the pipeline.

The current nested Enumerator design requires enumerators to pass down the CancellationToken through calls to `SetCancellationToken` to the next Enumerator.

Since the Enumerators are following the `IAsyncEnumerator` API, it does not pass a CancellationToken on the `MoveNext` API call.

The `CrossPartitionChangeFeedAsyncEnumerator` was missing the `SetCancellationToken` implementation required to pass down the token.

This PR fixes the `ChangeFeedIteratorCore` to invoke the `CrossPartitionChangeFeedAsyncEnumerator.SetCancellationToken` to pass the token, if any, down the pipeline. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #2478