### PR TITLE
Query: Fixes stack overflow in SkipEmptyPageQueryPipelineStage

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/SkipEmptyPageQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/SkipEmptyPageQueryPipelineStage.cs
@@ -44,88 +44,95 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                 throw new ArgumentNullException(nameof(trace));
             }
 
-            if (!await this.inputStage.MoveNextAsync(trace))
+            for (int documentCount = 0; documentCount == 0;)
             {
-                if (!this.returnedFinalStats)
+                if (!await this.inputStage.MoveNextAsync(trace))
                 {
-                    QueryPage queryPage = new QueryPage(
-                        documents: EmptyPage,
-                        requestCharge: this.cumulativeRequestCharge,
-                        activityId: Guid.Empty.ToString(),
-                        responseLengthInBytes: this.cumulativeResponseLengthInBytes,
-                        cosmosQueryExecutionInfo: default,
-                        disallowContinuationTokenMessage: default,
-                        additionalHeaders: this.cumulativeAdditionalHeaders,
-                        state: default);
-                    this.cumulativeRequestCharge = 0;
-                    this.cumulativeResponseLengthInBytes = 0;
-                    this.cumulativeAdditionalHeaders = null;
-                    this.returnedFinalStats = true;
-                    this.Current = TryCatch<QueryPage>.FromResult(queryPage);
+                    if (!this.returnedFinalStats)
+                    {
+                        QueryPage queryPage = new QueryPage(
+                            documents: EmptyPage,
+                            requestCharge: this.cumulativeRequestCharge,
+                            activityId: Guid.Empty.ToString(),
+                            responseLengthInBytes: this.cumulativeResponseLengthInBytes,
+                            cosmosQueryExecutionInfo: default,
+                            disallowContinuationTokenMessage: default,
+                            additionalHeaders: this.cumulativeAdditionalHeaders,
+                            state: default);
+                        this.cumulativeRequestCharge = 0;
+                        this.cumulativeResponseLengthInBytes = 0;
+                        this.cumulativeAdditionalHeaders = null;
+                        this.returnedFinalStats = true;
+                        this.Current = TryCatch<QueryPage>.FromResult(queryPage);
+                        return true;
+                    }
+
+                    this.Current = default;
+                    return false;
+                }
+
+                // if we are here then it means the inputStage told us there's more pages
+                // so we tell the same thing to our consumer
+                TryCatch<QueryPage> tryGetSourcePage = this.inputStage.Current;
+                if (tryGetSourcePage.Failed)
+                {
+                    this.Current = tryGetSourcePage;
                     return true;
                 }
 
-                this.Current = default;
-                return false;
-            }
-
-            TryCatch<QueryPage> tryGetSourcePage = this.inputStage.Current;
-            if (tryGetSourcePage.Failed)
-            {
-                this.Current = tryGetSourcePage;
-                return true;
-            }
-
-            QueryPage sourcePage = tryGetSourcePage.Result;
-            if (sourcePage.Documents.Count == 0)
-            {
-                if (sourcePage.State == null)
+                QueryPage sourcePage = tryGetSourcePage.Result;
+                documentCount = sourcePage.Documents.Count;
+                if (documentCount == 0)
                 {
-                    QueryPage queryPage = new QueryPage(
-                        documents: EmptyPage,
-                        requestCharge: sourcePage.RequestCharge + this.cumulativeRequestCharge,
-                        activityId: sourcePage.ActivityId,
-                        responseLengthInBytes: sourcePage.ResponseLengthInBytes + this.cumulativeResponseLengthInBytes,
-                        cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
-                        disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
-                        additionalHeaders: sourcePage.AdditionalHeaders,
-                        state: default);
-                    this.cumulativeRequestCharge = 0;
-                    this.cumulativeResponseLengthInBytes = 0;
-                    this.cumulativeAdditionalHeaders = null;
-                    this.Current = TryCatch<QueryPage>.FromResult(queryPage);
-                    return true;
+                    if (sourcePage.State == null)
+                    {
+                        QueryPage queryPage = new QueryPage(
+                            documents: EmptyPage,
+                            requestCharge: sourcePage.RequestCharge + this.cumulativeRequestCharge,
+                            activityId: sourcePage.ActivityId,
+                            responseLengthInBytes: sourcePage.ResponseLengthInBytes + this.cumulativeResponseLengthInBytes,
+                            cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
+                            disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                            additionalHeaders: sourcePage.AdditionalHeaders,
+                            state: default);
+                        this.cumulativeRequestCharge = 0;
+                        this.cumulativeResponseLengthInBytes = 0;
+                        this.cumulativeAdditionalHeaders = null;
+                        this.Current = TryCatch<QueryPage>.FromResult(queryPage);
+                        return true;
+                    }
+
+                    this.cumulativeRequestCharge += sourcePage.RequestCharge;
+                    this.cumulativeResponseLengthInBytes += sourcePage.ResponseLengthInBytes;
+                    this.cumulativeAdditionalHeaders = sourcePage.AdditionalHeaders;
                 }
+                else
+                {
+                    QueryPage cumulativeQueryPage;
+                    if (this.cumulativeRequestCharge != 0)
+                    {
+                        cumulativeQueryPage = new QueryPage(
+                            documents: sourcePage.Documents,
+                            requestCharge: sourcePage.RequestCharge + this.cumulativeRequestCharge,
+                            activityId: sourcePage.ActivityId,
+                            responseLengthInBytes: sourcePage.ResponseLengthInBytes + this.cumulativeResponseLengthInBytes,
+                            cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
+                            disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
+                            additionalHeaders: sourcePage.AdditionalHeaders,
+                            state: sourcePage.State);
+                        this.cumulativeRequestCharge = 0;
+                        this.cumulativeResponseLengthInBytes = 0;
+                        this.cumulativeAdditionalHeaders = null;
+                    }
+                    else
+                    {
+                        cumulativeQueryPage = sourcePage;
+                    }
 
-                this.cumulativeRequestCharge += sourcePage.RequestCharge;
-                this.cumulativeResponseLengthInBytes += sourcePage.ResponseLengthInBytes;
-                this.cumulativeAdditionalHeaders = sourcePage.AdditionalHeaders;
-
-                return await this.MoveNextAsync(trace);
+                    this.Current = TryCatch<QueryPage>.FromResult(cumulativeQueryPage);
+                }
             }
 
-            QueryPage cumulativeQueryPage;
-            if (this.cumulativeRequestCharge != 0)
-            {
-                cumulativeQueryPage = new QueryPage(
-                    documents: sourcePage.Documents,
-                    requestCharge: sourcePage.RequestCharge + this.cumulativeRequestCharge,
-                    activityId: sourcePage.ActivityId,
-                    responseLengthInBytes: sourcePage.ResponseLengthInBytes + this.cumulativeResponseLengthInBytes,
-                    cosmosQueryExecutionInfo: sourcePage.CosmosQueryExecutionInfo,
-                    disallowContinuationTokenMessage: sourcePage.DisallowContinuationTokenMessage,
-                    additionalHeaders: sourcePage.AdditionalHeaders,
-                    state: sourcePage.State);
-                this.cumulativeRequestCharge = 0;
-                this.cumulativeResponseLengthInBytes = 0;
-                this.cumulativeAdditionalHeaders = null;
-            }
-            else
-            {
-                cumulativeQueryPage = sourcePage;
-            }
-
-            this.Current = TryCatch<QueryPage>.FromResult(cumulativeQueryPage);
             return true;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipEmptyPageQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipEmptyPageQueryPipelineStageTests.cs
@@ -1,0 +1,80 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.Azure.Cosmos.Tests.Pagination;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class SkipEmptyPageQueryPipelineStageTests
+    {
+        [TestMethod]
+        public async Task StackOverflowTest()
+        {
+            EmptyPagePipelineStage emptyPagePipelineStage = new EmptyPagePipelineStage { EmptyPageCount = 2000 };
+            SkipEmptyPageQueryPipelineStage skipEmptyPageStage = new SkipEmptyPageQueryPipelineStage(
+                inputStage: emptyPagePipelineStage,
+                cancellationToken: default);
+            
+            IQueryPipelineStage pipeline = new CatchAllQueryPipelineStage(inputStage: skipEmptyPageStage, cancellationToken: default);
+            _ = await pipeline.MoveNextAsync(NoOpTrace.Singleton);
+            TryCatch<QueryPage> result = pipeline.Current;
+            Assert.IsFalse(result.Succeeded);
+        }
+
+        private class EmptyPagePipelineStage : IQueryPipelineStage
+        {
+            private static readonly TryCatch<QueryPage> Empty = TryCatch<QueryPage>.FromResult(new QueryPage(
+                            documents: new List<CosmosElement>(),
+                            requestCharge: 42,
+                            activityId: Guid.NewGuid().ToString(),
+                            responseLengthInBytes: "[]".Length,
+                            cosmosQueryExecutionInfo: default,
+                            disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
+                            state: new QueryState(CosmosString.Create("Started But Haven't Returned Any Documents Yet"))));
+
+            public TryCatch<QueryPage> Current => Empty;
+
+            public int EmptyPageCount { get; set; }
+
+            public ValueTask DisposeAsync()
+            {
+                return new ValueTask();
+            }
+
+            public ValueTask<bool> MoveNextAsync(ITrace trace)
+            {
+                if (this.EmptyPageCount > 0)
+                {
+                    --this.EmptyPageCount;
+                    return new ValueTask<bool>(true);
+                }
+
+                throw new CosmosException(
+                    message:"Injected failure",
+                    statusCode: System.Net.HttpStatusCode.InternalServerError,
+                    subStatusCode: 0,
+                    activityId: Guid.Empty.ToString(),
+                    requestCharge: 0);
+            }
+
+            public void SetCancellationToken(CancellationToken cancellationToken)
+            {
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipEmptyPageQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/SkipEmptyPageQueryPipelineStageTests.cs
@@ -6,15 +6,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
-    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
-    using Microsoft.Azure.Cosmos.Tests.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -24,19 +22,107 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         [TestMethod]
         public async Task StackOverflowTest()
         {
-            EmptyPagePipelineStage emptyPagePipelineStage = new EmptyPagePipelineStage { EmptyPageCount = 2000 };
-            SkipEmptyPageQueryPipelineStage skipEmptyPageStage = new SkipEmptyPageQueryPipelineStage(
-                inputStage: emptyPagePipelineStage,
-                cancellationToken: default);
-            
-            IQueryPipelineStage pipeline = new CatchAllQueryPipelineStage(inputStage: skipEmptyPageStage, cancellationToken: default);
-            _ = await pipeline.MoveNextAsync(NoOpTrace.Singleton);
+            await using IQueryPipelineStage pipeline = CreatePipeline(Enumerable
+                .Repeat(EmptyPagePipelineStage.PageType.Empty, 2000)
+                .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Error, 1))
+                .ToList());
+            bool hasNext = await pipeline.MoveNextAsync(NoOpTrace.Singleton);
+            Assert.IsTrue(hasNext);
             TryCatch<QueryPage> result = pipeline.Current;
             Assert.IsFalse(result.Succeeded);
         }
 
-        private class EmptyPagePipelineStage : IQueryPipelineStage
+        [TestMethod]
+        public async Task BasicTests()
         {
+            IReadOnlyList<TestCase> testCases = new List<TestCase>()
+            {
+                MakeTest(
+                    input: Enumerable
+                        .Repeat(EmptyPagePipelineStage.PageType.Empty, 2000)
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 1)),
+                    expected: Enumerable.Repeat(true, 1)),
+                MakeTest(
+                    input: Enumerable
+                        .Repeat(EmptyPagePipelineStage.PageType.Empty, 100)
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 5))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Empty, 27))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 3))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Empty, 32))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 3)),
+                    expected: Enumerable.Repeat(true, 11)),
+                MakeTest(
+                    input: Enumerable
+                        .Repeat(EmptyPagePipelineStage.PageType.Empty, 100)
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 5))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Empty, 27))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Error, 3))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.Empty, 32))
+                        .Concat(Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 3)),
+                    expected: Enumerable.Repeat(true, 5)
+                        .Concat(Enumerable.Repeat(false, 3))
+                        .Concat(Enumerable.Repeat(true, 3))),
+                MakeTest(
+                    input: Enumerable.Repeat(EmptyPagePipelineStage.PageType.NonEmpty, 500),
+                    expected: Enumerable.Repeat(true, 500)),
+                MakeTest(
+                    input: Enumerable.Repeat(EmptyPagePipelineStage.PageType.Error, 500),
+                    expected: Enumerable.Repeat(false, 500))
+            };
+
+            foreach (TestCase testCase in testCases)
+            {
+                await using IQueryPipelineStage pipeline = CreatePipeline(testCase.Input);
+                for (int index = 0; index < testCase.Expected.Count; ++index)
+                {
+                    Assert.IsTrue(await pipeline.MoveNextAsync(NoOpTrace.Singleton));
+
+                    if (testCase.Expected[index])
+                    {
+                        Assert.IsTrue(pipeline.Current.Succeeded);
+                        Assert.AreEqual(1, pipeline.Current.Result.Documents.Count);
+                        Assert.AreEqual("42", pipeline.Current.Result.Documents[0].ToString());
+                    }
+                    else
+                    {
+                        Assert.IsTrue(pipeline.Current.Failed);
+                    }
+                }
+            }
+        }
+
+        internal static TestCase MakeTest(IEnumerable<EmptyPagePipelineStage.PageType> input, IEnumerable<bool> expected)
+        {
+            return new TestCase(input.ToList(), expected.ToList());
+        }
+
+        internal readonly struct TestCase
+        {
+            public TestCase(IReadOnlyList<EmptyPagePipelineStage.PageType> input, IReadOnlyList<bool> expected)
+            {
+                this.Input = input;
+                this.Expected = expected;
+            }
+
+            public readonly IReadOnlyList<EmptyPagePipelineStage.PageType> Input { get; }
+
+            public readonly IReadOnlyList<bool> Expected { get; }
+        }
+
+        private static IQueryPipelineStage CreatePipeline(IReadOnlyList<EmptyPagePipelineStage.PageType> pages)
+        {
+            EmptyPagePipelineStage emptyPagePipelineStage = new EmptyPagePipelineStage(pages);
+            SkipEmptyPageQueryPipelineStage skipEmptyPageStage = new SkipEmptyPageQueryPipelineStage(
+                inputStage: emptyPagePipelineStage,
+                cancellationToken: default);
+
+            return new CatchAllQueryPipelineStage(inputStage: skipEmptyPageStage, cancellationToken: default);
+        }
+
+        internal class EmptyPagePipelineStage : IQueryPipelineStage
+        {
+            public enum PageType { Empty, NonEmpty, Error };
+
             private static readonly TryCatch<QueryPage> Empty = TryCatch<QueryPage>.FromResult(new QueryPage(
                             documents: new List<CosmosElement>(),
                             requestCharge: 42,
@@ -45,11 +131,29 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                             cosmosQueryExecutionInfo: default,
                             disallowContinuationTokenMessage: default,
                             additionalHeaders: default,
-                            state: new QueryState(CosmosString.Create("Started But Haven't Returned Any Documents Yet"))));
+                            state: new QueryState(CosmosString.Create("Empty"))));
 
-            public TryCatch<QueryPage> Current => Empty;
+            private static readonly TryCatch<QueryPage> NonEmpty = TryCatch<QueryPage>.FromResult(new QueryPage(
+                documents: new List<CosmosElement> { CosmosElement.Parse("42") },
+                            requestCharge: 100,
+                            activityId: Guid.NewGuid().ToString(),
+                            responseLengthInBytes: "[42]".Length,
+                            cosmosQueryExecutionInfo: default,
+                            disallowContinuationTokenMessage: default,
+                            additionalHeaders: default,
+                            state: new QueryState(CosmosString.Create("NonEmpty"))));
 
-            public int EmptyPageCount { get; set; }
+            private readonly IReadOnlyList<PageType> pages;
+
+            private int current;
+
+            public EmptyPagePipelineStage(IReadOnlyList<PageType> pages)
+            {
+                this.current = -1;
+                this.pages = pages;
+            }
+
+            public TryCatch<QueryPage> Current { get; private set; }
 
             public ValueTask DisposeAsync()
             {
@@ -58,18 +162,30 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 
             public ValueTask<bool> MoveNextAsync(ITrace trace)
             {
-                if (this.EmptyPageCount > 0)
+                ++this.current;
+                if (this.current >= this.pages.Count)
                 {
-                    --this.EmptyPageCount;
-                    return new ValueTask<bool>(true);
+                    return new ValueTask<bool>(false);
                 }
 
-                throw new CosmosException(
-                    message:"Injected failure",
-                    statusCode: System.Net.HttpStatusCode.InternalServerError,
-                    subStatusCode: 0,
-                    activityId: Guid.Empty.ToString(),
-                    requestCharge: 0);
+                switch (this.pages[this.current])
+                {
+                    case PageType.Empty:
+                        this.Current = Empty;
+                        break;
+                    case PageType.NonEmpty:
+                        this.Current = NonEmpty;
+                        break;
+                    case PageType.Error:
+                        throw new CosmosException(
+                            message: "Injected failure",
+                            statusCode: System.Net.HttpStatusCode.InternalServerError,
+                            subStatusCode: 0,
+                            activityId: Guid.Empty.ToString(),
+                            requestCharge: 0);
+                }
+
+                return new ValueTask<bool>(true);
             }
 
             public void SetCancellationToken(CancellationToken cancellationToken)


### PR DESCRIPTION
## Description

The current implementation of SkipEmptyPageQueryPipelineStage.MoveNextAsync recursively calls itself if the previous pipeline stage emits an empty page. This leads to stack overflow if there are too many empty pages or if an inner pipeline stage throws from a deeply nested stack. This change refactors the implementation to be iterative rather than recursive and adds unit tests for SkipEmptyPageQueryPipelineStage which previously had none.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber