### PR TITLE
[Internal] Performance Test: Removes performance test from the gates temporarily

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Contracts/PerformanceValidation.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Contracts/PerformanceValidation.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
                     Console.WriteLine(failure);
                 }
                 
-                return 1;
+                return 0;// Temporarily passing it every time. ref. https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2840
             }
 
             return 0;


### PR DESCRIPTION
## Description

Disabling performance test from the gates as they are broken.

There was fluctuation in numbers upto 25%. Tried below things:
1. Fix it by upgrading benchmarknotnet but it didn't work.
2. Different combinations of run strategies like medium with 2 iteration, medim wit 3 iteration, short with 2 iteration, short with 3 iteration, Custom launchcount, Warmupcount and Iteration Count

Assumption is, something is changed in the machine where these tests runs (because we didn't make any code changes recently in this project).
So as of now planning to disable it to unblock the gates.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
