### PR TITLE
Benchmark : Adds an option to override workloadName 

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -26,7 +26,7 @@ namespace CosmosBenchmark
         [JsonIgnore]
         public string Key { get; set; }
 
-        [Option('n', Required = false, HelpText = "Workload Name, it will override the workloadType value in published results")]
+        [Option(Required = false, HelpText = "Workload Name, it will override the workloadType value in published results")]
         public string WorkloadName { get; set; }
 
         [Option(Required = false, HelpText = "Database to use")]

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -26,6 +26,9 @@ namespace CosmosBenchmark
         [JsonIgnore]
         public string Key { get; set; }
 
+        [Option('n', Required = false, HelpText = "Workload Name, it will override the workloadType value in published results")]
+        public string WorkloadName { get; set; }
+
         [Option(Required = false, HelpText = "Database to use")]
         public string Database { get; set; } = "db";
 
@@ -146,7 +149,12 @@ namespace CosmosBenchmark
         internal static BenchmarkConfig From(string[] args)
         {
             BenchmarkConfig options = null;
-            Parser parser = new Parser((settings) => settings.CaseSensitive = false);
+            Parser parser = new Parser((settings) =>
+            {
+                settings.CaseSensitive = false;
+                settings.HelpWriter = Console.Error;
+                settings.AutoHelp = true;
+            });
             parser.ParseArguments<BenchmarkConfig>(args)
                 .WithParsed<BenchmarkConfig>(e => options = e)
                 .WithNotParsed<BenchmarkConfig>(e => BenchmarkConfig.HandleParseError(e));

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -90,7 +90,7 @@ Copyright (C) 2019 CosmosBenchmark
   -w                                Required. Workload type insert, read
   -e                                Required. Cosmos account end point
   -k                                Required. Cosmos account master key
-  -n                                Workload Name, it will override the workloadType value in published results
+  --workloadname                    Workload Name, it will override the workloadType value in published results
   --database                        Database to use
   --container                       Collection to use
   -t                                Collection throughput use

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/README.md
@@ -87,34 +87,41 @@ while($true){
 >dotnet run CosmosBenchmark.csproj
 CosmosBenchmark 1.0.0
 Copyright (C) 2019 CosmosBenchmark
-
-  -e                     Required. Cosmos account end point
-
-  -k                     Required. Cosmos account master key
-
-  --database             Database to use
-
-  --container            Collection to use
-
-  -t                     Collection throughput use
-
-  -n                     Number of documents to insert
-
-  --cleanuponstart       Start with new collection
-
-  --cleanuponfinish      Clean-up after run
-
-  --partitionkeypath     Container partition key path
-
-  --pl                   Degree of parallism
-
-  --itemtemplatefile     Item template
-
-  --minthreadpoolsize    Min thread pool size
-
-  --help                 Display this help screen.
-
-  --version              Display version information.
+  -w                                Required. Workload type insert, read
+  -e                                Required. Cosmos account end point
+  -k                                Required. Cosmos account master key
+  -n                                Workload Name, it will override the workloadType value in published results
+  --database                        Database to use
+  --container                       Collection to use
+  -t                                Collection throughput use
+  -n                                Number of documents to insert
+  --consistencylevel                Client consistency level to override
+  --enablelatencypercentiles        Enable latency percentiles
+  --cleanuponstart                  Start with new collection
+  --cleanuponfinish                 Clean-up after run
+  --partitionkeypath                Container partition key path
+  --pl                              Degree of parallism
+  --tcp                             MaxRequestsPerTcpConnection
+  --maxtcpconnectionsperendpoint    MaxTcpConnectionsPerEndpoint
+  --itemtemplatefile                Item template
+  --minthreadpoolsize               Min thread pool size
+  --tracefailures                   Write the task execution failure to console. Useful for debugging failures
+  --publishresults                  Publish run results
+  --commitid                        Commit ID, only for publish
+  --commitdate                      Commit date, only for publish
+  --committime                      Commit time, only for publish
+  --branchname                      Branch name, only for publish
+  --resultspartitionkeyvalue        Partitionkey, only for publish
+  --disablecoresdklogging           Disable core SDK logging
+  --enabletelemetry                 Enable Telemetry
+  --telemetryscheduleinsec          Telemetry Schedule in Seconds
+  --telemetryendpoint               Telemetry Endpoint
+  --resultsendpoint                 Endpoint to publish results to
+  --resultskey                      Key to publish results to
+  --resultsdatabase                 Database to publish results to
+  --resultscontainer                Container to publish results to
+  --help                            Display this help screen.
+  --version                         Display version information.
 ```
 
 ## Running on Azure

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/RunSummary.cs
@@ -34,7 +34,7 @@ namespace CosmosBenchmark
         public string Time { get; }
 
         public BenchmarkConfig BenchmarkConfig { get; }
-        public string WorkloadType => this.BenchmarkConfig.WorkloadType;
+        public string WorkloadType => String.IsNullOrWhiteSpace(this.BenchmarkConfig.WorkloadName) ? this.BenchmarkConfig.WorkloadType : this.BenchmarkConfig.WorkloadName;
         public string BranchName => this.BenchmarkConfig.BranchName;
         public string AccountName => this.BenchmarkConfig.EndPoint;
         public string Database => this.BenchmarkConfig.Database;


### PR DESCRIPTION
## Description

It has below changes:
1.  Adds ability to override workloadtype name in the results.: Today if We run same workload with diff configs, it will have same name always.
After this PR, there will be ability to override this name (if you want to)
2. In case of error, it will show all the options available.

After the change, on running a workload with custom name : 
`dotnet run -c Debug --no-build -- -w ReadTExistsV3 -e <cosmosdb account>-k <key> -n 20000 -t 1000000 --workloadname myworkload`

![image](https://user-images.githubusercontent.com/6362382/144603626-060fbd88-22d9-4302-9353-23f8f67d2535.png)

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)