### PR TITLE
Direct 3.22.1: Fixes RNTBD keep alive for linux

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
 		<ClientOfficialVersion>3.21.0</ClientOfficialVersion>
-		<ClientPreviewVersion>3.22.0</ClientPreviewVersion>
+		<ClientPreviewVersion>3.22.1</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
 		<DirectVersion>3.22.0</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV17</EncryptionVersion>


### PR DESCRIPTION
# Pull Request Template

## Description

This include a fix for linux to send the keep alive signal to match the windows settings.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber