### PR TITLE
Samples: Adds Change Feed Processor delegate context usage

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
@@ -420,8 +420,22 @@
         /// The delegate receives batches of changes as they are generated in the change feed and can process them.
         /// </summary>
         // <Delegate>
-        static async Task HandleChangesAsync(IReadOnlyCollection<ToDoItem> changes, CancellationToken cancellationToken)
+        static async Task HandleChangesAsync(
+            ChangeFeedProcessorContext context,
+            IReadOnlyCollection<ToDoItem> changes,
+            CancellationToken cancellationToken)
         {
+            Console.WriteLine($"Started handling changes for lease {context.LeaseToken}...");
+            Console.WriteLine($"Change Feed request consumed {context.Headers.RequestCharge} RU.");
+            // SessionToken if needed to enforce Session consistency on another client instance
+            Console.WriteLine($"SessionToken ${context.Headers.Session}");
+
+            // We may want to track any operation's Diagnostics that took longer than some threshold
+            if (context.Diagnostics.GetClientElapsedTime() > TimeSpan.FromSeconds(1))
+            {
+                Console.WriteLine($"Change Feed request took longer than expected. Diagnostics:" + context.Diagnostics.ToString());
+            }
+
             foreach (ToDoItem item in changes)
             {
                 Console.WriteLine($"\tDetected operation for item with id {item.id}, created at {item.creationTime}.");

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/Program.cs
@@ -420,10 +420,7 @@
         /// The delegate receives batches of changes as they are generated in the change feed and can process them.
         /// </summary>
         // <Delegate>
-        static async Task HandleChangesAsync(
-            ChangeFeedProcessorContext context,
-            IReadOnlyCollection<ToDoItem> changes,
-            CancellationToken cancellationToken)
+        static async Task HandleChangesAsync(ChangeFeedProcessorContext context, IReadOnlyCollection<ToDoItem> changes, CancellationToken cancellationToken)
         {
             Console.WriteLine($"Started handling changes for lease {context.LeaseToken}...");
             Console.WriteLine($"Change Feed request consumed {context.Headers.RequestCharge} RU.");


### PR DESCRIPTION
Now that 3.21.0 is out, update the samples to use the more detailed delegate.