### PR TITLE
Client Telemetry: Adds aggregationIntervalInSec Information

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -94,7 +94,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 processId: System.Diagnostics.Process.GetCurrentProcess().ProcessName, 
                 userAgent: userAgent, 
                 connectionMode: connectionMode,
-                preferredRegions: preferredRegions);
+                preferredRegions: preferredRegions,
+                aggregationIntervalInSec: (int)observingWindow.TotalSeconds);
 
             this.httpClient = documentClient.httpClient;
             this.cancellationTokenSource = new CancellationTokenSource();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal IReadOnlyList<string> PreferredRegions { get; set; }
 
         [JsonProperty(PropertyName = "aggregationIntervalInSec")]
-        internal int AggregationIntervalInSec { get; }
+        internal int AggregationIntervalInSec { get; set; }
 
         [JsonProperty(PropertyName = "systemInfo")]
         internal List<SystemInfo> SystemInfo { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -52,7 +52,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         [JsonProperty(PropertyName = "preferredRegions")]
         internal IReadOnlyList<string> PreferredRegions { get; set; }
-        
+
+        [JsonProperty(PropertyName = "aggregationIntervalInSec")]
+        internal int AggregationIntervalInSec { get; }
+
         [JsonIgnore]
         private readonly ConnectionMode ConnectionModeEnum;
 
@@ -60,7 +63,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                    string processId,
                                    string userAgent,
                                    ConnectionMode connectionMode,
-                                   IReadOnlyList<string> preferredRegions)
+                                   IReadOnlyList<string> preferredRegions,
+                                   int aggregationIntervalInSec)
         {
             this.ClientId = clientId;
             this.ProcessId = processId;
@@ -69,6 +73,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ConnectionMode = ClientTelemetryProperties.GetConnectionModeString(connectionMode);
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
+            this.AggregationIntervalInSec = aggregationIntervalInSec;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -38,15 +38,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         [JsonProperty(PropertyName = "acceleratedNetworking")]
         private bool? AcceleratedNetworking { get; set; }
 
-        [JsonProperty(PropertyName = "systemInfo")]
-        internal List<SystemInfo> SystemInfo { get; set; }
-
-        [JsonProperty(PropertyName = "cacheRefreshInfo")]
-        private List<OperationInfo> CacheRefreshInfo { get; set; }
-
-        [JsonProperty(PropertyName = "operationInfo")]
-        internal List<OperationInfo> OperationInfo { get; set; }
-        
         /// <summary>
         /// Preferred Region set by the client
         /// </summary>
@@ -55,6 +46,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         [JsonProperty(PropertyName = "aggregationIntervalInSec")]
         internal int AggregationIntervalInSec { get; }
+
+        [JsonProperty(PropertyName = "systemInfo")]
+        internal List<SystemInfo> SystemInfo { get; set; }
+
+        [JsonProperty(PropertyName = "cacheRefreshInfo")]
+        private List<OperationInfo> CacheRefreshInfo { get; set; }
+
+        [JsonProperty(PropertyName = "operationInfo")]
+        internal List<OperationInfo> OperationInfo { get; set; }
 
         [JsonIgnore]
         private readonly ConnectionMode ConnectionModeEnum;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(2, telemetryInfo.PreferredRegions.Count);
                 Assert.AreEqual("region1", telemetryInfo.PreferredRegions[0]);
                 Assert.AreEqual("region2", telemetryInfo.PreferredRegions[1]);
-
+                Assert.AreEqual(1, telemetryInfo.AggregationIntervalInSec);
             }
 
             IDictionary<string, long> actualOperationRecordCountMap = new Dictionary<string, long>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CheckJsonSerializerContract()
         {
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null), ClientTelemetryOptions.JsonSerializerSettings);
-            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"systemInfo\":[]}",json);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10), ClientTelemetryOptions.JsonSerializerSettings);
+            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"aggregationIntervalInSec\":10,\"systemInfo\":[]}", json);
         }
 
         [TestMethod]
@@ -113,8 +113,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 "region1"
             };
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion), ClientTelemetryOptions.JsonSerializerSettings);
-            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"systemInfo\":[],\"preferredRegions\":[\"region1\"]}", json);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1), ClientTelemetryOptions.JsonSerializerSettings);
+            Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"preferredRegions\":[\"region1\"],\"aggregationIntervalInSec\":1,\"systemInfo\":[]}", json);
         }
 
     }


### PR DESCRIPTION
## Description
Adding _aggregationIntervalInSec_ column in client telemetry payload which gives configured Aggregation interval in second.

![image](https://user-images.githubusercontent.com/6362382/139927838-852318cd-80ac-497e-8cce-95a651c639fc.png)

## Type of change
- [] New feature (non-breaking change which adds functionality)