### PR TITLE
Supportability: Refactors error message for invalid ApplicationRegion 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (!RegionProximityUtil.SourceRegionToTargetRegionsRTTInMs.ContainsKey(location))
             {
-                throw new ArgumentException("Current location is not a valid Azure region.");
+                throw new ArgumentException($"'{location}' is not a valid Azure region or the current SDK version does not recognize it. If the value represents a valid region, make sure you are using the latest SDK version.");
             }
 
             List<string> proximityBasedPreferredLocations = RegionProximityUtil.GeneratePreferredRegionList(location);

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (!RegionProximityUtil.SourceRegionToTargetRegionsRTTInMs.ContainsKey(location))
             {
-                throw new ArgumentException($"'{location}' is not a valid Azure region or the current SDK version does not recognize it. If the value represents a valid region, make sure you are using the latest SDK version.");
+                throw new ArgumentException($"ApplicationRegion configuration '{location}' is not a valid Azure region or the current SDK version does not recognize it. If the value represents a valid region, make sure you are using the latest SDK version.");
             }
 
             List<string> proximityBasedPreferredLocations = RegionProximityUtil.GeneratePreferredRegionList(location);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -489,6 +489,34 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsFalse(connectionPolicy.EnableEndpointDiscovery);
         }
 
+        [TestMethod]
+        public void WithUnrecognizedApplicationRegionThrows()
+        {
+            string notAValidAzureRegion = Guid.NewGuid().ToString();
+
+            {
+                CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder(
+                    accountEndpoint: AccountEndpoint,
+                    authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey)
+                    .WithApplicationRegion(notAValidAzureRegion);
+
+                ArgumentException argumentException = Assert.ThrowsException<ArgumentException>(() => cosmosClientBuilder.Build(new MockDocumentClient()));
+
+                Assert.IsTrue(argumentException.Message.Contains(notAValidAzureRegion), $"Expected error message to contain {notAValidAzureRegion} but got: {argumentException.Message}");
+            }
+
+            {
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                {
+                    ApplicationRegion = notAValidAzureRegion
+                };
+
+                ArgumentException argumentException = Assert.ThrowsException<ArgumentException>(() => new CosmosClient(AccountEndpoint, MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey, cosmosClientOptions));
+
+                Assert.IsTrue(argumentException.Message.Contains(notAValidAzureRegion), $"Expected error message to contain {notAValidAzureRegion} but got: {argumentException.Message}");
+            }
+        }
+
         private class TestWebProxy : IWebProxy
         {
             public ICredentials Credentials { get; set; }


### PR DESCRIPTION
## Description

`CosmosClientOptions.ApplicationRegion` can be used to define where the current application is running, and the SDK will use that to populate the Preferred Regions based on geographical distance.

For supportability purposes and to provide users with more information when their configuration is invalid, this PR changes the error message produced to include the invalid value.

Since the distance calculation is done using a known list, there could also be scenarios where using a very old SDK version and a very new Azure region name would also face the error, so the message now contains that hint.

Proposed message:

```
ApplicationRegion configuration '{location}' is not a valid Azure region or the current SDK version does not recognize it. If the value represents a valid region, make sure you are using the latest SDK version.
```

Closes #2865