### PR TITLE
[BREAKING CHANGE] DefaultTracing: Removes tracing by default 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -646,8 +646,6 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException("serviceEndpoint");
             }
 
-            DefaultTrace.InitEventListener();
-
             this.queryPartitionProvider = new AsyncLazy<QueryPartitionProvider>(async () =>
             {
                 await this.EnsureValidClientAsync(NoOpTrace.Singleton);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DefaultTracingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DefaultTracingTests.cs
@@ -1,0 +1,105 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class DefaultTracingTests
+    {
+        [TestMethod]
+        public async Task DefaultTracingDisabledByDefault()
+        {
+            TestTraceListener testTraceListener = new TestTraceListener();
+            DefaultTrace.TraceSource.Listeners.Add(testTraceListener);
+
+            Mock<IHttpHandler> mockHttpHandler = new Mock<IHttpHandler>();
+            mockHttpHandler.Setup(x => x.SendAsync(
+                It.IsAny<HttpRequestMessage>(),
+                It.IsAny<CancellationToken>())).Throws(new InvalidOperationException("Test exception that won't be retried"));
+
+            CosmosClient cosmosClient = new CosmosClient(
+                "https://localhost:8081",
+                Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+                new CosmosClientOptions()
+                {
+                    HttpClientFactory = () => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object)),
+                });
+
+            try
+            {
+                await cosmosClient.GetDatabase("randomDb").ReadAsync();
+                Assert.Fail("Should throw exception");
+            }
+            catch (InvalidOperationException ex)
+            {
+            }
+
+            if (Debugger.IsAttached)
+            {
+                Assert.IsTrue(testTraceListener.IsTraceWritten);
+            }
+            else
+            {
+                Assert.IsFalse(testTraceListener.IsTraceWritten);
+            }
+        }
+
+        [TestMethod]
+        public async Task DefaultTracingEnableTest()
+        {
+            TestTraceListener testTraceListener = new TestTraceListener();
+            DefaultTrace.TraceSource.Listeners.Add(testTraceListener);
+
+            Mock<IHttpHandler> mockHttpHandler = new Mock<IHttpHandler>();
+            mockHttpHandler.Setup(x => x.SendAsync(
+                It.IsAny<HttpRequestMessage>(),
+                It.IsAny<CancellationToken>())).Throws(new InvalidOperationException("Test exception that won't be retried"));
+
+            CosmosClient.EnableDefaultTrace();
+
+            CosmosClient cosmosClient = new CosmosClient(
+                "https://localhost:8081",
+                Convert.ToBase64String(Guid.NewGuid().ToByteArray()),
+                new CosmosClientOptions()
+                {
+                    HttpClientFactory = () => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object)),
+                });
+
+            try
+            {
+                await cosmosClient.GetDatabase("randomDb").ReadAsync();
+                Assert.Fail("Should throw exception");
+            }
+            catch (InvalidOperationException ex)
+            {
+            }
+
+            Assert.IsTrue(testTraceListener.IsTraceWritten);
+        }
+
+        private class TestTraceListener : TraceListener
+        {
+            public bool IsTraceWritten = false;
+
+            public override bool IsThreadSafe => true;
+            public override void Write(string message)
+            {
+                this.IsTraceWritten = true;
+            }
+
+            public override void WriteLine(string message)
+            {
+                this.IsTraceWritten = true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is removing the trace source by default unless there is a debugger attached. It is enabled by default for debugging scenario because performance is not an issue in those scenarios, and it can be helpful to root cause the issue being debugged.

The DefaultTrace add a significant amount of overhead and will cause lock contention. There has been several live site incidents caused by this. This issue is more problematic for .NET Core because the app config file is not supported which make it difficult to disable it. For example, the performance project had to use [reflection to get the trace source to remove it programmatically](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/4abf2907f18bfa35e5ddf143ccac9396ce012abe/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs#L283).

Customer can switch back to the previous behavior by calling the new API added. With this method it could be expanded later on to take in the tracing level based on customer feedback.

`CosmosClient.EnableDefaultTrace();`

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber