### PR TITLE
Security: Fixes ServiceInterop.dll to be BinSkim compliant by adding /guard /Qspectre flags

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.20.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.20.1</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.21.0</DirectVersion>
+		<DirectVersion>3.21.1</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV16</EncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -127,7 +127,7 @@
 		<PackageReference Include="Azure.Core" Version="1.3.0" />
 
 		<!--Direct Dependencies-->
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
 
 		<!--HybridRow Dependencies-->
 		<PackageReference Include="System.Memory" Version="4.5.4" />

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     cpuHistogram.RecordValue((long)cpuValue);
                 }
 
-                long? memoryLoad = systemUsage.MemoryUsage;
+                long? memoryLoad = systemUsage.MemoryAvailable;
                 if (memoryLoad.HasValue)
                 {
                     long memoryLoadInMb = memoryLoad.Value / ClientTelemetryOptions.BytesToMb;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Contracts
                 { "System.Numerics.Vectors", new Version(4, 5, 0) },
                 { "Newtonsoft.Json", new Version(10, 0, 2) },
                 { "Microsoft.Bcl.AsyncInterfaces", new Version(1, 0, 0) },
-                { "System.Configuration.ConfigurationManager", new Version(4, 5, 0) },
+                { "System.Configuration.ConfigurationManager", new Version(4, 7, 0) },
                 { "System.Memory", new Version(4, 5, 4) },
                 { "System.Buffers", new Version(4, 5, 1) },
                 { "System.Runtime.CompilerServices.Unsafe", new Version(4, 5, 3) },


### PR DESCRIPTION
This bump includes:

* Security: Fixed ServiceInterop.dll to be BinSkim compliant by adding /guard /Qspectre flags
* Diagnostics: Fixed memory consumption metric in Linux to match Windows unit

Closes #1724