### PR TITLE
Gateway: Fixes container recreate scenarios for Gateway Mode in session consistency

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -358,12 +358,15 @@ namespace Microsoft.Azure.Cosmos
                         NoOpTrace.Singleton);
                 }
 
-                partitonKeyRange = AddressResolver.TryResolveServerPartitionByPartitionKey(
-                    request: request,
-                    partitionKeyString: partitionKeyString,
-                    collectionCacheUptoDate: false,
-                    collection: collection,
-                    routingMap: collectionRoutingMap);
+                if (collectionRoutingMap != null)
+                {
+                    partitonKeyRange = AddressResolver.TryResolveServerPartitionByPartitionKey(
+                        request: request,
+                        partitionKeyString: partitionKeyString,
+                        collectionCacheUptoDate: false,
+                        collection: collection,
+                        routingMap: collectionRoutingMap);
+                }
             }
             else if (request.PartitionKeyRangeIdentity != null)
             {


### PR DESCRIPTION
This was introduced in PR #2165

The issue is when one client deletes and recreates a container, any request on another client gives a NullReferenceException.