### PR TITLE
LINQ: Adds support for Nullable<T>.Value or Nullable<T>.HasValue when using camelCase serialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -744,13 +744,13 @@ namespace Microsoft.Azure.Cosmos.Linq
             if (inputExpression.Expression.Type.IsNullable())
             {
                 // ignore .Value 
-                if (memberName == "Value")
+                if (memberName == CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(context?.linqSerializerOptions, "Value"))
                 {
                     return memberExpression;
                 }
 
                 // convert .HasValue to IS_DEFINED expression
-                if (memberName == "HasValue")
+                if (memberName == CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(context?.linqSerializerOptions, "HasValue"))
                 {
                     return SqlFunctionCallScalarExpression.CreateBuiltin("IS_DEFINED", memberExpression);
                 }

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -110,8 +110,10 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// </summary>
         /// <param name="inputExpression">Expression to translate.</param>
         /// <param name="context">Context for translation.</param>
-        public static Collection Translate(Expression inputExpression, TranslationContext context)
+        private static Collection Translate(Expression inputExpression, TranslationContext context)
         {
+            Debug.Assert(context != null, "Translation Context should not be null");
+
             if (inputExpression == null)
             {
                 throw new ArgumentNullException("inputExpression");
@@ -738,12 +740,12 @@ namespace Microsoft.Azure.Cosmos.Linq
         private static SqlScalarExpression VisitMemberAccess(MemberExpression inputExpression, TranslationContext context)
         {
             SqlScalarExpression memberExpression = ExpressionToSql.VisitScalarExpression(inputExpression.Expression, context);
-            string memberName = inputExpression.Member.GetMemberName(context?.linqSerializerOptions);
+            string memberName = inputExpression.Member.GetMemberName(context.linqSerializerOptions);
 
             // if expression is nullable
             if (inputExpression.Expression.Type.IsNullable())
             {
-                MemberNames memberNames = context?.memberNames ?? MemberNames.Default;
+                MemberNames memberNames = context.memberNames;
 
                 // ignore .Value 
                 if (memberName == memberNames.Value)

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -743,14 +743,16 @@ namespace Microsoft.Azure.Cosmos.Linq
             // if expression is nullable
             if (inputExpression.Expression.Type.IsNullable())
             {
+                MemberNames memberNames = context?.memberNames ?? MemberNames.Default;
+
                 // ignore .Value 
-                if (memberName == CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(context?.linqSerializerOptions, "Value"))
+                if (memberName == memberNames.Value)
                 {
                     return memberExpression;
                 }
 
                 // convert .HasValue to IS_DEFINED expression
-                if (memberName == CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(context?.linqSerializerOptions, "HasValue"))
+                if (memberName == memberNames.HasValue)
                 {
                     return SqlFunctionCallScalarExpression.CreateBuiltin("IS_DEFINED", memberExpression);
                 }

--- a/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// </summary>
         private Stack<SubqueryBinding> subqueryBindingStack;
 
-        public TranslationContext()
+        public TranslationContext(CosmosLinqSerializerOptions linqSerializerOptions, IDictionary<object, string> parameters = null)
         {
             this.InScope = new HashSet<ParameterExpression>();
             this.substitutions = new ParameterSubstitution();
@@ -67,11 +67,6 @@ namespace Microsoft.Azure.Cosmos.Linq
             this.collectionStack = new List<Collection>();
             this.currentQuery = new QueryUnderConstruction(this.GetGenFreshParameterFunc());
             this.subqueryBindingStack = new Stack<SubqueryBinding>();
-        }
-
-        public TranslationContext(CosmosLinqSerializerOptions linqSerializerOptions, IDictionary<object, string> parameters = null)
-            : this()
-        {
             this.linqSerializerOptions = linqSerializerOptions;
             this.parameters = parameters;
             this.memberNames = new MemberNames(linqSerializerOptions);

--- a/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
@@ -352,11 +352,6 @@ namespace Microsoft.Azure.Cosmos.Linq
         }
 
         /// <summary>
-        /// Default instance of <see cref="MemberNames"/> using default serialization options
-        /// </summary>
-        public static readonly MemberNames Default = new MemberNames(null);
-
-        /// <summary>
         /// HasValue for mapping <see cref="Nullable{T}.Value"/>
         /// </summary>
         public string Value { get; }

--- a/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TranslationContext.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Azure.Cosmos.Linq
     internal sealed class TranslationContext
     {
         /// <summary>
+        /// Member names for special mapping cases
+        /// </summary>
+        internal readonly MemberNames memberNames;
+
+        /// <summary>
         /// Set of parameters in scope at any point; used to generate fresh parameter names if necessary.
         /// </summary>
         public HashSet<ParameterExpression> InScope;
@@ -69,6 +74,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         {
             this.linqSerializerOptions = linqSerializerOptions;
             this.parameters = parameters;
+            this.memberNames = new MemberNames(linqSerializerOptions);
         }
 
         public CosmosLinqSerializerOptions linqSerializerOptions;
@@ -337,6 +343,33 @@ namespace Microsoft.Azure.Cosmos.Linq
         }
 
         public const string InputParameterName = "root";
+    }
+
+    /// <summary>
+    /// Special member names for mapping
+    /// </summary>
+    internal sealed class MemberNames
+    {
+        internal MemberNames(CosmosLinqSerializerOptions options)
+        {
+            this.Value = CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(options, nameof(this.Value));
+            this.HasValue = CosmosSerializationUtil.GetStringWithPropertyNamingPolicy(options, nameof(this.HasValue));
+        }
+
+        /// <summary>
+        /// Default instance of <see cref="MemberNames"/> using default serialization options
+        /// </summary>
+        public static readonly MemberNames Default = new MemberNames(null);
+
+        /// <summary>
+        /// HasValue for mapping <see cref="Nullable{T}.Value"/>
+        /// </summary>
+        public string Value { get; }
+
+        /// <summary>
+        /// HasValue for mapping <see cref="Nullable{T}.HasValue"/>
+        /// </summary>
+        public string HasValue { get; }
     }
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -469,7 +469,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             foreach(CosmosLinqSerializerOptions linqSerializerOptions in serializerOptions)
             {
-                IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions;
+                IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
                 // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
                 IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
                 Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items.");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -457,31 +457,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
 
-            // No serializer options set
-            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, null);
-            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
-            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with unspecified serialization");
-
-            // NamingPolicy - CamelCase set
-            CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
+            CosmosLinqSerializerOptions camelCaseSerialization = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             };
-            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
-            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with CamelCase serialization");
-
-            // Override camelcase client with default
-            linqSerializerOptions = new CosmosLinqSerializerOptions
+            CosmosLinqSerializerOptions defaultSerialization = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default
             };
-            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
-            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with default serialization");
+            CosmosLinqSerializerOptions[] serializerOptions = new[] { null, camelCaseSerialization, defaultSerialization };
+
+            foreach(CosmosLinqSerializerOptions linqSerializerOptions in serializerOptions)
+            {
+                IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions;
+                // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
+                IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+                Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items.");
+            }
         }
 
         [TestMethod]
@@ -500,28 +492,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(containerFromNulValuesClient, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
 
-            // No serializer options set
-            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, null);
-            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with unpsecified serialization");
-
-            // NamingPolicy - CamelCase set
-            CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
+            CosmosLinqSerializerOptions camelCaseSerialization = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             };
-            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with CamelCase serialization");
-
-            // Override camelcase client with default
-            linqSerializerOptions = new CosmosLinqSerializerOptions
+            CosmosLinqSerializerOptions defaultSerialization = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default
             };
-            linqQueryable = containerFromNulValuesClient.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
-            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with default serialization");
+            CosmosLinqSerializerOptions[] serializerOptions = new[] { null, camelCaseSerialization, defaultSerialization };
+
+            foreach (CosmosLinqSerializerOptions linqSerializerOptions in serializerOptions)
+            {
+                IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+                IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+                Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items.");
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             };
             IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            // Nullable<T>.HasValue transaltes to IS_DEFINED - should work regardless of serialization/casing
+            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
             IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
             Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with CamelCase serialization");
 
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default
             };
             linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            // Nullable<T>.HasValue transaltes to IS_DEFINED - should work regardless of serialization/casing
+            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
             queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
             Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with default serialization");
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -453,6 +453,67 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task LinqHasValue()
+        {
+            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
+
+            // NamingPolicy - CamelCase set
+            CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            };
+            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            // Nullable<T>.HasValue transaltes to IS_DEFINED - should work regardless of serialization/casing
+            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with CamelCase serialization");
+
+            // Override camelcase client with default
+            linqSerializerOptions = new CosmosLinqSerializerOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default
+            };
+            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            // Nullable<T>.HasValue transaltes to IS_DEFINED - should work regardless of serialization/casing
+            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with default serialization");
+        }
+
+        [TestMethod]
+        public async Task LinqWithIgnoreNullValuesHasValueNoResults()
+        {
+            static void builder(CosmosClientBuilder action)
+            {
+                action.WithSerializerOptions(new CosmosSerializationOptions()
+                {
+                    IgnoreNullValues = true
+                });
+            }
+            CosmosClient nullValuesClient = TestCommon.CreateCosmosClient(builder, false);
+            Cosmos.Database database = nullValuesClient.GetDatabase(this.database.Id);
+            Container containerFromNulValuesClient = database.GetContainer(this.Container.Id);
+
+            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(containerFromNulValuesClient, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
+
+            // NamingPolicy - CamelCase set
+            CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+            };
+            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with CamelCase serialization");
+
+            // Override camelcase client with default
+            linqSerializerOptions = new CosmosLinqSerializerOptions
+            {
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.Default
+            };
+            linqQueryable = containerFromNulValuesClient.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with default serialization");
+        }
+
+        [TestMethod]
         public async Task LinqParameterisedTest1()
         {
             //Creating items for query.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -457,14 +457,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
 
+            // No serializer options set
+            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, null);
+            // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
+            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with unspecified serialization");
+
             // NamingPolicy - CamelCase set
             CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             };
-            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
             // Nullable<T>.HasValue translates to IS_DEFINED - should work regardless of serialization/casing
-            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
             Assert.AreEqual(2, queriable.Count(), "HasValue should have returned two items with CamelCase serialization");
 
             // Override camelcase client with default
@@ -494,13 +500,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(containerFromNulValuesClient, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
 
+            // No serializer options set
+            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, null);
+            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with unpsecified serialization");
+
             // NamingPolicy - CamelCase set
             CosmosLinqSerializerOptions linqSerializerOptions = new CosmosLinqSerializerOptions
             {
                 PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
             };
-            IOrderedQueryable<ToDoActivity> linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
-            IQueryable<ToDoActivity> queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
+            linqQueryable = this.Container.GetItemLinqQueryable<ToDoActivity>(true, null, null, linqSerializerOptions);
+            queriable = linqQueryable.Where(item => item.nullableInt.HasValue);
             Assert.AreEqual(0, queriable.Count(), "HasValue should have returned zero items with CamelCase serialization");
 
             // Override camelcase client with default

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/ToDoActivity.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public string description { get; set; }
         public string pk { get; set; }
         public string CamelCase { get; set; }
+        public int? nullableInt { get; set; }
 
         public bool valid { get; set; }
 
@@ -90,7 +91,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 { new ToDoActivity { id = "child1", taskNum = 30 },
                   new ToDoActivity { id = "child2", taskNum = 40}
                 },
-                valid = true
+                valid = true,
+                nullableInt = null
             };
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Uses the configured serializer settings when checking for the special cases of `Nullable<T>.Value` and `Nullable<T>.HasValue`

This allows the use of .HasValue when using camelCase serialization, as it currently translates to `["propName"]["hasValue"]` in the resultant query instead of the intended `IS_DEFINED("propName")`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
## Closing issues
Closes #2916 