### PR TITLE
Bulk: Adds validation for ItemRequestOptions.Properties

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -123,6 +123,7 @@ namespace Microsoft.Azure.Cosmos
                                 || itemRequestOptions.PreTriggers != null
                                 || itemRequestOptions.PostTriggers != null
                                 || itemRequestOptions.SessionToken != null
+                                || itemRequestOptions.Properties != null
                                 || itemRequestOptions.DedicatedGatewayRequestOptions?.MaxIntegratedCacheStaleness != null)
                 {
                     throw new InvalidOperationException(ClientResources.UnsupportedBulkRequestOptions);

--- a/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
@@ -315,10 +315,8 @@ namespace Microsoft.Azure.Cosmos {
         /// <summary>
         ///   Looks up a localized string similar to Failed to get AAD token from the provided Azure.Core.TokenCredential..
         /// </summary>
-        internal static string FailedToGetAadToken
-        {
-            get
-            {
+        internal static string FailedToGetAadToken {
+            get {
                 return ResourceManager.GetString("FailedToGetAadToken", resourceCulture);
             }
         }
@@ -639,7 +637,7 @@ namespace Microsoft.Azure.Cosmos {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Consistency, Session, and Triggers are not allowed when AllowBulkExecution is set to true..
+        ///   Looks up a localized string similar to Consistency, Session, Properties, and Triggers are not allowed when AllowBulkExecution is set to true..
         /// </summary>
         internal static string UnsupportedBulkRequestOptions {
             get {

--- a/Microsoft.Azure.Cosmos/src/ClientResources.resx
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.resx
@@ -298,7 +298,7 @@
     <value>Instantiation of only value types, anonymous types and spatial types are supported.</value>
   </data>
   <data name="UnsupportedBulkRequestOptions" xml:space="preserve">
-    <value>Consistency, Session, and Triggers are not allowed when AllowBulkExecution is set to true.</value>
+    <value>Consistency, Session, Properties, and Triggers are not allowed when AllowBulkExecution is set to true.</value>
   </data>
   <data name="EncryptorNotConfigured" xml:space="preserve">
     <value>The client was not configured to allow for encryption. Create the client by using cosmosClientBuilder.WithEncryptor.</value>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System;
     using System.Collections.Generic;
     using System.Net;
-    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -16,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     [TestClass]
     public class BatchAsyncContainerExecutorTests
     {
-        private static CosmosSerializer cosmosDefaultJsonSerializer = new CosmosJsonDotNetSerializer();
+        private readonly static CosmosSerializer cosmosDefaultJsonSerializer = new CosmosJsonDotNetSerializer();
         private CosmosClient cosmosClient;
         private ContainerInternal cosmosContainer;
 
@@ -79,6 +78,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             MyDocument myDocument = new MyDocument() { id = id, Status = id };
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => executor.ValidateOperationAsync(new ItemBatchOperation(OperationType.Replace, 0, new Cosmos.PartitionKey(id), id, cosmosDefaultJsonSerializer.ToStream(myDocument)), new ItemRequestOptions() { SessionToken = "something" }));
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => executor.ValidateOperationAsync(
+                new ItemBatchOperation(OperationType.Replace, 0, new Cosmos.PartitionKey(id), id, cosmosDefaultJsonSerializer.ToStream(myDocument)), 
+                new ItemRequestOptions() { Properties = new Dictionary<string, object>() { { "test", "test" } } }));
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() => executor.ValidateOperationAsync(
                 new ItemBatchOperation(OperationType.Replace, 0, new Cosmos.PartitionKey(id), id, cosmosDefaultJsonSerializer.ToStream(myDocument)), 
                 new ItemRequestOptions() { DedicatedGatewayRequestOptions = new DedicatedGatewayRequestOptions { MaxIntegratedCacheStaleness = TimeSpan.FromMinutes(3) }  }));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(ExecuteCreateStreamAsync(this.container, CreateItem(i.ToString()), 
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, CosmosItemBulkTests.CreateItem(i.ToString()), 
                     new ItemRequestOptions() {
                         Properties = new Dictionary<string, object>() { { "test", "test" } },
                         DedicatedGatewayRequestOptions = new DedicatedGatewayRequestOptions { MaxIntegratedCacheStaleness = TimeSpan.FromMinutes(3) },
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(ExecuteCreateStreamAsync(this.container, CreateItem(i.ToString())));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, CosmosItemBulkTests.CreateItem(i.ToString())));
             }
 
             await Task.WhenAll(tasks);
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(ExecuteCreateAsync(this.container, CreateItem(i.ToString())));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateAsync(this.container, CosmosItemBulkTests.CreateItem(i.ToString())));
             }
 
             await Task.WhenAll(tasks);
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<JObject>>> tasks = new List<Task<ItemResponse<JObject>>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(this.container.CreateItemAsync(CreateJObjectWithoutPK(i.ToString())));
+                tasks.Add(this.container.CreateItemAsync(CosmosItemBulkTests.CreateJObjectWithoutPK(i.ToString())));
             }
 
             await Task.WhenAll(tasks);
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(ExecuteUpsertStreamAsync(this.container, CreateItem(i.ToString())));
+                tasks.Add(CosmosItemBulkTests.ExecuteUpsertStreamAsync(this.container, CosmosItemBulkTests.CreateItem(i.ToString())));
             }
 
             await Task.WhenAll(tasks);
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                tasks.Add(ExecuteUpsertAsync(this.container, CreateItem(i.ToString())));
+                tasks.Add(CosmosItemBulkTests.ExecuteUpsertAsync(this.container, CosmosItemBulkTests.CreateItem(i.ToString())));
             }
 
             await Task.WhenAll(tasks);
@@ -198,9 +198,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Delete the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                deleteTasks.Add(ExecuteDeleteStreamAsync(this.container, createdDocument));
+                deleteTasks.Add(CosmosItemBulkTests.ExecuteDeleteStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(deleteTasks);
@@ -233,9 +233,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Delete the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                deleteTasks.Add(ExecuteDeleteAsync(this.container, createdDocument));
+                deleteTasks.Add(CosmosItemBulkTests.ExecuteDeleteAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(deleteTasks);
@@ -268,9 +268,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -279,7 +279,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Read the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                readTasks.Add(ExecuteReadStreamAsync(this.container, createdDocument));
+                readTasks.Add(CosmosItemBulkTests.ExecuteReadStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(readTasks);
@@ -303,9 +303,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Read the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                readTasks.Add(ExecuteReadAsync(this.container, createdDocument));
+                readTasks.Add(CosmosItemBulkTests.ExecuteReadAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(readTasks);
@@ -338,9 +338,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -349,7 +349,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Replace the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                replaceTasks.Add(ExecuteReplaceStreamAsync(this.container, createdDocument));
+                replaceTasks.Add(CosmosItemBulkTests.ExecuteReplaceStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(replaceTasks);
@@ -373,9 +373,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -384,7 +384,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Replace the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                replaceTasks.Add(ExecuteReplaceAsync(this.container, createdDocument));
+                replaceTasks.Add(CosmosItemBulkTests.ExecuteReplaceAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(replaceTasks);
@@ -408,9 +408,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateStreamAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Patch the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                PatchTasks.Add(ExecutePatchStreamAsync((ContainerInternal)this.container, createdDocument, patch));
+                PatchTasks.Add(CosmosItemBulkTests.ExecutePatchStreamAsync((ContainerInternal)this.container, createdDocument, patch));
             }
 
             await Task.WhenAll(PatchTasks);
@@ -447,9 +447,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ItemResponse<ToDoActivity>>> tasks = new List<Task<ItemResponse<ToDoActivity>>>();
             for (int i = 0; i < 100; i++)
             {
-                ToDoActivity createdDocument = CreateItem(i.ToString());
+                ToDoActivity createdDocument = CosmosItemBulkTests.CreateItem(i.ToString());
                 createdDocuments.Add(createdDocument);
-                tasks.Add(ExecuteCreateAsync(this.container, createdDocument));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateAsync(this.container, createdDocument));
             }
 
             await Task.WhenAll(tasks);
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Patch the items
             foreach (ToDoActivity createdDocument in createdDocuments)
             {
-                patchTasks.Add(ExecutePatchAsync((ContainerInternal)this.container, createdDocument, patch));
+                patchTasks.Add(CosmosItemBulkTests.ExecutePatchAsync((ContainerInternal)this.container, createdDocument, patch));
             }
 
             await Task.WhenAll(patchTasks);
@@ -499,10 +499,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<Task<ResponseMessage>> tasks = new List<Task<ResponseMessage>>();
             for (int i = 0; i < 3; i++)
             {
-                ToDoActivity item = CreateItem(i.ToString());
+                ToDoActivity item = CosmosItemBulkTests.CreateItem(i.ToString());
 
                 if (i == 1) { item.description = new string('x', appxItemSize); }
-                tasks.Add(ExecuteCreateStreamAsync(this.container, item));
+                tasks.Add(CosmosItemBulkTests.ExecuteCreateStreamAsync(this.container, item));
             }
 
             await Task.WhenAll(tasks);


### PR DESCRIPTION
Bulk operations by design do not map 1:1 to network operations. `ItemRequestOptions.Properties` does not flow to the actual network requests Properties, and we should be validating that to avoid wrong expectations, just like we validate other attributes on ItemRequestOptions.


Closes #2741