### PR TITLE
Bulk: Adds SessionToken and ActivityId to item responses

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Cosmos
             this.ResourceStream = other.ResourceStream;
             this.RequestCharge = other.RequestCharge;
             this.RetryAfter = other.RetryAfter;
+            this.SessionToken = other.SessionToken;
         }
 
         /// <summary>
@@ -90,6 +91,11 @@ namespace Microsoft.Azure.Cosmos
         /// Gets detail on the completion status of the operation.
         /// </summary>
         internal virtual SubStatusCodes SubStatusCode { get; set; } 
+
+        /// <summary>
+        /// Gets the SessionToken assigned to this result, if any.
+        /// </summary>
+        internal virtual string SessionToken { get; set; }
 
         internal ITrace Trace { get; set; }
 
@@ -205,6 +211,7 @@ namespace Microsoft.Azure.Cosmos
                 ETag = this.ETag,
                 RetryAfter = this.RetryAfter,
                 RequestCharge = this.RequestCharge,
+                Session = this.SessionToken,
             };
 
             ResponseMessage responseMessage = new ResponseMessage(

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.Cosmos
             this.RequestCharge = other.RequestCharge;
             this.RetryAfter = other.RetryAfter;
             this.SessionToken = other.SessionToken;
+            this.ActivityId = other.ActivityId;
         }
 
         /// <summary>
@@ -96,6 +97,11 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the SessionToken assigned to this result, if any.
         /// </summary>
         internal virtual string SessionToken { get; set; }
+
+        /// <summary>
+        /// ActivityId related to the operation
+        /// </summary>
+        internal virtual string ActivityId { get; set; }
 
         internal ITrace Trace { get; set; }
 
@@ -212,6 +218,7 @@ namespace Microsoft.Azure.Cosmos
                 RetryAfter = this.RetryAfter,
                 RequestCharge = this.RequestCharge,
                 Session = this.SessionToken,
+                ActivityId = this.ActivityId,
             };
 
             ResponseMessage responseMessage = new ResponseMessage(

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
@@ -311,6 +311,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     SubStatusCode = this.SubStatusCode,
                     RetryAfter = TimeSpan.FromMilliseconds(retryAfterMilliseconds),
+                    SessionToken = this.Headers.Session
                 };
 
                 result.Trace = trace;
@@ -342,6 +343,7 @@ namespace Microsoft.Azure.Cosmos
                     }
 
                     operationResult.Trace = trace;
+                    operationResult.SessionToken = responseMessage.Headers.Session;
 
                     results.Add(operationResult);
                     return r;

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
@@ -311,7 +311,8 @@ namespace Microsoft.Azure.Cosmos
                 {
                     SubStatusCode = this.SubStatusCode,
                     RetryAfter = TimeSpan.FromMilliseconds(retryAfterMilliseconds),
-                    SessionToken = this.Headers.Session
+                    SessionToken = this.Headers.Session,
+                    ActivityId = this.ActivityId,
                 };
 
                 result.Trace = trace;
@@ -344,6 +345,7 @@ namespace Microsoft.Azure.Cosmos
 
                     operationResult.Trace = trace;
                     operationResult.SessionToken = responseMessage.Headers.Session;
+                    operationResult.ActivityId = responseMessage.Headers.ActivityId;
 
                     results.Add(operationResult);
                     return r;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -78,6 +79,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = tasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -99,6 +101,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<JObject>> task = tasks[i];
                 ItemResponse<JObject> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -121,6 +124,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -143,6 +147,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = tasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -176,6 +181,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ResponseMessage> task = deleteTasks[i];
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -209,6 +215,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = deleteTasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -242,6 +249,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ResponseMessage> task = readTasks[i];
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -275,6 +283,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = readTasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -308,6 +317,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ResponseMessage> task = replaceTasks[i];
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -341,6 +351,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = replaceTasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -378,6 +389,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ResponseMessage> task = PatchTasks[i];
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -415,6 +427,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = patchTasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.Session);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
                 Assert.AreEqual("patched", result.Resource.description);
@@ -456,6 +469,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 if (i == 0 || i == 2)
                 {
                     Assert.IsTrue(result.Headers.RequestCharge > 0);
+                    Assert.IsNotNull(result.Headers.Session);
                     Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                     Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     public class CosmosItemBulkTests
     {
         private Container container;
+        private Container nonBulkContainer;
         private Database database;
 
         [TestInitialize]
@@ -25,12 +26,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 AllowBulkExecution = true
             };
             CosmosClient client = TestCommon.CreateCosmosClient(clientOptions);
+            CosmosClient nonBulkClient = TestCommon.CreateCosmosClient();
 
             DatabaseResponse response = await client.CreateDatabaseIfNotExistsAsync(Guid.NewGuid().ToString());
             this.database = response.Database;
 
             ContainerResponse containerResponse = await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk", 10000);
             this.container = containerResponse;
+            this.nonBulkContainer = nonBulkClient.GetContainer(this.database.Id, this.container.Id);
         }
 
         [TestCleanup]
@@ -57,6 +60,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -80,6 +84,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -102,6 +107,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<JObject> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -125,6 +131,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -148,6 +155,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -182,6 +190,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -216,6 +225,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -250,6 +260,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -284,6 +295,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -318,6 +330,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -352,6 +365,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -390,6 +404,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ResponseMessage result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -428,6 +443,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
+                Assert.IsNotNull(result.Headers.ActivityId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
                 Assert.AreEqual("patched", result.Resource.description);
@@ -470,6 +486,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     Assert.IsTrue(result.Headers.RequestCharge > 0);
                     Assert.IsNotNull(result.Headers.Session);
+                    Assert.IsNotNull(result.Headers.ActivityId);
                     Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                     Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
@@ -17,6 +17,7 @@
             RequestCharge = 1.5,
             RetryAfter = TimeSpan.FromMilliseconds(1234),
             SessionToken = Guid.NewGuid().ToString(),
+            ActivityId = Guid.NewGuid().ToString(),
         };
 
         [TestMethod]
@@ -39,6 +40,7 @@
             Assert.AreEqual(other.RequestCharge, result.RequestCharge);
             Assert.AreEqual(other.RetryAfter, result.RetryAfter);
             Assert.AreEqual(other.SessionToken, result.SessionToken);
+            Assert.AreEqual(other.ActivityId, result.ActivityId);
             Assert.AreSame(other.ResourceStream, result.ResourceStream);
         }
         
@@ -56,6 +58,7 @@
             Assert.AreEqual(other.RetryAfter, result.RetryAfter);
             Assert.AreSame(other.ResourceStream, result.ResourceStream);
             Assert.AreEqual(other.SessionToken, result.SessionToken);
+            Assert.AreEqual(other.ActivityId, result.ActivityId);
             Assert.AreSame(testObject, result.Resource);
         }
 
@@ -72,6 +75,7 @@
             Assert.AreEqual(result.RequestCharge, response.Headers.RequestCharge);
             Assert.AreEqual(result.RetryAfter, response.Headers.RetryAfter);
             Assert.AreEqual(result.SessionToken, response.Headers.Session);
+            Assert.AreEqual(result.ActivityId, response.Headers.ActivityId);
             Assert.AreSame(result.ResourceStream, response.Content);
             Assert.IsNotNull(response.Diagnostics);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchOperationResultTests.cs
@@ -15,7 +15,8 @@
             ETag = "TestETag",
             ResourceStream = new MemoryStream(),
             RequestCharge = 1.5,
-            RetryAfter = TimeSpan.FromMilliseconds(1234)
+            RetryAfter = TimeSpan.FromMilliseconds(1234),
+            SessionToken = Guid.NewGuid().ToString(),
         };
 
         [TestMethod]
@@ -37,6 +38,7 @@
             Assert.AreEqual(other.ETag, result.ETag);
             Assert.AreEqual(other.RequestCharge, result.RequestCharge);
             Assert.AreEqual(other.RetryAfter, result.RetryAfter);
