### PR TITLE
Benchmark: Fixes null reference exception when executing v2 SDK

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/CosmosDiagnosticsLogger.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Fx/CosmosDiagnosticsLogger.cs
@@ -25,6 +25,11 @@ namespace CosmosBenchmark
 
         public static void Log(CosmosDiagnostics cosmosDiagnostics)
         {
+            if (cosmosDiagnostics == null)
+            {
+                return;
+            }
+
             TimeSpan elapsedTime = cosmosDiagnostics.GetClientElapsedTime();
             // Require the diagnostics to be at least 10 seconds apart to avoid getting the
             // diagnostics from the exact same time frame to avoid the same issue multiple times


### PR DESCRIPTION
# Pull Request Template

## Description

The v2 SDK does not have a Cosmos Diagnostics so it causes a null reference exception. This fixes the null reference exception be simply not logging the CosmosDiagnostics for the v2 SDK.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber