### PR TITLE
UserAgent: Fixes race condition in ClientId and max value for UserAgentString

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
             this.maxServerRequestBodyLength = maxServerRequestBodyLength;
             this.maxServerRequestOperationCount = maxServerRequestOperationCount;
             this.timerWheel = TimerWheel.CreateTimerWheel(BatchAsyncContainerExecutor.TimerWheelResolution, BatchAsyncContainerExecutor.TimerWheelBucketCount);
-            this.retryOptions = cosmosClientContext.ClientOptions.GetConnectionPolicy().RetryOptions;
+            this.retryOptions = cosmosClientContext.ClientOptions.GetConnectionPolicy(cosmosClientContext.Client.ClientId).RetryOptions;
         }
 
         public virtual async Task<TransactionalBatchOperationResult> AddAsync(

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Cosmos
             this.ConnectionMode = ConnectionMode.Gateway;
             this.MaxConcurrentFanoutRequests = defaultMaxConcurrentFanoutRequests;
             this.MediaReadMode = MediaReadMode.Buffered;
-            this.UserAgentContainer = new UserAgentContainer();
+            this.UserAgentContainer = new UserAgentContainer(clientId: 0);
             this.preferredLocations = new ObservableCollection<string>();
             this.EnableEndpointDiscovery = true;
             this.MaxConnectionLimit = defaultMaxConcurrentConnectionLimit;

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -250,11 +250,11 @@ namespace Microsoft.Azure.Cosmos
 
             clientOptions ??= new CosmosClientOptions();
 
+            this.ClientId = this.IncrementNumberOfClientsCreated();
             this.ClientContext = ClientContextCore.Create(
                 this,
                 clientOptions);
-
-            this.IncrementNumberOfClientsCreated();
+  
             this.ClientConfigurationTraceDatum = new ClientConfigurationTraceDatum(this.ClientContext, DateTime.UtcNow);
         }
 
@@ -479,6 +479,7 @@ namespace Microsoft.Azure.Cosmos
         internal RequestInvokerHandler RequestHandler => this.ClientContext.RequestHandler;
         internal CosmosClientContext ClientContext { get; }
         internal ClientConfigurationTraceDatum ClientConfigurationTraceDatum { get; }
+        internal int ClientId { get; }
 
         /// <summary>
         /// Reads the <see cref="Microsoft.Azure.Cosmos.AccountProperties"/> for the Azure Cosmos DB account.
@@ -1195,9 +1196,9 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        private void IncrementNumberOfClientsCreated()
+        private int IncrementNumberOfClientsCreated()
         {
-            Interlocked.Increment(ref numberOfClientsCreated);
+            return Interlocked.Increment(ref numberOfClientsCreated);
         }
 
         private async Task InitializeContainerAsync(string databaseId, string containerId, CancellationToken cancellationToken = default)

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -646,7 +646,7 @@ namespace Microsoft.Azure.Cosmos
             return cloneConfiguration;
         }
 
-        internal virtual ConnectionPolicy GetConnectionPolicy()
+        internal virtual ConnectionPolicy GetConnectionPolicy(int clientId)
         {
             this.ValidateDirectTCPSettings();
             this.ValidateLimitToEndpointSettings();
@@ -657,7 +657,7 @@ namespace Microsoft.Azure.Cosmos
                 RequestTimeout = this.RequestTimeout,
                 ConnectionMode = this.ConnectionMode,
                 ConnectionProtocol = this.ConnectionProtocol,
-                UserAgentContainer = this.CreateUserAgentContainerWithFeatures(),
+                UserAgentContainer = this.CreateUserAgentContainerWithFeatures(clientId),
                 UseMultipleWriteLocations = true,
                 IdleTcpConnectionTimeout = this.IdleTcpConnectionTimeout,
                 OpenTcpConnectionTimeout = this.OpenTcpConnectionTimeout,
@@ -808,7 +808,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        internal UserAgentContainer CreateUserAgentContainerWithFeatures()
+        internal UserAgentContainer CreateUserAgentContainerWithFeatures(int clientId)
         {
             CosmosClientOptionsFeatures features = CosmosClientOptionsFeatures.NoFeatures;
             if (this.AllowBulkExecution)
@@ -830,6 +830,7 @@ namespace Microsoft.Azure.Cosmos
             string regionConfiguration = this.GetRegionConfiguration();
 
             return new UserAgentContainer(
+                        clientId: clientId,
                         features: featureString,
                         regionConfiguration: regionConfiguration,
                         suffix: this.ApplicationName);

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos
                apitype: clientOptions.ApiType,
                sendingRequestEventArgs: clientOptions.SendingRequestEventArgs,
                transportClientHandlerFactory: clientOptions.TransportClientHandlerFactory,
-               connectionPolicy: clientOptions.GetConnectionPolicy(),
+               connectionPolicy: clientOptions.GetConnectionPolicy(cosmosClient.ClientId),
                enableCpuMonitor: clientOptions.EnableCpuMonitor,
                storeClientFactory: clientOptions.StoreClientFactory,
                desiredConsistencyLevel: clientOptions.GetDocumentsConsistencyLevel(),

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos
     internal class UserAgentContainer : Documents.UserAgentContainer
     {
         private const int MaxOperatingSystemString = 30;
+        private const int MaxClientId = 10;
         private readonly string cosmosBaseUserAgent;
 
         public UserAgentContainer(
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.Cosmos
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
             clientVersion = environmentInformation.ClientVersion;
             directVersion = environmentInformation.DirectVersion;
-            clientId = CosmosClient.numberOfClientsCreated.ToString();
+            clientId = System.Math.Min(CosmosClient.numberOfClientsCreated, UserAgentContainer.MaxClientId).ToString();
             processArchitecture = environmentInformation.ProcessArchitecture;
             operatingSystem = environmentInformation.OperatingSystem;
             runtimeFramework = environmentInformation.RuntimeFramework;

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -13,13 +13,16 @@ namespace Microsoft.Azure.Cosmos
         private const int MaxOperatingSystemString = 30;
         private const int MaxClientId = 10;
         private readonly string cosmosBaseUserAgent;
+        private readonly int clientId;
 
         public UserAgentContainer(
+            int clientId,
             string features = null,
             string regionConfiguration = "NS",
             string suffix = null) 
                : base()
         {
+            this.clientId = clientId;
             this.cosmosBaseUserAgent = this.CreateBaseUserAgentString(
                 features: features,
                 regionConfiguration: regionConfiguration);
@@ -39,7 +42,7 @@ namespace Microsoft.Azure.Cosmos
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
             clientVersion = environmentInformation.ClientVersion;
             directVersion = environmentInformation.DirectVersion;
-            clientId = System.Math.Min(CosmosClient.numberOfClientsCreated, UserAgentContainer.MaxClientId).ToString();
+            clientId = System.Math.Min(this.clientId, UserAgentContainer.MaxClientId).ToString();
             processArchitecture = environmentInformation.ProcessArchitecture;
             operatingSystem = environmentInformation.OperatingSystem;
             runtimeFramework = environmentInformation.RuntimeFramework;

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Cosmos
         private const int MaxOperatingSystemString = 30;
         private const int MaxClientId = 10;
         private readonly string cosmosBaseUserAgent;
-        private readonly int clientId;
+        private readonly string clientId;
 
         public UserAgentContainer(
             int clientId,
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos
             string suffix = null) 
                : base()
         {
-            this.clientId = clientId;
+            this.clientId = System.Math.Min(clientId, UserAgentContainer.MaxClientId).ToString();
             this.cosmosBaseUserAgent = this.CreateBaseUserAgentString(
                 features: features,
                 regionConfiguration: regionConfiguration);
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.Cosmos
         protected virtual void GetEnvironmentInformation(
             out string clientVersion,
             out string directVersion,
-            out string clientId,
             out string processArchitecture,
             out string operatingSystem,
             out string runtimeFramework)
@@ -42,7 +41,6 @@ namespace Microsoft.Azure.Cosmos
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
             clientVersion = environmentInformation.ClientVersion;
             directVersion = environmentInformation.DirectVersion;
-            clientId = System.Math.Min(this.clientId, UserAgentContainer.MaxClientId).ToString();
             processArchitecture = environmentInformation.ProcessArchitecture;
             operatingSystem = environmentInformation.OperatingSystem;
             runtimeFramework = environmentInformation.RuntimeFramework;
@@ -55,7 +53,6 @@ namespace Microsoft.Azure.Cosmos
             this.GetEnvironmentInformation(
                 out string clientVersion,
                 out string directVersion,
-                out string clientId,
                 out string processArchitecture,
                 out string operatingSystem,
                 out string runtimeFramework);
@@ -67,7 +64,7 @@ namespace Microsoft.Azure.Cosmos
 
             // Regex replaces all special characters with empty space except . - | since they do not cause format exception for the user agent string.
             // Do not change the cosmos-netstandard-sdk as it is required for reporting
-            string baseUserAgent = $"cosmos-netstandard-sdk/{clientVersion}" + Regex.Replace($"|{directVersion}|{clientId}|{processArchitecture}|{operatingSystem}|{runtimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
+            string baseUserAgent = $"cosmos-netstandard-sdk/{clientVersion}" + Regex.Replace($"|{directVersion}|{this.clientId}|{processArchitecture}|{operatingSystem}|{runtimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
 
             if (!string.IsNullOrEmpty(regionConfiguration))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ConnectionPolicy policy = new ConnectionPolicy();
             policy.UserAgentSuffix = suffix;
 
-            string expectedUserAgent = new Cosmos.UserAgentContainer().BaseUserAgent + suffix;
+            string expectedUserAgent = new Cosmos.UserAgentContainer(clientId: 0).BaseUserAgent + suffix;
             string actualUserAgent = policy.UserAgentContainer.UserAgent;
             int startIndexOfClientCounter = expectedUserAgent.IndexOfNth('|', 2) + 1;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string[] values = serialization.Split('|');
             Assert.AreEqual($"cosmos-netstandard-sdk/{envInfo.ClientVersion}", values[0]);
             Assert.AreEqual(envInfo.DirectVersion, values[1]);
-            Assert.AreEqual(CosmosClient.numberOfClientsCreated.ToString(), values[2]);
+            Assert.AreEqual(Math.Min(CosmosClient.numberOfClientsCreated, 10).ToString(), values[2]);
             Assert.AreEqual(envInfo.ProcessArchitecture, values[3]);
             Assert.AreEqual(envInfo.OperatingSystem, values[4]);
             Assert.AreEqual(envInfo.RuntimeFramework, values[5]);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -374,7 +374,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             protected override void GetEnvironmentInformation(
                 out string clientVersion,
                 out string directVersion,
-                out string clientId,
                 out string processArchitecture,
                 out string operatingSystem,
                 out string runtimeFramework)
@@ -385,7 +384,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 base.GetEnvironmentInformation(
                     clientVersion: out clientVersion,
                     directVersion: out directVersion,
-                    clientId: out clientId,
                     processArchitecture: out processArchitecture,
                     operatingSystem: out _,
                     runtimeFramework: out runtimeFramework);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             CosmosClient.numberOfClientsCreated = 0; // reset
             const int max = 10;
-            List<int> expected = new List<int>(max + 5);
+            List<int> expected = new List<int>();
             for (int i = 1; i < max + 5; i++)
             {
                 expected.Add(i > max ? max : i);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -181,12 +181,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public void VerifyClientIDForUserAgentString()
         {
             CosmosClient.numberOfClientsCreated = 0; // reset
-            for (int i = 0; i < 10; i++)
+            const int max = 10;
+            for (int i = 0; i < max + 5; i++)
             {
                 using (CosmosClient client = TestCommon.CreateCosmosClient())
                 {
                     string userAgentString = client.DocumentClient.ConnectionPolicy.UserAgentContainer.UserAgent;
-                    Assert.AreEqual(userAgentString.Split('|')[2], i.ToString());
+                    if (i <= max)
+                    {
+                        Assert.AreEqual(userAgentString.Split('|')[2], i.ToString());
+                    }
+                    else
+                    {
+                        Assert.AreEqual(userAgentString.Split('|')[2], max.ToString());
+                    }
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -351,6 +351,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                .Returns<string, RequestOptions, Func<ITrace, Task<object>>, TraceComponent, TraceLevel>(
                 (operationName, requestOptions, func, comp, level) => func(NoOpTrace.Singleton));
 
+            mockContext.Setup(x => x.Client).Returns(MockCosmosUtil.CreateMockCosmosClient());
+
             return mockContext;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsFalse(clientOptions.EnablePartitionLevelFailover);
 
             //Verify GetConnectionPolicy returns the correct values for default
-            ConnectionPolicy policy = clientOptions.GetConnectionPolicy();
+            ConnectionPolicy policy = clientOptions.GetConnectionPolicy(clientId: 0);
             Assert.AreEqual(ConnectionMode.Direct, policy.ConnectionMode);
             Assert.AreEqual(Protocol.Tcp, policy.ConnectionProtocol);
             Assert.AreEqual(clientOptions.GatewayModeMaxConnectionLimit, policy.MaxConnectionLimit);
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(clientOptions.EnablePartitionLevelFailover);
 
             //Verify GetConnectionPolicy returns the correct values
-            policy = clientOptions.GetConnectionPolicy();
+            policy = clientOptions.GetConnectionPolicy(clientId: 0);
             Assert.AreEqual(region, policy.PreferredLocations[0]);
             Assert.AreEqual(ConnectionMode.Gateway, policy.ConnectionMode);
             Assert.AreEqual(Protocol.Https, policy.ConnectionProtocol);
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CollectionAssert.AreEqual(preferredLocations.ToArray(), clientOptions.ApplicationPreferredRegions.ToArray());
 
             //Verify GetConnectionPolicy returns the correct values
-            policy = clientOptions.GetConnectionPolicy();
+            policy = clientOptions.GetConnectionPolicy(clientId: 0);
             Assert.AreEqual(idleTcpConnectionTimeout, policy.IdleTcpConnectionTimeout);
             Assert.AreEqual(openTcpConnectionTimeout, policy.OpenTcpConnectionTimeout);
             Assert.AreEqual(maxRequestsPerTcpConnection, policy.MaxRequestsPerTcpConnection);
@@ -250,12 +250,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             string userAgentSuffix = "testSuffix";
             cosmosClientOptions.ApplicationName = userAgentSuffix;
             Assert.AreEqual(userAgentSuffix, cosmosClientOptions.ApplicationName);
-            Cosmos.UserAgentContainer userAgentContainer = cosmosClientOptions.CreateUserAgentContainerWithFeatures();
+            Cosmos.UserAgentContainer userAgentContainer = cosmosClientOptions.CreateUserAgentContainerWithFeatures(clientId: 0);
             Assert.AreEqual(userAgentSuffix, userAgentContainer.Suffix);
             Assert.IsTrue(userAgentContainer.UserAgent.StartsWith(expectedValue));
             Assert.IsTrue(userAgentContainer.UserAgent.EndsWith(userAgentSuffix));
 
-            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
+            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy(clientId: 0);
             Assert.AreEqual(userAgentSuffix, connectionPolicy.UserAgentSuffix);
             Assert.IsTrue(connectionPolicy.UserAgentContainer.UserAgent.StartsWith(expectedValue));
             Assert.IsTrue(connectionPolicy.UserAgentContainer.UserAgent.EndsWith(userAgentSuffix));
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void VerifyLimitToEndpointSettings()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions { ApplicationRegion = Regions.EastUS, LimitToEndpoint = true };
-            cosmosClientOptions.GetConnectionPolicy();
+            cosmosClientOptions.GetConnectionPolicy(clientId: 0);
         }
 
         [TestMethod]
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void VerifyLimitToEndpointSettingsWithPreferredRegions()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions { ApplicationPreferredRegions = new List<string>() { Regions.EastUS }, LimitToEndpoint = true };
-            cosmosClientOptions.GetConnectionPolicy();
+            cosmosClientOptions.GetConnectionPolicy(clientId: 0);
         }
 
         [TestMethod]
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void VerifyApplicationRegionSettingsWithPreferredRegions()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions { ApplicationPreferredRegions = new List<string>() { Regions.EastUS }, ApplicationRegion = Regions.EastUS };
-            cosmosClientOptions.GetConnectionPolicy();
+            cosmosClientOptions.GetConnectionPolicy(clientId: 0);
         }
 
         [TestMethod]
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosClientOptions clientOptions = cosmosClient.ClientOptions;
 
             Assert.AreEqual(clientOptions.HttpClientFactory, this.HttpClientFactoryDelegate);
-            ConnectionPolicy policy = clientOptions.GetConnectionPolicy();
+            ConnectionPolicy policy = clientOptions.GetConnectionPolicy(clientId: 0);
             Assert.AreEqual(policy.HttpClientFactory, this.HttpClientFactoryDelegate);
         }
 
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosClientOptions cosmosClientOptions = cosmosClientBuilder.Build(new MockDocumentClient()).ClientOptions;
             Assert.IsFalse(cosmosClientOptions.LimitToEndpoint);
 
-            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
+            ConnectionPolicy connectionPolicy = cosmosClientOptions.GetConnectionPolicy(clientId: 0);
             Assert.IsTrue(connectionPolicy.EnableEndpointDiscovery);
 
             cosmosClientBuilder
@@ -461,7 +461,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             cosmosClientOptions = cosmosClientBuilder.Build(new MockDocumentClient()).ClientOptions;
             Assert.IsTrue(cosmosClientOptions.LimitToEndpoint);
 
-            connectionPolicy = cosmosClientOptions.GetConnectionPolicy();
+            connectionPolicy = cosmosClientOptions.GetConnectionPolicy(clientId: 0);
             Assert.IsFalse(connectionPolicy.EnableEndpointDiscovery);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Cosmos
                 SynchronizationContext.SetSynchronizationContext(syncContext);
                 syncContext.Post(_ =>
                 {
-                    UserAgentContainer container = new UserAgentContainer();
+                    UserAgentContainer container = new UserAgentContainer(clientId: 0);
                     FakeMessageHandler messageHandler = new FakeMessageHandler();
 
                     AccountProperties databaseAccount = new AccountProperties();


### PR DESCRIPTION
Issue introduced in #2552

The cap on the ClientId was removed in the above PR, as a result there was a increase in size of the Kusto tables.
The ClientId is also being made thread safe by introducing a clientId ref for every CosmosClient instance
