### PR TITLE
[INTERNAL] CTL: Adds diagnostic logging if request hit a 410 gone exceptions

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -13,6 +13,10 @@ namespace CosmosCTL
     using App.Metrics.Counter;
     using App.Metrics.Timer;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
+    using Microsoft.Azure.Documents;
     using Microsoft.Extensions.Logging;
 
     internal class ReadWriteQueryScenario : ICTLScenario
@@ -147,7 +151,6 @@ namespace CosmosCTL
                 if (index < readWriteQueryPercentage.ReadPercentage)
                 {
                     operations.Add(CTLOperationHandler<ItemResponse<Dictionary<string, string>>>.PerformOperationAsync(
-                        diagnosticsLoggingThreshold: diagnosticsThresholdDuration,
                         createTimerContext: () => metrics.Measure.Timer.Time(readLatencyTimer),
                         resultProducer: new SingleExecutionResultProducer<ItemResponse<Dictionary<string, string>>>(() => this.CreateReadOperation(
                             operation: i,
@@ -164,13 +167,16 @@ namespace CosmosCTL
                             metrics.Measure.Counter.Increment(readFailureMeter);
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during read operation");
                         },
-                        logDiagnostics: (ItemResponse<Dictionary<string, string>> response) => logger.LogInformation("Read request took more than latency threshold {0}, diagnostics: {1}", config.DiagnosticsThresholdDuration, response.Diagnostics.ToString()),
-                        cancellationToken: cancellationToken));
+                        logDiagnostics: (ItemResponse<Dictionary<string, string>> response, TimeSpan latency) => this.LogDiagnostics(
+                            operationName: "Read",
+                            logger: logger,
+                            diagnosticsThresholdDuration: diagnosticsThresholdDuration,
+                            latency: latency,
+                            cosmosDiagnostics: response.Diagnostics)));
                 }
                 else if (index < writeRange)
                 {
                     operations.Add(CTLOperationHandler<ItemResponse<Dictionary<string, string>>>.PerformOperationAsync(
-                        diagnosticsLoggingThreshold: diagnosticsThresholdDuration,
                         createTimerContext: () => metrics.Measure.Timer.Time(writeLatencyTimer),
                         resultProducer: new SingleExecutionResultProducer<ItemResponse<Dictionary<string, string>>>(() => this.CreateWriteOperation(
                             operation: i,
@@ -188,14 +194,17 @@ namespace CosmosCTL
                             metrics.Measure.Counter.Increment(writeFailureMeter);
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during write operation");
                         },
-                        logDiagnostics: (ItemResponse<Dictionary<string, string>> response) => logger.LogInformation("Write request took more than latency threshold {0}, diagnostics: {1}", config.DiagnosticsThresholdDuration, response.Diagnostics.ToString()),
-                        cancellationToken: cancellationToken));
+                        logDiagnostics: (ItemResponse<Dictionary<string, string>> response, TimeSpan latency) => this.LogDiagnostics(
+                            operationName: "Create",
+                            logger: logger,
+                            diagnosticsThresholdDuration: diagnosticsThresholdDuration,
+                            latency: latency,
+                            cosmosDiagnostics: response.Diagnostics)));
 
                 }
                 else
                 {
                     operations.Add(CTLOperationHandler<FeedResponse<Dictionary<string, string>>>.PerformOperationAsync(
-                        diagnosticsLoggingThreshold: diagnosticsThresholdDuration,
                         createTimerContext: () => metrics.Measure.Timer.Time(queryLatencyTimer),
                         resultProducer: new IteratorResultProducer<Dictionary<string, string>>(this.CreateQueryOperation(
                             operation: i,
@@ -211,8 +220,12 @@ namespace CosmosCTL
                             metrics.Measure.Counter.Increment(queryFailureMeter);
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during query operation");
                         },
-                        logDiagnostics: (FeedResponse<Dictionary<string, string>> response) => logger.LogInformation("Query request took more than latency threshold {0}, diagnostics: {1}", config.DiagnosticsThresholdDuration, response.Diagnostics.ToString()),
-                        cancellationToken: cancellationToken));
+                        logDiagnostics: (FeedResponse<Dictionary<string, string>> response, TimeSpan latency) => this.LogDiagnostics(
+                            operationName: "Query",
+                            logger: logger,
+                            diagnosticsThresholdDuration: diagnosticsThresholdDuration,
+                            latency: latency,
+                            cosmosDiagnostics: response.Diagnostics)));
                 }
             }
 
@@ -220,6 +233,61 @@ namespace CosmosCTL
             stopwatch.Stop();
             logger.LogInformation("[{0}] operations performed in [{1}] seconds.",
                 operations.Count, stopwatch.Elapsed.TotalSeconds);
+        }
+
+        private void LogDiagnostics(
+            string operationName,
+            ILogger logger,
+            long diagnosticsThresholdDuration,
+            TimeSpan latency,
+            CosmosDiagnostics cosmosDiagnostics)
+        {
+            if (latency.TotalMilliseconds <= diagnosticsThresholdDuration)
+            {
+                logger.LogInformation(operationName + " request took more than latency threshold {0}, diagnostics: {1}", diagnosticsThresholdDuration, cosmosDiagnostics.ToString());
+            }
+
+            CosmosTraceDiagnostics traceDiagnostics = (CosmosTraceDiagnostics)cosmosDiagnostics;
+            if (traceDiagnostics.IsGoneExceptionHit())
+            {
+                logger.LogInformation(operationName + " request contains 410(GoneExceptions), latencyInMS:{0}; diagnostics:{1}", latency.TotalMilliseconds, cosmosDiagnostics.ToString());
+            }
+            
+        }
+
+        private bool ContainsGoneException(ITrace trace)
+        {
+            if(trace == null)
+            {
+                return false;
+            }
+
+            if (trace.Data.Count > 0)
+            {
+                foreach(KeyValuePair<string, object> item in trace.Data)
+                {
+                    if(item.Value is ClientSideRequestStatisticsTraceDatum data)
+                    {
+                        if(data.StoreResponseStatisticsList.Count > 1)
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            if (trace.Children.Count > 0)
+            {
+                foreach(ITrace child in trace.Children)
+                {
+                    if (this.ContainsGoneException(child))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private Task<ItemResponse<Dictionary<string, string>>> CreateReadOperation(

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -16,7 +16,6 @@ namespace CosmosCTL
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
-    using Microsoft.Azure.Documents;
     using Microsoft.Extensions.Logging;
 
     internal class ReadWriteQueryScenario : ICTLScenario
@@ -147,7 +146,7 @@ namespace CosmosCTL
             for (long i = 0; ShouldContinue(stopwatch, i, config); i++)
             {
                 await concurrencyControlSemaphore.WaitAsync(cancellationToken);
-                long index = (long)i % 100;
+                long index = i % 100;
                 if (index < readWriteQueryPercentage.ReadPercentage)
                 {
                     operations.Add(CTLOperationHandler<ItemResponse<Dictionary<string, string>>>.PerformOperationAsync(

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -467,12 +467,12 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceCritical("GlobalEndpointManager: StartLocationBackgroundRefreshWithTimer() - Unable to refresh database account from any location. Exception: {0}", ex.ToString());
-
                 if (this.cancellationTokenSource.IsCancellationRequested && (ex is OperationCanceledException || ex is ObjectDisposedException))
                 {
                     return;
                 }
+                
+                DefaultTrace.TraceCritical("GlobalEndpointManager: StartLocationBackgroundRefreshWithTimer() - Unable to refresh database account from any location. Exception: {0}", ex.ToString());
             }
 
             // Call itself to create a loop to continuously do background refresh every 5 minutes


### PR DESCRIPTION
# Pull Request Template

## Description

This logs all diagnostics that hit a 410 gone exception. This will allow us to better determine how many requests hit a 410 and how long it took the request to complete.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber