### PR TITLE
[INTERNAL] EmulatorTests: Fixes tests to use DeleteStreamAsync to avoid throwing on test cleanup

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
@@ -666,7 +666,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.AreEqual(HttpStatusCode.Created, batchResponse[0].StatusCode);
             Assert.AreEqual(HttpStatusCode.OK, batchResponse[1].StatusCode);
-            testDoc.Cost = testDoc.Cost + 1;
+            testDoc.Cost++;
             await BatchTestBase.VerifyByReadAsync(BatchTestBase.JsonContainer, testDoc, isStream: false, isSchematized: false, useEpk:false);
         }
 
@@ -804,7 +804,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 Assert.AreEqual(this.TestDocPk1ExistingC, batchResponse.GetOperationResultAtIndex<TestDoc>(1).Resource);
                 Assert.AreEqual(HttpStatusCode.OK, batchResponse[6].StatusCode);
-                testDocToPatch.Cost = testDocToPatch.Cost + 1;
+                testDocToPatch.Cost++;
                 await BatchTestBase.VerifyByReadAsync(container, testDocToPatch, isStream, isSchematized, useEpk);
             }
             else
@@ -834,7 +834,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     BatchTestBase.Client.Endpoint.ToString(),
                     BatchTestBase.Client.AccountKey)
                     .WithThrottlingRetryOptions(
-                    maxRetryWaitTimeOnThrottledRequests: default(TimeSpan),
+                    maxRetryWaitTimeOnThrottledRequests: default,
                     maxRetryAttemptsOnThrottledRequests: 0)
                 .Build();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -20,8 +20,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestInitialize]
         public async Task TestInitialize()
         {
-            CosmosClientOptions clientOptions = new CosmosClientOptions();
-            clientOptions.AllowBulkExecution = true;
+            CosmosClientOptions clientOptions = new CosmosClientOptions
+            {
+                AllowBulkExecution = true
+            };
             CosmosClient client = TestCommon.CreateCosmosClient(clientOptions);
 
             DatabaseResponse response = await client.CreateDatabaseIfNotExistsAsync(Guid.NewGuid().ToString());
@@ -536,8 +538,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static JObject CreateJObjectWithoutPK(string id)
         {
-            JObject document = new JObject();
-            document["id"] = id;
+            JObject document = new JObject
+            {
+                ["id"] = id
+            };
             return document;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosContainerTests.cs
@@ -23,7 +23,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     {
         private CosmosClient cosmosClient = null;
         private Cosmos.Database cosmosDatabase = null;
-        private static long ToEpoch(DateTime dateTime) => (long)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds;
+        private static long ToEpoch(DateTime dateTime)
+        {
+            return (long)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds;
+        }
 
         [TestInitialize]
         public async Task TestInit()
@@ -74,8 +77,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await container.ReplaceContainerAsync(existingContainerProperties);
 
             // Check progress
-            ContainerRequestOptions requestOptions = new ContainerRequestOptions();
-            requestOptions.PopulateQuotaInfo = true;
+            ContainerRequestOptions requestOptions = new ContainerRequestOptions
+            {
+                PopulateQuotaInfo = true
+            };
 
             while (true)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -695,9 +695,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
 
             ContainerInternal containerInternal = (ContainerInternal)this.Container;
-            ItemResponse<dynamic> itemResponse = await this.Container.CreateItemAsync<dynamic>(testItem1);
-            ItemResponse<dynamic> itemResponse2 = await this.Container.CreateItemAsync<dynamic>(testItem2);
-            ItemResponse<dynamic> itemResponse3 = await this.Container.CreateItemAsync<dynamic>(testItem3);
+            await this.Container.CreateItemAsync<dynamic>(testItem1);
+            await this.Container.CreateItemAsync<dynamic>(testItem2);
+            await this.Container.CreateItemAsync<dynamic>(testItem3);
             Cosmos.PartitionKey partitionKey1 = new Cosmos.PartitionKey(pKString);
             Cosmos.PartitionKey partitionKey2 = new Cosmos.PartitionKey(pKString2);
             using (ResponseMessage pKDeleteResponse = await containerInternal.DeleteAllItemsByPartitionKeyStreamAsync(partitionKey1))
@@ -1392,7 +1392,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ItemEpkQuerySingleKeyRangeValidation()
         {
-            IList<ToDoActivity> deleteList = new List<ToDoActivity>();
             ContainerInternal container = null;
             try
             {
@@ -1438,7 +1437,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (container != null)
                 {
-                    await container.DeleteContainerAsync();
+                    await container.DeleteContainerStreamAsync();
                 }
             }
         }
@@ -1562,7 +1561,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task NegativeQueryTest()
         {
-            IList<ToDoActivity> items = await ToDoActivity.CreateRandomItems(container: this.Container, pkCount: 10, perPKItemCount: 20, randomPartitionKey: true);
+            await ToDoActivity.CreateRandomItems(container: this.Container, pkCount: 10, perPKItemCount: 20, randomPartitionKey: true);
 
             try
             {
@@ -1690,9 +1689,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity testItem = (await ToDoActivity.CreateRandomItems(this.Container, 1, randomPartitionKey: true)).First();
             ContainerInternal containerInternal = (ContainerInternal)this.Container;
 
-            List<PatchOperation> patchOperations = new List<PatchOperation>();
-            patchOperations.Add(PatchOperation.Add("/nonExistentParent/Child", "bar"));
-            patchOperations.Add(PatchOperation.Remove("/cost"));
+            List<PatchOperation> patchOperations = new List<PatchOperation>
+            {
+                PatchOperation.Add("/nonExistentParent/Child", "bar"),
+                PatchOperation.Remove("/cost")
+            };
 
             // item does not exist - 404 Resource Not Found error
             try
@@ -2373,7 +2374,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (fixedContainer != null)
                 {
-                    await fixedContainer.DeleteContainerAsync();
+                    await fixedContainer.DeleteContainerStreamAsync();
                 }
             }
         }
@@ -2461,7 +2462,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (fixedContainer != null)
                 {
-                    await fixedContainer.DeleteContainerAsync();
+                    await fixedContainer.DeleteContainerStreamAsync();
                 }
             }
         }
@@ -2512,7 +2513,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                await db.DeleteAsync();
+                await db.DeleteStreamAsync();
             }
         }
 
@@ -2562,7 +2563,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                await database.Database.DeleteAsync();
+                await database.Database.DeleteStreamAsync();
             }
         }
 
@@ -2586,7 +2587,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataTestMethod]
         public async Task ContainterReCreateStatelessTest(bool operationBetweenRecreate, bool isQuery)
         {
-            Func<Container, HttpStatusCode, Task> operation = null;
+            Func<Container, HttpStatusCode, Task> operation;
             if (isQuery)
             {
                 operation = ExecuteQueryAsync;
@@ -2636,7 +2637,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                await db1.DeleteAsync();
+                await db1.DeleteStreamAsync();
                 cc1.Dispose();
                 cc2.Dispose();
             }
@@ -2683,22 +2684,19 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string customHeaderValue = "value1";
 
             CosmosClient clientWithIntercepter = TestCommon.CreateCosmosClient(
-               builder =>
-               {
-                   builder.WithTransportClientHandlerFactory(transportClient => new TransportClientHelper.TransportClientWrapper(
-                       transportClient,
-                       (uri, resourceOperation, request) =>
-                           {
-                               if (resourceOperation.resourceType == ResourceType.Document &&
-                                    resourceOperation.operationType == OperationType.Create)
-                               {
-                                   bool customHeaderExists = request.Properties.TryGetValue(customHeaderName, out object value);
+               builder => builder.WithTransportClientHandlerFactory(transportClient => new TransportClientHelper.TransportClientWrapper(
+                transportClient,
+                (uri, resourceOperation, request) =>
+                    {
+                        if (resourceOperation.resourceType == ResourceType.Document &&
+                             resourceOperation.operationType == OperationType.Create)
+                        {
+                            bool customHeaderExists = request.Properties.TryGetValue(customHeaderName, out object value);
 
-                                   Assert.IsTrue(customHeaderExists);
-                                   Assert.AreEqual(customHeaderValue, value);
-                               }
-                           }));
-               });
+                            Assert.IsTrue(customHeaderExists);
+                            Assert.AreEqual(customHeaderValue, value);
+                        }
+                    })));
 
             Container container = clientWithIntercepter.GetContainer(this.database.Id, this.Container.Id);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosThroughputTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosThroughputTests.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             throughputResponse = await containerCore.ReplaceThroughputIfExistsAsync(
                 ThroughputProperties.CreateAutoscaleThroughput(6000),
                 requestOptions: null,
-                default(CancellationToken));
+                default);
             Assert.IsNotNull(throughputResponse);
             Assert.AreEqual(HttpStatusCode.NotFound, throughputResponse.StatusCode);
             Assert.IsNull(throughputResponse.Resource);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ReadFeedTokenTests.cs
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             }
             finally
             {
-                await container?.DeleteContainerAsync();
+                await container?.DeleteContainerStreamAsync();
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

1. If the CreateContainerAsync fails the container delete operation throws an exception causing the test to hide the original exception.
2. Applied several Visual Studio suggestions about code formatting

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber