### PR TITLE
[Internal] CTL: Fixes container lifetime and parallelism on Query scenario

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
@@ -93,6 +93,10 @@ namespace CosmosCTL
                             }
                         }
                     }
+                    catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                    {
+                        //Logging 429s is not relevant
+                    }
                     catch (Exception ex)
                     {
                         metrics.Measure.Gauge.SetValue(documentGauge, documentTotal);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
@@ -44,7 +44,7 @@ namespace CosmosCTL
             }
         }
 
-        public Task RunAsync(
+        public async Task RunAsync(
             CTLConfig config,
             CosmosClient cosmosClient,
             ILogger logger,
@@ -52,68 +52,87 @@ namespace CosmosCTL
             string loggingContextIdentifier,
             CancellationToken cancellationToken)
         {
-            return Task.WhenAll(
-                QueryScenario.ExecuteQueryAndGatherResultsAsync(
-                    config, 
-                    cosmosClient, 
-                    logger, 
-                    metrics, 
-                    loggingContextIdentifier, 
-                    cancellationToken, 
-                    queryText: "select * from c", 
-                    queryName: "Star",
-                    expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments: 0),
-                QueryScenario.ExecuteQueryAndGatherResultsAsync(
-                    config, 
-                    cosmosClient, 
-                    logger, 
-                    metrics, 
-                    loggingContextIdentifier, 
-                    cancellationToken, 
-                    queryText: "select * from c order by c.id", 
-                    queryName: "OrderBy",
-                    expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
-                QueryScenario.ExecuteQueryAndGatherResultsAsync(
-                    config, 
-                    cosmosClient, 
-                    logger, 
-                    metrics, 
-                    loggingContextIdentifier, 
-                    cancellationToken, 
-                    queryText: "select count(1) from c", 
-                    queryName: "Aggregates",
-                    expectedResults: 1),
-                QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
-                    config,
-                    cosmosClient,
-                    logger,
-                    metrics,
-                    loggingContextIdentifier,
-                    cancellationToken,
-                    queryText: "select * from c",
-                    queryName: "Star",
-                    expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
-                QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
-                    config,
-                    cosmosClient,
-                    logger,
-                    metrics,
-                    loggingContextIdentifier,
-                    cancellationToken,
-                    queryText: "select * from c order by c.id",
-                    queryName: "OrderBy",
-                    expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
-                QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
-                    config,
-                    cosmosClient,
-                    logger,
-                    metrics,
-                    loggingContextIdentifier,
-                    cancellationToken,
-                    queryText: "select count(1) from c",
-                    queryName: "Aggregates",
-                    expectedResults: 1)
-                );
+            try
+            {
+                await Task.WhenAll(
+                        QueryScenario.ExecuteQueryAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select * from c",
+                            queryName: "Star",
+                            expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
+                        QueryScenario.ExecuteQueryAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select * from c order by c.id",
+                            queryName: "OrderBy",
+                            expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
+                        QueryScenario.ExecuteQueryAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select count(1) from c",
+                            queryName: "Aggregates",
+                            expectedResults: 1),
+                        QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select * from c",
+                            queryName: "Star",
+                            expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
+                        QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select * from c order by c.id",
+                            queryName: "OrderBy",
+                            expectedResults: config.PreCreatedDocuments > 0 ? this.initializationResult.InsertedDocuments : 0),
+                        QueryScenario.ExecuteQueryWithContinuationAndGatherResultsAsync(
+                            config,
+                            cosmosClient,
+                            logger,
+                            metrics,
+                            loggingContextIdentifier,
+                            cancellationToken,
+                            queryText: "select count(1) from c",
+                            queryName: "Aggregates",
+                            expectedResults: 1)
+                        );
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failure during Query scenario");
+            }
+            finally
+            {
+                if (this.initializationResult.CreatedContainer)
+                {
+                    await cosmosClient.GetContainer(config.Database, config.Collection).DeleteContainerStreamAsync();
+                }
+
+                if (this.initializationResult.CreatedDatabase)
+                {
+                    await cosmosClient.GetDatabase(config.Database).DeleteStreamAsync();
+                }
+            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
@@ -199,6 +199,10 @@ namespace CosmosCTL
                         logger.LogError(errorDetail.ToString());
                     }
                 }
+                catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                {
+                    //Logging 429s is not relevant
+                }
                 catch (Exception ex)
                 {
                     metrics.Measure.Gauge.SetValue(documentGauge, documentTotal);
@@ -265,6 +269,10 @@ namespace CosmosCTL
 
                         logger.LogError(errorDetail.ToString());
                     }
+                }
+                catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.TooManyRequests)
+                {
+                    //Logging 429s is not relevant
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
The new Change Feed Pull scenario and Query scenario were creating containers but not cleaning them up afterwards. 

This made it so the first run would work, but a next run would fail because the container already existed, we would populate the container again and then the comparison with the results would fail:

1. Create container
2. Populate X documents
3. Run queries, results Y match X
4. Run the workload again
5. Populate X documents (now container has 2X)
6. Run queries, results Y does not match X (it matches 2X)

Finally, the Query workload was not gating the volume of operations on concurrency configuration, we should honor concurrency to avoid hitting 429s.