### PR TITLE
OperationCanceledException: Fixes lost CancellationToken on CosmosOperationCanceledException 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos
         internal CosmosOperationCanceledException(
             OperationCanceledException originalException,
             ITrace trace)
+            : base(originalException.CancellationToken)
         {
             this.originalException = originalException ?? throw new ArgumentNullException(nameof(originalException));
             if (trace == null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Azure.Cosmos
                 CosmosOperationCanceledException ex = await Assert.ThrowsExceptionAsync<CosmosOperationCanceledException>(() => client.GetContainer("test", "test").ReadItemAsync<dynamic>("id", partitionKey: new Cosmos.PartitionKey("id"), cancellationToken: cancellationToken),
                     "Should have surfaced OperationCanceledException because the token was canceled.");
                 Assert.IsTrue(ex.CancellationToken.IsCancellationRequested);
+                Assert.ReferenceEquals(cancellationToken, ex.CancellationToken);
 
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.MarkEndpointUnavailableForRead(It.IsAny<Uri>()), Times.Once, "Should had marked the endpoint unavailable");
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(false), Times.Once, "Should had refreshed the account information");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -169,6 +169,7 @@ namespace Microsoft.Azure.Cosmos
 
                 CosmosOperationCanceledException ex = await Assert.ThrowsExceptionAsync<CosmosOperationCanceledException>(() => client.GetContainer("test", "test").ReadItemAsync<dynamic>("id", partitionKey: new Cosmos.PartitionKey("id"), cancellationToken: cancellationToken),
                     "Should have surfaced OperationCanceledException because the token was canceled.");
+                Assert.IsTrue(ex.CancellationToken.IsCancellationRequested);
 
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.MarkEndpointUnavailableForRead(It.IsAny<Uri>()), Times.Once, "Should had marked the endpoint unavailable");
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(false), Times.Once, "Should had refreshed the account information");


### PR DESCRIPTION
# Pull Request Template

## Description

internal CosmosOperationCanceledException constructor lost cancellationToken of original exception

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Closing issues

To automatically close an issue: closes #IssueNumber