### PR TITLE
[Internal] Diagnostics: Adds test for Point Operation With Service Unavailable Exception

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.PointOperationsExceptionsAsync.xml
@@ -1659,4 +1659,219 @@
 }]]></Json>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description>Point Operation with Service Unavailable</Description>
+      <Setup><![CDATA[
+    ItemRequestOptions requestOptions = new ItemRequestOptions();
+
+    Guid exceptionActivityId = Guid.NewGuid();
+    string ServiceUnavailableExceptionDescription = "ServiceUnavailableExceptionDescription" + Guid.NewGuid();
+    Container containerWithTransportException = TransportClientHelper.GetContainerWithItemServiceUnavailableException(
+        database.Id,
+        container.Id,
+        exceptionActivityId,
+        ServiceUnavailableExceptionDescription);
+
+    //Checking point operation diagnostics on typed operations
+    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+
+    ITrace trace = null;
+    try
+    {
+        ItemResponse<ToDoActivity> createResponse = await containerWithTransportException.CreateItemAsync<ToDoActivity>(
+          item: testItem,
+          requestOptions: requestOptions);
+        Assert.Fail("Should have thrown a Service Unavailable Exception");
+    }
+    catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+    {
+        trace = ((CosmosTraceDiagnostics)ce.Diagnostics).Value;                    
+    }
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── CreateItemAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   (
+    │       [Client Configuration]
+    │       Redacted To Not Change The Baselines From Run To Run
+    │   )
+    ├── ItemSerialize(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    ├── Get PkValue From Stream(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   │   └── Waiting for Initialization of client to complete(00000000-0000-0000-0000-000000000000)  Unknown-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Read Collection(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           (
+    │               [Client Side Request Stats]
+    │               Redacted To Not Change The Baselines From Run To Run
+    │           )
+    ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │       │   (
+    │       │       [System Info]
+    │       │       Redacted To Not Change The Baselines From Run To Run
+    │       │   )
+    │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+    │                           (
+    │                               [Client Side Request Stats]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                               [Point Operation Statistics]
+    │                               Redacted To Not Change The Baselines From Run To Run
+    │                           )
+    └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  MemberName@FilePath:42  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "Summary": {},
+  "name": "CreateItemAsync",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "caller info": {
+    "member": "MemberName",
+    "file": "FilePath",
+    "line": 42
+  },
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "data": {
+    "Client Configuration": "Redacted To Not Change The Baselines From Run To Run"
+  },
+  "children": [
+    {
+      "name": "ItemSerialize",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
+    },
+    {
+      "name": "Get PkValue From Stream",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "children": [
+        {
+          "name": "Get Collection Cache",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "Waiting for Initialization of client to complete",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "caller info": {
+                "member": "MemberName",
+                "file": "FilePath",
+                "line": 42
+              },
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0
+            }
+          ]
+        },
+        {
+          "name": "Read Collection",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "caller info": {
+            "member": "MemberName",
+            "file": "FilePath",
+            "line": 42
+          },
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "data": {
+            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "children": [
+        {
+          "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "data": {
+            "System Info": "Redacted To Not Change The Baselines From Run To Run"
+          },
+          "children": [
+            {
+              "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "caller info": {
+                            "member": "MemberName",
+                            "file": "FilePath",
+                            "line": 42
+                          },
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "data": {
+                            "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                            "Point Operation Statistics": "Redacted To Not Change The Baselines From Run To Run"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Get Collection Cache",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "caller info": {
+        "member": "MemberName",
+        "file": "FilePath",
+        "line": 42
+      },
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -666,7 +666,7 @@
                 {
                     trace = ((CosmosTraceDiagnostics)ce.Diagnostics).Value;
                 }
-                  endLineNumber = GetLineNumber();
+                endLineNumber = GetLineNumber();
 
                 inputs.Add(new Input("Point Operation with Request Timeout", trace, startLineNumber, endLineNumber));
             }
@@ -828,7 +828,7 @@
                     ItemResponse<ToDoActivity> createResponse = await containerWithTransportException.CreateItemAsync<ToDoActivity>(
                       item: testItem,
                       requestOptions: requestOptions);
-                    Assert.Fail("Should have thrown a request timeout exception");
+                    Assert.Fail("Should have thrown a Service Unavailable Exception");
                 }
                 catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
                 {
@@ -836,7 +836,7 @@
                 }
                 endLineNumber = GetLineNumber();
 
-                inputs.Add(new Input("Point Operation with Request Timeout", trace, startLineNumber, endLineNumber));
+                inputs.Add(new Input("Point Operation with Service Unavailable", trace, startLineNumber, endLineNumber));
             }
             //----------------------------------------------------------------
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -666,7 +666,7 @@
                 {
                     trace = ((CosmosTraceDiagnostics)ce.Diagnostics).Value;
                 }
-                endLineNumber = GetLineNumber();
+                  endLineNumber = GetLineNumber();
 
                 inputs.Add(new Input("Point Operation with Request Timeout", trace, startLineNumber, endLineNumber));
             }
@@ -801,6 +801,42 @@
                     Assert.IsTrue(nextLength < currLength * 2,
                         $"The diagnostic string is growing faster than linear. Length: {currLength}, Next Length: {nextLength}");
                 }
+            }
+            //----------------------------------------------------------------
+
+            //----------------------------------------------------------------
+            //  Point Operation With Service Unavailable Exception
+            //----------------------------------------------------------------
+            {
+                startLineNumber = GetLineNumber();
+                ItemRequestOptions requestOptions = new ItemRequestOptions();
+
+                Guid exceptionActivityId = Guid.NewGuid();
+                string ServiceUnavailableExceptionDescription = "ServiceUnavailableExceptionDescription" + Guid.NewGuid();
+                Container containerWithTransportException = TransportClientHelper.GetContainerWithItemServiceUnavailableException(
+                    database.Id,
+                    container.Id,
+                    exceptionActivityId,
+                    ServiceUnavailableExceptionDescription);
+
+                //Checking point operation diagnostics on typed operations
+                ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+
+                ITrace trace = null;
+                try
+                {
+                    ItemResponse<ToDoActivity> createResponse = await containerWithTransportException.CreateItemAsync<ToDoActivity>(
+                      item: testItem,
+                      requestOptions: requestOptions);
+                    Assert.Fail("Should have thrown a request timeout exception");
+                }
+                catch (CosmosException ce) when (ce.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable)
+                {
+                    trace = ((CosmosTraceDiagnostics)ce.Diagnostics).Value;                    
+                }
+                endLineNumber = GetLineNumber();
+
+                inputs.Add(new Input("Point Operation with Request Timeout", trace, startLineNumber, endLineNumber));
             }
             //----------------------------------------------------------------
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
@@ -138,14 +138,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             if (request.ResourceType == ResourceType.Document)
             {
-                //ServiceUnavailableException serviceUnavailableException = new ServiceUnavailableException(
-                //    // errorCode: HttpStatusCode.ServiceUnavailable,
-                //    innerException: null,
-                //    activityId: activityId,
-                //    requestUri: physicalAddress,
-                //    sourceDescription: transportExceptionSourceDescription,
-                //    userPayload: true,
-                //    payloadSent: false);
                 TransportException transportException = new TransportException(
                     errorCode: TransportErrorCode.RequestTimeout,
                     innerException: null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
@@ -37,6 +37,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     transportExceptionSourceDescription));
         }
 
+        internal static Container GetContainerWithItemServiceUnavailableException(
+            string databaseId,
+            string containerId,
+            Guid activityId,
+            string serviceUnavailableExceptionSourceDescription)
+        {
+            return GetContainerWithIntercepter(
+                databaseId,
+                containerId,
+                (uri, resourceOperation, request) => TransportClientHelper.ThrowServiceUnavailableExceptionOnItemOperation(
+                    uri,
+                    resourceOperation,
+                    request,
+                    activityId,
+                    serviceUnavailableExceptionSourceDescription));
+        }
+
         internal static Container GetContainerWithIntercepter(
             string databaseId,
             string containerId,
@@ -108,6 +125,37 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     payloadSent: false);
 
                 throw Documents.Rntbd.TransportExceptions.GetRequestTimeoutException(physicalAddress, Guid.NewGuid(),
+                    transportException);
+            }
+        }
+
+        public static void ThrowServiceUnavailableExceptionOnItemOperation(
+                Uri physicalAddress,
+                ResourceOperation resourceOperation,
+                DocumentServiceRequest request,
+                Guid activityId,
+                string transportExceptionSourceDescription)
+        {
+            if (request.ResourceType == ResourceType.Document)
+            {
+                //ServiceUnavailableException serviceUnavailableException = new ServiceUnavailableException(
+                //    // errorCode: HttpStatusCode.ServiceUnavailable,
+                //    innerException: null,
+                //    activityId: activityId,
+                //    requestUri: physicalAddress,
+                //    sourceDescription: transportExceptionSourceDescription,
+                //    userPayload: true,
+                //    payloadSent: false);
+                TransportException transportException = new TransportException(
+                    errorCode: TransportErrorCode.RequestTimeout,
+                    innerException: null,
+                    activityId: activityId,
+                    requestUri: physicalAddress,
+                    sourceDescription: transportExceptionSourceDescription,
+                    userPayload: true,
+                    payloadSent: false);
+
+                throw Documents.Rntbd.TransportExceptions.GetServiceUnavailableException(physicalAddress, Guid.NewGuid(),
                     transportException);
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

The following diagnostics is from the 3.18.1 SDK. This hit an exception which seems to have cause the diagnostics to be improperly nested. The "Microsoft.Azure.Documents.ServerStoreModel Transport Request" should be at the same level but are some how nested. This needs to be root caused and fixed if it hasn't already been fixed in the latest SDK version.

Added Point Operation With Service Unavailable Exception and verified the output json in test method. Now its generating ServerStoreModel  once . There was no nesting issue found.


## Type of change

- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #2809