### PR TITLE
Client Telemetry: Fixes consistency level issue

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 databaseId: request.DatabaseId,
                                 operationType: request.OperationType,
                                 resourceType: request.ResourceType,
-                                consistencyLevel: request.Headers[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
+                                consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
                                 requestCharge: response.Headers.RequestCharge);
                 }
                 catch (Exception ex)

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -27,9 +27,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage response = await base.SendAsync(request, cancellationToken);
             if (this.IsAllowed(request))
             {
-                Enum.TryParse(request.Headers[Documents.HttpConstants.HttpHeaders.ConsistencyLevel], 
-                    out ConsistencyLevel consistencyLevel);
-
                 try
                 {
                     this.telemetry
@@ -41,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 databaseId: request.DatabaseId,
                                 operationType: request.OperationType,
                                 resourceType: request.ResourceType,
-                                consistencyLevel: consistencyLevel,
+                                consistencyLevel: request.Headers[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
                                 requestCharge: response.Headers.RequestCharge);
                 }
                 catch (Exception ex)

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage response = await base.SendAsync(request, cancellationToken);
             if (this.IsAllowed(request))
             {
+                Enum.TryParse(request.Headers[Documents.HttpConstants.HttpHeaders.ConsistencyLevel], 
+                    out ConsistencyLevel consistencyLevel);
+
                 try
                 {
                     this.telemetry
@@ -38,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 databaseId: request.DatabaseId,
                                 operationType: request.OperationType,
                                 resourceType: request.ResourceType,
-                                consistencyLevel: this.GetConsistencyLevel(request),
+                                consistencyLevel: consistencyLevel,
                                 requestCharge: response.Headers.RequestCharge);
                 }
                 catch (Exception ex)
@@ -52,11 +55,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
         private bool IsAllowed(RequestMessage request)
         { 
             return ClientTelemetryOptions.AllowedResourceTypes.Equals(request.ResourceType);
-        }
-
-        private ConsistencyLevel? GetConsistencyLevel(RequestMessage request)
-        {
-            return request.RequestOptions?.BaseConsistencyLevel.GetValueOrDefault();   
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         private readonly CancellationTokenSource cancellationTokenSource;
 
-        private static string accountConsistencyLevel;
-
         private Task telemetryTask;
 
         private ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoMap 
@@ -128,7 +126,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     {
                         AccountProperties accountProperties = await ClientTelemetryHelper.SetAccountNameAsync(this.documentClient);
                         this.clientTelemetryInfo.GlobalDatabaseAccountName = accountProperties?.Id;
-                        accountConsistencyLevel = accountProperties?.Consistency.DefaultConsistencyLevel.ToString();
                     }
 
                     // Load host information if not available (it caches the information)
@@ -158,7 +155,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoSnapshot 
                         = Interlocked.Exchange(ref this.operationInfoMap, new ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)>());
 
-                    this.clientTelemetryInfo.OperationInfo = ClientTelemetryHelper.ToListWithMetricsInfo(operationInfoSnapshot, accountConsistencyLevel);
+                    this.clientTelemetryInfo.OperationInfo = ClientTelemetryHelper.ToListWithMetricsInfo(operationInfoSnapshot);
 
                     await this.SendAsync();
                 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -143,10 +143,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Convert map with operation information to list of operations along with request latency and request charge metrics
         /// </summary>
         /// <param name="metrics"></param>
-        /// <param name="accountConsistencyLevel"></param>
         /// <returns>Collection of ReportPayload</returns>
-        internal static List<OperationInfo> ToListWithMetricsInfo(IDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> metrics,
-            string accountConsistencyLevel)
+        internal static List<OperationInfo> ToListWithMetricsInfo(IDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> metrics)
         {
             DefaultTrace.TraceInformation("Aggregating operation information to list started");
 
@@ -154,11 +152,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             foreach (KeyValuePair<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> entry in metrics)
             {
                 OperationInfo payloadForLatency = entry.Key;
-
-                if (payloadForLatency.Consistency == null)
-                {
-                    payloadForLatency.Consistency = accountConsistencyLevel;
-                }
                 payloadForLatency.MetricInfo = new MetricInfo(ClientTelemetryOptions.RequestLatencyName, ClientTelemetryOptions.RequestLatencyUnit);
                 payloadForLatency.SetAggregators(entry.Value.latency, ClientTelemetryOptions.TicksToMsFactor);
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -143,8 +143,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Convert map with operation information to list of operations along with request latency and request charge metrics
         /// </summary>
         /// <param name="metrics"></param>
+        /// <param name="accountConsistencyLevel"></param>
         /// <returns>Collection of ReportPayload</returns>
-        internal static List<OperationInfo> ToListWithMetricsInfo(IDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> metrics)
+        internal static List<OperationInfo> ToListWithMetricsInfo(IDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> metrics,
+            string accountConsistencyLevel)
         {
             DefaultTrace.TraceInformation("Aggregating operation information to list started");
 
@@ -152,6 +154,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             foreach (KeyValuePair<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> entry in metrics)
             {
                 OperationInfo payloadForLatency = entry.Key;
+
+                if (payloadForLatency.Consistency == null)
+                {
+                    payloadForLatency.Consistency = accountConsistencyLevel;
+                }
                 payloadForLatency.MetricInfo = new MetricInfo(ClientTelemetryOptions.RequestLatencyName, ClientTelemetryOptions.RequestLatencyUnit);
                 payloadForLatency.SetAggregators(entry.Value.latency, ClientTelemetryOptions.TicksToMsFactor);
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal string Resource { get; }
 
         [JsonProperty(PropertyName = "consistency")]
-        internal string Consistency { get; }
+        internal string Consistency { get; set; }
 
         [JsonProperty(PropertyName = "statusCode")]
         public int? StatusCode { get; }
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         internal OperationInfo(string regionsContacted, 
             long? responseSizeInBytes,            
-            Cosmos.ConsistencyLevel? consistency, 
+            string consistency, 
             string databaseName, 
             string containerName, 
             OperationType? operation, 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
             }
-            this.Consistency = OperationInfo.GetConsistencyString(consistency);
+            this.Consistency = consistency;
             this.DatabaseName = databaseName;
             this.ContainerName = containerName;
             this.Operation = operation?.ToOperationTypeString();
@@ -91,24 +91,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.StatusCode = statusCode;
             this.ResponseSizeInBytes = responseSizeInBytes;
             this.MetricInfo = metricInfo;
-        }
-
-        private static string GetConsistencyString(Cosmos.ConsistencyLevel? consistency)
-        {
-            if (consistency == null)
-            {
-                return null;
-            }
-
-            return consistency switch
-            {
-                Cosmos.ConsistencyLevel.Strong => "STRONG",
-                Cosmos.ConsistencyLevel.Session => "SESSION",
-                Cosmos.ConsistencyLevel.Eventual => "EVENTUAL",
-                Cosmos.ConsistencyLevel.ConsistentPrefix => "CONSISTENTPREFIX",
-                Cosmos.ConsistencyLevel.BoundedStaleness => "BOUNDEDSTALENESS",
-                _ => consistency.ToString().ToUpper(),
-            };
         }
 
         public OperationInfo Copy()
@@ -142,14 +124,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         public override bool Equals(object obj)
         {
             bool isequal = obj is OperationInfo payload &&
-                   this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted) &&
-                   this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb) &&
-                   this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency) &&
-                   this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName) &&
-                   this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName) &&
-                   this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation) &&
-                   this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource) &&
-                   this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode);
+                   ((this.RegionsContacted == null && payload.RegionsContacted == null) || (this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted))) &&
+                   ((this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null ) || (this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb))) &&
+                   ((this.Consistency == null && payload.Consistency == null) || (this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency))) &&
+                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
+                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
+                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
+                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
+                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode)));
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal string Resource { get; }
 
         [JsonProperty(PropertyName = "consistency")]
-        internal string Consistency { get; set; }
+        internal string Consistency { get; }
 
         [JsonProperty(PropertyName = "statusCode")]
         public int? StatusCode { get; }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -331,8 +331,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(operation.Resource, "Resource Type is null");
                 Assert.IsNotNull(operation.ResponseSizeInBytes, "ResponseSizeInBytes is null");
                 Assert.IsNotNull(operation.StatusCode, "StatusCode is null");
-                Assert.IsNotNull(operation.Consistency, "Consistency is null");
-                Assert.AreEqual(expectedConsistencyLevel.ToString(), operation.Consistency, $"Consistency is not {expectedConsistencyLevel}");
+                Assert.AreEqual(expectedConsistencyLevel?.ToString(), operation.Consistency, $"Consistency is not {expectedConsistencyLevel}");
 
                 Assert.IsNotNull(operation.MetricInfo, "MetricInfo is null");
                 Assert.IsNotNull(operation.MetricInfo.MetricsName, "MetricsName is null");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private List<ClientTelemetryProperties> actualInfo;
 
-        private AccountProperties accountProperties;
-
         [TestInitialize]
         public void TestInitialize()
         {
@@ -308,11 +306,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<OperationInfo> actualOperationList = new List<OperationInfo>();
             List<SystemInfo> actualSystemInformation = new List<SystemInfo>();
 
-            if (!expectedConsistencyLevel.HasValue)
-            {
-                expectedConsistencyLevel = this.accountProperties.Consistency.DefaultConsistencyLevel;
-            }
-
             // Asserting If basic client telemetry object is as expected
             foreach (ClientTelemetryProperties telemetryInfo in localCopyOfActualInfo)
             {
@@ -378,12 +371,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.cosmosClientBuilder = this.cosmosClientBuilder.WithConsistencyLevel(consistency.Value);
             }
 
-            if (mode == ConnectionMode.Gateway)
-            {
-                this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeGateway().Build();
-            }
+            this.cosmosClient = mode == ConnectionMode.Gateway
+                ? this.cosmosClientBuilder.WithConnectionModeGateway().Build()
+                : this.cosmosClientBuilder.Build();
 
-            this.accountProperties = await this.cosmosClient.ReadAccountAsync();
             this.database = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
             return await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private List<ClientTelemetryProperties> actualInfo;
 
+        private AccountProperties accountProperties;
+
         [TestInitialize]
         public void TestInitialize()
         {
@@ -134,10 +136,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Fail Read
             try
             {
-                Container container = await this.GetContainer(mode);
+                Container container = await this.GetContainer(mode, ConsistencyLevel.ConsistentPrefix);
                 await container.ReadItemAsync<JObject>(
                     new Guid().ToString(),
-                    new Cosmos.PartitionKey(new Guid().ToString()));
+                    new Cosmos.PartitionKey(new Guid().ToString()),
+                     new ItemRequestOptions()
+                     {
+                         BaseConsistencyLevel = ConsistencyLevel.Eventual // overriding client level consistency
+                     });
             }
             catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.NotFound)
             {
@@ -145,7 +151,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(message);
             }
 
-            await this.WaitAndAssert(2);
+            await this.WaitAndAssert(expectedOperationCount: 2,
+                expectedConsistencyLevel: ConsistencyLevel.Eventual);
         }
 
         [TestMethod]
@@ -160,7 +167,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 await container.ReadItemStreamAsync(
                     new Guid().ToString(),
-                    new Cosmos.PartitionKey(new Guid().ToString()));
+                    new Cosmos.PartitionKey(new Guid().ToString()),
+                    new ItemRequestOptions()
+                    {
+                        BaseConsistencyLevel = ConsistencyLevel.ConsistentPrefix // Request level consistency
+                    });
             }
             catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.NotFound)
             {
@@ -168,7 +179,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(message);
             }
 
-            await this.WaitAndAssert(2);
+            await this.WaitAndAssert(expectedOperationCount: 2,
+                expectedConsistencyLevel: ConsistencyLevel.ConsistentPrefix);
         }
 
         [TestMethod]
@@ -213,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(ConnectionMode.Gateway)]
         public async Task BatchOperationsTest(ConnectionMode mode)
         {
-            Container container = await this.GetContainer(mode);
+            Container container = await this.GetContainer(mode, ConsistencyLevel.Eventual); // Client level consistency
             using (BatchAsyncContainerExecutor executor =
                 new BatchAsyncContainerExecutor(
                     (ContainerInlineCore)container,
@@ -231,7 +243,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 await Task.WhenAll(tasks);
             }
 
-            await this.WaitAndAssert(2);
+            await this.WaitAndAssert(expectedOperationCount: 2,
+                expectedConsistencyLevel: ConsistencyLevel.Eventual);
         }
 
         [TestMethod]
@@ -264,7 +277,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.WaitAndAssert(4);
         }
 
-        private async Task WaitAndAssert(int expectedOperationCount)
+        private async Task WaitAndAssert(int expectedOperationCount, ConsistencyLevel? expectedConsistencyLevel = null)
         {
             Assert.IsNotNull(this.actualInfo, "Telemetry Information not available");
 
@@ -295,6 +308,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<OperationInfo> actualOperationList = new List<OperationInfo>();
             List<SystemInfo> actualSystemInformation = new List<SystemInfo>();
 
+            if (!expectedConsistencyLevel.HasValue)
+            {
+                expectedConsistencyLevel = this.accountProperties.Consistency.DefaultConsistencyLevel;
+            }
+
             // Asserting If basic client telemetry object is as expected
             foreach (ClientTelemetryProperties telemetryInfo in localCopyOfActualInfo)
             {
@@ -321,6 +339,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(operation.ResponseSizeInBytes, "ResponseSizeInBytes is null");
                 Assert.IsNotNull(operation.StatusCode, "StatusCode is null");
                 Assert.IsNotNull(operation.Consistency, "Consistency is null");
+                Assert.AreEqual(expectedConsistencyLevel.ToString(), operation.Consistency, $"Consistency is not {expectedConsistencyLevel}");
 
                 Assert.IsNotNull(operation.MetricInfo, "MetricInfo is null");
                 Assert.IsNotNull(operation.MetricInfo.MetricsName, "MetricsName is null");
@@ -352,18 +371,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             return new ItemBatchOperation(Documents.OperationType.Create, 0, new Cosmos.PartitionKey(itemId), itemId, TestCommon.SerializerCore.ToStream(testItem));
         }
 
-        private async Task<Container> GetContainer(ConnectionMode mode)
+        private async Task<Container> GetContainer(ConnectionMode mode, ConsistencyLevel? consistency = null)
         {
+            if (consistency.HasValue)
+            {
+                this.cosmosClientBuilder = this.cosmosClientBuilder.WithConsistencyLevel(consistency.Value);
+            }
+
             if (mode == ConnectionMode.Direct)
             {
                 this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeDirect().Build();
-            }
-
-            if (mode == ConnectionMode.Gateway)
+            } else if (mode == ConnectionMode.Gateway)
             {
                 this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeGateway().Build();
             }
 
+            this.accountProperties = await this.cosmosClient.ReadAccountAsync();
             this.database = await this.cosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
             return await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -381,7 +381,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             if (mode == ConnectionMode.Direct)
             {
                 this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeDirect().Build();
-            } else if (mode == ConnectionMode.Gateway)
+            } 
+            else if (mode == ConnectionMode.Gateway)
             {
                 this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeGateway().Build();
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -378,11 +378,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.cosmosClientBuilder = this.cosmosClientBuilder.WithConsistencyLevel(consistency.Value);
             }
 
-            if (mode == ConnectionMode.Direct)
-            {
-                this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeDirect().Build();
-            } 
-            else if (mode == ConnectionMode.Gateway)
+            if (mode == ConnectionMode.Gateway)
             {
                 this.cosmosClient = this.cosmosClientBuilder.WithConnectionModeGateway().Build();
             }


### PR DESCRIPTION
## Description

1. Right now, if user is not sending consistency level in the request but sending request option with other configuration. Telemetry is logging Consistency level as "Strong" which is wrong. So fixing it as part of this PR.
2. Optimizing getting consistency level information in telemetry by removing blocking call.
3. Add consistency related tests in client telemetry.
4. Making sure that if user is not passing consistency level (in request or client), it will be stored as NULL in telemetry data.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber