### PR TITLE
Documentation: Invalid remark

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.Cosmos
         ///    status = "InProgress"
         /// };
         ///
-        /// ItemResponse item = await this.container.CreateItemAsync<ToDoActivity>(test, new PartitionKey(test.status));
+        /// ItemResponse item = await this.container.CreateItemAsync<ToDoActivity>(tests, new PartitionKey(test.status));
         /// ]]>
         /// </code>
         /// </example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -366,7 +366,7 @@ namespace Microsoft.Azure.Cosmos
         ///    status = "InProgress"
         /// };
         ///
-        /// ItemResponse item = await this.container.CreateItemAsync<ToDoActivity>(tests, new PartitionKey(test.status));
+        /// ItemResponse item = await this.container.CreateItemAsync<ToDoActivity>(test, new PartitionKey(test.status));
         /// ]]>
         /// </code>
         /// </example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -49,11 +49,6 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
-        /// <remarks>
-        /// <para>
-        /// Doing a read of a resource is the most efficient way to get a resource from the Database. If you know the resource's ID, do a read instead of a query by ID.
-        /// </para>
-        /// </remarks>
         public abstract Task<DatabaseResponse> ReadAsync(
                     RequestOptions requestOptions = null,
                     CancellationToken cancellationToken = default);


### PR DESCRIPTION
Closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2595
# Pull Request Template

## Description

Remarks talks about querying with id - there is no id parameter in the method, seems to be a remark whether to use CosmosClient.GetDatabaseQueryIterator or not.

It's not obvious from the documentation why you would use this method at all, since you already have a reference to the database - the sample which show it's use starts with database, then gets another reference to the database from the result, which doesn't seem to do anything useful as you already had a reference to the database.

## Type of change

Removed Remarks from the method  in the comment section.


## Closing issues

To automatically close an issue: closes #IssueNumber