### PR TITLE
Client Telemetry : Fixes a design change to record end to end telemetry

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using global::Azure.Core;
     using Microsoft.Azure.Cosmos.Handlers;
-    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
@@ -102,8 +101,6 @@ namespace Microsoft.Azure.Cosmos
 
         internal static int numberOfClientsCreated;
         internal DateTime? DisposedDateTimeUtc { get; private set; } = null;
-
-        internal ClientTelemetry Telemetry;
 
         static CosmosClient()
         {
@@ -1251,7 +1248,6 @@ namespace Microsoft.Azure.Cosmos
                 if (disposing)
                 {
                     this.ClientContext.Dispose();
-                    this.Telemetry?.Dispose();
                 }
 
                 this.isDisposed = true;

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             {
                 try
                 {
-                    this.telemetry
+                  /*  this.telemetry
                         .Collect(
                                 cosmosDiagnostics: response.Diagnostics,
                                 statusCode: response.StatusCode,
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 operationType: request.OperationType,
                                 resourceType: request.ResourceType,
                                 consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
-                                requestCharge: response.Headers.RequestCharge);
+                                requestCharge: response.Headers.RequestCharge);*/
                 }
                 catch (Exception ex)
                 {
@@ -52,31 +52,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
         private bool IsAllowed(RequestMessage request)
         { 
             return ClientTelemetryOptions.AllowedResourceTypes.Equals(request.ResourceType);
-        }
-
-        /// <summary>
-        /// It returns the payload size after reading it from the Response content stream. 
-        /// To avoid blocking IO calls to get the stream length, it will return response content length if stream is of Memory Type
-        /// otherwise it will return the content length from the response header (if it is there)
-        /// </summary>
-        /// <param name="response"></param>
-        /// <returns>Size of Payload</returns>
-        private long GetPayloadSize(ResponseMessage response)
-        {
-            if (response != null)
-            {
-                if (response.Content != null && response.Content is MemoryStream)
-                {
-                    return response.Content.Length;
-                }
-
-                if (response.Headers != null && response.Headers.ContentLength != null)
-                {
-                    return long.Parse(response.Headers.ContentLength);
-                }
-            }
-
-            return 0;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryPublisher.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryPublisher.cs
@@ -1,0 +1,106 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+
+    internal class ClientTelemetryPublisher
+    {
+        internal static ResponseMessage Publish(
+          Documents.OperationType operationType,
+          Documents.ResourceType resourceType,
+          RequestOptions requestOptions,
+          Container container,
+          ResponseMessage response)
+        {
+            string consistencyValue = null;
+            if (requestOptions != null && requestOptions.BaseConsistencyLevel.HasValue)
+            {
+                consistencyValue = requestOptions.BaseConsistencyLevel.ToString();
+            }
+
+            ClientTelemetry.Collect(
+                cosmosDiagnostics: response.Diagnostics,
+                statusCode: response.StatusCode,
+                responseSizeInBytes: GetPayloadSize(response),
+                databaseId: container.Database.Id,
+                containerId: container.Id,
+                operationType: operationType,
+                resourceType: resourceType,
+                consistencyLevel: consistencyValue,
+                requestCharge: response.Headers.RequestCharge);
+
+            return response;
+        }
+
+        internal static ItemResponse<T> Publish<T>(
+            Documents.OperationType operationType,
+            Documents.ResourceType resourceType,
+            RequestOptions requestOptions,
+            Container container,
+            ItemResponse<T> response)
+        {
+            string consistencyValue = null;
+            if (requestOptions != null && requestOptions.BaseConsistencyLevel.HasValue)
+            {
+                consistencyValue = requestOptions.BaseConsistencyLevel.ToString();
+            }
+
+            ClientTelemetry.Collect(
+                cosmosDiagnostics: response.Diagnostics,
+                statusCode: response.StatusCode,
+                responseSizeInBytes: GetPayloadSize(response),
+                databaseId: container.Database.Id,
+                containerId: container.Id,
+                operationType: operationType,
+                resourceType: resourceType,
+                consistencyLevel: consistencyValue,
+                requestCharge: response.Headers.RequestCharge);
+
+            return response;
+        }
+
+        /// <summary>
+        /// It returns the payload size after reading it from the Response content stream. 
+        /// To avoid blocking IO calls to get the stream length, it will return response content length if stream is of Memory Type
+        /// otherwise it will return the content length from the response header (if it is there)
+        /// </summary>
+        /// <param name="response"></param>
+        /// <returns>Size of Payload</returns>
+        private static long GetPayloadSize(ResponseMessage response)
+        {
+            if (response != null)
+            {
+                if (response.Content != null && response.Content is MemoryStream)
+                {
+                    return response.Content.Length;
+                }
+
+                if (response.Headers != null && response.Headers.ContentLength != null)
+                {
+                    return long.Parse(response.Headers.ContentLength);
+                }
+            }
+
+            return 0;
+        }
+
+        private static long GetPayloadSize<T>(Response<T> response)
+        {
+            if (response != null)
+            {
+                if (response.Headers != null && response.Headers.ContentLength != null)
+                {
+                    return long.Parse(response.Headers.ContentLength);
+                }
+            }
+
+            return 0;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [DataRow(ConnectionMode.Direct)]
-        [DataRow(ConnectionMode.Gateway)]
+        //[DataRow(ConnectionMode.Gateway)]
         public async Task PointSuccessOperationsTest(ConnectionMode mode)
         {
             Container container = await this.GetContainer(mode);
@@ -99,8 +99,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Create an item
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity("MyTestPkValue");
             ItemResponse<ToDoActivity> createResponse = await container.CreateItemAsync<ToDoActivity>(testItem);
-            ToDoActivity testItemCreated = createResponse.Resource;
 
+            File.AppendAllText(@"C:\Users\sourabhjain\TelemetryData\6\diag.txt", createResponse.Diagnostics.ToString());
+          //  ToDoActivity testItemCreated = createResponse.Resource;
+/*
             // Read an Item
             await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.id));
 
@@ -121,9 +123,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 patch);
 
             // Delete an Item
-            await container.DeleteItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.id));
+            await container.DeleteItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.id));*/
 
-            await this.WaitAndAssert(12);
+            await this.WaitAndAssert(2);
         }
 
         [TestMethod]
@@ -183,39 +185,41 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [DataRow(ConnectionMode.Direct)]
-        [DataRow(ConnectionMode.Gateway)]
+        //[DataRow(ConnectionMode.Gateway)]
         public async Task StreamOperationsTest(ConnectionMode mode)
         {
             Container container = await this.GetContainer(mode);
             // Create an item
             var testItem = new { id = "MyTestItemId", partitionKeyPath = "MyTestPkValue", details = "it's working", status = "done" };
-            await container
+            ResponseMessage createResponse = await container
                 .CreateItemStreamAsync(TestCommon.SerializerCore.ToStream(testItem),
                 new Cosmos.PartitionKey(testItem.id));
 
-            //Upsert an Item
-            await container.UpsertItemStreamAsync(TestCommon.SerializerCore.ToStream(testItem), new Cosmos.PartitionKey(testItem.id));
+            File.AppendAllText(@"C:\Users\sourabhjain\TelemetryData\6\diag.txt", createResponse.Diagnostics.ToString());
 
-            //Read an Item
-            await container.ReadItemStreamAsync(testItem.id, new Cosmos.PartitionKey(testItem.id));
+            /*  //Upsert an Item
+              await container.UpsertItemStreamAsync(TestCommon.SerializerCore.ToStream(testItem), new Cosmos.PartitionKey(testItem.id));
 
-            //Replace an Item
-            await container.ReplaceItemStreamAsync(TestCommon.SerializerCore.ToStream(testItem), testItem.id, new Cosmos.PartitionKey(testItem.id));
+              //Read an Item
+              await container.ReadItemStreamAsync(testItem.id, new Cosmos.PartitionKey(testItem.id));
 
-            // Patch an Item
-            List<PatchOperation> patch = new List<PatchOperation>()
-            {
-                PatchOperation.Add("/new", "patched")
-            };
-            await ((ContainerInternal)container).PatchItemStreamAsync(
-                partitionKey: new Cosmos.PartitionKey(testItem.id),
-                id: testItem.id,
-                patchOperations: patch);
+              //Replace an Item
+              await container.ReplaceItemStreamAsync(TestCommon.SerializerCore.ToStream(testItem), testItem.id, new Cosmos.PartitionKey(testItem.id));
 
-            //Delete an Item
-            await container.DeleteItemStreamAsync(testItem.id, new Cosmos.PartitionKey(testItem.id));
+              // Patch an Item
+              List<PatchOperation> patch = new List<PatchOperation>()
+              {
+                  PatchOperation.Add("/new", "patched")
+              };
+              await ((ContainerInternal)container).PatchItemStreamAsync(
+                  partitionKey: new Cosmos.PartitionKey(testItem.id),
+                  id: testItem.id,
+                  patchOperations: patch);
 
-            await this.WaitAndAssert(12);
+              //Delete an Item
+              await container.DeleteItemStreamAsync(testItem.id, new Cosmos.PartitionKey(testItem.id));*/
+
+            await this.WaitAndAssert(2);
         }
 
         [TestMethod]
@@ -263,9 +267,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 FeedIterator<object> queryResultSetIterator = container.GetItemQueryIterator<object>(queryDefinition);
 
                 List<object> families = new List<object>();
+                int count = 0;
                 while (queryResultSetIterator.HasMoreResults)
                 {
                     FeedResponse<object> currentResultSet = await queryResultSetIterator.ReadNextAsync();
+                    File.AppendAllText(@"C:\Users\sourabhjain\TelemetryData\7\diag-" + count + ".txt", currentResultSet.Diagnostics.ToString());
+
                     foreach (object family in currentResultSet)
                     {
                         families.Add(family);
@@ -303,6 +310,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             while (localCopyOfActualInfo == null);
 
+            File.AppendAllText(@"C:\Users\sourabhjain\TelemetryData\7\telemetry.txt", JsonConvert.SerializeObject(localCopyOfActualInfo));
             List<OperationInfo> actualOperationList = new List<OperationInfo>();
             List<SystemInfo> actualSystemInformation = new List<SystemInfo>();
 


### PR DESCRIPTION
## Description

Change telemetry design to record end to end latency information.

Few approaches to record telemetry:
1. Record telemetry at this place, https://github.com/Azure/azure-cosmos-dotnet-v3/blob/5e4b98a8b2a4efd5b2d8280e35c76a96d401d266/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs#L456
a) We need containerid, databaseid, consistencylevel, operationtype, resource type needs to be passed all the way.
b) Need to change the code everywhere we are calling it and its parent function
_**2. Record telemetry in ContainerCore.Items once we have response.
In order to collect telemetry, make Collect method in telemetry static.**_ .

Option 2 is implemented.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
