### PR TITLE
Documentation: Fixes  Error in LINQ

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -1138,7 +1138,7 @@ namespace Microsoft.Azure.Cosmos
         /// <![CDATA[
         ///
         /// // LINQ query generation
-        /// using (FeedIterator setIterator = container.GetItemLinqQueryable<Book>()
+        /// using (FeedIterator<Book> setIterator = container.GetItemLinqQueryable<Book>()
         ///                      .Where(b => b.Title == "War and Peace")
         ///                      .ToFeedIterator())
         /// {                   


### PR DESCRIPTION
Closes  https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2520

## Description

The code for the example should compile, possible the return type should be `FeedIterator<Book>`. Please verify if the example code compiles.

## Type of change

Change in the Linq query return type should be FeedIterator<Book> to avoid compilation error.

