### PR TITLE
[INTERNAL] CTL: Adds 410 logging to other operations

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
@@ -87,11 +87,12 @@ namespace CosmosCTL
                             using (TimerContext timerContext = metrics.Measure.Timer.Time(readLatencyTimer))
                             {
                                 response = await changeFeedPull.ReadNextAsync();
-                                long latency = (long)timerContext.Elapsed.TotalMilliseconds;
-                                if (latency > diagnosticsThresholdDuration)
-                                {
-                                    logger.LogInformation("Change Feed request took more than latency threshold {0}, diagnostics: {1}", config.DiagnosticsThresholdDuration, response.Diagnostics.ToString());
-                                }
+                                Utils.LogDiagnsotics(
+                                    logger: logger,
+                                    operationName: nameof(ChangeFeedPullScenario),
+                                    timerContextLatency: timerContext.Elapsed,
+                                    config: config,
+                                    cosmosDiagnostics: response.Diagnostics);
                             }
 
                             documentTotal += response.Count;

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
@@ -6,15 +6,15 @@ namespace CosmosCTL
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Net;
-    using System.Diagnostics;
     using App.Metrics;
-    using Microsoft.Azure.Cosmos;
-    using Microsoft.Extensions.Logging;
     using App.Metrics.Gauge;
     using App.Metrics.Timer;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Extensions.Logging;
 
     internal class ChangeFeedPullScenario : ICTLScenario
     {
@@ -55,7 +55,6 @@ namespace CosmosCTL
         {
             Stopwatch stopWatch = Stopwatch.StartNew();
 
-            long diagnosticsThresholdDuration = (long)config.DiagnosticsThresholdDurationAsTimespan.TotalMilliseconds;
             GaugeOptions documentGauge= new GaugeOptions { Name = "#Documents received", Context = loggingContextIdentifier };
 
             TimerOptions readLatencyTimer = new TimerOptions

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/QueryScenario.cs
@@ -190,6 +190,13 @@ namespace CosmosCTL
                             query.Dispose();
                             query = container.GetItemQueryIterator<Dictionary<string, string>>(queryText, continuation);
                         }
+
+                        Utils.LogDiagnsotics(
+                            logger: logger,
+                            operationName: queryName,
+                            timerContextLatency: response.Diagnostics.GetClientElapsedTime(),
+                            config: config,
+                            cosmosDiagnostics: response.Diagnostics);
                     }
 
                     query.Dispose();
@@ -268,6 +275,13 @@ namespace CosmosCTL
                         FeedResponse<Dictionary<string, string>> response = await query.ReadNextAsync();
                         documentTotal += response.Count;
                         continuation = response.ContinuationToken;
+
+                        Utils.LogDiagnsotics(
+                            logger: logger,
+                            operationName: queryName,
+                            timerContextLatency: response.Diagnostics.GetClientElapsedTime(),
+                            config: config,
+                            cosmosDiagnostics: response.Diagnostics);
                     }
 
                     metrics.Measure.Gauge.SetValue(documentGauge, documentTotal);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadManyScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadManyScenario.cs
@@ -79,7 +79,6 @@ namespace CosmosCTL
                     Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
                 };
 
-                long diagnosticsThresholdDuration = (long)config.DiagnosticsThresholdDurationAsTimespan.TotalMilliseconds;
                 Container container = cosmosClient.GetContainer(config.Database, config.Collection);
                 while (stopWatch.Elapsed <= config.RunningTimeDurationAsTimespan
                     && !cancellationToken.IsCancellationRequested)
@@ -90,11 +89,12 @@ namespace CosmosCTL
                         using (TimerContext timerContext = metrics.Measure.Timer.Time(readLatencyTimer))
                         {
                             response = await container.ReadManyItemsAsync<Dictionary<string, string>>(this.idAndPkPairs);
-                            long latency = (long)timerContext.Elapsed.TotalMilliseconds;
-                            if (latency > diagnosticsThresholdDuration)
-                            {
-                                logger.LogInformation("ReadMany request took more than latency threshold {0}, diagnostics: {1}", config.DiagnosticsThresholdDuration, response.Diagnostics.ToString());
-                            }
+                            Utils.LogDiagnsotics(
+                                logger: logger,
+                                operationName: nameof(ReadManyScenario),
+                                timerContextLatency: stopWatch.Elapsed,
+                                config: config,
+                                cosmosDiagnostics: response.Diagnostics);
                         }
 
                         metrics.Measure.Gauge.SetValue(documentGauge, response.Count);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -13,9 +13,6 @@ namespace CosmosCTL
     using App.Metrics.Counter;
     using App.Metrics.Timer;
     using Microsoft.Azure.Cosmos;
-    using Microsoft.Azure.Cosmos.Diagnostics;
-    using Microsoft.Azure.Cosmos.Tracing;
-    using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Extensions.Logging;
 
     internal class ReadWriteQueryScenario : ICTLScenario
@@ -141,7 +138,6 @@ namespace CosmosCTL
             SemaphoreSlim concurrencyControlSemaphore = new SemaphoreSlim(config.Concurrency);
             Stopwatch stopwatch = Stopwatch.StartNew();
             int writeRange = readWriteQueryPercentage.ReadPercentage + readWriteQueryPercentage.WritePercentage;
-            long diagnosticsThresholdDuration = (long)config.DiagnosticsThresholdDurationAsTimespan.TotalMilliseconds;
             List<Task> operations = new List<Task>();
             for (long i = 0; ShouldContinue(stopwatch, i, config); i++)
             {
@@ -168,11 +164,11 @@ namespace CosmosCTL
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during read operation");
                         },
                         logDiagnostics: (ItemResponse<Dictionary<string, string>> response, TimeSpan latency) => Utils.LogDiagnsotics(
-                                logger: logger,
-                                operationName: "Read",
-                                timerContextLatency: latency,
-                                config: config,
-                                cosmosDiagnostics: response.Diagnostics)));
+                            logger: logger,
+                            operationName: "Read",
+                            timerContextLatency: latency,
+                            config: config,
+                            cosmosDiagnostics: response.Diagnostics)));
                 }
                 else if (index < writeRange)
                 {
@@ -195,11 +191,11 @@ namespace CosmosCTL
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during write operation");
                         },
                         logDiagnostics: (ItemResponse<Dictionary<string, string>> response, TimeSpan latency) => Utils.LogDiagnsotics(
-                                logger: logger,
-                                operationName: "Write",
-                                timerContextLatency: latency,
-                                config: config,
-                                cosmosDiagnostics: response.Diagnostics)));
+                            logger: logger,
+                            operationName: "Write",
+                            timerContextLatency: latency,
+                            config: config,
+                            cosmosDiagnostics: response.Diagnostics)));
 
                 }
                 else
@@ -221,11 +217,11 @@ namespace CosmosCTL
                             Utils.LogError(logger, loggingContextIdentifier, ex, "Failure during query operation");
                         },
                         logDiagnostics: (FeedResponse<Dictionary<string, string>> response, TimeSpan latency) => Utils.LogDiagnsotics(
-                                logger: logger,
-                                operationName: "Query",
-                                timerContextLatency: latency,
-                                config: config,
-                                cosmosDiagnostics: response.Diagnostics)));
+                            logger: logger,
+                            operationName: "Query",
+                            timerContextLatency: latency,
+                            config: config,
+                            cosmosDiagnostics: response.Diagnostics)));
                 }
             }
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Utils.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Utils.cs
@@ -12,6 +12,7 @@ namespace CosmosCTL
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Extensions.Logging;
 
     internal static class Utils
@@ -153,6 +154,27 @@ namespace CosmosCTL
             }
 
             return result;
+        }
+
+        public static void LogDiagnsotics(
+            ILogger logger,
+            string operationName,
+            TimeSpan timerContextLatency,
+            CTLConfig config,
+            CosmosDiagnostics cosmosDiagnostics)
+        {
+
+            if (timerContextLatency > config.DiagnosticsThresholdDurationAsTimespan)
+            {
+                logger.LogInformation($"{operationName}; LatencyInMs:{timerContextLatency.TotalMilliseconds}; request took more than latency threshold {config.DiagnosticsThresholdDuration}, diagnostics: {cosmosDiagnostics}");
+            }
+
+            CosmosTraceDiagnostics traceDiagnostics = (CosmosTraceDiagnostics)cosmosDiagnostics;
+            if (traceDiagnostics.IsGoneExceptionHit())
+            {
+                logger.LogInformation($"{operationName}; LatencyInMs:{timerContextLatency.TotalMilliseconds}; request contains 410(GoneExceptions), diagnostics:{cosmosDiagnostics}");
+                return;
+            }
         }
 
         public static void LogError(


### PR DESCRIPTION
# Pull Request Template

## Description

Adding 410 logging for query, changefeed pull, and read many scenarios. Moved the logic to Util to make it common across all the operations.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber