### PR TITLE
Updating Authorization header size limit for AAD and Resource tokens

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationHelper.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Cosmos
         public const int MaxAuthorizationHeaderSize = 1024;
         public const int DefaultAllowedClockSkewInSeconds = 900;
         public const int DefaultMasterTokenExpiryInSeconds = 900;
+        private const int MaxAadAuthorizationHeaderSize = 16 * 1024;
+        private const int MaxResourceTokenAuthorizationHeaderSize = 8 * 1024;
         private static readonly string AuthorizationFormatPrefixUrlEncoded = HttpUtility.UrlEncode(string.Format(CultureInfo.InvariantCulture, Constants.Properties.AuthorizationFormat,
                 Constants.Properties.MasterToken,
                 Constants.Properties.TokenVersion,
@@ -207,10 +209,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new UnauthorizedException(RMResources.MissingAuthHeader);
             }
 
-            if (authorizationTokenString.Length > AuthorizationHelper.MaxAuthorizationHeaderSize)
-            {
-                throw new UnauthorizedException(RMResources.InvalidAuthHeaderFormat);
-            }
+            int authorizationTokenLength = authorizationTokenString.Length;
 
             authorizationTokenString = HttpUtility.UrlDecode(authorizationTokenString);
  
@@ -255,6 +254,25 @@ namespace Microsoft.Azure.Cosmos
             }
 
             ReadOnlyMemory<char> authTypeValue = authType.Slice(typeKeyValueSepartorPosition + 1);
+
+            if (MemoryExtensions.Equals(authTypeValue.Span, Constants.Properties.AadToken.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                if (authorizationTokenLength > AuthorizationHelper.MaxAadAuthorizationHeaderSize)
+                {
+                    throw new UnauthorizedException(RMResources.InvalidAuthHeaderFormat, SubStatusCodes.InvalidAuthHeaderFormat);
+                }
+            }
+            else if (MemoryExtensions.Equals(authTypeValue.Span, Constants.Properties.ResourceToken.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                if (authorizationTokenLength > AuthorizationHelper.MaxResourceTokenAuthorizationHeaderSize)
+                {
+                    throw new UnauthorizedException(RMResources.InvalidAuthHeaderFormat, SubStatusCodes.InvalidAuthHeaderFormat);
+                }
+            }
+            else if (authorizationTokenLength > AuthorizationHelper.MaxAuthorizationHeaderSize)
+            {
+                throw new UnauthorizedException(RMResources.InvalidAuthHeaderFormat, SubStatusCodes.InvalidAuthHeaderFormat);
+            }
 
             int versionKeyValueSeparatorPosition = version.Span.IndexOf('=');
             if (versionKeyValueSeparatorPosition == -1


### PR DESCRIPTION
# Pull Request Template

## Description

Microsoft.Azure.Documents AuthorizationHelper allows for Resource Tokens to be upto 8*1024 characters in length, and AAD tokens to be upto 16*1024 characters in length.

This PR carries that logic over to AuthorizationHelper for Microsoft.Azure.Cosmos

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber