### PR TITLE
Session: Fixes token being sent if request had a different consistency level on Gateway mode

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -265,10 +265,11 @@ namespace Microsoft.Azure.Cosmos
             }
 
             string requestConsistencyLevel = request.Headers[HttpConstants.HttpHeaders.ConsistencyLevel];
+            bool requestHasConsistencySet = !string.IsNullOrEmpty(requestConsistencyLevel);
 
             bool sessionConsistency =
-                defaultConsistencyLevel == ConsistencyLevel.Session ||
-                (!string.IsNullOrEmpty(requestConsistencyLevel)
+                (!requestHasConsistencySet && defaultConsistencyLevel == ConsistencyLevel.Session) ||
+                (requestHasConsistencySet
                     && string.Equals(requestConsistencyLevel, GatewayStoreModel.sessionConsistencyAsString, StringComparison.OrdinalIgnoreCase));
 
             bool isMultiMasterEnabledForRequest = globalEndpointManager.CanUseMultipleWriteLocations(request);

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -265,8 +265,8 @@ namespace Microsoft.Azure.Cosmos
             }
 
             string requestConsistencyLevel = request.Headers[HttpConstants.HttpHeaders.ConsistencyLevel];
-            bool isConsideredAReadRequest = request.IsReadOnlyRequest || request.OperationType == OperationType.Batch;
-            bool requestHasConsistencySet = !string.IsNullOrEmpty(requestConsistencyLevel) && isConsideredAReadRequest; // Only read requests can have their consistency modified
+            bool isReadOrBatchRequest = request.IsReadOnlyRequest || request.OperationType == OperationType.Batch;
+            bool requestHasConsistencySet = !string.IsNullOrEmpty(requestConsistencyLevel) && isReadOrBatchRequest; // Only read requests can have their consistency modified
             
             bool sessionConsistencyApplies =
                 (!requestHasConsistencySet && defaultConsistencyLevel == ConsistencyLevel.Session) ||
@@ -276,7 +276,7 @@ namespace Microsoft.Azure.Cosmos
             bool isMultiMasterEnabledForRequest = globalEndpointManager.CanUseMultipleWriteLocations(request);
 
             if (!sessionConsistencyApplies
-                || (!isConsideredAReadRequest
+                || (!isReadOrBatchRequest
                     && !isMultiMasterEnabledForRequest))
             {
                 return; // Only apply the session token in case of session consistency and the request is read only or read/write on multimaster

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -445,10 +445,17 @@ namespace Microsoft.Azure.Cosmos
                     sMock.Object,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
                     clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
-                    globalEndpointManager: new Mock<IGlobalEndpointManager>().Object);
+                    globalEndpointManager: globalEndpointManager.Object);
 
-                // Should not add the session token because the request is lower
-                Assert.IsNull(dsrNoSessionToken.Headers[HttpConstants.HttpHeaders.SessionToken]);
+                if (isWriteRequest && multiMaster)
+                {
+                    // Multi master write requests should not lower the consistency and remove the session token
+                    Assert.AreEqual(dsrSessionToken, dsrNoSessionToken.Headers[HttpConstants.HttpHeaders.SessionToken]);
+                }
+                else
+                {
+                    Assert.IsNull(dsrNoSessionToken.Headers[HttpConstants.HttpHeaders.SessionToken]);
+                }
             });
         }
 


### PR DESCRIPTION
## Description

On Gateway mode, if the account is Session consistency but the user is sending a request where the `ItemRequestOptions` has a ConsistencyLevel != Session, we were sending the session token anyway.

This PR makes it so the request level configuration is honored over the account level configuration **only on read requests**.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)