### PR TITLE
[Internal] MigrateToAnalyticalStore: Fixes script to use default polling interval to 60 seconds

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellScripts/MigrateToAnalyticalStore.ps1
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellScripts/MigrateToAnalyticalStore.ps1
@@ -29,7 +29,7 @@ param(
 
     [Parameter(Mandatory = $False, Position = 6, ValueFromPipeline = $false)]
     [int]
-    $PollingIntervalInSeconds = 300 
+    $PollingIntervalInSeconds = 60 
 )
 
 Add-Type -AssemblyName System.Web

--- a/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellScripts/MigrateToAnalyticalStore.ps1
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellScripts/MigrateToAnalyticalStore.ps1
@@ -27,6 +27,8 @@ param(
     [int]
     $NewAnalyticalTTL = -1,
 
+    # The progress on the backend is updated every 60 seconds.
+    # PollingIntervalInSeconds is how often we want to fetch this value from the backend (any less than 60 is redundant).
     [Parameter(Mandatory = $False, Position = 6, ValueFromPipeline = $false)]
     [int]
     $PollingIntervalInSeconds = 60 


### PR DESCRIPTION
# Pull Request Template

## Description

Change default polling interval to 60 seconds as per customer 

## Type of change

## Closing issues

To automatically close an issue: closes #IssueNumber