### PR TITLE
[Internal] Query: Adds coverage for gateway mode to the query emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/AggregateQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/AggregateQueryTests.cs
@@ -375,7 +375,7 @@
             documents.Add(undefinedDoc.ToString());
 
             await this.CreateIngestQueryDeleteAsync<AggregateQueryMixedTypes>(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
                 this.TestQueryCrossPartitionAggregateFunctionsWithMixedTypesHelper,
@@ -585,7 +585,7 @@
             };
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 /*CollectionTypes.SinglePartition |*/ CollectionTypes.MultiPartition,
                 documents,
                 this.TestNonValueAggregates);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -648,7 +648,7 @@
             };
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
                 this.TestMultiOrderByQueriesHelper,
@@ -1091,7 +1091,7 @@
             }
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync,
@@ -1159,7 +1159,7 @@
             OrderByTypes all = primitives | nonPrimitives | OrderByTypes.Undefined;
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
                 this.TestMixedTypeOrderByHelper,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -450,17 +450,31 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             QueryOracleUtil util = new QueryOracle2(seed);
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
+            ConnectionModes connectionModes = ConnectionModes.Direct;
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                connectionModes,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
 
-            static async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
+            connectionModes = ConnectionModes.Gateway;
+            await this.CreateIngestQueryDeleteAsync(
+                connectionModes,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                inputDocuments,
+                ImplementationAsync);
+
+            async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {
                 ContainerInternal containerCore = (ContainerInlineCore)container;
 
-                foreach (bool isGatewayQueryPlan in new bool[] { true, false })
+                List<bool> isGatewayQueryPlanOptions = new List<bool> { true };
+                if (connectionModes == ConnectionModes.Direct)
+                {
+                    isGatewayQueryPlanOptions.Append(false);
+                }
+
+                foreach (bool isGatewayQueryPlan in isGatewayQueryPlanOptions)
                 {
                     MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
                         containerCore.ClientContext,
@@ -735,8 +749,17 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 @"{""id"":""documentId12"",""prop"":1,""shortArray"":[{""a"":7}]}",
             };
 
+            ConnectionModes connectionModes = ConnectionModes.Direct;
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                connectionModes,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                inputDocs,
+                ImplementationAsync,
+                "/key");
+
+            connectionModes = ConnectionModes.Gateway;
+            await this.CreateIngestQueryDeleteAsync(
+                connectionModes,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocs,
                 ImplementationAsync,
@@ -750,7 +773,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     {
                         ContainerInternal containerCore = (ContainerInlineCore)container;
 
-                        foreach (bool isGatewayQueryPlan in new bool[] { true, false })
+                        List<bool> isGatewayQueryPlanOptions = new List<bool>{ true };
+                        if (connectionModes == ConnectionModes.Direct)
+                        {
+                            isGatewayQueryPlanOptions.Append(false);
+                        }
+
+                        foreach (bool isGatewayQueryPlan in isGatewayQueryPlanOptions)
                         {
                             foreach (Cosmos.PartitionKey? partitionKey in new Cosmos.PartitionKey?[] { new Cosmos.PartitionKey(5), default })
                             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> documents = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 documents,
                 ImplementationAsync);
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -409,7 +409,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -555,7 +555,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         public async Task TestTryExecuteQuery()
         {
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition,
                 QueryTestsBase.NoDocuments,
                 this.TestTryExecuteQueryHelper);
@@ -651,7 +651,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         public async Task TestMalformedPipelinedContinuationToken()
         {
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 NoDocuments,
                 this.TestMalformedPipelinedContinuationTokenHelper);
@@ -980,7 +980,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);
@@ -1029,7 +1029,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             IEnumerable<string> inputDocuments = util.GetDocuments(numberOfDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 inputDocuments,
                 ImplementationAsync);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SkipTakeQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SkipTakeQueryTests.cs
@@ -23,7 +23,7 @@
             IEnumerable<string> documentsToInsert = util.GetDocuments(numDocuments);
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documentsToInsert,
                 ImplementationAsync,
@@ -128,7 +128,7 @@
             }
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documentsToInsert,
                 ImplementationAsync,


### PR DESCRIPTION
## Description

Add coverage for gateway mode in the emulator tests for query. This will be used in the Compute test pipelines as well.
