### PR TITLE
[Client Encryption] : Adds support for PatchItem in Transactional Batch

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionTransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Custom/EncryptionTransactionalBatch.cs
@@ -229,10 +229,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         {
             List<TransactionalBatchOperationResult> decryptedTransactionalBatchOperationResults = new List<TransactionalBatchOperationResult>();
 
-            for (int index = 0; index < response.Count; index++)
+            foreach (TransactionalBatchOperationResult result in response)
             {
-                TransactionalBatchOperationResult result = response[index];
-
                 if (response.IsSuccessStatusCode && result.ResourceStream != null)
                 {
                     (Stream decryptedStream, _) = await EncryptionProcessor.DecryptAsync(
@@ -241,10 +239,12 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                         diagnosticsContext,
                         cancellationToken);
 
-                    result = new EncryptionTransactionalBatchOperationResult(response[index], decryptedStream);
+                    decryptedTransactionalBatchOperationResults.Add(new EncryptionTransactionalBatchOperationResult(result, decryptedStream));
                 }
-
-                decryptedTransactionalBatchOperationResults.Add(result);
+                else
+                {
+                    decryptedTransactionalBatchOperationResults.Add(result);
+                }
             }
 
             return new EncryptionTransactionalBatchResponse(

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -673,7 +673,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             }
         }
 
-        private async Task<List<PatchOperation>> PatchItemHelperAsync(
+        public async Task<List<PatchOperation>> PatchItemHelperAsync(
             IReadOnlyList<PatchOperation> patchOperations,
             EncryptionSettings encryptionSettings,
             CancellationToken cancellationToken = default)

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionTransactionalBatch.cs
@@ -246,7 +246,42 @@ namespace Microsoft.Azure.Cosmos.Encryption
             IReadOnlyList<PatchOperation> patchOperations,
             TransactionalBatchPatchItemRequestOptions requestOptions = null)
         {
-            throw new NotImplementedException();
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (patchOperations == null ||
+                !patchOperations.Any())
+            {
+                throw new ArgumentNullException(nameof(patchOperations));
+            }
+
+            EncryptionSettings encryptionSettings = this.encryptionContainer.GetOrUpdateEncryptionSettingsFromCacheAsync(
+                obsoleteEncryptionSettings: null,
+                cancellationToken: default)
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+
+            CosmosDiagnosticsContext diagnosticsContext = CosmosDiagnosticsContext.Create(requestOptions);
+            using (diagnosticsContext.CreateScope("PatchItem"))
+            {
+                List<PatchOperation> encryptedPatchOperations = this.encryptionContainer.PatchItemHelperAsync(
+                    patchOperations,
+                    encryptionSettings,
+                    cancellationToken: default)
+                    .ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+
+                this.transactionalBatch = this.transactionalBatch.PatchItem(
+                    id,
+                    encryptedPatchOperations,
+                    requestOptions);
+
+                return this;
+            }
         }
 
         private async Task<TransactionalBatchResponse> DecryptTransactionalBatchResponseAsync(
@@ -262,10 +297,8 @@ namespace Microsoft.Azure.Cosmos.Encryption
 
             List<TransactionalBatchOperationResult> decryptedTransactionalBatchOperationResults = new List<TransactionalBatchOperationResult>();
 
-            for (int index = 0; index < response.Count; index++)
+            foreach (TransactionalBatchOperationResult result in response)
             {
-                TransactionalBatchOperationResult result = response[index];
-
                 if (response.IsSuccessStatusCode && result.ResourceStream != null)
                 {
                     Stream decryptedStream = await EncryptionProcessor.DecryptAsync(
@@ -274,10 +307,12 @@ namespace Microsoft.Azure.Cosmos.Encryption
                         diagnosticsContext,
                         cancellationToken);
 
-                    result = new EncryptionTransactionalBatchOperationResult(response[index], decryptedStream);
+                    decryptedTransactionalBatchOperationResults.Add(new EncryptionTransactionalBatchOperationResult(result, decryptedStream));
                 }
-
-                decryptedTransactionalBatchOperationResults.Add(result);
+                else
+                {
+                    decryptedTransactionalBatchOperationResults.Add(result);
+                }
             }
 
             return new EncryptionTransactionalBatchResponse(

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -671,6 +671,16 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
 
             TestDoc docToDelete = await MdeEncryptionTests.MdeCreateItemAsync(MdeEncryptionTests.encryptionContainer, partitionKey);
 
+            TestDoc docToPatch = await MdeEncryptionTests.MdeCreateItemAsync(MdeEncryptionTests.encryptionContainer, partitionKey);
+            docToPatch.Sensitive_StringFormat = Guid.NewGuid().ToString();
+            docToPatch.Sensitive_DecimalFormat = 11.11m;
+
+            List<PatchOperation> patchOperations = new List<PatchOperation>
+            {
+                PatchOperation.Replace("/Sensitive_StringFormat", docToPatch.Sensitive_StringFormat),
+                PatchOperation.Replace("/Sensitive_DecimalFormat", docToPatch.Sensitive_DecimalFormat),
+            };
+
             TransactionalBatchResponse batchResponse = await MdeEncryptionTests.encryptionContainer.CreateTransactionalBatch(new Cosmos.PartitionKey(partitionKey))
                 .CreateItem(doc1ToCreate)
                 .CreateItemStream(doc2ToCreate.ToStream())
@@ -681,6 +691,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 .UpsertItem(doc1ToUpsert)
                 .DeleteItem(docToDelete.Id)
                 .UpsertItemStream(doc2ToUpsert.ToStream())
+                //.PatchItem(docToPatch.Id, patchOperations)
                 .ExecuteAsync();
 
             Assert.AreEqual(HttpStatusCode.OK, batchResponse.StatusCode);
@@ -709,6 +720,9 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
             TransactionalBatchOperationResult<TestDoc> doc8 = batchResponse.GetOperationResultAtIndex<TestDoc>(8);
             VerifyExpectedDocResponse(doc2ToUpsert, doc8.Resource);
 
+            TransactionalBatchOperationResult<TestDoc> doc9 = batchResponse.GetOperationResultAtIndex<TestDoc>(9);
+            VerifyExpectedDocResponse(docToPatch, doc9.Resource);
+            
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc1ToCreate);
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc2ToCreate);
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc3ToCreate);
@@ -717,10 +731,10 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc2ToReplace);
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc1ToUpsert);
             await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, doc2ToUpsert);
+            await MdeEncryptionTests.VerifyItemByReadAsync(MdeEncryptionTests.encryptionContainer, docToPatch);
 
             ResponseMessage readResponseMessage = await MdeEncryptionTests.encryptionContainer.ReadItemStreamAsync(docToDelete.Id, new PartitionKey(docToDelete.PK));
             Assert.AreEqual(HttpStatusCode.NotFound, readResponseMessage.StatusCode);
-            
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

Adds support for PatchItem in Transactional Batch. Support for Patch via point operation already exists. Extending to Batch as well.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
