### PR TITLE
[INTERNAL] ClientSideRequestStatisticsTraceDatum: Fixes system usage causing null reference on INTERNAL build

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -267,12 +267,14 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
 
         public void UpdateSystemUsage()
         {
+#if !INTERNAL
             if (this.systemUsageHistory == null ||
                 this.systemUsageHistory.Values.Count == 0 ||
                 this.systemUsageHistory.LastTimestamp + DiagnosticsHandlerHelper.DiagnosticsRefreshInterval < DateTime.UtcNow)
             {
                 this.systemUsageHistory = DiagnosticsHandlerHelper.Instance.GetDiagnosticsSystemHistory();
             }
+#endif
         }
 
         internal override void Accept(ITraceDatumVisitor traceDatumVisitor)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes a null reference for internal teams using the SDK. Internal teams do not want to collect system usage.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber