### PR TITLE
[PREVIEW] Diagnostics : Fixes CosmosResponseFactory.CreateItemResponse to use ResponseMessage.Diagnostics instead of creating a new instance

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Utils/CosmosContainerExtensions.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                         response.StatusCode, 
                         response.Headers, 
                         item, 
-                        response.Trace);
+                        response.Diagnostics);
                 }
             }
         }
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Utils
                         response.StatusCode, 
                         response.Headers,
                         item, 
-                        response.Trace);
+                        response.Diagnostics);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Linq
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
 
     /// <summary>
@@ -715,7 +716,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     System.Net.HttpStatusCode.OK,
                     new Headers(),
                     value,
-                    NoOpTrace.Singleton));
+                    new CosmosTraceDiagnostics(NoOpTrace.Singleton)));
         }
 
         private static MethodInfo GetMethodInfoOf<T1, T2>(Func<T1, T2> func)

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqQuery.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                 System.Net.HttpStatusCode.OK,
                 headers,
                 result.FirstOrDefault(),
-                rootTrace);
+                new CosmosTraceDiagnostics(rootTrace));
         }
 
         private FeedIteratorInternal CreateStreamIterator(bool isContinuationExcpected)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
@@ -37,6 +37,18 @@ namespace Microsoft.Azure.Cosmos
             this.Diagnostics = new CosmosTraceDiagnostics(trace);
         }
 
+        internal ItemResponse(
+            HttpStatusCode httpStatusCode,
+            Headers headers,
+            T item,
+            CosmosDiagnostics diagnostics)
+        {
+            this.StatusCode = httpStatusCode;
+            this.Headers = headers;
+            this.Resource = item;
+            this.Diagnostics = diagnostics;
+        }
+
         /// <inheritdoc/>
         public override Headers Headers { get; }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ItemResponse.cs
@@ -29,18 +29,6 @@ namespace Microsoft.Azure.Cosmos
             HttpStatusCode httpStatusCode,
             Headers headers,
             T item,
-            ITrace trace)
-        {
-            this.StatusCode = httpStatusCode;
-            this.Headers = headers;
-            this.Resource = item;
-            this.Diagnostics = new CosmosTraceDiagnostics(trace);
-        }
-
-        internal ItemResponse(
-            HttpStatusCode httpStatusCode,
-            Headers headers,
-            T item,
             CosmosDiagnostics diagnostics)
         {
             this.StatusCode = httpStatusCode;

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosResponseFactoryCore.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
                     cosmosResponseMessage.StatusCode,
                     cosmosResponseMessage.Headers,
                     item,
-                    cosmosResponseMessage.Trace);
+                    cosmosResponseMessage.Diagnostics);
             });
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSeriliazerUnitTests.cs
@@ -186,7 +186,8 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             mockUserJsonSerializer.Setup(x => x.FromStream<ToDoActivity>(storedProcedureExecuteResponse.Content)).Callback<Stream>(input => input.Dispose()).Returns(new ToDoActivity());
 
             // Verify all the user types use the user specified version
-            cosmosResponseFactory.CreateItemResponse<ToDoActivity>(itemResponse);
+            ItemResponse<ToDoActivity> itemResponseFromFactory = cosmosResponseFactory.CreateItemResponse<ToDoActivity>(itemResponse);
+            Assert.IsNotNull(itemResponseFromFactory.Diagnostics);
             cosmosResponseFactory.CreateStoredProcedureExecuteResponse<ToDoActivity>(storedProcedureExecuteResponse);
 
             // Throw if the setups were not called


### PR DESCRIPTION
# Pull Request Template

## Description

Use Diagnostics instead of Trace while creating ItemResponse from ResponseMessage. The other methods in the ResponseFactory are using Diagnostics except for the this one CreateItemResponse method.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)