### PR TITLE
[PartitionMerge] Add SDKSupportedCapabilities to hint that SDK has merge support

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -155,6 +155,8 @@ namespace Microsoft.Azure.Cosmos.Handlers
                         Content = streamPayload,
                     };
 
+                    request.Headers[HttpConstants.HttpHeaders.SDKSupportedCapabilities] = SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities().ToString();
+
                     if (feedRange != null)
                     {
                         if (feedRange is FeedRangePartitionKey feedRangePartitionKey)

--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -156,6 +156,9 @@ namespace Microsoft.Azure.Cosmos
             httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Version,
                 HttpConstants.Versions.CurrentVersion);
 
+            httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.SDKSupportedCapabilities,
+                SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities().ToString());
+
             httpClient.DefaultRequestHeaders.Add(HttpConstants.HttpHeaders.Accept, RuntimeConstants.MediaTypes.Json);
 
             return new CosmosHttpClientCore(

--- a/Microsoft.Azure.Cosmos/src/SDKSupportedCapabilities.cs
+++ b/Microsoft.Azure.Cosmos/src/SDKSupportedCapabilities.cs
@@ -1,0 +1,15 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    [Flags]
+    internal enum SDKSupportedCapabilities : ulong
+    {
+        None = 0,
+        PartitionMerge = 1 << 0,
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/SDKSupportedCapabilitiesHelpers.cs
+++ b/Microsoft.Azure.Cosmos/src/SDKSupportedCapabilitiesHelpers.cs
@@ -1,0 +1,23 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    internal static class SDKSupportedCapabilitiesHelpers
+    {
+        private static readonly ulong sdkSupportedCapabilities;
+
+        static SDKSupportedCapabilitiesHelpers()
+        {
+            SDKSupportedCapabilities capabilities = SDKSupportedCapabilities.None;
+            capabilities |= SDKSupportedCapabilities.PartitionMerge;
+            SDKSupportedCapabilitiesHelpers.sdkSupportedCapabilities = (ulong)capabilities;
+        }
+
+        internal static ulong GetSDKSupportedCapabilities()
+        {
+            return SDKSupportedCapabilitiesHelpers.sdkSupportedCapabilities;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
@@ -30,6 +30,9 @@ namespace Microsoft.Azure.Cosmos.Contracts
             Assert.AreEqual(HttpConstants.Versions.v2018_12_31, HttpConstants.Versions.CurrentVersion);
             CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(HttpConstants.Versions.v2018_12_31), HttpConstants.Versions.CurrentVersionUTF8);
 #endif
+
+            ulong capabilitites = SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities();
+            Assert.AreEqual(capabilitites & (ulong)SDKSupportedCapabilities.PartitionMerge, (ulong)SDKSupportedCapabilities.PartitionMerge);
         }
 
         [TestMethod]


### PR DESCRIPTION
There are V3 sdk with API version v2018_12_31, which don't have merge support, the most recent sdks have merge support. one way CosmosDB service can distinguish between the SDKs is by making the latest sdk's  API version to v2020_07_15, but this API version is reserved for hierarchical partition keys which is still in preview

Without bumping up the service API version, the service can not distinguish SDKs that have merge support or are missing them.

With SDKSupportedCapabilities, a header is passed to backend to indicate the merge support has been added.

