### PR TITLE
Benchmark: Fixes throttles, run.sh script, adds unique useragent strings

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -174,11 +174,20 @@ namespace CosmosBenchmark
             return options;
         }
 
+        /// <summary>
+        /// Give each workload a unique user agent string
+        /// so the backend logs can be filtered by the workload.
+        /// </summary>
+        private string GetUserAgentPrefix()
+        {
+            return this.WorkloadName ?? this.WorkloadType ?? BenchmarkConfig.UserAgentSuffix;
+        }
+
         internal Microsoft.Azure.Cosmos.CosmosClient CreateCosmosClient(string accountKey)
         {
             Microsoft.Azure.Cosmos.CosmosClientOptions clientOptions = new Microsoft.Azure.Cosmos.CosmosClientOptions()
             {
-                ApplicationName = BenchmarkConfig.UserAgentSuffix,
+                ApplicationName = this.GetUserAgentPrefix(),
                 MaxRetryAttemptsOnRateLimitedRequests = 0,
                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
                 MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint
@@ -232,7 +241,7 @@ namespace CosmosBenchmark
                                 ConnectionProtocol = Protocol.Tcp,
                                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
                                 MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
-                                UserAgentSuffix = BenchmarkConfig.UserAgentSuffix,
+                                UserAgentSuffix = this.GetUserAgentPrefix(),
                                 RetryOptions = new RetryOptions()
                                 {
                                     MaxRetryAttemptsOnThrottledRequests = 0

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/run.sh
@@ -68,10 +68,11 @@ sleep 45 #Wait
 if [ "$INCLUDE_QUERY" = true ]
 then
     #Query operations
-    # n value is lowered to 100000 because queries are significantly slower. This prevents the runs from taking to long.
+    # n value is lowered to 200000 because queries are significantly slower. This prevents the runs from taking to long.
+    # pl is 16 because 18 was casuing a small amount of thorrtles.
     for WORKLOAD_NAME in ReadFeedStreamV3 QueryTSinglePkV3 QueryTSinglePkOrderByWithPaginationV3 QueryTSinglePkOrderByFullDrainV3 QueryTCrossPkV3 QueryTCrossPkOrderByWithPaginationV3 QueryTCrossPkOrderByFullDrainV3 QueryStreamSinglePkV3 QueryStreamSinglePkOrderByWithPaginationV3 QueryStreamSinglePkOrderByFullDrainV3 QueryStreamCrossPkV3 QueryStreamCrossPkOrderByWithPaginationV3 QueryStreamCrossPkOrderByFullDrainV3
-    $do
-        dotnet run -c Release  -- -n 200000 -w $WORKLOAD_NAME --pl $PL --enableTelemetry --telemetryScheduleInSec 60 --telemetryEndpoint $TELEMETRY_ENDPOINT --tcp 10 -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --enablelatencypercentiles --disablecoresdklogging --publishresults --resultspartitionkeyvalue $RESULTS_PK --commitid $COMMIT_ID --commitdate $COMMIT_DATE --committime $COMMIT_TIME  --branchname $BRANCH_NAME --database testdb --container testcol --partitionkeypath /pk 
+    do
+        dotnet run -c Release  -- -n 200000 -w $WORKLOAD_NAME --pl 16 --enableTelemetry --telemetryScheduleInSec 60 --telemetryEndpoint $TELEMETRY_ENDPOINT --tcp 10 -e $ACCOUNT_ENDPOINT -k $ACCOUNT_KEY --enablelatencypercentiles --disablecoresdklogging --publishresults --resultspartitionkeyvalue $RESULTS_PK --commitid $COMMIT_ID --commitdate $COMMIT_DATE --committime $COMMIT_TIME  --branchname $BRANCH_NAME --database testdb --container testcol --partitionkeypath /pk 
         sleep 10 #Wait
     done
 fi


### PR DESCRIPTION
# Pull Request Template

## Description

1. The query and read feed operations are getting throttled on a 100k RU container. To reduce the number of throttles the concurrency is being reduced. 
2. Fixed a bug in the run.sh where there was an extra $ causing query operations to not run
3. Added the workload name to user agent prefix to make it possible in the backend logs to easily see the different runs.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber