### PR TITLE
Session: Fixes scoped session token on partition splits and multiple write endpoints enabled

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Cosmos
                     && request.OperationType != OperationType.Batch
                     && !isMultiMasterEnabledForRequest))
             {
-                return; // Only apply the session token in case of session consistency and the request is read only
+                return; // Only apply the session token in case of session consistency and the request is read only or read/write on multimaster
             }
 
             (bool isSuccess, string sessionToken) = await GatewayStoreModel.TryResolveSessionTokenAsync(

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.Cosmos
     // Marking it as non-sealed in order to unit test it using Moq framework
     internal class GatewayStoreModel : IStoreModel, IDisposable
     {
+        private static readonly string sessionConsistencyAsString = ConsistencyLevel.Session.ToString();
+
         private readonly GlobalEndpointManager endpointManager;
         private readonly DocumentClientEventSource eventSource;
         private readonly ISessionContainer sessionContainer;
@@ -267,7 +269,7 @@ namespace Microsoft.Azure.Cosmos
             bool sessionConsistency =
                 defaultConsistencyLevel == ConsistencyLevel.Session ||
                 (!string.IsNullOrEmpty(requestConsistencyLevel)
-                    && string.Equals(requestConsistencyLevel, ConsistencyLevel.Session.ToString(), StringComparison.OrdinalIgnoreCase));
+                    && string.Equals(requestConsistencyLevel, GatewayStoreModel.sessionConsistencyAsString, StringComparison.OrdinalIgnoreCase));
 
             bool isMultiMasterEnabledForRequest = globalEndpointManager.CanUseMultipleWriteLocations(request);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewaySessionTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewaySessionTokenTests.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                                                            Cosmos.ConsistencyLevel.Session,
                                                            sessionContainer,
                                                            await this.cosmosClient.DocumentClient.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton),
-                                                           await this.cosmosClient.DocumentClient.GetCollectionCacheAsync(NoOpTrace.Singleton));
+                                                           await this.cosmosClient.DocumentClient.GetCollectionCacheAsync(NoOpTrace.Singleton),
+                                                           this.cosmosClient.DocumentClient.GlobalEndpointManager);
 
             string sessionToken = request.Headers[HttpConstants.HttpHeaders.SessionToken];
             Assert.IsTrue(!string.IsNullOrEmpty(sessionToken) && sessionToken.Split(',').Length == 1);
@@ -139,7 +140,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                                                                Cosmos.ConsistencyLevel.Session,
                                                                client.DocumentClient.sessionContainer,
                                                                await client.DocumentClient.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton),
-                                                               await client.DocumentClient.GetCollectionCacheAsync(NoOpTrace.Singleton));
+                                                               await client.DocumentClient.GetCollectionCacheAsync(NoOpTrace.Singleton),
+                                                               client.DocumentClient.GlobalEndpointManager);
 
                 string readSessionToken = request.Headers[HttpConstants.HttpHeaders.SessionToken];
                 Assert.AreEqual(readSessionToken, createSessionToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// When the response contains a PKRangeId header different than the one targetted with the session token, trigger a refresh of the PKRange cache
+        /// When the response contains a PKRangeId header different than the one targeted with the session token, trigger a refresh of the PKRange cache
         /// </summary>
         [DataTestMethod]
         [DataRow("0", "0", false)]
@@ -887,12 +887,7 @@ namespace Microsoft.Azure.Cosmos
                 AuthorizationTokenType.PrimaryMasterKey,
                 headers))
                 {
-                    ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId("dbs/OVJwAA==/colls/OVJwAOcMtA0=");
-                    clientCollectionCache.Setup(collCache => collCache.ResolveCollectionAsync(
-                        It.Is<DocumentServiceRequest>(dsr => dsr == request),
-                        It.IsAny<CancellationToken>(),
-                        It.IsAny<ITrace>())).ReturnsAsync(containerProperties);
-                    
+                    request.RequestContext.ResolvedCollectionRid = "dbs/OVJwAA==/colls/OVJwAOcMtA0=";
                     request.RequestContext.ResolvedPartitionKeyRange = new PartitionKeyRange() { Id = originalPKRangeId };
                     await storeModel.ProcessMessageAsync(request);
                     Assert.AreEqual(updatedSessionToken, sessionContainer.GetSessionToken("dbs/OVJwAA==/colls/OVJwAOcMtA0="));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -211,7 +211,8 @@ namespace Microsoft.Azure.Cosmos
                            ConsistencyLevel.Session,
                            new Mock<ISessionContainer>().Object,
                            partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                           clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object);