+            Assert.AreEqual(other.SessionToken, result.SessionToken);
             Assert.AreSame(other.ResourceStream, result.ResourceStream);
         }
         
@@ -53,6 +55,7 @@
             Assert.AreEqual(other.RequestCharge, result.RequestCharge);
             Assert.AreEqual(other.RetryAfter, result.RetryAfter);
             Assert.AreSame(other.ResourceStream, result.ResourceStream);
+            Assert.AreEqual(other.SessionToken, result.SessionToken);
             Assert.AreSame(testObject, result.Resource);
         }
 
@@ -68,6 +71,7 @@
             Assert.AreEqual(result.ETag, response.Headers.ETag);
             Assert.AreEqual(result.RequestCharge, response.Headers.RequestCharge);
             Assert.AreEqual(result.RetryAfter, response.Headers.RetryAfter);
+            Assert.AreEqual(result.SessionToken, response.Headers.Session);
             Assert.AreSame(result.ResourceStream, response.Content);
             Assert.IsNotNull(response.Diagnostics);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 cancellationToken: CancellationToken.None);
             ResponseMessage response = new ResponseMessage((HttpStatusCode)StatusCodes.MultiStatus) { Content = responseContent };
             response.Headers.Session = Guid.NewGuid().ToString();
+            response.Headers.ActivityId = Guid.NewGuid().ToString();
             TransactionalBatchResponse batchResponse = await TransactionalBatchResponse.FromResponseMessageAsync(
                 response,
                 batchRequest,
@@ -115,6 +116,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(2, batchResponse.Count);
             Assert.AreEqual(response.Headers.Session, batchResponse[0].SessionToken);
             Assert.AreEqual(response.Headers.Session, batchResponse[1].SessionToken);
+            Assert.AreEqual(response.Headers.ActivityId, batchResponse[0].ActivityId);
+            Assert.AreEqual(response.Headers.ActivityId, batchResponse[1].ActivityId);
 
 
             CosmosBatchOperationResultEqualityComparer comparer = new CosmosBatchOperationResultEqualityComparer();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 RetryAfter = TimeSpan.FromSeconds(10),
                 RequestCharge = 4.3,
                 SessionToken = Guid.NewGuid().ToString(),
+                ActivityId = Guid.NewGuid().ToString(),
             };
 
             using (ITrace trace = Trace.GetRootTrace("testtrace"))
@@ -115,6 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(result.StatusCode, response.StatusCode);
             Assert.AreEqual(result.RequestCharge, response.Headers.RequestCharge);
             Assert.AreEqual(result.SessionToken, response.Headers.Session);
+            Assert.AreEqual(result.ActivityId, response.Headers.ActivityId);
             string diagnostics = response.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);
             Assert.IsTrue(diagnostics.Contains(pointOperationStatistics.ActivityId));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/PartitionKeyRangeBatchExecutionResultTests.cs
@@ -97,7 +97,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 ETag = "1234",
                 SubStatusCode = SubStatusCodes.CompletingSplit,
                 RetryAfter = TimeSpan.FromSeconds(10),
-                RequestCharge = 4.3
+                RequestCharge = 4.3,
+                SessionToken = Guid.NewGuid().ToString(),
             };
 
             using (ITrace trace = Trace.GetRootTrace("testtrace"))
@@ -113,6 +114,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(result.RetryAfter, response.Headers.RetryAfter);
             Assert.AreEqual(result.StatusCode, response.StatusCode);
             Assert.AreEqual(result.RequestCharge, response.Headers.RequestCharge);
+            Assert.AreEqual(result.SessionToken, response.Headers.Session);
             string diagnostics = response.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);
             Assert.IsTrue(diagnostics.Contains(pointOperationStatistics.ActivityId));


### PR DESCRIPTION
Bulk operations, when un-packed from the Bulk response, were not wiring the Session Token and ActivityId into the respective resulting operations.

All the operations included in a Bulk response contain the same Session Token and ActivityId as they were all committed in the same transaction.

Closes #2738