### PR TITLE
Diagnostics: Fixes default setting in Consistency Config Serialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ConsistencyConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ConsistencyConfig.cs
@@ -14,16 +14,16 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             ConsistencyLevel? consistencyLevel,
             IReadOnlyList<string> preferredRegions)
         {
-            this.ConsistencyLevel = consistencyLevel.GetValueOrDefault();
+            this.ConsistencyLevel = consistencyLevel;
             this.PreferredRegions = preferredRegions;
             this.lazyString = new Lazy<string>(() => string.Format(CultureInfo.InvariantCulture,
                                 "(consistency: {0}, prgns:[{1}])",
-                                consistencyLevel.GetValueOrDefault(),
+                                consistencyLevel?.ToString() ?? "NotSet",
                                 ConsistencyConfig.PreferredRegionsInternal(preferredRegions)));
             this.lazyJsonString = new Lazy<string>(() => Newtonsoft.Json.JsonConvert.SerializeObject(this));
         }
 
-        public ConsistencyLevel ConsistencyLevel { get; }
+        public ConsistencyLevel? ConsistencyLevel { get; }
         public IReadOnlyList<string> PreferredRegions { get; }
 
         private readonly Lazy<string> lazyString;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -72,9 +73,24 @@
             Assert.AreEqual(gwConfig.MaxConnectionLimit, 20);
 
             ConsistencyConfig consistencyConfig = cosmosClient.ClientConfigurationTraceDatum.ConsistencyConfig;
-            Assert.AreEqual(consistencyConfig.ConsistencyLevel, ConsistencyLevel.Session);
+            Assert.AreEqual(consistencyConfig.ConsistencyLevel.Value, ConsistencyLevel.Session);
         }
-        
+
+        [TestMethod]
+        public void ConsistencyConfigSerializationTest()
+        {
+            List<string> preferredRegions = new List<string> { "EastUS", "WestUs" };
+            ConsistencyLevel consistencyLevel = ConsistencyLevel.Session;
+
+            ConsistencyConfig consistencyConfig = new ConsistencyConfig(consistencyLevel, preferredRegions);
+            Assert.AreEqual(consistencyConfig.ToString(), "(consistency: Session, prgns:[EastUS, WestUs])");
+
+            ConsistencyConfig consistencyConfigWithNull = new ConsistencyConfig(consistencyLevel: null,
+                                                                                preferredRegions: null);
+
+            Assert.AreEqual(consistencyConfigWithNull.ToString(), "(consistency: NotSet, prgns:[])");
+        }
+
         [TestMethod]
         public async Task CachedSerializationTest()
         {


### PR DESCRIPTION
## Description

When serializing ConsistencyConfig class, if the user is not setting the ConsistencyLevel, we defaulted it to Strong. This PR adds "NotSet" to such cases.
