### PR TITLE
Diagnostics: Adds Duration field to HttpResponseStatistics in Diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 Exception exception)
             {
                 this.RequestStartTime = requestStartTime;
-                this.RequestEndTime = requestEndTime;
+                this.Duration = requestEndTime - requestStartTime;
                 this.HttpResponseMessage = responseMessage;
                 this.Exception = exception;
                 this.ResourceType = resourceType;
@@ -399,7 +399,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             }
 
             public DateTime RequestStartTime { get; }
-            public DateTime RequestEndTime { get; }
+            public TimeSpan Duration { get; }
             public HttpResponseMessage HttpResponseMessage { get; }
             public Exception Exception { get; }
             public ResourceType ResourceType { get; }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -253,8 +253,8 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 jsonWriter.WriteFieldName("StartTimeUTC");
                 this.WriteDateTimeStringValue(stat.RequestStartTime);
 
-                jsonWriter.WriteFieldName("EndTimeUTC");
-                this.WriteDateTimeStringValue(stat.RequestEndTime);
+                jsonWriter.WriteFieldName("DurationInMs");
+                jsonWriter.WriteNumber64Value(stat.Duration.TotalMilliseconds);
 
                 jsonWriter.WriteFieldName("RequestUri");
                 jsonWriter.WriteStringValue(stat.RequestUri.ToString());

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
@@ -447,7 +447,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
                         {
                             stringBuilder.AppendLine($"{space}HttpResponse");
                             stringBuilder.AppendLine($"{space}{space}RequestStartTime: {stat.RequestStartTime.ToString("o", CultureInfo.InvariantCulture)}");
-                            stringBuilder.AppendLine($"{space}{space}RequestEndTime: {stat.RequestEndTime.ToString("o", CultureInfo.InvariantCulture)}");
+                            stringBuilder.AppendLine($"{space}{space}DurationInMs: {stat.Duration.TotalMilliseconds:0.00}");
                             stringBuilder.AppendLine($"{space}{space}RequestUri: {stat.RequestUri}");
                             stringBuilder.AppendLine($"{space}{space}ResourceType: {stat.ResourceType}");
                             stringBuilder.AppendLine($"{space}{space}HttpMethod: {stat.HttpMethod}");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayClientSideRequestStatsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayClientSideRequestStatsTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(datum.HttpResponseStatisticsList);
             Assert.AreEqual(datum.HttpResponseStatisticsList.Count, 1);
             Assert.IsNotNull(datum.HttpResponseStatisticsList[0].HttpResponseMessage);
-            Assert.AreEqual(datum.RequestEndTimeUtc, datum.HttpResponseStatisticsList[0].RequestEndTime);
+            Assert.AreEqual(datum.RequestEndTimeUtc, datum.HttpResponseStatisticsList[0].RequestStartTime + datum.HttpResponseStatisticsList[0].Duration);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -653,14 +653,14 @@
             Http Response Statistics
               HttpResponse
                 RequestStartTime: 0001-01-01T00:00:00.0000000
-                RequestEndTime: 9999-12-31T23:59:59.9999999
+                DurationInMs: 315537897600000.00
                 RequestUri: http://someuri1.com/
                 ResourceType: Document
                 HttpMethod: GET
                 StatusCode: OK
               HttpResponse
                 RequestStartTime: 0001-01-01T00:00:00.0000000
-                RequestEndTime: 9999-12-31T23:59:59.9999999
+                DurationInMs: 315537897600000.00
                 RequestUri: http://someuri1.com/
                 ResourceType: Document
                 HttpMethod: GET
@@ -689,7 +689,7 @@
       "HttpResponseStats": [
         {
           "StartTimeUTC": "0001-01-01T00:00:00",
-          "EndTimeUTC": "9999-12-31T23:59:59.9999999",
+          "DurationInMs": 315537897600000,
           "RequestUri": "http://someuri1.com/",
           "ResourceType": "Document",
           "HttpMethod": "GET",
@@ -698,7 +698,7 @@
         },
         {
           "StartTimeUTC": "0001-01-01T00:00:00",
-          "EndTimeUTC": "9999-12-31T23:59:59.9999999",
+          "DurationInMs": 315537897600000,
           "RequestUri": "http://someuri1.com/",
           "ResourceType": "Document",
           "HttpMethod": "GET",


### PR DESCRIPTION
This PR replaces the EndTimeUtc with a Duration field in HttpResponseStats, which makes it easier to read.