+                           clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                           globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                         Assert.IsNull(dsr.Headers[HttpConstants.HttpHeaders.SessionToken]);
                     });
@@ -237,7 +238,8 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     new Mock<ISessionContainer>().Object,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object);
+                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                    globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                 Assert.IsNull(dsrQueryPlan.Headers[HttpConstants.HttpHeaders.SessionToken]);
             });
@@ -288,7 +290,8 @@ namespace Microsoft.Azure.Cosmos
                                 ConsistencyLevel.Session,
                                 new Mock<ISessionContainer>().Object,
                                 partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object);
+                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                                globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                             Assert.AreEqual(dsrSessionToken, dsr.Headers[HttpConstants.HttpHeaders.SessionToken]);
                         });
@@ -313,7 +316,8 @@ namespace Microsoft.Azure.Cosmos
                                 ConsistencyLevel.Session,
                                 sMock.Object,
                                 partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object);
+                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                                globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                             if (dsrNoSessionToken.IsReadOnlyRequest || dsrNoSessionToken.OperationType == OperationType.Batch)
                             {
@@ -363,7 +367,8 @@ namespace Microsoft.Azure.Cosmos
                             ConsistencyLevel.Session,
                             sMock.Object,
                             partitionKeyRangeCache: mockPartitionKeyRangeCache.Object,
-                            clientCollectionCache: mockCollectionCahce.Object);
+                            clientCollectionCache: mockCollectionCahce.Object,
+                            globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                         if (dsr.IsReadOnlyRequest || dsr.OperationType == OperationType.Batch)
                         {
@@ -398,7 +403,8 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     new Mock<ISessionContainer>().Object,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object);
+                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                    globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                 Assert.AreEqual(sessionToken, dsrSprocExecute.Headers[HttpConstants.HttpHeaders.SessionToken]);
             });


### PR DESCRIPTION
Mirror of https://github.com/Azure/azure-sdk-for-java/pull/25555

## Scenario

> :grey_exclamation: The scenario described here does not apply if customers are manually passing session tokens as part of the RequestOptions, it only applies when users are **not passing session tokens as input to operations**.

When a write operation is done through the SDK instance on Session consistency, the SDK stores locally the session token in a cache and also returns the token to the user. When a read operation for the same partition is done, and the user does not pass a session token in the input, we extract the session token from the cache from the write operation and pass it along.

Since the token that travels to the Gateway and is returned is scoped to a partition, the issue arises when a partition split occurs:

1. User performs a write that is for partition 1, returns token A.
2. User performs a read for partition 1, sdk sends token A, returns token B.
3. User performs another operation for partition 1, sdk sends token B.
4. Partition 1 is split into 2 and 3.
5. Gateway returns token C for partition 2 in the response
6. SDK stores token C for partition 2.
7. User performs another operation that should map to partition 2, but because SDK has no knowledge of partition 2, it resolves to partition 1 and sends the last known token for partition 1, which is B.

Ideally on step 7, the SDK should be sending the cached token for partition 2, which is C.

## Fix

To fix this scenario, we are detecting which was the resulting partition for the operation and compare that with the initial partition SDK thought it was targeting. If the partitions do not match, it triggers a refresh of the partition map. That way when Step 7 happens, the SDK is aware of partitions 2 and 3 and it would identify the operation is for partition 2 and use token C.

## Additional fix

For accounts that have multiple write endpoints enabled, the cached session token was not being sent on write operations. This PR also fixes that scenario so writes contain the cached token.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

