### PR TITLE
[Internal] Benchmark: Adds options for ClientTelemetry TelemetryEndpoint and TelemetryScheduleInSec

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -99,7 +99,7 @@ namespace CosmosBenchmark
         public bool EnableTelemetry { get; set; }
 
         [Option(Required = false, HelpText = "Telemetry Schedule in Seconds")]
-        public string TelemetryScheduleInSec { get; set; }
+        public int  TelemetryScheduleInSec { get; set; }
 
         [Option(Required = false, HelpText = "Telemetry Endpoint")]
         public string TelemetryEndpoint { get; set; }
@@ -181,9 +181,13 @@ namespace CosmosBenchmark
                 Environment.SetEnvironmentVariable(
                     Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, 
                     "true");
-                Environment.SetEnvironmentVariable(
-                    Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, 
-                    this.TelemetryScheduleInSec ?? "600");
+
+                if (this.TelemetryScheduleInSec > 0)
+                {
+                    Environment.SetEnvironmentVariable(
+                        Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, 
+                        Convert.ToString(this.TelemetryScheduleInSec));
+                }
 
                 if (!string.IsNullOrEmpty(this.TelemetryEndpoint))
                 {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -178,11 +178,18 @@ namespace CosmosBenchmark
 
             if (this.EnableTelemetry)
             {
-                Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, "true");
-                Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, this.TelemetryScheduleInSec ?? "600");
+                Environment.SetEnvironmentVariable(
+                    Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, 
+                    "true");
+                Environment.SetEnvironmentVariable(
+                    Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, 
+                    this.TelemetryScheduleInSec ?? "600");
+
                 if (!string.IsNullOrEmpty(this.TelemetryEndpoint))
                 {
-                    Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, this.TelemetryEndpoint);
+                    Environment.SetEnvironmentVariable(
+                        Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, 
+                        this.TelemetryEndpoint);
                 }
             }
 

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -98,6 +98,12 @@ namespace CosmosBenchmark
         [Option(Required = false, HelpText = "Enable Telemetry")]
         public bool EnableTelemetry { get; set; }
 
+        [Option(Required = false, HelpText = "Telemetry Schedule in Seconds")]
+        public string TelemetryScheduleInSec { get; set; }
+
+        [Option(Required = false, HelpText = "Telemetry Endpoint")]
+        public string TelemetryEndpoint { get; set; }
+
         [Option(Required = false, HelpText = "Endpoint to publish results to")]
         public string ResultsEndpoint { get; set; }
 
@@ -167,13 +173,17 @@ namespace CosmosBenchmark
                 ApplicationName = BenchmarkConfig.UserAgentSuffix,
                 MaxRetryAttemptsOnRateLimitedRequests = 0,
                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
-                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
-                EnableClientTelemetry = this.EnableTelemetry
+                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint
             };
 
-            if(this.EnableTelemetry)
+            if (this.EnableTelemetry)
             {
-                Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, "1");
+                Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, "true");
+                Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, this.TelemetryScheduleInSec ?? "600");
+                if (!string.IsNullOrEmpty(this.TelemetryEndpoint))
+                {
+                    Environment.SetEnvironmentVariable(Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, this.TelemetryEndpoint);
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))


### PR DESCRIPTION
## Description

Right now, Client Telemetry can be only Enabled or disabled in Performance tests. This PR will give flexibility to pass other configurations related to telemetry i.e ScheduledTimeInSec and EndPointURL

![image](https://user-images.githubusercontent.com/6362382/141156081-f9dba63d-ac03-4e77-885a-6c4c8cf88599.png)

I was able to see data in  ClientRequest table
![image](https://user-images.githubusercontent.com/6362382/141187395-c75b70d8-1968-4edf-8be9-8b88eaf9c7ae.png)

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
