### PR TITLE
[INTERNAL] IncludedPath: Adds IsFullIndex for compute

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -4,7 +4,7 @@
 1. Create 1 Cosmos database named 'testdb' without shared throughput. Make sure the account is not geo-replicated as this will impact the performance. 
 2. Create a container named 'testcol' 100,000 RUs
 3. Create a container named 'runsummary' 5,000 RUs. This is where the results will be sent.
-4. Allocate a VM in the same region as the Cosmos account. Recommend Standard F4s_v2 (4 vcpus, 8 GiB memory). Anything larger might result in request being throttled.
+4. Allocate a VM (preferably Linux VM) in the same region as the Cosmos account. Recommend Standard F4s_v2 (4 vcpus, 8 GiB memory). Anything larger might result in request being throttled.
 5. Clone the github repo to the VM. 
 6. Follow the [Running on linux](linux) or [Running on Windows](windows) sections below.
 7. The concurrency changed to ensure the request P99 latency is completing is under 10ms to match SLA requirements.
@@ -13,30 +13,51 @@
 
 ## Sample tool usage
 ```
-dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
+dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}  -w {workloadtype}
 ```
 
 Dry tun targeting emulator will look like below
 ```
-dotnet run CosmosBenchmark.csproj -e "https://localhost:8081" -k "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+dotnet run CosmosBenchmark.csproj -e "https://localhost:8081" -k "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==" -w {workloadtype}
 ```
 
 To target Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj
 ```
 export OSSProjectRef=True
-dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY}
+dotnet run CosmosBenchmark.csproj -e {ACCOUNT_ENDPOINT} -k {ACCOUNT_KEY} -w {workloadtype}
 ```
 
 ## Running on Linux <a name="linux"></a>
-For PerfRuns with reports (INTERNAL)
+Set up your VM machine using below steps
 ```
+# Install .Net SDK and Runtime
+wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
+sudo apt update
+sudo apt install apt-transport-https -y
+sudo apt install dotnet-sdk-3.1 -y
+sudo apt install dotnet-runtime-3.1
+
+# Install Git to checkout latest code
+sudo apt-get install git
+git clone https://github.com/Azure/azure-cosmos-dotnet-v3.git
+
+# Set environment variables
 export OSSProjectRef=True
-export ACCOUNT_ENDPOINT=<ENDPOINT
+export ACCOUNT_ENDPOINT=<ENDPOINT>
 export ACCOUNT_KEY=<KEY>
 export RESULTS_PK="runs-summary" #For test runs use different one
 export PL=18
 
-dotnet run -c Release  -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --tcp 10 --enablelatencypercentiles --disablecoresdklogging --publishresults --resultspartitionkeyvalue $RESULTS_PK --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 2000000 -w ReadStreamExistsV3 --pl $PL 
+# Build Benchmark Project
+cd 'azure-cosmos-dotnet-v3/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark'
+dotnet build --configuration Release -p:"OSSProjectRef=true;ShouldUnsetParentConfigurationAndPlatform=false"
+
+```
+For PerfRuns with reports (INTERNAL)
+```
+
+dotnet run -c Release --no-build -- -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --tcp 10 --enablelatencypercentiles --disablecoresdklogging --publishresults --resultspartitionkeyvalue $RESULTS_PK --commitid $(git log -1 | head -n 1 | cut -d ' ' -f 2) --commitdate $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 1 -d ' ') --committime $(git log -1 --date=format:'%Y-%m-%d %H:%M:%S' | grep Date | cut -f 2- -d ':' | sed 's/^[ \t]*//;s/[ \t]*$//' | cut -f 2 -d ' ') --branchname $(git rev-parse --abbrev-ref HEAD)  --database testdb --container testcol --partitionkeypath /pk -n 2000000 -w ReadStreamExistsV3 --pl $PL 
 ```
 
 ![image](https://user-images.githubusercontent.com/6880899/61565403-8e41bd00-aa96-11e9-9996-b7fc77c3aed3.png)
@@ -50,7 +71,7 @@ $commit = $log.Split([Environment]::NewLine)[0].Substring(7)
 
 $branch = git branch --show-current
 
- dotnet build --configuration Release -p:"OSSProjectRef=true;ShouldUnsetParentConfigurationAndPlatform=false"
+dotnet build --configuration Release -p:"OSSProjectRef=true;ShouldUnsetParentConfigurationAndPlatform=false"
  
 $commit
 $branch
@@ -98,4 +119,4 @@ Copyright (C) 2019 CosmosBenchmark
 
 ## Running on Azure
 
-If you quickly get results, you can use our [guide to leverage Azure Container Instances](./AzureContainerInstances/README.md) to execute the benchmarks in any number of Azure regions with very little setup required.
+If you want to quickly get results, you can use our [guide to leverage Azure Container Instances](./AzureContainerInstances/README.md) to execute the benchmarks in any number of Azure regions with very little setup required.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
@@ -11,11 +11,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary> 
     /// Specifies a path within a JSON document to be included in the Azure Cosmos DB service.
     /// </summary>
-    public
-#if !INTERNAL
-    sealed
-#endif
-    class IncludedPath
+    public sealed class IncludedPath
     {
         /// <summary>
         /// Gets or sets the path to be indexed in the Azure Cosmos DB service.
@@ -38,5 +34,13 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         [JsonProperty(PropertyName = Constants.Properties.Indexes)]
         internal Collection<Index> Indexes { get; set; } = new Collection<Index>();
+
+#if INTERNAL
+        /// <summary>
+        /// Gets or sets whether this is a full index used for collection types.
+        /// </summary>
+        [JsonProperty(PropertyName = Constants.Properties.IsFullIndex, NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsFullIndex { get; set; }
+#endif
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IncludedPath.cs
@@ -35,12 +35,10 @@ namespace Microsoft.Azure.Cosmos
         [JsonProperty(PropertyName = Constants.Properties.Indexes)]
         internal Collection<Index> Indexes { get; set; } = new Collection<Index>();
 
-#if INTERNAL
         /// <summary>
         /// Gets or sets whether this is a full index used for collection types.
         /// </summary>
         [JsonProperty(PropertyName = Constants.Properties.IsFullIndex, NullValueHandling = NullValueHandling.Ignore)]
-        public bool? IsFullIndex { get; set; }
-#endif
+        internal bool? IsFullIndex { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.IO;
     using System.Linq;
     using System.Text;
+    using System.Text.RegularExpressions;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -120,7 +121,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosContainerSettingsTests.AssertSerializedPayloads(containerSettings, dc);
         }
 
-#if INTERNAL
         [TestMethod]
         public void ValidateIncludedPathSerialization()
         {
@@ -144,9 +144,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 StreamReader reader = new StreamReader(stream);
                 string content = reader.ReadToEnd();
 
-                System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(
-                    content,
-                    "\"includedPaths\":\\[(.+?)\\],\"excludedPaths\"");
+                Match match = Regex.Match(content, "\"includedPaths\":\\[(.+?)\\],\"excludedPaths\"");
                 Assert.IsTrue(match.Success, "IncludedPaths not found in serialized content");
 
                 // verify IncludedPath ignores null IsFullIndex
@@ -166,7 +164,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 Assert.IsTrue((bool)containerSettings.IndexingPolicy.IncludedPaths[1].IsFullIndex, "listprop IsFullIndex is not set to true");
             }
         }
-#endif
 
         private static string SerializeDocumentCollection(DocumentCollection collection)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -120,6 +120,54 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosContainerSettingsTests.AssertSerializedPayloads(containerSettings, dc);
         }
 
+#if INTERNAL
+        [TestMethod]
+        public void ValidateIncludedPathSerialization()
+        {
+            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey")
+            {
+                IndexingPolicy = new Cosmos.IndexingPolicy()
+            };
+
+            containerSettings.IndexingPolicy.IncludedPaths.Add(new Cosmos.IncludedPath()
+            {
+                Path = "/textprop/?",
+            });
+            containerSettings.IndexingPolicy.IncludedPaths.Add(new Cosmos.IncludedPath()
+            {
+                Path = "/listprop/?",
+                IsFullIndex = true,
+            });
+
+            using (Stream stream = MockCosmosUtil.Serializer.ToStream<ContainerProperties>(containerSettings))
+            {
+                StreamReader reader = new StreamReader(stream);
+                string content = reader.ReadToEnd();
+
+                System.Text.RegularExpressions.Match match = System.Text.RegularExpressions.Regex.Match(
+                    content,
+                    "\"includedPaths\":\\[(.+?)\\],\"excludedPaths\"");
+                Assert.IsTrue(match.Success, "IncludedPaths not found in serialized content");
+
+                // verify IncludedPath ignores null IsFullIndex
+                string includedPaths = match.Groups[1].Value;
+                string delimiter = "},{";
+                int position = includedPaths.IndexOf(delimiter);
+                string textPropIncludedPath = includedPaths.Substring(0, position + 1);
+                string listPropIncludedPath = includedPaths.Substring(position + delimiter.Length - 1);
+
+                Assert.AreEqual("{\"path\":\"/textprop/?\",\"indexes\":[]}", textPropIncludedPath);
+                Assert.AreEqual("{\"path\":\"/listprop/?\",\"indexes\":[],\"isFullIndex\":true}", listPropIncludedPath);
+
+                // verify deserialization
+                stream.Position = 0;
+                containerSettings = MockCosmosUtil.Serializer.FromStream<ContainerProperties>(stream);
+                Assert.IsNull(containerSettings.IndexingPolicy.IncludedPaths[0].IsFullIndex, "textprop IsFullIndex is not null");
+                Assert.IsTrue((bool)containerSettings.IndexingPolicy.IncludedPaths[1].IsFullIndex, "listprop IsFullIndex is not set to true");
+            }
+        }
+#endif
+
         private static string SerializeDocumentCollection(DocumentCollection collection)
         {
             using (MemoryStream ms = new MemoryStream())


### PR DESCRIPTION
# Pull Request Template

## Description

IsFullIndex was introduced to the IncludedPath, which is only used for Collection column types. The previous implementation was to make the IncludedPath unsealed and we added InteropIncludedPath class. ref: https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2059.

That approach works for creating full collection column index, but fails when we need to update container properties containing full collection index.
That is because when Compute service reads the Container Properties back from backend, the deserialization code uses IndexPolicy which references IncludedPath. As a result, after reading from backend response, we lose the content of IsFullIndex, and when we update ContainerProperties, backend is expecting IsFullIndex flag but missing.

The correct way of handling it is to expose the extra IsFullIndex property in SDK but gate it using INTERNAL macro.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber