### PR TITLE
Query: Fixes substatus code for GROUP BY queries in PartitionRoutingHelper

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
@@ -314,6 +314,7 @@ namespace Microsoft.Azure.Cosmos.Query
                         isContinuationExpected: this.isContinuationExpected,
                         hasLogicalPartitionKey: false,
                         allowDCount: false,
+                        allowNonValueAggregates: false,
                         partitionKeyDefinition: partitionKeyDefinition,
                         queryPartitionProvider: queryPartitionProvider,
                         clientApiVersion: version,

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -32,32 +32,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             bool isContinuationExpected,
             bool hasLogicalPartitionKey,
             bool allowDCount,
-            PartitionKeyDefinition partitionKeyDefinition,
-            QueryPartitionProvider queryPartitionProvider,
-            string clientApiVersion,
-            out QueryInfo queryInfo)
-        {
-            return PartitionRoutingHelper.GetProvidedPartitionKeyRanges(
-                querySpec: querySpec,
-                enableCrossPartitionQuery: enableCrossPartitionQuery,
-                parallelizeCrossPartitionQuery: parallelizeCrossPartitionQuery,
-                isContinuationExpected: isContinuationExpected,
-                hasLogicalPartitionKey: hasLogicalPartitionKey,
-                allowDCount: allowDCount,
-                allowNonValueAggregates: false,
-                partitionKeyDefinition: partitionKeyDefinition,
-                queryPartitionProvider: queryPartitionProvider,
-                clientApiVersion: clientApiVersion,
-                out queryInfo);
-        }
-
-        public static IReadOnlyList<Range<string>> GetProvidedPartitionKeyRanges(
-            SqlQuerySpec querySpec,
-            bool enableCrossPartitionQuery,
-            bool parallelizeCrossPartitionQuery,
-            bool isContinuationExpected,
-            bool hasLogicalPartitionKey,
-            bool allowDCount,
             bool allowNonValueAggregates,
             PartitionKeyDefinition partitionKeyDefinition,
             QueryPartitionProvider queryPartitionProvider,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPlanBaselineTests.Negative.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/QueryPlanBaselineTests.Negative.xml
@@ -15,7 +15,13 @@
   <Result>
     <Input>
       <Description>Max UDF Calls</Description>
-      <Query>SELECT udf.func1(r.a), udf.func2(r.b), udf.func3(r.c), udf.func1(r.d), udf.func2(r.e), udf.func3(r.f) FROM Root r</Query>
+      <Query>
+                    SELECT
+                        udf.func1(r.a), udf.func2(r.b), udf.func3(r.c),
+                        udf.func1(r.d), udf.func2(r.e), udf.func3(r.f),
+                        udf.func1(r.g), udf.func2(r.h), udf.func3(r.i),
+                        udf.func1(r.j), udf.func2(r.k), udf.func3(r.l),
+                    FROM Root r</Query>
       <PartitionKeys>
         <Key>/key</Key>
       </PartitionKeys>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -24,30 +24,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     [TestClass]
     public class FullPipelineTests
     {
-        private static readonly Dictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
-        {
-            {"maxSqlQueryInputLength", 30720},
-            {"maxJoinsPerSqlQuery", 5},
-            {"maxLogicalAndPerSqlQuery", 200},
-            {"maxLogicalOrPerSqlQuery", 200},
-            {"maxUdfRefPerSqlQuery", 2},
-            {"maxInExpressionItemsCount", 8000},
-            {"queryMaxInMemorySortDocumentCount", 500},
-            {"maxQueryRequestTimeoutFraction", 0.90},
-            {"sqlAllowNonFiniteNumbers", false},
-            {"sqlAllowAggregateFunctions", true},
-            {"sqlAllowSubQuery", true},
-            {"sqlAllowScalarSubQuery", false},
-            {"allowNewKeywords", true},
-            {"sqlAllowLike", false},
-            {"sqlAllowGroupByClause", false},
-            {"maxSpatialQueryCells", 12},
-            {"spatialMaxGeometryPointCount", 256},
-            {"sqlDisableQueryILOptimization", false},
-            {"sqlDisableFilterPlanOptimization", false}
-        };
-
-        private static readonly QueryPartitionProvider queryPartitionProvider = new QueryPartitionProvider(DefaultQueryEngineConfiguration);
         private static readonly PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition()
         {
             Paths = new Collection<string>()
@@ -409,7 +385,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 
         private static QueryInfo GetQueryPlan(string query)
         {
-            TryCatch<PartitionedQueryExecutionInfoInternal> info = queryPartitionProvider.TryGetPartitionedQueryExecutionInfoInternal(
+            TryCatch<PartitionedQueryExecutionInfoInternal> info = QueryPartitionProviderTestInstance.Object.TryGetPartitionedQueryExecutionInfoInternal(
                 new SqlQuerySpec(query),
                 partitionKeyDefinition,
                 requireFormattableOrderByQuery: true,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
@@ -22,31 +22,6 @@
     [TestClass]
     public class QueryPlanBaselineTests : BaselineTests<QueryPlanBaselineTestInput, QueryPlanBaselineTestOutput>
     {
-        private static readonly IDictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
-        {
-            {"maxSqlQueryInputLength", 30720},
-            {"maxJoinsPerSqlQuery", 5},
-            {"maxLogicalAndPerSqlQuery", 200},
-            {"maxLogicalOrPerSqlQuery", 200},
-            {"maxUdfRefPerSqlQuery", 2},
-            {"maxInExpressionItemsCount", 8000},
-            {"queryMaxInMemorySortDocumentCount", 500},
-            {"maxQueryRequestTimeoutFraction", 0.90},
-            {"sqlAllowNonFiniteNumbers", false},
-            {"sqlAllowAggregateFunctions", true},
-            {"sqlAllowSubQuery", true},
-            {"sqlAllowScalarSubQuery", false},
-            {"allowNewKeywords", true},
-            {"sqlAllowLike", true},
-            {"sqlAllowGroupByClause", false},
-            {"maxSpatialQueryCells", 12},
-            {"spatialMaxGeometryPointCount", 256},
-            {"sqlDisableQueryILOptimization", false},
-            {"sqlDisableFilterPlanOptimization", false}
-        };
-
-        private static readonly QueryPartitionProvider queryPartitionProvider = new QueryPartitionProvider(DefaultQueryEngineConfiguration);
-
         [TestMethod]
         [Owner("brchon")]
         public void Aggregates()
@@ -684,7 +659,13 @@
 
                 Hash(
                 @"Max UDF Calls",
-                @"SELECT udf.func1(r.a), udf.func2(r.b), udf.func3(r.c), udf.func1(r.d), udf.func2(r.e), udf.func3(r.f) FROM Root r",
+                @"
+                    SELECT
+                        udf.func1(r.a), udf.func2(r.b), udf.func3(r.c),
+                        udf.func1(r.d), udf.func2(r.e), udf.func3(r.f),
+                        udf.func1(r.g), udf.func2(r.h), udf.func3(r.i),
+                        udf.func1(r.j), udf.func2(r.k), udf.func3(r.l),
+                    FROM Root r",
                 @"/key"),
 
                 Hash(
@@ -1397,7 +1378,7 @@
 
         public override QueryPlanBaselineTestOutput ExecuteTest(QueryPlanBaselineTestInput input)
         {
-            TryCatch<PartitionedQueryExecutionInfoInternal> info = queryPartitionProvider.TryGetPartitionedQueryExecutionInfoInternal(
+            TryCatch<PartitionedQueryExecutionInfoInternal> info = QueryPartitionProviderTestInstance.Object.TryGetPartitionedQueryExecutionInfoInternal(
                 input.SqlQuerySpec,
                 input.PartitionKeyDefinition,
                 requireFormattableOrderByQuery: true,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
@@ -26,32 +26,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
     [TestClass]
     public class PartitionRoutingHelperTest
     {
-        private static readonly Dictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
-        {
-            {"maxSqlQueryInputLength", 262144},
-            {"maxJoinsPerSqlQuery", 5},
-            {"maxLogicalAndPerSqlQuery", 2000},
-            {"maxLogicalOrPerSqlQuery", 2000},
-            {"maxUdfRefPerSqlQuery", 10},
-            {"maxInExpressionItemsCount", 16000},
-            {"queryMaxGroupByTableCellCount", 500000 },
-            {"queryMaxInMemorySortDocumentCount", 500},
-            {"maxQueryRequestTimeoutFraction", 0.90},
-            {"sqlAllowNonFiniteNumbers", false},
-            {"sqlAllowAggregateFunctions", true},
-            {"sqlAllowSubQuery", true},
-            {"sqlAllowScalarSubQuery", true},
-            {"allowNewKeywords", true},
-            {"sqlAllowLike", true},
-            {"sqlAllowGroupByClause", true},
-            {"maxSpatialQueryCells", 12},
-            {"spatialMaxGeometryPointCount", 256},
-            {"sqlDisableQueryILOptimization", false},
-            {"sqlDisableFilterPlanOptimization", false}
-        };
-
-        private static readonly QueryPartitionProvider QueryPartitionProvider = new QueryPartitionProvider(DefaultQueryEngineConfiguration);
-
         private readonly PartitionRoutingHelper partitionRoutingHelper = new PartitionRoutingHelper();
 
         /// <summary>
@@ -337,7 +311,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
                         allowDCount: false,
                         allowNonValueAggregates: true,
                         partitionKeyDefinition: new PartitionKeyDefinition { Paths = new Collection<string> { testcase.PartitionKey }, Kind = PartitionKind.Hash },
-                        queryPartitionProvider: PartitionRoutingHelperTest.QueryPartitionProvider,
+                        queryPartitionProvider: QueryPartitionProviderTestInstance.Object,
                         clientApiVersion: testcase.ClientApiVersion,
                         out QueryInfo info);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
     using Microsoft.Azure.Documents.Collections;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using System.Collections.ObjectModel;
+    using System.Net;
 
     /// <summary>
     /// Tests for <see cref="PartitionRoutingHelper"/> class.
@@ -23,11 +26,33 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
     [TestClass]
     public class PartitionRoutingHelperTest
     {
-        PartitionRoutingHelper partitionRoutingHelper;
-        public PartitionRoutingHelperTest()
+        private static readonly Dictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
         {
-            this.partitionRoutingHelper = new PartitionRoutingHelper();
-        }
+            {"maxSqlQueryInputLength", 262144},
+            {"maxJoinsPerSqlQuery", 5},
+            {"maxLogicalAndPerSqlQuery", 2000},
+            {"maxLogicalOrPerSqlQuery", 2000},
+            {"maxUdfRefPerSqlQuery", 10},
+            {"maxInExpressionItemsCount", 16000},
+            {"queryMaxGroupByTableCellCount", 500000 },
+            {"queryMaxInMemorySortDocumentCount", 500},
+            {"maxQueryRequestTimeoutFraction", 0.90},
+            {"sqlAllowNonFiniteNumbers", false},
+            {"sqlAllowAggregateFunctions", true},
+            {"sqlAllowSubQuery", true},
+            {"sqlAllowScalarSubQuery", true},
+            {"allowNewKeywords", true},
+            {"sqlAllowLike", true},
+            {"sqlAllowGroupByClause", true},
+            {"maxSpatialQueryCells", 12},
+            {"spatialMaxGeometryPointCount", 256},
+            {"sqlDisableQueryILOptimization", false},
+            {"sqlDisableFilterPlanOptimization", false}
+        };
+
+        private static readonly QueryPartitionProvider QueryPartitionProvider = new QueryPartitionProvider(DefaultQueryEngineConfiguration);
+
+        private readonly PartitionRoutingHelper partitionRoutingHelper = new PartitionRoutingHelper();
 
         /// <summary>
         /// Tests for <see cref="PartitionRoutingHelper.ExtractPartitionKeyRangeFromContinuationToken"/> method.
@@ -247,6 +272,104 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
                 }
             }
         }
+
+        [TestMethod]
+        public void TestCrossPartitionAggregateQueries()
+        {
+            PartitionRoutingHelperTestCase[] testcases = new[]
+            {
+                new PartitionRoutingHelperTestCase
+                {
+                    Query = "SELECT AVG(r.key) FROM r WHERE IS_NUMBER(r.key)",
+                    PartitionKey = "/key",
+                    ClientApiVersion = "2018-12-31",
+                    StatusCode = HttpStatusCode.BadRequest,
+                    SubStatusCode = SubStatusCodes.CrossPartitionQueryNotServable,
+                    Message = RMResources.UnsupportedCrossPartitionQuery
+                },
+                new PartitionRoutingHelperTestCase
+                {
+                    Query = "SELECT COUNT(1), MAX(r.key) FROM r",
+                    PartitionKey = "/key",
+                    ClientApiVersion = "2018-12-31",
+                    StatusCode = HttpStatusCode.BadRequest,
+                    SubStatusCode = SubStatusCodes.CrossPartitionQueryNotServable,
+                    Message = RMResources.UnsupportedCrossPartitionQuery
+                },
+                new PartitionRoutingHelperTestCase
+                {
+                    Query = "SELECT c.age, COUNT(1) as count FROM c GROUP BY c.age",
+                    PartitionKey = "/key",
+                    ClientApiVersion = "2018-12-31",
+                    StatusCode = HttpStatusCode.BadRequest,
+                    SubStatusCode = SubStatusCodes.CrossPartitionQueryNotServable,
+                    Message = RMResources.UnsupportedCrossPartitionQuery
+                },
+                new PartitionRoutingHelperTestCase
+                {
+                    Query = @"SELECT
+                                c.age,
+                                AVG(c.doesNotExist) as undefined_avg,
+                                MIN(c.doesNotExist) as undefined_min,
+                                MAX(c.doesNotExist) as undefined_max,
+                                COUNT(c.doesNotExist) as undefined_count,
+                                SUM(c.doesNotExist) as undefined_sum
+                              FROM c
+                              GROUP BY c.age",
+                    PartitionKey = "/key",
+                    ClientApiVersion = "2018-12-31",
+                    StatusCode = HttpStatusCode.BadRequest,
+                    SubStatusCode = SubStatusCodes.CrossPartitionQueryNotServable,
+                    Message = RMResources.UnsupportedCrossPartitionQuery
+                }
+            };
+
+            foreach(PartitionRoutingHelperTestCase testcase in testcases)
+            {
+                try
+                {
+                    IReadOnlyList<Range<string>> _ = PartitionRoutingHelper.GetProvidedPartitionKeyRanges(
+                        querySpec: new Cosmos.Query.Core.SqlQuerySpec(testcase.Query),
+                        enableCrossPartitionQuery: true,
+                        parallelizeCrossPartitionQuery: false,
+                        isContinuationExpected: true,
+                        hasLogicalPartitionKey: testcase.HasLogicalPartitionKey,
+                        allowDCount: false,
+                        allowNonValueAggregates: true,
+                        partitionKeyDefinition: new PartitionKeyDefinition { Paths = new Collection<string> { testcase.PartitionKey }, Kind = PartitionKind.Hash },
+                        queryPartitionProvider: PartitionRoutingHelperTest.QueryPartitionProvider,
+                        clientApiVersion: testcase.ClientApiVersion,
+                        out QueryInfo info);
+
+                    Assert.Fail();
+                }
+                catch(DocumentClientException dce)
+                {
+                    Assert.AreEqual(testcase.StatusCode, dce.StatusCode);
+                    Assert.AreEqual(testcase.SubStatusCode, dce.GetSubStatus());
+                    Assert.IsTrue(dce.Message.Contains(testcase.Message));
+                    Assert.IsFalse(string.IsNullOrEmpty(dce.Error.AdditionalErrorInfo));
+                }
+            }
+        }
+
+        internal struct PartitionRoutingHelperTestCase
+        {
+            internal string Query { get; set; }
+
+            internal string PartitionKey { get; set; }
+
+            internal string ClientApiVersion { get; set; }
+
+            internal bool HasLogicalPartitionKey { get; set; }
+
+            internal HttpStatusCode StatusCode { get; set;}
+
+            internal SubStatusCodes SubStatusCode { get; set; }
+
+            internal string Message { get; set; }
+        }
+
 
         private class RoutingMapProvider : IRoutingMapProvider
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -45,30 +45,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
             IndexUtilizationInfoTests.MockIndexUtilizationInfo,
             ClientSideMetricsTests.MockClientSideMetrics);
 
-        private static readonly Dictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
-        {
-            {"maxSqlQueryInputLength", 30720},
-            {"maxJoinsPerSqlQuery", 5},
-            {"maxLogicalAndPerSqlQuery", 200},
-            {"maxLogicalOrPerSqlQuery", 200},
-            {"maxUdfRefPerSqlQuery", 2},
-            {"maxInExpressionItemsCount", 8000},
-            {"queryMaxInMemorySortDocumentCount", 500},
-            {"maxQueryRequestTimeoutFraction", 0.90},
-            {"sqlAllowNonFiniteNumbers", false},
-            {"sqlAllowAggregateFunctions", true},
-            {"sqlAllowSubQuery", true},
-            {"sqlAllowScalarSubQuery", false},
-            {"allowNewKeywords", true},
-            {"sqlAllowLike", false},
-            {"sqlAllowGroupByClause", false},
-            {"maxSpatialQueryCells", 12},
-            {"spatialMaxGeometryPointCount", 256},
-            {"sqlDisableQueryILOptimization", false},
-            {"sqlDisableFilterPlanOptimization", false}
-        };
-
-        private static readonly QueryPartitionProvider queryPartitionProvider = new QueryPartitionProvider(DefaultQueryEngineConfiguration);
         private static readonly Documents.PartitionKeyDefinition partitionKeyDefinition = new Documents.PartitionKeyDefinition()
         {
             Paths = new Collection<string>()
@@ -789,7 +765,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
 
         private static QueryInfo GetQueryPlan(string query)
         {
-            TryCatch<PartitionedQueryExecutionInfoInternal> info = queryPartitionProvider.TryGetPartitionedQueryExecutionInfoInternal(
+            TryCatch<PartitionedQueryExecutionInfoInternal> info = QueryPartitionProviderTestInstance.Object.TryGetPartitionedQueryExecutionInfoInternal(
                 new SqlQuerySpec(query),
                 partitionKeyDefinition,
                 requireFormattableOrderByQuery: true,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/QueryPartitionProviderTestInstance.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/QueryPartitionProviderTestInstance.cs
@@ -1,0 +1,39 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+
+    public static class QueryPartitionProviderTestInstance
+    {
+        public static readonly IReadOnlyDictionary<string, object> DefaultQueryEngineConfiguration = new Dictionary<string, object>()
+        {
+            {"maxSqlQueryInputLength", 262144},
+            {"maxJoinsPerSqlQuery", 5},
+            {"maxLogicalAndPerSqlQuery", 2000},
+            {"maxLogicalOrPerSqlQuery", 2000},
+            {"maxUdfRefPerSqlQuery", 10},
+            {"maxInExpressionItemsCount", 16000},
+            {"queryMaxGroupByTableCellCount", 500000 },
+            {"queryMaxInMemorySortDocumentCount", 500},
+            {"maxQueryRequestTimeoutFraction", 0.90},
+            {"sqlAllowNonFiniteNumbers", false},
+            {"sqlAllowAggregateFunctions", true},
+            {"sqlAllowSubQuery", true},
+            {"sqlAllowScalarSubQuery", true},
+            {"allowNewKeywords", true},
+            {"sqlAllowLike", true},
+            {"sqlAllowGroupByClause", true},
+            {"maxSpatialQueryCells", 12},
+            {"spatialMaxGeometryPointCount", 256},
+            {"sqlDisableQueryILOptimization", false},
+            {"sqlDisableFilterPlanOptimization", false}
+        };
+
+        internal static readonly QueryPartitionProvider Object = new QueryPartitionProvider(DefaultQueryEngineConfiguration as IDictionary<string, object>);
+    }
+
+}


### PR DESCRIPTION
## Description

Currently PartitionRoutingHelper.GetProvidedPartitionKeyRanges does not correctly set the substatus code for group by queries. This change also exposes allowNonValueAggregates as a parameter in this method, whereas it was previously hardcoded to false. This meant that Non value aggregate queries would not get back a proper substatus code either. This new parameter will be used by the Compute Gateway.

Other SDKs are supposed to use this substatus code to fetch a query plan. In the absence of this, certain hacks have been put into the NodeJS SDk for example where they check if the error text contains certain strings. as we move from Routing gateway to compute Gateway, some of these strings may change since the v3 sdk has slightly different code paths from the v2 sdk and it also localizes some error messages.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
