### PR TITLE
[INTERNAL] Pipeline: Fixes PR triggers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ pr:
      - '*'
   paths:
     include:
-    - /*
+    - '*'
 
 variables:
   DebugArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional" --verbosity normal '

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,15 +1,10 @@
 # A pipeline with no CI trigger
-trigger:
-  branches:
-    include:
-    - master
-    - releases/*
+trigger: none
 
 pr:
   branches:
     include:
-    - master
-    - releases/*
+     - '*'
   paths:
     include:
     - /*

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,9 @@
 # A pipeline with no CI trigger
-trigger: none
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
 
 pr:
   branches:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,8 @@ trigger: none
 pr:
   branches:
     include:
-     - '*'
+    - master
+    - releases/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
# Pull Request Template

## Description

It appears that Azure DevOps no longer supports the wild card /*.  It has been this way since 2018. My only guess is there was some breaking change done on Azure DevOps side.

I updated it to use the wild card I found in the documentation which now causes the gates to trigger correctly.
    - '*'  # must quote since "*" is a YAML reserved character; we want a string
https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#branches
## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber