### PR TITLE
[Encryption] Change Feed: Fixes change feed decryptableresponse to not throw exceptions on NotModified

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<ClientPreviewVersion>3.20.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
 		<DirectVersion>3.19.3</DirectVersion>
-		<EncryptionVersion>1.0.0-previewV15</EncryptionVersion>
+		<EncryptionVersion>1.0.0-previewV16</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
 		<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/DecryptableFeedResponse.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/DecryptableFeedResponse.cs
@@ -49,7 +49,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
 
             using (responseMessage)
             {
-                responseMessage.EnsureSuccessStatusCode();
+                // ReadFeed can return 304 on Change Feed responses
+                if (responseMessage.StatusCode != HttpStatusCode.NotModified)
+                {
+                    responseMessage.EnsureSuccessStatusCode();
+                }
 
                 return new DecryptableFeedResponse<T>(
                     responseMessage,

--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionContainer.cs
@@ -931,12 +931,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 async (
                     ChangeFeedProcessorContext context,
                     IReadOnlyCollection<JObject> documents,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     List<T> decryptItems = await this.DecryptChangeFeedDocumentsAsync<T>(
@@ -978,12 +973,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 async (
                     ChangeFeedProcessorContext context,
                     Stream changes,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     Stream decryptedChanges = await EncryptionProcessor.DeserializeAndDecryptResponseAsync(

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -789,12 +789,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 async (
                     ChangeFeedProcessorContext context,
                     IReadOnlyCollection<JObject> documents,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     List<T> decryptedItems = await this.DecryptChangeFeedDocumentsAsync<T>(
@@ -840,12 +835,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 async (
                     ChangeFeedProcessorContext context,
                     Stream changes,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     EncryptionSettings encryptionSettings = await this.GetOrUpdateEncryptionSettingsFromCacheAsync(

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
 	<ItemGroup Condition=" '$(SdkProjectRef)' != 'True' ">
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.19.0-preview1" />
+		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.20.0-preview" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(SdkProjectRef)' == 'True' ">

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -1916,19 +1916,16 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
 
             while (changeIterator.HasMoreResults)
             {
-                try
+                FeedResponse<TestDoc> testDocs = await changeIterator.ReadNextAsync();
+                if (testDocs.StatusCode == HttpStatusCode.NotModified)
                 {
-                    FeedResponse<TestDoc> testDocs = await changeIterator.ReadNextAsync();
-                    Assert.AreEqual(testDocs.Count, 2);
-
-                    VerifyExpectedDocResponse(testDoc1, testDocs.Resource.ElementAt(0));
-                    VerifyExpectedDocResponse(testDoc2, testDocs.Resource.ElementAt(1));
-                }
-                catch (CosmosException ex)
-                {
-                    Assert.IsTrue(ex.Message.Contains("Response status code does not indicate success: NotModified (304)"));
                     break;
                 }
+
+                Assert.AreEqual(testDocs.Count, 2);
+
+                VerifyExpectedDocResponse(testDoc1, testDocs.Resource.ElementAt(0));
+                VerifyExpectedDocResponse(testDoc2, testDocs.Resource.ElementAt(1));
             }
         }
 
@@ -2042,12 +2039,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 (
                     ChangeFeedProcessorContext context,
                     IReadOnlyCollection<TestDoc> changes,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     changeFeedReturnedDocs.AddRange(changes);
@@ -2151,12 +2143,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 (
                     ChangeFeedProcessorContext context,
                     Stream changes,
-#if SDKPROJECTREF
                     Func<Task> tryCheckpointAsync,
-#else
-                    // Remove on next release
-                    Func<Task<(bool isSuccess, Exception error)>> tryCheckpointAsync,
-#endif
                     CancellationToken cancellationToken) =>
                 {
                     string changeFeed = string.Empty;


### PR DESCRIPTION
https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2499 introduced a behavior change for Change Feed responses where exceptions are no longer thrown.

The Encryption package runs on top of these responses and had logic that was throwing on NotModified still.

The PR bumps the Encryption package version and increases the dependency to 3.20.0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)