### PR TITLE
Client Telemetry : Fixes data precision and telemetry handler position

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -105,15 +105,15 @@ namespace Microsoft.Azure.Cosmos
         ///                                                 |
         ///                                    +-----------------------------+
         ///                                    |                             |
+        ///                                    |       TelemetryHandler     |-> Trigger a thread to monitor system usage/operation information and send it to juno
+        ///                                    |                             |
+        ///                                    +-----------------------------+
+        ///                                                 |
+        ///                                                 |
+        ///                                                 |
+        ///                                    +-----------------------------+
+        ///                                    |                             |
         ///                                    |       RetryHandler          |-> RetryPolicy -> ResetSessionTokenRetryPolicyFactory -> ClientRetryPolicy -> ResourceThrottleRetryPolicy
-        ///                                    |                             |
-        ///                                    +-----------------------------+
-        ///                                                 |
-        ///                                                 |
-        ///                                                 |
-        ///                                    +-----------------------------+
-        ///                                    |                             |
-        ///                                    |       Telemetry Handler     |-> Trigger a thread to monitor system usage/operation information and send it to juno
         ///                                    |                             |
         ///                                    +-----------------------------+
         ///                                                 |
@@ -176,15 +176,15 @@ namespace Microsoft.Azure.Cosmos
                 current = current.InnerHandler;
             }
 
-            Debug.Assert(this.retryHandler != null, nameof(this.retryHandler));
-            current.InnerHandler = this.retryHandler;
-            current = current.InnerHandler;
-
             if (this.telemetryHandler != null)
             {
                 current.InnerHandler = this.telemetryHandler;
                 current = current.InnerHandler;
             }
+
+            Debug.Assert(this.retryHandler != null, nameof(this.retryHandler));
+            current.InnerHandler = this.retryHandler;
+            current = current.InnerHandler;
 
             // Have a router handler
             RequestHandler feedHandler = this.CreateDocumentFeedPipeline();

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos
         ///                                                 |
         ///                                    +-----------------------------+
         ///                                    |                             |
-        ///                                    |       TelemetryHandler     |-> Trigger a thread to monitor system usage/operation information and send it to juno
+        ///                                    |       TelemetryHandler     |-> Trigger a thread to monitor system usage/operation information and sends to an API
         ///                                    |                             |
         ///                                    +-----------------------------+
         ///                                                 |

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos
         ///                                                 |
         ///                                    +-----------------------------+
         ///                                    |                             |
-        ///                                    |       TelemetryHandler     |-> Trigger a thread to monitor system usage/operation information and sends to an API
+        ///                                    |       TelemetryHandler      |-> Trigger a thread to monitor system usage/operation information and sends to an API
         ///                                    |                             |
         ///                                    +-----------------------------+
         ///                                                 |

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -148,9 +148,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         return;
                     }
 
-                    this.clientTelemetryInfo.DateTimeUtc = DateTime.UtcNow.ToString(ClientTelemetryOptions.DateFormat);
-
                     this.RecordSystemUtilization();
+
+                    this.clientTelemetryInfo.DateTimeUtc = DateTime.UtcNow.ToString(ClientTelemetryOptions.DateFormat);
 
                     ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoSnapshot 
                         = Interlocked.Exchange(ref this.operationInfoMap, new ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)>());

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -216,21 +216,19 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                             statusCode: (int)statusCode);
 
             (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge) = this.operationInfoMap
