### PR TITLE
[INTERNAL] Query: Adds additional error info on unsupported cross partition queries for compute paths

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryFeature.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryFeature.cs
@@ -27,5 +27,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
         OrderBy = 1 << 7,
         Top = 1 << 8,
         NonValueAggregate = 1 << 9,
+        DCount = 1 << 10
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             | QueryFeatures.OffsetAndLimit
             | QueryFeatures.OrderBy
             | QueryFeatures.Top
-            | QueryFeatures.NonValueAggregate;
+            | QueryFeatures.NonValueAggregate
+            | QueryFeatures.DCount;
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
 

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -81,7 +81,9 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 if (!enableCrossPartitionQuery)
                 {
-                    throw new BadRequestException(RMResources.CrossPartitionQueryDisabled);
+                    BadRequestException exception = new BadRequestException(RMResources.CrossPartitionQueryDisabled);
+                    exception.Error.AdditionalErrorInfo = JsonConvert.SerializeObject(queryExecutionInfo);
+                    throw exception;
                 }
                 else
                 {
@@ -98,11 +100,15 @@ namespace Microsoft.Azure.Cosmos.Routing
                     {
                         if (!IsSupportedPartitionedQueryExecutionInfo(queryExecutionInfo, clientApiVersion))
                         {
-                            throw new BadRequestException(RMResources.UnsupportedCrossPartitionQuery);
+                            BadRequestException exception = new BadRequestException(RMResources.UnsupportedCrossPartitionQuery);
+                            exception.Error.AdditionalErrorInfo = JsonConvert.SerializeObject(queryExecutionInfo);
+                            throw exception;
                         }
                         else if (queryExecutionInfo.QueryInfo.HasAggregates && !IsAggregateSupportedApiVersion(clientApiVersion))
                         {
-                            throw new BadRequestException(RMResources.UnsupportedCrossPartitionQueryWithAggregate);
+                            BadRequestException exception = new BadRequestException(RMResources.UnsupportedCrossPartitionQueryWithAggregate);
+                            exception.Error.AdditionalErrorInfo = JsonConvert.SerializeObject(queryExecutionInfo);
+                            throw exception;
                         }
                         else
                         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/DistinctQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/DistinctQueryTests.cs
@@ -302,7 +302,7 @@
             }
 
             await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
+                ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 documents,
                 query,


### PR DESCRIPTION
## Description

- [x] Adds a feature flag for DCount.
- [x] Adds additional error info for unsupported cross partition queries. This is not used on the usual V3 paths that go through the pagination library. This is used for Compute. 

1. DCount has special logic that doesn't block the query unless the flag is set to false. The flag missing will not block the query. This is necessary to avoid any breaking changes where the old SDKs did not set the flag.
2.  The PartitionRoutingHelper is only used by compute and not by any of the v3 query code.
3.  Adding the query plan info to the additional info is for back compatibility with the old SDKs that do the try execute instead of the get query plan call.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

