### PR TITLE
Samples: add custom timeout and retry sample

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Cosmos.Samples.Usage.sln
@@ -47,6 +47,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Geospatial", "Geospatial\Ge
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SystemTextJson", "SystemTextJson\SystemTextJson.csproj", "{C0C25501-9C49-4B6F-BB7D-40E4FB47CE7B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CustomTimeoutRetry", "CustomTimeoutRetry\CustomTimeoutRetry.csproj", "{CE36CAFD-02E8-4550-80FD-88D1E546BE96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -141,6 +143,10 @@ Global
 		{C0C25501-9C49-4B6F-BB7D-40E4FB47CE7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C0C25501-9C49-4B6F-BB7D-40E4FB47CE7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C0C25501-9C49-4B6F-BB7D-40E4FB47CE7B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE36CAFD-02E8-4550-80FD-88D1E546BE96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE36CAFD-02E8-4550-80FD-88D1E546BE96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE36CAFD-02E8-4550-80FD-88D1E546BE96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE36CAFD-02E8-4550-80FD-88D1E546BE96}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Attempt.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Attempt.cs
@@ -1,0 +1,122 @@
+﻿namespace Cosmos.Samples.CustomTimeoutRetry
+{
+    using Microsoft.Azure.Cosmos;
+    using System;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Defines the set of states for a Cosmos DB request relevant to retry + timeout logic
+    /// </summary>
+    internal enum AttemptStatus
+    {
+        /// <summary>
+        /// Not started, or started and still running (no difference in these states, for our purposes)
+        /// </summary>
+        Unresolved = 1,
+        /// <summary>
+        /// Completed successfully within timeout window
+        /// </summary>
+        Succeeded,
+        /// <summary>
+        /// Generated an error within timeout window
+        /// </summary>
+        Failed,
+        /// <summary>
+        /// Timed out and still cleaning up
+        /// </summary>
+        TimedOutUnresolved,
+        /// <summary>
+        /// Ran to completion after timing out
+        /// </summary>
+        TimedOutSucceeded,
+        /// <summary>
+        /// Generated an error after timing out
+        /// </summary>
+        TimedOutFailed,
+        /// <summary>
+        /// Canceled with no result/error after timing out
+        /// </summary>
+        TimedOutCanceled
+    }
+
+    /// <summary>
+    /// encapsulates the result of a Cosmos DB request (states + transitions, end result or exception if any)
+    ///  note that due to "cooperative cancellation" behavior inherent in CancellationToken, some timed-out operations may still
+    ///  *eventually* produce a value or an error
+    /// </summary>
+    /// <typeparam name="TItem"></typeparam>
+    internal class Attempt<TItem>
+    {
+        public Attempt()
+        {
+            this.Status = AttemptStatus.Unresolved;
+        }
+
+        /// <summary>
+        /// This method harvests the results of the original operation passed to it (represented as a Task<Response<typeparamref name="TItem"/>>)
+        /// </summary>
+        /// <param name="original">Task representing the Cosmos DB request</param>
+        /// <param name="diagnosticsFunc">Optional delegate defining diagnostics handling</param>
+        public void OnTimeout(Task<Response<TItem>> original, Action<CosmosDiagnostics>? diagnosticsFunc = default)
+        {
+            if (original.IsFaulted)
+            {
+                // this might need to handle AggregateException better (iterate all the inner exceptions?)
+
+                Debug.Assert(original.Exception != null);
+                Debug.Assert(original.Exception is AggregateException);
+                Debug.Assert(original.Exception.InnerException != null);
+
+                if (original.Exception.InnerException is CosmosOperationCanceledException coce)
+                {
+                    // this is how TaskCanceledException and OperationCanceledException are surfaced in Cosmos DB SDK
+                    //  if we get here, it means the original operation canceled with no "harvestable" output
+
+                    this.Result = default;
+                    this.Exception = null;
+                    this.Status = AttemptStatus.TimedOutCanceled;
+
+                    diagnosticsFunc?.Invoke(coce.Diagnostics);
+                }
+                else
+                {
+                    // we eventually got an error for this Cosmos DB operation, let's make it available
+
+                    this.Result = default;
+                    this.Exception = original.Exception.InnerException;
+                    this.Status = AttemptStatus.TimedOutFailed;
+
+                    if (this.Exception is CosmosException ce)
+                    {
+                        diagnosticsFunc?.Invoke(ce.Diagnostics);
+                    }
+                }
+            }
+            else if (original.IsCompletedSuccessfully)
+            {
+                // we eventually got real data for this Cosmos DB operation, let's make that available
+
+                this.Result = original.Result;
+                this.Exception = default;
+                this.Status = AttemptStatus.TimedOutSucceeded;
+
+                diagnosticsFunc?.Invoke(this.Result.Diagnostics);
+            }
+            else
+            {
+                // in theory we shouldn't get here, but just in case let's just assume there's nothing for us to harvest
+
+                this.Result = default;
+                this.Exception = default;
+                this.Status = AttemptStatus.TimedOutCanceled;
+            }
+        }
+
+        public AttemptStatus Status { get; set; }
+
+        public Response<TItem>? Result { get; set; }
+
+        public Exception? Exception { get; set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/CustomTimeoutRetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/CustomTimeoutRetry.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>Cosmos.Samples.CustomTimeoutRetry</AssemblyName>
+    <RootNamespace>Cosmos.Samples.CustomTimeoutRetry</RootNamespace>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="33.0.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Polly" Version="7.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\AppSettings.json" Link="AppSettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
@@ -80,6 +80,7 @@
 
                 await BulkInsert(endpoint, authKey);
 
+                // TODO: other settings needed to disable default retry behavior?
                 CosmosClientOptions options = new CosmosClientOptions
                 {
                     MaxRetryAttemptsOnRateLimitedRequests = 0   // we'll control these ourselves instead of relying on SDK defaults
@@ -134,6 +135,7 @@
             // define retryable operation
             async Task<Response<IEnumerable<Item>>> DoQuery(CancellationToken ct)
             {
+                // TODO:
                 // careful observers will note here we create a new iterator for each page of query results, which is not the ideal pattern
                 //  the issue with the ideal pattern is that it conflicts with our retry logic
                 //

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
@@ -1,0 +1,277 @@
+﻿namespace Cosmos.Samples.CustomTimeoutRetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Extensions.Configuration;
+    using Newtonsoft.Json;
+
+    // ----------------------------------------------------------------------------------------------------------
+    // Prerequisites - 
+    // 
+    // 1. An Azure Cosmos account - 
+    //    https://docs.microsoft.com/azure/cosmos-db/create-cosmosdb-resources-portal
+    //
+    // 2. Microsoft.Azure.Cosmos NuGet package - 
+    //    http://www.nuget.org/packages/Microsoft.Azure.Cosmos/ 
+    // ----------------------------------------------------------------------------------------------------------
+    //
+    // Sample - demonstrates custom timeout and retry behavior for SDK operations
+    //
+    // 1. turn off default 429 (Too Many Requests) retry behavior 
+    //
+    // 2. customize timeout and number of retries for each Cosmos DB request
+    //
+    // 3. graceful cancellation + cleanup of timed-out requests
+    //
+    // 4. short-circuit of additional retries if able to harvest results or errors from timed-out prior attempts
+    //
+    // 5. retry for common error codes + honor RetryAfter response headers (if present)
+    //      https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk?tabs=diagnostics-v3#common-error-status-codes-
+    //
+    // 6. provide hooks for harvesting CosmosDiagnostics from Response<T>, whenever available
+    //      https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk-slow-request#capture-diagnostics
+    //
+    //-----------------------------------------------------------------------------------------------------------
+
+    public class Program
+    {
+        private const string DatabaseName = "customtimeoutretry";
+        private const string ContainerName = "items";
+
+        private const int ItemsToInsert = 100000;
+        private const int Retries = 3;
+
+        private static readonly TimeSpan PointReadTimeout = TimeSpan.FromMilliseconds(100);
+        private static readonly TimeSpan QueryTimeout = TimeSpan.FromMilliseconds(500);
+
+        private static readonly QueryDefinition QueryDefinition = new QueryDefinition("SELECT * FROM items i WHERE i.State = 'UT'");
+        private static readonly int QueryBatchSize = 500;
+
+        static async Task Main()
+        {
+            Trace.Listeners.Add(new TextWriterTraceListener(Console.Out));
+
+            try
+            {
+                IConfigurationRoot configuration = new ConfigurationBuilder()
+                    .AddJsonFile("appSettings.json")
+                    .Build();
+
+                string endpoint = configuration["EndPointUrl"];
+
+                if (string.IsNullOrEmpty(endpoint))
+                {
+                    throw new ArgumentNullException("Please specify a valid endpoint in the appSettings.json");
+                }
+
+                string authKey = configuration["AuthorizationKey"];
+
+                if (string.IsNullOrEmpty(authKey) || string.Equals(authKey, "Super secret key"))
+                {
+                    throw new ArgumentException("Please specify a valid AuthorizationKey in the appSettings.json");
+                }
+
+                Console.WriteLine("Ensure test data exists.");
+
+                await BulkInsert(endpoint, authKey);
+
+                CosmosClientOptions options = new CosmosClientOptions
+                {
+                    MaxRetryAttemptsOnRateLimitedRequests = 0   // we'll control these ourselves instead of relying on SDK defaults
+                };
+
+                using CosmosClient cosmosClient = new CosmosClient(endpoint, authKey, options);
+
+                Database database = cosmosClient.GetDatabase(Program.DatabaseName);
+
+                Container container = database.GetContainer(Program.ContainerName);
+
+                Console.WriteLine();
+                Console.WriteLine("Demonstrate retryable, paged queries.");
+                Console.WriteLine();
+
+                (string id, string pk) pointReadInfo = await Query(container);
+
+                Console.WriteLine();
+                Console.WriteLine("Demonstrate retryable point reads.");
+                Console.WriteLine();
+
+                await PointRead(pointReadInfo, container);
+            }
+            finally
+            {
+                Console.WriteLine();
+                Console.WriteLine("End of demo, press any key to exit.");
+                Console.WriteLine();
+                Console.ReadKey();
+            }
+        }
+
+        private static async Task PointRead((string id, string pk) pointReadInfo, Container container)
+        {
+            // define retryable operation
+            async Task<Response<Item>> DoPointRead(CancellationToken ct)
+            {
+                return await container.ReadItemAsync<Item>(pointReadInfo.id, new PartitionKey(pointReadInfo.pk), null, ct);
+            }
+
+            // invoke operation
+            Response<Item> response = await Retryable.ExecuteAsync(DoPointRead, Program.PointReadTimeout, Retries, OnDiagnostics);
+
+            // $$$$$
+            Console.WriteLine($"{response.Resource.State} -> {response.Resource.FirstName} {response.Resource.LastName}");
+        }
+
+        private static async Task<(string id, string pk)> Query(Container container)
+        {
+            string? continuationToken = null;
+
+            // define retryable operation
+            async Task<Response<IEnumerable<Item>>> DoQuery(CancellationToken ct)
+            {
+                // careful observers will note here we create a new iterator for each page of query results, which is not the ideal pattern
+                //  the issue with the ideal pattern is that it conflicts with our retry logic
+                //
+                //  - retry logic uses cooperative cancellation (via CancellationToken) and when canceling a request, Cosmos SDK will sometimes still get a valid value
+                //  - the retry logic tracks prior (timed out) query attempts and uses any results from those before trying new attempts (if results happen to appear after cancellation is requested)
+                //  - the iterator is stateful, and each call to ReadNextAsync() modifies the iterator state
+                //  - a prior attempt (call to ReadNextAsync()) which timed out but eventually receives results and mutates the iterator will be in conflict with
+                //     another (current) attempt (call to ReadNextAsync()) which also mutates the iterator. This results in an error.
+                //
+                //  the solution to the above is to use a separate iterator instance for each retry... not as efficient as using a single iterator, but as long
+                //   as you honor the continuation token, you get all query result pages
+                //
+                //  other options don't seem much fun either:
+                //
+                //  1. define the full query drain as the retryable operation (get all pages within scope of atomic retryable operation), and buffer all results of all pages back to caller (please, no)
+                //  2. same as last, but push an Action delegate to act on each page of results as they arrive... the problem here is that
+                //      in the face of retries you have to restart at first page which you may have already processed on the last pass (before you eventually timed out while processing page N)
+                //
+                //  so what i've got here seems "least bad" but curious if others see better options?
+                //
+
+                QueryRequestOptions options = new QueryRequestOptions { MaxItemCount = Program.QueryBatchSize };
+
+                using FeedIterator<Item> iterator = container.GetItemQueryIterator<Item>(Program.QueryDefinition, continuationToken, options);
+
+                return await iterator.ReadNextAsync(ct);
+            }
+
+            (string id, string pk) result = default;
+
+            // invoke operation
+            while (true)
+            {
+                // get a page of results
+                FeedResponse<Item> response = (FeedResponse<Item>) await Retryable.ExecuteAsync(DoQuery, Program.QueryTimeout, Retries, OnDiagnostics);
+
+                // party on, wayne
+                foreach (Item item in response)
+                {
+                    Console.WriteLine($"{item.FirstName} {item.LastName}");
+                    result = (item.Id, item.State);
+                }
+
+                // if we're done, we're done...
+                if (string.IsNullOrWhiteSpace(response.ContinuationToken))
+                {
+                    break;
+                }
+
+                // ...if we're not, we're not
+                continuationToken = response.ContinuationToken;
+            }
+
+            return result;
+        }
+
+        private static void OnDiagnostics(CosmosDiagnostics diagnostics)
+        {
+            if (diagnostics != null)
+            {
+                Debug.WriteLine(diagnostics.ToString());    // write to log, etc.
+            }
+        }
+
+        private static async Task BulkInsert(string endpoint, string authKey)
+        {
+            // using bulk-optimized client here for one-off insert operations
+
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                AllowBulkExecution = true
+            };
+
+            using CosmosClient cosmosClient = new CosmosClient(endpoint, authKey, options);
+
+            Database database = await cosmosClient.CreateDatabaseIfNotExistsAsync(Program.DatabaseName);
+
+            try
+            {
+                Container container = await database.CreateContainerAsync(Program.ContainerName, "/State", 10000);
+
+                IReadOnlyCollection<Item> itemsToInsert = Program.GetItemsToInsert();
+
+                Task[] tasks = itemsToInsert.Select(item => container.CreateItemAsync(item, new PartitionKey(item.State))
+                        .ContinueWith(itemResponse =>
+                        {
+                            if (!itemResponse.IsCompletedSuccessfully)
+                            {
+                                Debug.Assert(itemResponse.Exception != null);
+
+                                AggregateException innerException = itemResponse.Exception.Flatten();
+
+                                if (innerException.InnerExceptions.FirstOrDefault(innerEx => innerEx is CosmosException) is CosmosException cosmosException)
+                                {
+                                    Debug.WriteLine($"Received {cosmosException.StatusCode} ({cosmosException.Message}).");
+                                }
+                                else
+                                {
+                                    Debug.WriteLine($"Exception {innerException.InnerExceptions.FirstOrDefault()}.");
+                                }
+                            }
+                        })).ToArray();
+
+                await Task.WhenAll(tasks);
+
+                Debug.WriteLine("Bulk insert complete.");
+            }
+            catch (CosmosException ex)
+            {
+                if (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+                {
+                    return; // container already exists
+                }
+            }
+        }
+
+        private static IReadOnlyCollection<Item> GetItemsToInsert()
+        {
+            return new Bogus.Faker<Item>()
+                .StrictMode(true)
+                .RuleFor(o => o.Id, f => Guid.NewGuid().ToString())
+                .RuleFor(o => o.FirstName, f => f.Name.FirstName())
+                .RuleFor(o => o.LastName, f => f.Name.LastName())
+                .RuleFor(o => o.State, (f, o) => f.Address.StateAbbr())
+                .RuleFor(o => o.Address, (f, o) => $"{f.Address.StreetAddress()} {f.Address.City()}, {o.State} {f.Address.ZipCode()}")
+                .RuleFor(o => o.Email, (f, o) => f.Internet.Email(firstName: o.FirstName, lastName: o.LastName))
+                .Generate(ItemsToInsert);
+        }
+    }
+
+    public class Item
+    {
+        [JsonProperty(PropertyName = "id")]
+        public string Id { get; set; } = string.Empty;
+        public string Address { get; set; } = string.Empty;
+        public string State { get; set; } = string.Empty;
+        public string FirstName { get; set; } = string.Empty;
+        public string LastName { get; set; } = string.Empty;
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Program.cs
@@ -192,9 +192,9 @@
             return result;
         }
 
-        private static void OnDiagnostics(CosmosDiagnostics diagnostics)
+        private static void OnDiagnostics(CosmosDiagnostics diagnostics, Func<TimeSpan, bool> filter)
         {
-            if (diagnostics != null)
+            if (diagnostics != null && filter(diagnostics.GetClientElapsedTime()))
             {
                 Debug.WriteLine(diagnostics.ToString());    // write to log, etc.
             }

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
@@ -142,7 +142,7 @@
 
                         if (retryAfter != null)
                         {
-                            await Task.Delay(retryAfter.Value);
+                            await Task.Delay(retryAfter.Value, ct);
                             continue;
                         }
                     }
@@ -177,9 +177,7 @@
                         Debug.WriteLine($"Current attempt timed out; retrying after {jitter.TotalMilliseconds} milliseconds.");
                         Debug.WriteLine("**********");
 
-                        await Task.Delay(jitter);
-
-                        continue;
+                        await Task.Delay(jitter, ct);
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
@@ -110,7 +110,7 @@
 
                         TimeSpan? retryAfter = ce.RetryAfter;
 
-                        if (retryAfter.HasValue)   // handles 449?
+                        if (retryAfter.HasValue)   // TODO: handles 449?
                         {
                             // we want to honor any RetryAfter response headers from the server
 
@@ -187,7 +187,8 @@
 
         private static TimeSpan GetJitter()
         {
-            // do we want exponential backoff here too?
+            // TODO: do we want exponential backoff here too?
+            //  many customer scenarios require "fail fast" which seems counter to behavior of EB
 
             return TimeSpan.FromMilliseconds(1000 * _random.NextDouble());
         }
@@ -244,6 +245,7 @@
         {
             Task OnTimeout(Context context, TimeSpan timeoutValue, Task originalTask)
             {
+                // TODO:
                 // a few notes here:
                 //
                 //  we don't await or return the originalTask, because doing so would defeat the timeout itself, by forcing the policy to wait for it to fully complete

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
@@ -1,0 +1,274 @@
+﻿namespace Cosmos.Samples.CustomTimeoutRetry
+{
+    using Microsoft.Azure.Cosmos;
+    using Polly;
+    using Polly.Timeout;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Retryable encapsulates the logic for retrying atomic, time-bound Cosmos DB SDK operations
+    /// </summary>
+    internal static class Retryable
+    {
+        private static readonly Random _random = new Random(Environment.TickCount);
+
+        public static async Task<Response<TItem>> ExecuteAsync<TItem>(
+            Func<CancellationToken, Task<Response<TItem>>> retryableFunc,
+            TimeSpan perAttemptTimeout,
+            int retries,
+            Action<CosmosDiagnostics>? diagnosticsFunc = default,
+            CancellationToken ct = default)
+        {
+            // we keep track of all attempts, some timed-out attempts may eventually
+            //  resolve with a result or error which we can use
+            List<Attempt<TItem>> attempts = new List<Attempt<TItem>>();
+
+            while (true)
+            {
+                // do we have any prior timed-out attempts that have completed since we last checked?
+                Attempt<TItem>? attempt = attempts.FirstOrDefault(att => att.Status == AttemptStatus.TimedOutSucceeded ||
+                                                                         att.Status == AttemptStatus.TimedOutFailed);
+
+                if (attempt != null)
+                {
+                    if (attempt.Status == AttemptStatus.TimedOutSucceeded)
+                    {
+                        // prior attempt succeeded, no need to try any more... just use this result
+
+                        Debug.WriteLine("**********");
+                        Debug.WriteLine("Prior attempt completed successfully; using that result.");
+                        Debug.WriteLine("**********");
+
+                        Debug.Assert(attempt.Result != null);
+
+                        return attempt.Result;
+                    }
+                    else
+                    {
+                        // prior attempt failed, no need to try any more... just use this error
+
+                        Debug.Assert(attempt.Status == AttemptStatus.TimedOutFailed);
+
+                        Debug.WriteLine("**********");
+                        Debug.WriteLine("Prior attempt completed and failed; re-throwing that exception.");
+                        Debug.WriteLine("**********");
+
+                        Debug.Assert(attempt.Exception != null);
+
+                        throw new Exception("An error occurred during retried Cosmos operation.", attempt.Exception);
+                    }
+                }
+
+                // try a new attempt
+
+                attempt = new Attempt<TItem>();
+
+                attempts.Add(attempt);
+
+                Debug.WriteLine("**********");
+                Debug.WriteLine($"Starting attempt #{attempts.Count}.");
+                Debug.WriteLine("**********");
+
+                await ExecuteAttemptAsync(attempt, retryableFunc, perAttemptTimeout, diagnosticsFunc, ct);
+
+                if (attempt.Status == AttemptStatus.Succeeded)
+                {
+                    // attempt succeeded within timeout, use this result
+
+                    Debug.WriteLine("**********");
+                    Debug.WriteLine("Current attempt completed successfully; using that result.");
+                    Debug.WriteLine("**********");
+
+                    Debug.Assert(attempt.Result != null);
+
+                    return attempt.Result;
+                }
+                else if (attempt.Status == AttemptStatus.Failed)
+                {
+                    Debug.Assert(attempt.Exception != null);
+
+                    if (attempt.Exception is CosmosException ce)
+                    {
+                        if (attempts.Count > retries)
+                        {
+                            // final attempt failed within timeout, use this error
+
+                            Debug.WriteLine("**********");
+                            Debug.WriteLine($"Final attempt failed; re-throwing that exception.");
+                            Debug.WriteLine("**********");
+
+                            throw new Exception("An error occurred during Cosmos operation.", attempt.Exception);
+                        }
+
+                        // https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk?tabs=diagnostics-v3#common-error-status-codes-
+
+                        TimeSpan? retryAfter = ce.RetryAfter;
+
+                        if (retryAfter.HasValue)   // handles 449?
+                        {
+                            // we want to honor any RetryAfter response headers from the server
+
+                            Debug.WriteLine("**********");
+                            Debug.WriteLine($"Current attempt failed; using RetryAfter value from Cosmos response header ({retryAfter.Value.TotalMilliseconds} milliseconds).");
+                            Debug.WriteLine("**********");
+                        }
+                        else
+                        {
+                            // no RetryAfter from server... if this is a retryable error, let's pause then retry
+
+                            switch (ce.StatusCode)
+                            {
+                                case HttpStatusCode.RequestTimeout:
+                                case HttpStatusCode.Gone:
+                                case HttpStatusCode.TooManyRequests:
+                                case HttpStatusCode.InternalServerError:
+                                case HttpStatusCode.ServiceUnavailable:
+
+                                    retryAfter = GetJitter();
+
+                                    Debug.WriteLine("**********");
+                                    Debug.WriteLine($"Current attempt failed; Cosmos DB service response code is retryable. Retrying after {retryAfter.Value.TotalMilliseconds} milliseconds.");
+                                    Debug.WriteLine("**********");
+
+                                    break;
+                            }
+                        }
+
+                        if (retryAfter != null)
+                        {
+                            await Task.Delay(retryAfter.Value);
+                            continue;
+                        }
+                    }
+
+                    // current attempt failed within timeout, use this error
+
+                    Debug.WriteLine("**********");
+                    Debug.WriteLine($"Current attempt failed; re-throwing that exception.");
+                    Debug.WriteLine("**********");
+
+                    throw new Exception("An error occurred during Cosmos operation.", attempt.Exception);
+                }
+                else
+                {
+                    if (attempts.Count > retries)
+                    {
+                        // final attempt timed out, throw TimeoutException
+
+                        Debug.WriteLine("**********");
+                        Debug.WriteLine($"Final attempt timed out; raising TimeoutException to caller.");
+                        Debug.WriteLine("**********");
+
+                        throw new TimeoutException();
+                    }
+                    else
+                    {
+                        // current attempt timed out, pause then retry
+
+                        TimeSpan jitter = GetJitter();
+
+                        Debug.WriteLine("**********");
+                        Debug.WriteLine($"Current attempt timed out; retrying after {jitter.TotalMilliseconds} milliseconds.");
+                        Debug.WriteLine("**********");
+
+                        await Task.Delay(jitter);
+
+                        continue;
+                    }
+                }
+            }
+        }
+
+        private static TimeSpan GetJitter()
+        {
+            // do we want exponential backoff here too?
+
+            return TimeSpan.FromMilliseconds(1000 * _random.NextDouble());
+        }
+
+        private static async Task ExecuteAttemptAsync<TItem>(
+            Attempt<TItem> attempt,
+            Func<CancellationToken, Task<Response<TItem>>> func,
+            TimeSpan timeout,
+            Action<CosmosDiagnostics>? diagnosticsFunc = default,
+            CancellationToken token = default)
+        {
+            // Polly has elegant timeout policy handling with support for out-of-band resolution, etc.
+            //  https://github.com/App-vNext/Polly/wiki/Timeout
+
+            AsyncTimeoutPolicy? policy = GetPolicy(timeout, attempt, diagnosticsFunc);
+
+            try
+            {
+                // invoke the timed operation, will throw TimeoutRejectedException upon timeout
+                Response<TItem>? response = await policy.ExecuteAsync((ctxt, ct) => func(ct), new Context(), token);
+
+                // no timeout, woooooo
+                attempt.Result = response;
+                attempt.Exception = null;
+                attempt.Status = AttemptStatus.Succeeded;
+
+                // don't forget your diagnostics
+                diagnosticsFunc?.Invoke(response.Diagnostics);
+            }
+            catch (TimeoutRejectedException)
+            {
+                // let the caller know we timed out (might want to retry)
+                attempt.Result = default;
+                attempt.Exception = default;
+                attempt.Status = AttemptStatus.TimedOutUnresolved;
+            }
+            catch (Exception ex)
+            {
+                // no timeout, but our timed operation is sad :-(
+                attempt.Result = default;
+                attempt.Exception = ex;
+                attempt.Status = AttemptStatus.Failed;
+
+                // don't forget your diagnostics
+                if (ex is CosmosException ce)
+                {
+                    diagnosticsFunc?.Invoke(ce.Diagnostics);
+                }
+            }
+        }
+
+        private static AsyncTimeoutPolicy GetPolicy<TItem>(
+            TimeSpan timeout, Attempt<TItem> attempt, Action<CosmosDiagnostics>? diagnosticsFunc)
+        {
+            Task OnTimeout(Context context, TimeSpan timeoutValue, Task originalTask)
+            {
+                // a few notes here:
+                //
+                //  we don't await or return the originalTask, because doing so would defeat the timeout itself, by forcing the policy to wait for it to fully complete
+                //   see the note here https://github.com/App-vNext/Polly/wiki/Timeout under "What happens to the timed-out delegate?" -> "Pessimistic Timeout"
+                //
+                //  ContinueWith() can cause annoying call stacks etc. but we need a way to attach cleanup code to run immediately after the timed-out (but perhaps not completed) task
+                //   this is the recommended pattern with Polly but if we can find a better approach I'm happy to go with it
+                //
+
+                originalTask.ContinueWith(t =>
+                {
+                    Task<Response<TItem>>? responseTask = (Task<Response<TItem>>)t;
+
+                    attempt.OnTimeout(responseTask, diagnosticsFunc);
+
+                    return attempt;
+                });
+
+                return Task.CompletedTask;
+            }
+
+            // need pessimistic strategy because we need to wait for CosmosClient to (eventually) handle task cancellation
+            //  in optimistic mode you don't get access to the original task (and therefore can't harvest the diagnostics)
+
+            return Policy.TimeoutAsync(timeout, TimeoutStrategy.Pessimistic, OnTimeout);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomTimeoutRetry/Retryable.cs
@@ -8,6 +8,7 @@
     using System.Diagnostics;
     using System.Linq;
     using System.Net;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -61,7 +62,7 @@
 
                         Debug.Assert(attempt.Exception != null);
 
-                        throw new Exception("An error occurred during retried Cosmos operation.", attempt.Exception);
+                        ExceptionDispatchInfo.Capture(attempt.Exception).Throw();
                     }
                 }
 
@@ -103,7 +104,7 @@
                             Debug.WriteLine($"Final attempt failed; re-throwing that exception.");
                             Debug.WriteLine("**********");
 
-                            throw new Exception("An error occurred during Cosmos operation.", attempt.Exception);
+                            ExceptionDispatchInfo.Capture(attempt.Exception).Throw();
                         }
 
                         // https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk?tabs=diagnostics-v3#common-error-status-codes-
@@ -153,7 +154,7 @@
                     Debug.WriteLine($"Current attempt failed; re-throwing that exception.");
                     Debug.WriteLine("**********");
 
-                    throw new Exception("An error occurred during Cosmos operation.", attempt.Exception);
+                    ExceptionDispatchInfo.Capture(attempt.Exception).Throw();
                 }
                 else
                 {


### PR DESCRIPTION
This PR adds a new sample to demonstrate how to customize retry and request timeout behavior using logic external to SDK. The motivation is to accommodate a wide variety of customer contexts and empower users to actively trade off latency vs. throughput, implement "fail fast" strategies, etc.

Goals for the sample:

1. turn off default 429 (Too Many Requests) retry behavior 
1. customize timeout and number of retries for each Cosmos DB request
1. graceful cancellation + cleanup of timed-out requests
1. tracking of prior timed-out attempts and short-circuit of additional retries if (eventually) able to harvest results or errors from those prior attempts
1. retry for common error codes + honor RetryAfter response headers (if present) https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk?tabs=diagnostics-v3#common-error-status-codes-
1. provide hooks for harvesting CosmosDiagnostics from Response<>, whenever available https://docs.microsoft.com/en-us/azure/cosmos-db/sql/troubleshoot-dot-net-sdk-slow-request#capture-diagnostics

The sample is self-contained and can run against emulator or a live Cosmos DB SQL account. It uses the Bogus Nuget package to generate test data, and will re-use existing data upon subsequent runs.

Timeouts + gracefully cleanup of timed-out requests is implemented using the Polly Nuget package. Polly also supports retries but I implemented the retry strategy using a custom implementation, as I wasn't able to achieve the "short-circuit retry attempts if a prior timed-out attempt eventually yields a result/error" requirement with Polly retries.

During review, please note TODO items in the code... these indicate specific areas/questions for feedback (other feedback is of course welcome too :-) ).

One other item I'd like feedback on (not listed in TODOs)... the examples so far highlight point reads and queries, I'd like to show some examples of timeout + retry for writes. Which are complicated due to need for idempotency. Suggestions on the right approach here?

There are no breaking changes for this PR.
