### PR TITLE
[INTERNAL] Query: Fixes corruption in JsonBinaryWriter while writing four byte offsets for shared strings

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
@@ -954,7 +954,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 else
                 {
                     this.binaryWriter.Write(JsonBinaryEncoding.TypeMarker.ReferenceString4ByteOffset);
-                    this.binaryWriter.Write(hashAndIndex.index);
+                    this.binaryWriter.Write((int)hashAndIndex.index);
                 }
 
                 return true;

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
@@ -951,10 +951,14 @@ namespace Microsoft.Azure.Cosmos.Json
                     this.binaryWriter.Write(JsonBinaryEncoding.TypeMarker.ReferenceString3ByteOffset);
                     this.binaryWriter.Write((JsonBinaryEncoding.UInt24)(int)hashAndIndex.index);
                 }
-                else
+                else if (sharedString.MaxOffset <= int.MaxValue)
                 {
                     this.binaryWriter.Write(JsonBinaryEncoding.TypeMarker.ReferenceString4ByteOffset);
                     this.binaryWriter.Write((int)hashAndIndex.index);
+                }
+                else
+                {
+                    return false;
                 }
 
                 return true;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonRoundtripTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonRoundtripTests.cs
@@ -398,7 +398,21 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
         [Owner("ndeshpan")]
         public void LargeArrayBinaryJsonTest()
         {
-            string json = System.IO.File.ReadAllText("TestJsons/Array32MB.json");
+            StringBuilder builder = new StringBuilder((1 << 24) + 50);
+            builder.Append('[');
+            for (int x = 1 << 24; x < (1 << 24) + 3355450; ++x)
+            {
+                builder.Append(x);
+                builder.Append(',');
+            }
+            builder.Append("\"string_one\"");
+            builder.Append(',');
+            builder.Append("\"string_two\"");
+            builder.Append(',');
+            builder.Append("\"string_two\"");
+            builder.Append(']');
+
+            string json = builder.ToString();
             byte[] binaryJson = JsonTestUtils.ConvertTextToBinary(json);
             IJsonNavigator navigator = JsonNavigator.Create(binaryJson);
             int count = navigator.GetArrayItemCount(navigator.GetRootNode());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonRoundtripTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/JsonRoundtripTests.cs
@@ -1,4 +1,4 @@
-﻿//-----------------------------------------------------------------------
+//-----------------------------------------------------------------------
 // <copyright file="JsonRoundTripsTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation.  All rights reserved.
 // </copyright>
@@ -392,6 +392,19 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
         public void MsnCollectionTest()
         {
             this.RoundTripTestCuratedJson("MsnCollection.json");
+        }
+
+        [TestMethod]
+        [Owner("ndeshpan")]
+        public void LargeArrayBinaryJsonTest()
+        {
+            string json = System.IO.File.ReadAllText("TestJsons/Array32MB.json");
+            byte[] binaryJson = JsonTestUtils.ConvertTextToBinary(json);
+            IJsonNavigator navigator = JsonNavigator.Create(binaryJson);
+            int count = navigator.GetArrayItemCount(navigator.GetRootNode());
+            IJsonNavigatorNode node = navigator.GetArrayItemAt(navigator.GetRootNode(), count - 1);
+            string stringValue = navigator.GetStringValue(node);
+            Assert.AreEqual("string_two", stringValue);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
@@ -298,6 +298,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestJsons\twitter_data\*.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestJsons\Array32MB.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestJsons\ups1\*.txt">

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -300,9 +300,6 @@
     <None Update="TestJsons\twitter_data\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="TestJsons\Array32MB.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
     <None Update="TestJsons\ups1\*.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Description

JsonBinaryWriter was writing four byte offsets as IEEE 754 floats instead of simple ints. This was due to a missing cast in the writer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