-                    .GetOrAdd(payloadKey, x => (latency: new LongConcurrentHistogram(1,
+                    .GetOrAdd(payloadKey, x => (latency: new LongConcurrentHistogram(ClientTelemetryOptions.RequestLatencyMin,
                                                         ClientTelemetryOptions.RequestLatencyMax,
                                                         ClientTelemetryOptions.RequestLatencyPrecision),
                             requestcharge: new LongConcurrentHistogram(ClientTelemetryOptions.RequestChargeMin,
                                                         ClientTelemetryOptions.RequestChargeMax,
                                                         ClientTelemetryOptions.RequestChargePrecision)));
-
-            long totalElapsedTimeInMs = (long)cosmosDiagnostics.GetClientElapsedTime().TotalMilliseconds;
             try
             {
-                latency.RecordValue(totalElapsedTimeInMs * ClientTelemetryOptions.HistogramPrecisionFactor);
+                latency.RecordValue(cosmosDiagnostics.GetClientElapsedTime().Ticks);
             } 
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Latency Value : " + totalElapsedTimeInMs + "  Exception : " + ex.Message);
+                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Exception : " + ex.Message);
             }
 
             long requestChargeToRecord = (long)(requestCharge * ClientTelemetryOptions.HistogramPrecisionFactor);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -280,11 +280,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 DefaultTrace.TraceVerbose("Started Recording System Usage for telemetry.");
 
-                SystemUsageHistory systemUsageRecorder = this.diagnosticsHelper.GetClientTelemtrySystemHistory();
+                SystemUsageHistory systemUsageHistory = this.diagnosticsHelper.GetClientTelemtrySystemHistory();
 
-                if (systemUsageRecorder != null )
+                if (systemUsageHistory != null )
                 {
-                    (SystemInfo cpuUsagePayload, SystemInfo memoryUsagePayload) = ClientTelemetryHelper.RecordSystemUsage(systemUsageRecorder);
+                    (SystemInfo cpuUsagePayload, SystemInfo memoryUsagePayload) = ClientTelemetryHelper.RecordSystemUsage(systemUsageHistory);
                     if (cpuUsagePayload != null)
                     {
                         this.clientTelemetryInfo.SystemInfo.Add(cpuUsagePayload);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -88,9 +88,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Record System Usage and return recorded metrics
         /// </summary>
-        /// <param name="systemUsageRecorder"></param>
+        /// <param name="systemUsageHistory"></param>
         /// <returns>ReportPayload</returns>
-        internal static (SystemInfo cpuInfo, SystemInfo memoryInfo) RecordSystemUsage(SystemUsageHistory systemUsageRecorder)
+        internal static (SystemInfo cpuInfo, SystemInfo memoryInfo) RecordSystemUsage(SystemUsageHistory systemUsageHistory)
         {
             LongConcurrentHistogram cpuHistogram = new LongConcurrentHistogram(ClientTelemetryOptions.CpuMin,
                                                         ClientTelemetryOptions.CpuMax,
@@ -100,12 +100,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                                            ClientTelemetryOptions.MemoryMax,
                                                            ClientTelemetryOptions.MemoryPrecision);
 
-            if (systemUsageRecorder.Values == null)
+            if (systemUsageHistory.Values == null)
             {
                 return (null, null);
             }
 
-            foreach (SystemUsageLoad systemUsage in systemUsageRecorder.Values)
+            DefaultTrace.TraceInformation("System Usage recorded by telemetry is : " + systemUsageHistory);
+
+            foreach (SystemUsageLoad systemUsage in systemUsageHistory.Values)
             {
                 float? cpuValue = systemUsage.CpuUsage;
                 if (cpuValue.HasValue && !float.IsNaN(cpuValue.Value))

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             if (memoryHistogram.TotalCount > 0)
             {
                 memoryInfoPayload = new SystemInfo(ClientTelemetryOptions.MemoryName, ClientTelemetryOptions.MemoryUnit);
-                memoryInfoPayload.SetAggregators(memoryHistogram, ClientTelemetryOptions.KbToMb);
+                memoryInfoPayload.SetAggregators(memoryHistogram, ClientTelemetryOptions.KbToMbFactor);
             }
 
             SystemInfo cpuInfoPayload = null;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 OperationInfo payloadForLatency = entry.Key;
                 payloadForLatency.MetricInfo = new MetricInfo(ClientTelemetryOptions.RequestLatencyName, ClientTelemetryOptions.RequestLatencyUnit);
-                payloadForLatency.SetAggregators(entry.Value.latency, ClientTelemetryOptions.HistogramPrecisionFactor);
+                payloadForLatency.SetAggregators(entry.Value.latency, ClientTelemetryOptions.TicksToMsFactor);
 
                 payloadWithMetricInformation.Add(payloadForLatency);
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -15,12 +15,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     {
         internal const String RequestKey = "telemetry";
 
-        internal const long HistogramPrecisionFactor = 100;
-        
+        internal const double HistogramPrecisionFactor = 100;
+        internal const double TicksToMsFactor = 10000;
+
         internal const int BytesToMb = 1024 * 1024;
         internal const int OneKbToBytes = 1024;
 
-        internal const int RequestLatencyMax = Int32.MaxValue;
+        internal const long RequestLatencyMax = TimeSpan.TicksPerHour;
+        internal const long RequestLatencyMin = 10;
         internal const int RequestLatencyPrecision = 5;
         internal const string RequestLatencyName = "RequestLatency";
         internal const string RequestLatencyUnit = "MilliSecond";
@@ -29,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const string RequestChargeName = "RequestCharge";
         internal const string RequestChargeUnit = "RU";
 
-        internal const int CpuMax = 100;
+        internal const int CpuMax = 9999;
         internal const int CpuPrecision = 3;
         internal const String CpuName = "CPU";
         internal const String CpuUnit = "Percentage";
@@ -58,8 +60,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         internal static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
-        internal static readonly int RequestChargeMax = 99999 * Convert.ToInt32(HistogramPrecisionFactor);
-        internal static readonly int RequestChargeMin = 1 * Convert.ToInt32(HistogramPrecisionFactor);
+        internal static readonly long RequestChargeMax = 9999900;
+        internal static readonly long RequestChargeMin = 100;
 
         private static Uri vmMetadataUrl;
         private static TimeSpan scheduledTimeSpan = TimeSpan.Zero;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const double HistogramPrecisionFactor = 100;
         internal const double TicksToMsFactor = 10000;
 
-        internal const int BytesToMb = 1024 * 1024;
+        internal const int KbToMb = 1024;
         internal const int OneKbToBytes = 1024;
 
         internal const long RequestLatencyMax = TimeSpan.TicksPerHour;
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const long MemoryMax = Int64.MaxValue;
         internal const long MemoryMin = 1;
         internal const int MemoryPrecision = 5;
-        internal const String MemoryName = "Memory Remaining";
+        internal const String MemoryName = "MemoryRemaining";
         internal const String MemoryUnit = "MB";
 
         internal const string DefaultVmMetadataUrL = "http://169.254.169.254/metadata/instance?api-version=2020-06-01";
@@ -116,13 +116,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             return JObject.Parse(jsonVmInfo).ToObject<AzureVMMetadata>();
         }
 
-        internal static string GetHostInformation(Compute vmInformation) 
+        internal static string GetHostInformation(Compute vmInformation)
         {
             return String.Concat(vmInformation?.OSType, "|",
                     vmInformation?.SKU, "|",
                     vmInformation?.VMSize, "|",
                     vmInformation?.AzEnvironment);
-        } 
+        }
 
         internal static Uri GetClientTelemetryEndpoint()
         {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -22,21 +22,25 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const int OneKbToBytes = 1024;
 
         internal const long RequestLatencyMax = TimeSpan.TicksPerHour;
-        internal const long RequestLatencyMin = 10;
+        internal const long RequestLatencyMin = 1;
         internal const int RequestLatencyPrecision = 5;
         internal const string RequestLatencyName = "RequestLatency";
         internal const string RequestLatencyUnit = "MilliSecond";
 
+        internal const long RequestChargeMax = 9999900;
+        internal const long RequestChargeMin = 1;
         internal const int RequestChargePrecision = 5;
         internal const string RequestChargeName = "RequestCharge";
         internal const string RequestChargeUnit = "RU";
 
-        internal const int CpuMax = 9999;
-        internal const int CpuPrecision = 3;
+        internal const long CpuMax = 9999;
+        internal const long CpuMin = 1;
+        internal const int CpuPrecision = 5;
         internal const String CpuName = "CPU";
         internal const String CpuUnit = "Percentage";
 
         internal const long MemoryMax = Int64.MaxValue;
+        internal const long MemoryMin = 1;
         internal const int MemoryPrecision = 5;
         internal const String MemoryName = "Memory Remaining";
         internal const String MemoryUnit = "MB";
@@ -59,9 +63,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal static readonly ResourceType AllowedResourceTypes = ResourceType.Document;
 
         internal static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
-
-        internal static readonly long RequestChargeMax = 9999900;
-        internal static readonly long RequestChargeMin = 100;
 
         private static Uri vmMetadataUrl;
         private static TimeSpan scheduledTimeSpan = TimeSpan.Zero;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const String RequestKey = "telemetry";
 
         internal const double HistogramPrecisionFactor = 100;
-        internal const double TicksToMsFactor = 10000;
+        internal const double TicksToMsFactor = TimeSpan.TicksPerMillisecond;
 
         internal const int KbToMb = 1024;
         internal const int OneKbToBytes = 1024;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -13,32 +13,38 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
     internal class ClientTelemetryOptions
     {
-        internal const String RequestKey = "telemetry";
-
+        // ConversionFactor used in Histogram calculation to maintain precision or to collect data in desired unit
         internal const double HistogramPrecisionFactor = 100;
         internal const double TicksToMsFactor = TimeSpan.TicksPerMillisecond;
+        internal const int KbToMbFactor = 1024;
 
-        internal const int KbToMb = 1024;
         internal const int OneKbToBytes = 1024;
 
+        // Expecting histogram to have Minimum Latency of 1 and Maximum Latency of 1 hour (which is never going to happen)
         internal const long RequestLatencyMax = TimeSpan.TicksPerHour;
         internal const long RequestLatencyMin = 1;
         internal const int RequestLatencyPrecision = 5;
         internal const string RequestLatencyName = "RequestLatency";
         internal const string RequestLatencyUnit = "MilliSecond";
 
+        // Expecting histogram to have Minimum Request Charge of 1 and Maximum Request Charge of 9999900
+        // Maximum precision can be set as 5 so consider maximum value in 5 digit i.e. 99999 of request charge
+        // So 99999 * HistogramPrecisionFactor = 9999900 is the maximum request charge we have set.
+        // For all the Document ReadWriteQuery Operations there will be at least 1 request charge.
         internal const long RequestChargeMax = 9999900;
         internal const long RequestChargeMin = 1;
         internal const int RequestChargePrecision = 5;
         internal const string RequestChargeName = "RequestCharge";
         internal const string RequestChargeUnit = "RU";
 
-        internal const long CpuMax = 9999;
+        // Expecting histogram to have Minimum CPU Usage of .001% and Maximum CPU Usage of 999.99%
+        internal const long CpuMax = 99999;
         internal const long CpuMin = 1;
-        internal const int CpuPrecision = 5;
+        internal const int CpuPrecision = 5; // 100 (max CPU Usage) * 100(Historam Precision factor) = 10000 which is 5 digit and that is what we can set as maximum precision in histogram
         internal const String CpuName = "CPU";
         internal const String CpuUnit = "Percentage";
 
+        // Expecting histogram to have Minimum Memory Remaining of 1 MB and Maximum Memory Remaining of Long Max Value
         internal const long MemoryMax = Int64.MaxValue;
         internal const long MemoryMin = 1;
         internal const int MemoryPrecision = 5;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ProcessId = processId;
             this.UserAgent = userAgent;
             this.ConnectionModeEnum = connectionMode;
-            this.ConnectionMode = GetConnectionModeString(connectionMode);
+            this.ConnectionMode = ClientTelemetryProperties.GetConnectionModeString(connectionMode);
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
         }
@@ -74,19 +74,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Needed by Serializer to deserialize the json
         /// </summary>
-        /// <param name="dateTimeUtc"></param>
-        /// <param name="clientId"></param>
-        /// <param name="processId"></param>
-        /// <param name="userAgent"></param>
-        /// <param name="connectionMode"></param>
-        /// <param name="globalDatabaseAccountName"></param>
-        /// <param name="applicationRegion"></param>
-        /// <param name="hostEnvInfo"></param>
-        /// <param name="acceleratedNetworking"></param>
-        /// <param name="preferredRegions"></param>
-        /// <param name="systemInfo"></param>
-        /// <param name="cacheRefreshInfo"></param>
-        /// <param name="operationInfo"></param>
         public ClientTelemetryProperties(string dateTimeUtc,
             string clientId,
             string processId,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ProcessId = processId;
             this.UserAgent = userAgent;
             this.ConnectionModeEnum = connectionMode;
-            this.ConnectionMode = connectionMode.ToString();
+            this.ConnectionMode = connectionMode.ToString().ToUpper();
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ClientId = clientId;
             this.ProcessId = processId;
             this.UserAgent = userAgent;
-            this.ConnectionMode = connectionMode;
+            this.ConnectionMode = connectionMode.ToUpper();
             this.GlobalDatabaseAccountName = globalDatabaseAccountName;
             this.ApplicationRegion = applicationRegion;
             this.HostEnvInfo = hostEnvInfo;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -71,6 +71,22 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.PreferredRegions = preferredRegions;
         }
 
+        /// <summary>
+        /// Needed by Serializer to deserialize the json
+        /// </summary>
+        /// <param name="dateTimeUtc"></param>
+        /// <param name="clientId"></param>
+        /// <param name="processId"></param>
+        /// <param name="userAgent"></param>
+        /// <param name="connectionMode"></param>
+        /// <param name="globalDatabaseAccountName"></param>
+        /// <param name="applicationRegion"></param>
+        /// <param name="hostEnvInfo"></param>
+        /// <param name="acceleratedNetworking"></param>
+        /// <param name="preferredRegions"></param>
+        /// <param name="systemInfo"></param>
+        /// <param name="cacheRefreshInfo"></param>
+        /// <param name="operationInfo"></param>
         public ClientTelemetryProperties(string dateTimeUtc,
             string clientId,
             string processId,
@@ -89,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ClientId = clientId;
             this.ProcessId = processId;
             this.UserAgent = userAgent;
-            this.ConnectionMode = connectionMode.ToUpper();
+            this.ConnectionMode = connectionMode;
             this.GlobalDatabaseAccountName = globalDatabaseAccountName;
             this.ApplicationRegion = applicationRegion;
             this.HostEnvInfo = hostEnvInfo;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ProcessId = processId;
             this.UserAgent = userAgent;
             this.ConnectionModeEnum = connectionMode;
-            this.ConnectionMode = connectionMode.ToString().ToUpper();
+            this.ConnectionMode = GetConnectionModeString(connectionMode);
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
         }
@@ -98,6 +98,16 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.CacheRefreshInfo = cacheRefreshInfo;
             this.OperationInfo = operationInfo;
             this.PreferredRegions = preferredRegions;
+        }
+
+        private static string GetConnectionModeString(ConnectionMode connectionMode)
+        {
+            return connectionMode switch
+            {
+                Cosmos.ConnectionMode.Direct => "DIRECT",
+                Cosmos.ConnectionMode.Gateway => "GATEWAY",
+                _ => connectionMode.ToString().ToUpper(),
+            };
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/MetricInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/MetricInfo.cs
@@ -48,13 +48,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal long Count { get; set; }
 
         [JsonProperty(PropertyName = "min")]
-        internal long Min { get; set; }
+        internal double Min { get; set; }
 
         [JsonProperty(PropertyName = "max")]
-        internal long Max { get; set; }
+        internal double Max { get; set; }
 
         [JsonProperty(PropertyName = "percentiles")]
-        internal IReadOnlyDictionary<Double, Double> Percentiles { get; set; }
+        internal IReadOnlyDictionary<double, double> Percentiles { get; set; }
 
         /// <summary>
         /// It will set the current object with the aggregated values from the given histogram
@@ -62,15 +62,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <param name="histogram"></param>
         /// <param name="adjustment"></param>
         /// <returns>MetricInfo</returns>
-        internal MetricInfo SetAggregators(LongConcurrentHistogram histogram, long adjustment = 1)
+        internal MetricInfo SetAggregators(LongConcurrentHistogram histogram, double adjustment = 1)
         {
             if (histogram != null)
             {
                 this.Count = histogram.TotalCount;
                 this.Max = histogram.GetMaxValue() / adjustment;
                 this.Min = histogram.GetMinValue() / adjustment;
-                this.Mean = histogram.GetMean() / Convert.ToDouble(adjustment);
-                IReadOnlyDictionary<Double, Double> percentile = new Dictionary<Double, Double>
+                this.Mean = histogram.GetMean() / adjustment;
+                IReadOnlyDictionary<double, double> percentile = new Dictionary<double, double>
                 {
                     { ClientTelemetryOptions.Percentile50,  histogram.GetValueAtPercentile(ClientTelemetryOptions.Percentile50) / adjustment },
                     { ClientTelemetryOptions.Percentile90,  histogram.GetValueAtPercentile(ClientTelemetryOptions.Percentile90) / adjustment },

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             return isequal;
         }
 
-        internal void SetAggregators(LongConcurrentHistogram histogram, long adjustment = 1)
+        internal void SetAggregators(LongConcurrentHistogram histogram, double adjustment = 1)
         {
             this.MetricInfo.SetAggregators(histogram, adjustment);
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.StatusCode = statusCode;
         }
 
-        private OperationInfo(string regionsContacted, 
+        public OperationInfo(string regionsContacted, 
             bool? greaterThan1Kb, 
             string databaseName, 
             string containerName, 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
             }
-            this.Consistency = GetConsistencyString(consistency);
+            this.Consistency = OperationInfo.GetConsistencyString(consistency);
             this.DatabaseName = databaseName;
             this.ContainerName = containerName;
             this.Operation = operation?.ToOperationTypeString();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
             }
-            this.Consistency = consistency?.ToString();
+            this.Consistency = consistency?.ToString().ToUpper();
             this.DatabaseName = databaseName;
             this.ContainerName = containerName;
             this.Operation = operation?.ToOperationTypeString();
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ContainerName = containerName;
             this.Operation = operation;
             this.Resource = resource;
-            this.Consistency = consistency;
+            this.Consistency = consistency.ToUpper();
             this.StatusCode = statusCode;
             this.ResponseSizeInBytes = responseSizeInBytes;
             this.MetricInfo = metricInfo;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.StatusCode = statusCode;
         }
 
-        public OperationInfo(string regionsContacted, 
+        private OperationInfo(string regionsContacted, 
             bool? greaterThan1Kb, 
             string databaseName, 
             string containerName, 
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ContainerName = containerName;
             this.Operation = operation;
             this.Resource = resource;
-            this.Consistency = consistency.ToUpper();
+            this.Consistency = consistency;
             this.StatusCode = statusCode;
             this.ResponseSizeInBytes = responseSizeInBytes;
             this.MetricInfo = metricInfo;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
             }
-            this.Consistency = consistency?.ToString().ToUpper();
+            this.Consistency = GetConsistencyString(consistency);
             this.DatabaseName = databaseName;
             this.ContainerName = containerName;
             this.Operation = operation?.ToOperationTypeString();
@@ -91,6 +91,24 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.StatusCode = statusCode;
             this.ResponseSizeInBytes = responseSizeInBytes;
             this.MetricInfo = metricInfo;
+        }
+
+        private static string GetConsistencyString(Cosmos.ConsistencyLevel? consistency)
+        {
+            if (consistency == null)
+            {
+                return null;
+            }
+
+            return consistency switch
+            {
+                Cosmos.ConsistencyLevel.Strong => "STRONG",
+                Cosmos.ConsistencyLevel.Session => "SESSION",
+                Cosmos.ConsistencyLevel.Eventual => "EVENTUAL",
+                Cosmos.ConsistencyLevel.ConsistentPrefix => "CONSISTENTPREFIX",
+                Cosmos.ConsistencyLevel.BoundedStaleness => "BOUNDEDSTALENESS",
+                _ => consistency.ToString().ToUpper(),
+            };
         }
 
         public OperationInfo Copy()

--- a/Microsoft.Azure.Cosmos/src/Telemetry/SystemInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/SystemInfo.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.MetricInfo = metricInfo;
         }
 
-        internal void SetAggregators(LongConcurrentHistogram histogram, long adjustment = 1)
+        internal void SetAggregators(LongConcurrentHistogram histogram, double adjustment = 1)
         {
             this.MetricInfo.SetAggregators(histogram, adjustment);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void CheckJsonSerializerContract()
         {
             string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null), ClientTelemetryOptions.JsonSerializerSettings);
-            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"Direct\",\"systemInfo\":[]}",json);
+            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"systemInfo\":[]}",json);
         }
 
         [TestMethod]
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 "region1"
             };
             string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion), ClientTelemetryOptions.JsonSerializerSettings);
-            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"Direct\",\"systemInfo\":[],\"preferredRegions\":[\"region1\"]}", json);
+            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"systemInfo\":[],\"preferredRegions\":[\"region1\"]}", json);
         }
 
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 typeof(RequestInvokerHandler),
                 typeof(DiagnosticsHandler),
-                typeof(RetryHandler),
                 typeof(TelemetryHandler),
+                typeof(RetryHandler),
                 typeof(RouterHandler)
             };
 


### PR DESCRIPTION
## Description

This PR has following changes:
1. Improved precision of all the metrics:
So we are collecting different kind of metrics, Somewhere using conversion as a precision factor and if value needs not to be converted then using HistogramPrecisionfactor to preserve data precision.
2. Move telemetry handler before retry handler:
Telemetry should be collected from the toppest layer of the operation.
3. Test cases improvement : 
There were chances that test cases started failing due to thread starvation or related issues. So added waiting till 30 sec.
4. Upper Case Connection Mode and Consistency : Just like Java 
## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
