### PR TITLE
Query: Fixes handling of pipeline execution on partition merge

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
@@ -184,11 +184,21 @@ namespace Microsoft.Azure.Cosmos.Pagination
                                 error: new Microsoft.Azure.Documents.Error { Code = "SDK_invariant_violated_4795CC37", Message = errorMessage });
                         }
 
-                        foreach (FeedRangeInternal childRange in childRanges)
+                        if (childRanges.Count == 1)
                         {
-                            PartitionRangePageAsyncEnumerator<TPage, TState> childPaginator = this.createPartitionRangeEnumerator(
-                                new FeedRangeState<TState>(childRange, currentPaginator.FeedRangeState.State));
-                            enumerators.Enqueue(childPaginator);
+                            // On a merge, the 410/1002 results in a single parent
+                            // We maintain the current enumerator's range and let the RequestInvokerHandler logic kick in
+                            enumerators.Enqueue(currentPaginator);
+                        }
+                        else
+                        {
+                            // Split
+                            foreach (FeedRangeInternal childRange in childRanges)
+                            {
+                                PartitionRangePageAsyncEnumerator<TPage, TState> childPaginator = this.createPartitionRangeEnumerator(
+                                    new FeedRangeState<TState>(childRange, currentPaginator.FeedRangeState.State));
+                                enumerators.Enqueue(childPaginator);
+                            }
                         }
 
                         // Recursively retry

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -323,7 +323,15 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             {
                 // On a merge, the 410/1002 results in a single parent
                 // We maintain the current enumerator's range and let the RequestInvokerHandler logic kick in
-                this.enumerators.Enqueue(uninitializedEnumerator);
+                OrderByQueryPartitionRangePageAsyncEnumerator childPaginator = new OrderByQueryPartitionRangePageAsyncEnumerator(
+                    this.documentContainer,
+                    uninitializedEnumerator.SqlQuerySpec,
+                    new FeedRangeState<QueryState>(uninitializedEnumerator.FeedRangeState.FeedRange, uninitializedEnumerator.StartOfPageState),
+                    partitionKey: null,
+                    uninitializedEnumerator.QueryPaginationOptions,
+                    uninitializedEnumerator.Filter,
+                    this.cancellationToken);
+                this.uninitializedEnumeratorsAndTokens.Enqueue((childPaginator, token));
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
@@ -111,15 +111,15 @@
     │           └── Read Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  ReadFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Read Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  ReadFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Read Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  ReadFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Read Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  ReadFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
         └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1182,7 +1182,7 @@
           "duration in milliseconds": 0,
           "children": [
             {
-              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
               "id": "00000000-0000-0000-0000-000000000000",
               "caller info": {
                 "member": "MemberName",
@@ -1232,7 +1232,7 @@
           "duration in milliseconds": 0,
           "children": [
             {
-              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
               "id": "00000000-0000-0000-0000-000000000000",
               "caller info": {
                 "member": "MemberName",
@@ -1282,7 +1282,7 @@
           "duration in milliseconds": 0,
           "children": [
             {
-              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
               "id": "00000000-0000-0000-0000-000000000000",
               "caller info": {
                 "member": "MemberName",
@@ -1401,7 +1401,7 @@
     │           └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── ChangeFeed MoveNextAsync(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │           └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── ChangeFeed MoveNextAsync(00000000-0000-0000-0000-000000000000)  ChangeFeed-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1429,7 +1429,7 @@
             │   └── [BF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │       └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-            │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+            │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │       └── Change Feed Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
             │   └── [7F-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,9F-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -1796,7 +1796,7 @@
           "duration in milliseconds": 0,
           "children": [
             {
-              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+              "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
               "id": "00000000-0000-0000-0000-000000000000",
               "caller info": {
                 "member": "MemberName",
@@ -2142,7 +2142,7 @@
               "duration in milliseconds": 0,
               "children": [
                 {
-                  "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+                  "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
                   "id": "00000000-0000-0000-0000-000000000000",
                   "caller info": {
                     "member": "MemberName",
@@ -2321,10 +2321,10 @@
     │   └── [BF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Query Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Query Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
-    │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── [DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     │       └── Query Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
     └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
@@ -2931,7 +2931,7 @@
       "duration in milliseconds": 0,
       "children": [
         {
-          "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+          "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",
@@ -2968,7 +2968,7 @@
       "duration in milliseconds": 0,
       "children": [
         {
-          "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,) move next",
+          "name": "[DF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF,FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next",
           "id": "00000000-0000-0000-0000-000000000000",
           "caller info": {
             "member": "MemberName",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -84,6 +84,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         cancellationToken: default);
 
                     await this.DocumentContainer.MergeAsync(ranges[0], ranges[1], default);
+                    await this.DocumentContainer.RefreshProviderAsync(NoOpTrace.Singleton, default);
                     this.ShouldMerge = TriState.Done;
 
                     return new CosmosException(
@@ -116,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 await this.DocumentContainer.SplitAsync(ranges.First(), cancellationToken: default);
 
                 IAsyncEnumerator<TryCatch<CrossFeedRangePage<ReadFeedPage, ReadFeedState>>> enumerator = this.CreateEnumerator(this.DocumentContainer);
-                HashSet<string> identifiers = new HashSet<string>();
+                List<string> identifiers = new List<string>();
                 int iteration = 0;
                 while (await enumerator.MoveNextAsync())
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -6,13 +6,18 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
+    using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.ReadFeed.Pagination;
+    using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
 
     [TestClass]
     public sealed class CrossPartitionPartitionRangeEnumeratorTests
@@ -43,6 +48,159 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         {
             Implementation implementation = new Implementation(true);
             await implementation.TestMergeToSinglePartition();
+        }
+
+        // Validates that on a merge (split with 1 result) we do not create new child enumerators for the merge result
+        [TestMethod]
+        public async Task OnMergeRequeueRange()
+        {
+            // We expect only creation of enumerators for the original ranges, not any child ranges
+            List<EnumeratorThatSplits> createdEnumerators = new List<EnumeratorThatSplits>();
+            PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> createEnumerator(
+                FeedRangeState<ReadFeedState> feedRangeState)
+            {
+                EnumeratorThatSplits enumerator = new EnumeratorThatSplits(feedRangeState, default, createdEnumerators.Count == 0);
+                createdEnumerators.Add(enumerator);
+                return enumerator;
+            }
+
+            // We expect a request for children and we return the merged range
+            Mock<IFeedRangeProvider> feedRangeProvider = new Mock<IFeedRangeProvider>();
+            feedRangeProvider.Setup(p => p.GetChildRangeAsync(
+                It.Is<FeedRangeInternal>(splitRange => ((FeedRangeEpk)splitRange).Range.Min == "" && ((FeedRangeEpk)splitRange).Range.Max == "A"),
+                It.IsAny<ITrace>(), 
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<FeedRangeEpk>() { 
+                    FeedRangeEpk.FullRange});
+
+            CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator = new CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
+                feedRangeProvider: feedRangeProvider.Object,
+                createPartitionRangeEnumerator: createEnumerator,
+                comparer: null,
+                maxConcurrency: 0,
+                cancellationToken: default,
+                state: new CrossFeedRangeState<ReadFeedState>(
+                    new FeedRangeState<ReadFeedState>[]
+                    {
+                        // start with 2 ranges
+                        new FeedRangeState<ReadFeedState>(new FeedRangeEpk(new Documents.Routing.Range<string>("", "A", true, false)), ReadFeedState.Beginning()),
+                        new FeedRangeState<ReadFeedState>(new FeedRangeEpk(new Documents.Routing.Range<string>("A", "FF", true, false)), ReadFeedState.Beginning())
+                    }));
+
+            // Trigger merge, should requeue and read second enumerator
+            await enumerator.MoveNextAsync();
+
+            // Should read first enumerator again
+            await enumerator.MoveNextAsync();
+
+            Assert.AreEqual(2, createdEnumerators.Count, "Should only create the original 2 enumerators");
+            Assert.AreEqual("", ((FeedRangeEpk)createdEnumerators[0].FeedRangeState.FeedRange).Range.Min);
+            Assert.AreEqual("A", ((FeedRangeEpk)createdEnumerators[0].FeedRangeState.FeedRange).Range.Max);
+            Assert.AreEqual("A", ((FeedRangeEpk)createdEnumerators[1].FeedRangeState.FeedRange).Range.Min);
+            Assert.AreEqual("FF", ((FeedRangeEpk)createdEnumerators[1].FeedRangeState.FeedRange).Range.Max);
+
+            Assert.AreEqual(2, createdEnumerators[0].GetNextPageAsyncCounter, "First enumerator should have been requeued and called again");
+            Assert.AreEqual(1, createdEnumerators[1].GetNextPageAsyncCounter, "Second enumerator should be used once");
+        }
+
+        // Validates that on a merge (split with 1 result) we do not create new child enumerators for the merge result
+        [TestMethod]
+        public async Task OnSplitQueueNewEnumerators()
+        {
+            // We expect creation of the initial full range enumerator and the 2 children
+            List<EnumeratorThatSplits> createdEnumerators = new List<EnumeratorThatSplits>();
+            PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> createEnumerator(
+                FeedRangeState<ReadFeedState> feedRangeState)
+            {
+                EnumeratorThatSplits enumerator = new EnumeratorThatSplits(feedRangeState, default, createdEnumerators.Count == 0);
+                createdEnumerators.Add(enumerator);
+                return enumerator;
+            }
+
+            // We expect a request for children and we return the new children
+            Mock<IFeedRangeProvider> feedRangeProvider = new Mock<IFeedRangeProvider>();
+            feedRangeProvider.Setup(p => p.GetChildRangeAsync(
+                It.Is<FeedRangeInternal>(splitRange => ((FeedRangeEpk)splitRange).Range.Min == FeedRangeEpk.FullRange.Range.Min && ((FeedRangeEpk)splitRange).Range.Max == FeedRangeEpk.FullRange.Range.Max),
+                It.IsAny<ITrace>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<FeedRangeEpk>() {
+                    new FeedRangeEpk(new Documents.Routing.Range<string>("", "A", true, false)),
+                    new FeedRangeEpk(new Documents.Routing.Range<string>("A", "FF", true, false))});
+
+            CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> enumerator = new CrossPartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>(
+                feedRangeProvider: feedRangeProvider.Object,
+                createPartitionRangeEnumerator: createEnumerator,
+                comparer: null,
+                maxConcurrency: 0,
+                cancellationToken: default,
+                state: new CrossFeedRangeState<ReadFeedState>(
+                    new FeedRangeState<ReadFeedState>[]
+                    {
+                        // start with 1 range
+                        new FeedRangeState<ReadFeedState>(FeedRangeEpk.FullRange, ReadFeedState.Beginning())
+                    }));
+
+            // Trigger split, should create children and call first children
+            await enumerator.MoveNextAsync();
+
+            // Should read second children
+            await enumerator.MoveNextAsync();
+
+            Assert.AreEqual(3, createdEnumerators.Count, "Should have the original enumerator and the children");
+            Assert.AreEqual(FeedRangeEpk.FullRange.Range.Min, ((FeedRangeEpk)createdEnumerators[0].FeedRangeState.FeedRange).Range.Min);
+            Assert.AreEqual(FeedRangeEpk.FullRange.Range.Max, ((FeedRangeEpk)createdEnumerators[0].FeedRangeState.FeedRange).Range.Max);
+            Assert.AreEqual("", ((FeedRangeEpk)createdEnumerators[1].FeedRangeState.FeedRange).Range.Min);
+            Assert.AreEqual("A", ((FeedRangeEpk)createdEnumerators[1].FeedRangeState.FeedRange).Range.Max);
+            Assert.AreEqual("A", ((FeedRangeEpk)createdEnumerators[2].FeedRangeState.FeedRange).Range.Min);
+            Assert.AreEqual("FF", ((FeedRangeEpk)createdEnumerators[2].FeedRangeState.FeedRange).Range.Max);
+
+            Assert.AreEqual(1, createdEnumerators[0].GetNextPageAsyncCounter, "First enumerator should have been called once");
+            Assert.AreEqual(1, createdEnumerators[1].GetNextPageAsyncCounter, "Second enumerator should have been called once");
+            Assert.AreEqual(1, createdEnumerators[2].GetNextPageAsyncCounter, "Second enumerator should not be used");
+        }
+
+        private class EnumeratorThatSplits : PartitionRangePageAsyncEnumerator<ReadFeedPage,ReadFeedState>
+        {
+            private readonly bool throwError;
+
+            public EnumeratorThatSplits(
+                FeedRangeState<ReadFeedState> feedRangeState, 
+                CancellationToken cancellationToken,
+                bool throwError = true)
+                : base(feedRangeState, cancellationToken)
+            {
+                this.throwError = throwError;
+            }
+
+            public override ValueTask DisposeAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public int GetNextPageAsyncCounter { get; private set; }
+
+            protected override Task<TryCatch<ReadFeedPage>> GetNextPageAsync(ITrace trace, CancellationToken cancellationToken)
+            {
+                this.GetNextPageAsyncCounter++;
+
+                if (this.GetNextPageAsyncCounter == 1
+                    && this.throwError)
+                {
+                    CosmosException splitError = new CosmosException("merge", System.Net.HttpStatusCode.Gone, (int)Documents.SubStatusCodes.PartitionKeyRangeGone, string.Empty, 0);
+                    TryCatch<ReadFeedPage> state = TryCatch<ReadFeedPage>.FromException(splitError);
+                    return Task.FromResult(state);
+                }
+                else
+                {
+                    return Task.FromResult(TryCatch<ReadFeedPage>.FromResult(
+                        new ReadFeedPage(
+                            new MemoryStream(Encoding.UTF8.GetBytes("{\"Documents\": [], \"_count\": 0, \"_rid\": \"asdf\"}")),
+                            requestCharge: 1,
+                            activityId: Guid.NewGuid().ToString(),
+                            additionalHeaders: null,
+                            state: ReadFeedState.Beginning())));
+                }
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             Assert.AreEqual(1, createdEnumerators[1].GetNextPageAsyncCounter, "Second enumerator should be used once");
         }
 
-        // Validates that on a merge (split with 1 result) we do not create new child enumerators for the merge result
+        // Validates that on a split we create children enumerators and use them
         [TestMethod]
         public async Task OnSplitQueueNewEnumerators()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         PartitionKeyHashRange userRange = FeedRangeEpkToHashRange(feedRangeEpk);
                         foreach (PartitionKeyHashRange systemRange in this.cachedPartitionKeyRangeIdToHashRange.Values)
                         {
-                            if (systemRange.TryGetOverlappingRange(userRange, out PartitionKeyHashRange overlappingRange))
+                            if (userRange.TryGetOverlappingRange(systemRange, out PartitionKeyHashRange overlappingRange))
                             {
                                 overlappingRanges.Add(HashRangeToFeedRangeEpk(systemRange));
                             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             PartitionKeyDefinition partitionKeyDefinition)
         {
             this.partitionKeyDefinition = partitionKeyDefinition ?? throw new ArgumentNullException(nameof(partitionKeyDefinition));
-            PartitionKeyHashRange fullRange = new PartitionKeyHashRange(startInclusive: null, endExclusive: null);
+            PartitionKeyHashRange fullRange = new PartitionKeyHashRange(startInclusive: null, endExclusive: new PartitionKeyHash(Cosmos.UInt128.MaxValue));
             PartitionKeyHashRanges partitionKeyHashRanges = PartitionKeyHashRanges.Create(new PartitionKeyHashRange[] { fullRange });
             this.partitionedRecords = new PartitionKeyHashRangeDictionary<Records>(partitionKeyHashRanges);
             this.partitionedRecords[fullRange] = new Records();
@@ -131,9 +131,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         PartitionKeyHashRange userRange = FeedRangeEpkToHashRange(feedRangeEpk);
                         foreach (PartitionKeyHashRange systemRange in this.cachedPartitionKeyRangeIdToHashRange.Values)
                         {
-                            if (userRange.TryGetOverlappingRange(systemRange, out PartitionKeyHashRange overlappingRange))
+                            if (systemRange.TryGetOverlappingRange(userRange, out PartitionKeyHashRange overlappingRange))
                             {
-                                overlappingRanges.Add(HashRangeToFeedRangeEpk(overlappingRange));
+                                overlappingRanges.Add(HashRangeToFeedRangeEpk(systemRange));
                             }
                         }
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         {
                             if (userRange.TryGetOverlappingRange(systemRange, out PartitionKeyHashRange overlappingRange))
                             {
-                                overlappingRanges.Add(HashRangeToFeedRangeEpk(systemRange));
+                                overlappingRanges.Add(HashRangeToFeedRangeEpk(overlappingRange));
                             }
                         }
                     }


### PR DESCRIPTION
# Pull Request Template

## Description

The `CrossPartitionRangePageAsyncEnumerator` when facing a merge, was adding the merge result as part of the list of Enumerators, instead of maintaining the current Range and draining it.

In this sample scenario, let's assume a 2 partition collection (partition A and B).

When the query pipeline starts, it generates a queue with 2 enumerators, one for A, one for B. Assume each partition has 10 documents.

Assume we fetch the first page which contains 10 documents from A, which returns a ContinuationToken like:

`{token: null, range {B}}`

Which normally would make the query continue with B and drain it.

If there is a merge and A and B merge into C (with C having all the 20 documents), the current logic adds a new enumerator for C in the queue copying the continuation from the parent (B), so the query would not continue on C (full range) with continuation `null` (all the documents).

The effect is that the query end ups returning 30 documents (10 from the first page, 20 from the second because it used C).

### What is the fix

In the case of a merge where the result is a single parent range, instead of creating a new Queue Enumerator for the merge result, we re-enqueue the current Range Enumerator. 

When this happens, the logic in the RequestInvokerHandler kicks in and applies the EPK filtering:

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs#L244-L263

There was a test currently trying to cover this scenario but it was failing to catch the bug due to a bug in the test itself and how the InMemoryContainer behaved on a merge.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
