### PR TITLE
Change Feed Processor: Adds support for Graph API accounts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     [JsonConverter(typeof(DocumentServiceLeaseConverter))]
     internal abstract class DocumentServiceLease
     {
+        public const string IdPropertyName = "id";
+        public const string LeasePartitionKeyPropertyName = "partitionKey";
+
         /// <summary>
         /// Gets the processing distribution unit identifier.
         /// </summary>
@@ -52,6 +55,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         /// Gets the lease Id.
         /// </summary>
         public abstract string Id { get; }
+
+        /// <summary>
+        /// Gets the lease PartitionKey.
+        /// </summary>
+        public abstract string PartitionKey { get; set;  }
 
         /// <summary>
         /// Gets the Concurrency Token.

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         /// <summary>
         /// Gets the lease PartitionKey.
         /// </summary>
-        public abstract string PartitionKey { get; set;  }
+        public abstract string PartitionKey { get; }
 
         /// <summary>
         /// Gets the Concurrency Token.

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCheckpointerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCheckpointerCore.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             return await this.leaseUpdater.UpdateLeaseAsync(
                 lease,
                 lease.Id,
-                this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                 serverLease =>
                 {
                     if (serverLease.Owner != lease.Owner)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
@@ -26,11 +26,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         [JsonProperty(IdPropertyName)]
         public string LeaseId { get; set; }
 
-        /// <summary>
-        /// Gets or sets property to be used as partition key path for lease collections.
-        /// This is clone of existing Id property to maintain backward compat.
-        /// This property name is compatible to both GremlinAccounts and SqlAccounts
-        /// </summary>
         [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
         public override string PartitionKey { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
@@ -23,8 +23,16 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         {
         }
 
-        [JsonProperty("id")]
+        [JsonProperty(IdPropertyName)]
         public string LeaseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets property to be used as partition key path for lease collections.
+        /// This is clone of existing Id property to maintain backward compat.
+        /// This property name is compatible to both GremlinAccounts and SqlAccounts
+        /// </summary>
+        [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
+        public override string PartitionKey { get; set; }
 
         [JsonProperty("version")]
         public DocumentServiceLeaseVersion Version => DocumentServiceLeaseVersion.PartitionKeyRangeBasedLease;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         public string LeaseId { get; set; }
 
         [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
-        public override string PartitionKey { get; set; }
+        public string LeasePartitionKey { get; set; }
+
+        [JsonIgnore]
+        public override string PartitionKey => this.LeasePartitionKey;
 
         [JsonProperty("version")]
         public DocumentServiceLeaseVersion Version => DocumentServiceLeaseVersion.PartitionKeyRangeBasedLease;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
@@ -24,7 +24,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         public string LeaseId { get; set; }
 
         [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
-        public override string PartitionKey { get; set; }
+        public string LeasePartitionKey { get; set; }
+
+        [JsonIgnore]
+        public override string PartitionKey => this.LeasePartitionKey;
 
         [JsonProperty("version")]
         public DocumentServiceLeaseVersion Version => DocumentServiceLeaseVersion.EPKRangeBasedLease;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
@@ -23,11 +23,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         [JsonProperty(IdPropertyName)]
         public string LeaseId { get; set; }
 
-        /// <summary>
-        /// Gets or sets property to be used as partition key path for lease collections.
-        /// This is clone of existing Id property to maintain backward compat.
-        /// This property name is compatible to both GremlinAccounts and SqlAccounts
-        /// </summary>
         [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
         public override string PartitionKey { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
@@ -20,8 +20,16 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         {
         }
 
-        [JsonProperty("id")]
+        [JsonProperty(IdPropertyName)]
         public string LeaseId { get; set; }
+
+        /// <summary>
+        /// Gets or sets property to be used as partition key path for lease collections.
+        /// This is clone of existing Id property to maintain backward compat.
+        /// This property name is compatible to both GremlinAccounts and SqlAccounts
+        /// </summary>
+        [JsonProperty(LeasePartitionKeyPropertyName, NullValueHandling = NullValueHandling.Ignore)]
+        public override string PartitionKey { get; set; }
 
         [JsonProperty("version")]
         public DocumentServiceLeaseVersion Version => DocumentServiceLeaseVersion.EPKRangeBasedLease;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -115,6 +115,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange())
             };
 
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, Guid.NewGuid().ToString());
+
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
 
@@ -136,6 +138,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 ContinuationToken = continuationToken,
                 FeedRange = feedRange
             };
+
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, Guid.NewGuid().ToString());
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -237,8 +241,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         private async Task<DocumentServiceLease> TryCreateDocumentServiceLeaseAsync(DocumentServiceLease documentServiceLease)
         {
-            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.PartitionKey = pk, Guid.NewGuid().ToString());
-
             bool created = await this.leaseContainer.TryCreateItemAsync<DocumentServiceLease>(
                 this.requestOptionsFactory.GetPartitionKey(documentServiceLease.Id, documentServiceLease.PartitionKey),
                 documentServiceLease).ConfigureAwait(false) != null;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             return await this.leaseUpdater.UpdateLeaseAsync(
                 lease,
                 lease.Id,
-                this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                 serverLease =>
                 {
                     if (serverLease.Owner != oldOwner)
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             await this.leaseUpdater.UpdateLeaseAsync(
                 refreshedLease,
                 refreshedLease.Id,
-                this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                 serverLease =>
                 {
                     if (serverLease.Owner != lease.Owner)
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             }
 
             await this.leaseContainer.TryDeleteItemAsync<DocumentServiceLeaseCore>(
-                    this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                    this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                     lease.Id).ConfigureAwait(false);
         }
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             return await this.leaseUpdater.UpdateLeaseAsync(
                 refreshedLease,
                 refreshedLease.Id,
-                this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                 serverLease =>
                 {
                     if (serverLease.Owner != lease.Owner)
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             return await this.leaseUpdater.UpdateLeaseAsync(
                 lease,
                 lease.Id,
-                this.requestOptionsFactory.GetPartitionKey(lease.Id),
+                this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey),
                 serverLease =>
                 {
                     if (serverLease.Owner != lease.Owner)
@@ -237,8 +237,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         private async Task<DocumentServiceLease> TryCreateDocumentServiceLeaseAsync(DocumentServiceLease documentServiceLease)
         {
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.PartitionKey = pk, Guid.NewGuid().ToString());
+
             bool created = await this.leaseContainer.TryCreateItemAsync<DocumentServiceLease>(
-                this.requestOptionsFactory.GetPartitionKey(documentServiceLease.Id),
+                this.requestOptionsFactory.GetPartitionKey(documentServiceLease.Id, documentServiceLease.PartitionKey),
                 documentServiceLease).ConfigureAwait(false) != null;
             if (created)
             {
@@ -252,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         private async Task<DocumentServiceLease> TryGetLeaseAsync(DocumentServiceLease lease)
         {
-            return await this.leaseContainer.TryGetItemAsync<DocumentServiceLease>(this.requestOptionsFactory.GetPartitionKey(lease.Id), lease.Id).ConfigureAwait(false);
+            return await this.leaseContainer.TryGetItemAsync<DocumentServiceLease>(this.requestOptionsFactory.GetPartitionKey(lease.Id, lease.PartitionKey), lease.Id).ConfigureAwait(false);
         }
 
         private string GetDocumentId(string partitionId)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/PartitionedByIdCollectionRequestOptionsFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/PartitionedByIdCollectionRequestOptionsFactory.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 {
+    using System;
     using Microsoft.Azure.Cosmos;
 
     /// <summary>
@@ -11,8 +12,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     /// </summary>
     internal sealed class PartitionedByIdCollectionRequestOptionsFactory : RequestOptionsFactory
     {
-        public override PartitionKey GetPartitionKey(string itemId) => new PartitionKey(itemId);
+        public override PartitionKey GetPartitionKey(string itemId, string partitionKey) => new PartitionKey(itemId);
 
-        public override FeedOptions CreateFeedOptions() => new FeedOptions { EnableCrossPartitionQuery = true };
+        public override void AddPartitionKeyIfNeeded(Action<string> partitionKeySetter, string partitionKey)
+        {
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/PartitionedByPartitionKeyCollectionRequestOptionsFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/PartitionedByPartitionKeyCollectionRequestOptionsFactory.cs
@@ -8,14 +8,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     using Microsoft.Azure.Cosmos;
 
     /// <summary>
-    /// Used to create request options for non-partitioned lease collections.
+    /// Used to create request options for partitioned lease collections, when partition key is defined as /partitionKey.
     /// </summary>
-    internal sealed class SinglePartitionRequestOptionsFactory : RequestOptionsFactory
+    internal sealed class PartitionedByPartitionKeyCollectionRequestOptionsFactory : RequestOptionsFactory
     {
+        public override PartitionKey GetPartitionKey(string itemId, string partitionKey) => new PartitionKey(partitionKey);
+
         public override void AddPartitionKeyIfNeeded(Action<string> partitionKeySetter, string partitionKey)
         {
+            partitionKeySetter(partitionKey);
         }
-
-        public override PartitionKey GetPartitionKey(string itemId, string partitionKey) => PartitionKey.None;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/RequestOptionsFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/RequestOptionsFactory.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 {
+    using System;
     using Microsoft.Azure.Cosmos;
 
     /// <summary>
@@ -11,8 +12,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     /// </summary>
     internal abstract class RequestOptionsFactory
     {
-        public abstract PartitionKey GetPartitionKey(string itemId);
+        public abstract PartitionKey GetPartitionKey(string itemId, string partitionKey);
 
-        public abstract FeedOptions CreateFeedOptions();
+        public abstract void AddPartitionKeyIfNeeded(Action<string> partitionKeySetter, string partitionKey);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/BaseChangeFeedClientHelper.cs
@@ -14,13 +14,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
         public Container LeaseContainer = null;
 
-        public async Task ChangeFeedTestInit()
+        public async Task ChangeFeedTestInit(string leaseContainerPk = "/id")
         {
             await base.TestInit(customizeClientBuilder: (builder) => builder.WithContentResponseOnWrite(false));
-            string PartitionKey = "/id";
 
             ContainerResponse response = await this.database.CreateContainerAsync(
-                new ContainerProperties(id: "leases", partitionKeyPath: PartitionKey),
+                new ContainerProperties(id: "leases", partitionKeyPath: leaseContainerPk),
                 cancellationToken: this.cancellationToken);
 
             this.LeaseContainer = response;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
@@ -1,0 +1,118 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class GremlinSmokeTests : BaseChangeFeedClientHelper
+    {
+        private Container Container;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await base.ChangeFeedTestInit("/partitionKey");
+            ContainerResponse response = await this.database.CreateContainerAsync(
+                new ContainerProperties(id: "monitored", partitionKeyPath: "/pk"),
+                cancellationToken: this.cancellationToken);
+            this.Container = response;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            await base.TestCleanup();
+        }
+
+        [TestMethod]
+        public async Task WritesTriggerDelegate_WithLeaseContainer()
+        {
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
+
+            IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
+            List<int> receivedIds = new List<int>();
+            ChangeFeedProcessor processor = this.Container
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) =>
+                {
+                    foreach (TestClass doc in docs)
+                    {
+                        receivedIds.Add(int.Parse(doc.id));
+                    }
+
+                    if (receivedIds.Count == 100)
+                    {
+                        allDocsProcessed.Set();
+                    }
+
+                    return Task.CompletedTask;
+                })
+                .WithInstanceName("random")
+                .WithLeaseContainer(this.LeaseContainer).Build();
+
+            await processor.StartAsync();
+            // Letting processor initialize
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            // Inserting documents
+            foreach (int id in expectedIds)
+            {
+                await this.Container.CreateItemAsync<dynamic>(new { id = id.ToString() });
+            }
+
+            // Waiting on all notifications to finish
+            bool isStartOk = allDocsProcessed.WaitOne(30 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
+            // Verify that we maintain order
+            CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
+
+        }
+
+        [TestMethod]
+        public async Task Schema_DefaultsToHavingPartitionKey()
+        {
+            ChangeFeedProcessor processor = this.Container
+                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) => Task.CompletedTask)
+                .WithInstanceName("random")
+                .WithLeaseContainer(this.LeaseContainer).Build();
+
+            await processor.StartAsync();
+            // Letting processor initialize
+            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+
+            // Verify that leases have the partitionKey attribute
+            using FeedIterator<dynamic> iterator = this.LeaseContainer.GetItemQueryIterator<dynamic>();
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<dynamic> page = await iterator.ReadNextAsync();
+                foreach (dynamic lease in page)
+                {
+                    string leaseId = lease.id;
+                    Assert.IsNotNull(lease.partitionKey);
+                    if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                    {
+                        // These are the store initialization marks
+                        continue;
+                    }
+
+                    Assert.IsNotNull(lease.LeaseToken);
+                    Assert.IsNull(lease.PartitionId);
+                }
+            }
+
+            await processor.StopAsync();
+        }
+
+        public class TestClass
+        {
+            public string id { get; set; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/SmokeTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         [TestMethod]
         public async Task WritesTriggerDelegate_WithLeaseContainer()
         {
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
@@ -47,6 +48,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     foreach (TestClass doc in docs)
                     {
                         receivedIds.Add(int.Parse(doc.id));
+                    }
+
+                    if (receivedIds.Count == 100)
+                    {
+                        allDocsProcessed.Set();
                     }
 
                     return Task.CompletedTask;
@@ -64,8 +70,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
+            bool isStartOk = allDocsProcessed.WaitOne(30 * BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
         }
@@ -141,6 +148,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                 foreach (dynamic lease in page)
                 {
                     string leaseId = lease.id;
+                    Assert.IsNull(lease.partitionKey);
                     if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
                     {
                         // These are the store initialization marks
@@ -268,6 +276,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         [TestMethod]
         public async Task WritesTriggerDelegate_WithLeaseContainerWithDynamic()
         {
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
@@ -276,6 +285,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     foreach (dynamic doc in docs)
                     {
                         receivedIds.Add(int.Parse(doc.id.Value));
+                    }
+
+                    if (receivedIds.Count == 100)
+                    {
+                        allDocsProcessed.Set();
                     }
 
                     return Task.CompletedTask;
@@ -293,8 +307,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
+            bool isStartOk = allDocsProcessed.WaitOne(30 * BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
         }
@@ -302,6 +317,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         [TestMethod]
         public async Task WritesTriggerDelegate_WithInMemoryContainer()
         {
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
@@ -310,6 +326,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     foreach (TestClass doc in docs)
                     {
                         receivedIds.Add(int.Parse(doc.id));
+                    }
+
+                    if (receivedIds.Count == 100)
+                    {
+                        allDocsProcessed.Set();
                     }
 
                     return Task.CompletedTask;
@@ -330,9 +351,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
+            bool isStartOk = allDocsProcessed.WaitOne(30 * BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
-
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
         }
@@ -340,6 +361,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         [TestMethod]
         public async Task WritesTriggerDelegate_WithInMemoryContainerWithDynamic()
         {
+            ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
             IEnumerable<int> expectedIds = Enumerable.Range(0, 100);
             List<int> receivedIds = new List<int>();
             ChangeFeedProcessor processor = this.Container
@@ -348,6 +370,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                     foreach (dynamic doc in docs)
                     {
                         receivedIds.Add(int.Parse(doc.id.Value));
+                    }
+
+                    if (receivedIds.Count == 100)
+                    {
+                        allDocsProcessed.Set();
                     }
 
                     return Task.CompletedTask;
@@ -365,8 +392,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
 
             // Waiting on all notifications to finish
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
+            bool isStartOk = allDocsProcessed.WaitOne(30 * BaseChangeFeedClientHelper.ChangeFeedCleanupTime);
             await processor.StopAsync();
+            Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
             // Verify that we maintain order
             CollectionAssert.AreEqual(expectedIds.ToList(), receivedIds);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreManagerBuilderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseStoreManagerBuilderTests.cs
@@ -1,0 +1,111 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class DocumentServiceLeaseStoreManagerBuilderTests
+    {
+        [TestMethod]
+        public async Task InitializeAsync_WithContainerPartitionedById()
+        {
+            ContainerProperties containerProperties = new ContainerProperties
+            {
+                PartitionKey = new Documents.PartitionKeyDefinition() { Paths = new System.Collections.ObjectModel.Collection<string>() { "/id" } }
+            };
+
+
+            Mock<ContainerInternal> leaseContainerMock = new Mock<ContainerInternal>();
+            leaseContainerMock.Setup(c => c.GetCachedContainerPropertiesAsync(
+                It.Is<bool>(b => b == false),
+                It.IsAny<ITrace>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties);
+
+            await DocumentServiceLeaseStoreManagerBuilder.InitializeAsync(
+                Mock.Of<ContainerInternal>(),
+                leaseContainerMock.Object,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString());
+        }
+
+        [TestMethod]
+        public async Task InitializeAsync_WithContainerPartitionedByPartitionKey()
+        {
+            ContainerProperties containerProperties = new ContainerProperties
+            {
+                PartitionKey = new Documents.PartitionKeyDefinition() { Paths = new System.Collections.ObjectModel.Collection<string>() { "/partitionKey" } }
+            };
+
+
+            Mock<ContainerInternal> leaseContainerMock = new Mock<ContainerInternal>();
+            leaseContainerMock.Setup(c => c.GetCachedContainerPropertiesAsync(
+                It.Is<bool>(b => b == false),
+                It.IsAny<ITrace>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties);
+
+            await DocumentServiceLeaseStoreManagerBuilder.InitializeAsync(
+                Mock.Of<ContainerInternal>(),
+                leaseContainerMock.Object,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString());
+        }
+
+        [TestMethod]
+        public async Task InitializeAsync_WithContainerPartitionedBySystemPK()
+        {
+            ContainerProperties containerProperties = new ContainerProperties
+            {
+                PartitionKey = new Documents.PartitionKeyDefinition() { IsSystemKey = true }
+            };
+
+
+            Mock<ContainerInternal> leaseContainerMock = new Mock<ContainerInternal>();
+            leaseContainerMock.Setup(c => c.GetCachedContainerPropertiesAsync(
+                It.Is<bool>(b => b == false),
+                It.IsAny<ITrace>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties);
+
+            await DocumentServiceLeaseStoreManagerBuilder.InitializeAsync(
+                Mock.Of<ContainerInternal>(),
+                leaseContainerMock.Object,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString());
+        }
+
+        [TestMethod]
+        public async Task InitializeAsync_WithContainerPartitionedByRandom()
+        {
+            ContainerProperties containerProperties = new ContainerProperties
+            {
+                PartitionKey = new Documents.PartitionKeyDefinition() { Paths = new System.Collections.ObjectModel.Collection<string>() { "/random" } }
+            };
+
+
+            Mock<ContainerInternal> leaseContainerMock = new Mock<ContainerInternal>();
+            leaseContainerMock.Setup(c => c.GetCachedContainerPropertiesAsync(
+                It.Is<bool>(b => b == false),
+                It.IsAny<ITrace>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => DocumentServiceLeaseStoreManagerBuilder.InitializeAsync(
+                Mock.Of<ContainerInternal>(),
+                leaseContainerMock.Object,
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()));
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 LeaseToken = "0",
                 Owner = "owner",
                 ContinuationToken = "continuation",
-                PartitionKey = "pk",
+                LeasePartitionKey = "pk",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
                 Properties = new Dictionary<string, string> { { "key", "value" } }
             };
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Owner = "owner",
                 ContinuationToken = "continuation",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
-                PartitionKey = "partitionKey",
+                LeasePartitionKey = "partitionKey",
                 Properties = new Dictionary<string, string> { { "key", "value" } },
                 FeedRange = new FeedRangePartitionKeyRange("0")
             };
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Owner = "owner",
                 ContinuationToken = "continuation",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
-                PartitionKey = "partitionKey",
+                LeasePartitionKey = "partitionKey",
                 Properties = new Dictionary<string, string> { { "key", "value" } },
                 FeedRange = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false))
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 LeaseToken = "0",
                 Owner = "owner",
                 ContinuationToken = "continuation",
+                PartitionKey = "pk",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
                 Properties = new Dictionary<string, string> { { "key", "value" } }
             };
@@ -77,6 +78,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(originalLease.Owner, lease.Owner);
             Assert.AreEqual(originalLease.ContinuationToken, lease.ContinuationToken);
             Assert.AreEqual(originalLease.Timestamp, lease.Timestamp);
+            Assert.AreEqual(originalLease.PartitionKey, lease.PartitionKey);
             Assert.AreEqual(originalLease.Properties["key"], lease.Properties["key"]);
         }
 
@@ -98,6 +100,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.IsNull(lease.LeaseToken);
             Assert.IsNull(lease.Owner);
             Assert.IsNull(lease.ContinuationToken);
+            Assert.IsNull(lease.PartitionKey);
             Assert.AreEqual(new DocumentServiceLeaseCore().Timestamp, lease.Timestamp);
             Assert.IsTrue(lease.Properties.Count == 0);
         }
@@ -113,6 +116,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Owner = "owner",
                 ContinuationToken = "continuation",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
+                PartitionKey = "partitionKey",
                 Properties = new Dictionary<string, string> { { "key", "value" } },
                 FeedRange = new FeedRangePartitionKeyRange("0")
             };
@@ -127,6 +131,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Assert.AreEqual(originalLease.ETag, documentServiceLeaseCore.ETag);
                 Assert.AreEqual(originalLease.LeaseToken, documentServiceLeaseCore.LeaseToken);
                 Assert.AreEqual(originalLease.Owner, documentServiceLeaseCore.Owner);
+                Assert.AreEqual(originalLease.PartitionKey, documentServiceLeaseCore.PartitionKey);
                 Assert.AreEqual(originalLease.ContinuationToken, documentServiceLeaseCore.ContinuationToken);
                 Assert.AreEqual(originalLease.Timestamp, documentServiceLeaseCore.Timestamp);
                 Assert.AreEqual(originalLease.Properties["key"], documentServiceLeaseCore.Properties["key"]);
@@ -149,6 +154,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Owner = "owner",
                 ContinuationToken = "continuation",
                 Timestamp = DateTime.Now - TimeSpan.FromSeconds(5),
+                PartitionKey = "partitionKey",
                 Properties = new Dictionary<string, string> { { "key", "value" } },
                 FeedRange = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false))
             };
@@ -163,6 +169,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Assert.AreEqual(originalLease.ETag, documentServiceLeaseCore.ETag);
                 Assert.AreEqual(originalLease.LeaseToken, documentServiceLeaseCore.LeaseToken);
                 Assert.AreEqual(originalLease.Owner, documentServiceLeaseCore.Owner);
+                Assert.AreEqual(originalLease.PartitionKey, documentServiceLeaseCore.PartitionKey);
                 Assert.AreEqual(originalLease.ContinuationToken, documentServiceLeaseCore.ContinuationToken);
                 Assert.AreEqual(originalLease.Timestamp, documentServiceLeaseCore.Timestamp);
                 Assert.AreEqual(originalLease.Properties["key"], documentServiceLeaseCore.Properties["key"]);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RequestOptionsFactoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/RequestOptionsFactoryTests.cs
@@ -1,0 +1,88 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    [TestCategory("ChangeFeed")]
+    public class RequestOptionsFactoryTests
+    {
+        private const string IdValue = "anId";
+        private const string PartitionKeyValue = "aPartitionKey";
+
+        [TestMethod]
+        public void SinglePartitionRequestOptionsFactory_GetPartitionKey()
+        {
+            SinglePartitionRequestOptionsFactory factory = new SinglePartitionRequestOptionsFactory();
+            Assert.AreEqual(PartitionKey.None, factory.GetPartitionKey(IdValue, PartitionKeyValue));
+        }
+
+        [TestMethod]
+        public void PartitionedByIdCollectionRequestOptionsFactory_GetPartitionKey()
+        {
+            PartitionedByIdCollectionRequestOptionsFactory factory = new PartitionedByIdCollectionRequestOptionsFactory();
+            Assert.AreEqual(new PartitionKey(IdValue), factory.GetPartitionKey(IdValue, PartitionKeyValue));
+        }
+
+        [TestMethod]
+        public void PartitionedByPartitionKeyCollectionRequestOptionsFactory_GetPartitionKey()
+        {
+            PartitionedByPartitionKeyCollectionRequestOptionsFactory factory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            Assert.AreEqual(new PartitionKey(PartitionKeyValue), factory.GetPartitionKey(IdValue, PartitionKeyValue));
+        }
+
+        [TestMethod]
+        public void SinglePartitionRequestOptionsFactory_AddPartitionKeyIfNeeded()
+        {
+            bool invoked = false;
+            void action(string pk)
+            {
+                invoked = true;
+                Assert.Fail("Should not invoke");
+            }
+
+            SinglePartitionRequestOptionsFactory factory = new SinglePartitionRequestOptionsFactory();
+            factory.AddPartitionKeyIfNeeded(action, PartitionKeyValue);
+            Assert.IsFalse(invoked);
+        }
+
+        [TestMethod]
+        public void PartitionedByIdCollectionRequestOptionsFactory_AddPartitionKeyIfNeeded()
+        {
+            bool invoked = false;
+            void action(string pk)
+            {
+                invoked = true;
+                Assert.Fail("Should not invoke");
+            }
+
+            PartitionedByIdCollectionRequestOptionsFactory factory = new PartitionedByIdCollectionRequestOptionsFactory();
+            factory.AddPartitionKeyIfNeeded(action, PartitionKeyValue);
+            Assert.IsFalse(invoked);
+        }
+
+        [TestMethod]
+        public void PartitionedByPartitionKeyCollectionRequestOptionsFactory_AddPartitionKeyIfNeeded()
+        {
+            bool invoked = false;
+            void action(string pk)
+            {
+                invoked = true;
+                Assert.AreEqual(PartitionKeyValue, pk); ;
+            }
+
+            PartitionedByPartitionKeyCollectionRequestOptionsFactory factory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            factory.AddPartitionKeyIfNeeded(action, PartitionKeyValue);
+            Assert.IsTrue(invoked);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Graph API accounts are allowed to perform operations through the SQL API and as such, can also read the Change Feed.

Change Feed Processor uses a Lease Container that has, by default, a Partition Key Definition of `/id` . But `/id` is not allowed in Graph API accounts, so Graph API users could not leverage Change Feed Processor even though they could do any SQL API operation.

https://github.com/Azure/azure-documentdb-changefeedprocessor-dotnet/pull/158 added Graph API support to the V2 Change Feed Processor.

This PR aims to port the same capability to V3 SDK to allow for users to migrate from V2 to V3 without any blocking issues.

The PR does not modify the public surface but just enables users to use Lease Containers that are partitioned by `/id` (current behavior) or partitioned by `/partitionKey` (valid in Graph API accounts). The internal implementations will detect the path and generate the extra attribute on the leases in case it is needed.

## Strategic value

Since we are also migrating Azure Functions to V3 SDK (https://github.com/Azure/azure-webjobs-sdk-extensions/pull/717) this will also mean that it would enable Azure Functions Triggers to be used on Graph API accounts, which was not previously possible.

## Key changes

The PR introduces a new implementation of `RequestOptionsFactory`, so based on the Lease Container partition key definition, the CFP builder uses a different Factory implementation. The current `PartitionedByIdCollectionRequestOptionsFactory` or the new `PartitionedByPartitionKeyCollectionRequestOptionsFactory` and the difference is one uses the value of the `id` as `PartitionKey` and the other, the value of the `partitionKey`, and one does not add the `PartitionKey` property to lease documents (default), while the other does.

## Misc

Besides adding new sets of tests to cover the new behavior, the PR adds new tests for pre-existing APIs that had no test coverage and improves test run time (decreasing Emulator tests time) by using ManualResetEvent instead of waiting pre-defined amount of time on CFP tests.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

Closes #2291