### PR TITLE
[Internal] Diagnostics: Fixes missing Accumulator.RecordResponse

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 request.OperationType,
                 locationEndpoint);
 
+            this.Accumulator?.RecordResponse(storeResult);
             lock (this.storeResponseStatistics)
             {
                 if (locationEndpoint != null)


### PR DESCRIPTION
# Pull Request Template

## Description

Call Accumulator.RecordResponse so that responses from the BE are recorded & we can count retries/time spent retrying etc. This seems to have been accidentally removed during Direct sync.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber