### PR TITLE
LINQ : Fixes ArgumentNullException while calling ToQueryDefinition()

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (sqlQuery == null)
             {
-                throw new ArgumentNullException(nameof(sqlQuery));
+                return null;
             }
 
             QueryDefinition queryDefinition = new QueryDefinition(sqlQuery.QueryText);

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -55,6 +55,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (sqlQuery == null)
             {
+                // It is to support scenarios where all the data needs to be read 
                 return null;
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -797,6 +797,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         }
 
+        [TestMethod]
+        public async Task LinqSelectEverythingWithoutQueryableTest()
+        {
+            await ToDoActivity.CreateRandomItems(this.Container, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
+
+            QueryDefinition queryDefinition = this.Container
+                 .GetItemLinqQueryable<ToDoActivity>()
+                 .ToQueryDefinition();
+
+            Assert.AreEqual(2, (await this.FetchResults<ToDoActivity>(queryDefinition)).Count);
+        }
+
         private class NumberLinqItem
         {
             public string id;


### PR DESCRIPTION
## Description

This fixes ArguementNullException in ToQueryDefinition for read feed scenarios where there has been no filters applied to the linq query.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #1438 