### PR TITLE
Session: Fixes Gateway session scope during merges

### DIFF
--- a/Microsoft.Azure.Cosmos/src/SessionContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionContainer.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Azure.Cosmos.Common
                         }
                     }
 
+                    // When we don't have the session token for a partition, we can leverage the session token of the parent(s)
                     if (parentSessionToken != null)
                     {
                         return partitionKeyRangeId + SessionContainer.sessionTokenSeparator + parentSessionToken.ConvertToString();

--- a/Microsoft.Azure.Cosmos/src/SessionContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionContainer.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Azure.Cosmos.Common
                         if (partitionKeyRangeIdToTokenMap.TryGetValue(request.RequestContext.ResolvedPartitionKeyRange.Parents[parentIndex], 
                                                                       out sessionToken))
                         {
+                            // A partition can have more than 1 parent (merge). In that case, we apply Merge to generate a token with both parent's max LSNs
                             parentSessionToken = parentSessionToken != null ? parentSessionToken.Merge(sessionToken) : sessionToken;
                         }
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Tests;
     using Microsoft.Azure.Cosmos.Tracing;
     using Newtonsoft.Json;
+    using System.Collections.ObjectModel;
 
     /// <summary>
     /// Tests for <see cref="GatewayStoreModel"/>.
@@ -944,6 +945,119 @@ namespace Microsoft.Azure.Cosmos
                          It.Is<bool>(b => b == true)), shouldCallRefresh ? Times.Once : Times.Never);
                 }
             }
+        }
+
+        /// <summary>
+        /// Simulating partition split and cache having only the parent token
+        /// </summary>
+        [TestMethod]
+        public async Task GatewayStoreModel_ObtainsSessionFromParent_AfterSplit()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string collectionResourceId = ResourceId.NewDocumentCollectionId(42, 129).DocumentCollectionId.ToString();
+            string collectionFullname = "dbs/db1/colls/collName";
+
+            // Set token for the parent
+            string parentPKRangeId = "0";
+            string parentSession = "1#100#4=90#5=1";
+            sessionContainer.SetSessionToken(
+                collectionResourceId,
+                collectionFullname,
+                new StoreRequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, $"{parentPKRangeId}:{parentSession}" } }
+            );
+
+            // Create the request for the child
+            string childPKRangeId = "1";
+            DocumentServiceRequest documentServiceRequestToChild = DocumentServiceRequest.CreateFromName(OperationType.Read, "dbs/db1/colls/collName/docs/42", ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey, null);
+
+            documentServiceRequestToChild.RequestContext.ResolvedPartitionKeyRange = new PartitionKeyRange()
+            {
+                Id = childPKRangeId,
+                MinInclusive = "",
+                MaxExclusive = "AA",
+                Parents = new Collection<string>() { parentPKRangeId } // PartitionKeyRange says who is the parent
+            };
+
+            Mock<IGlobalEndpointManager> globalEndpointManager = new Mock<IGlobalEndpointManager>();
+            await this.GetGatewayStoreModelForConsistencyTest(async (gatewayStoreModel) =>
+            {
+                await GatewayStoreModel.ApplySessionTokenAsync(
+                    documentServiceRequestToChild,
+                    ConsistencyLevel.Session,
+                    sessionContainer,
+                    partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null).Object,
+                    globalEndpointManager: globalEndpointManager.Object);
+
+                Assert.AreEqual($"{childPKRangeId}:{parentSession}", documentServiceRequestToChild.Headers[HttpConstants.HttpHeaders.SessionToken]);
+            });
+        }
+
+        /// <summary>
+        /// Simulating partition merge and cache having only the parents tokens
+        /// </summary>
+        [TestMethod]
+        public async Task GatewayStoreModel_ObtainsSessionFromParents_AfterMerge()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string collectionResourceId = ResourceId.NewDocumentCollectionId(42, 129).DocumentCollectionId.ToString();
+            string collectionFullname = "dbs/db1/colls/collName";
+
+            // Set tokens for the parents
+            string parentPKRangeId = "0";
+            int maxGlobalLsn = 100;
+            int maxLsnRegion1 = 200;
+            int maxLsnRegion2 = 300;
+            int maxLsnRegion3 = 400;
+
+            // Generate 2 tokens, one has max global but lower regional, the other lower global but higher regional
+            // Expect the merge to contain all the maxes
+            string parentSession = $"1#{maxGlobalLsn}#1={maxLsnRegion1 - 1}#2={maxLsnRegion2}#3={maxLsnRegion3 - 1}";
+            sessionContainer.SetSessionToken(
+                collectionResourceId,
+                collectionFullname,
+                new StoreRequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, $"{parentPKRangeId}:{parentSession}" } }
+            );
+
+            string parent2PKRangeId = "1";
+            string parent2Session = $"1#{maxGlobalLsn - 1}#1={maxLsnRegion1}#2={maxLsnRegion2 - 1}#3={maxLsnRegion3}";
+            sessionContainer.SetSessionToken(
+                collectionResourceId,
+                collectionFullname,
+                new StoreRequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, $"{parent2PKRangeId}:{parent2Session}" } }
+            );
+
+            string tokenWithAllMax = $"1#{maxGlobalLsn}#1={maxLsnRegion1}#2={maxLsnRegion2}#3={maxLsnRegion3}";
+
+            // Create the request for the child
+            // Request for a child from both parents
+            string childPKRangeId = "2";
+
+            DocumentServiceRequest documentServiceRequestToChild = DocumentServiceRequest.CreateFromName(OperationType.Read, "dbs/db1/colls/collName/docs/42", ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey, null);
+
+            documentServiceRequestToChild.RequestContext.ResolvedPartitionKeyRange = new PartitionKeyRange()
+            {
+                Id = childPKRangeId,
+                MinInclusive = "",
+                MaxExclusive = "FF",
+                Parents = new Collection<string>() { parentPKRangeId, parent2PKRangeId } // PartitionKeyRange says who are the parents
+            };
+
+            Mock<IGlobalEndpointManager> globalEndpointManager = new Mock<IGlobalEndpointManager>();
+            await this.GetGatewayStoreModelForConsistencyTest(async (gatewayStoreModel) =>
+            {
+                await GatewayStoreModel.ApplySessionTokenAsync(
+                    documentServiceRequestToChild,
+                    ConsistencyLevel.Session,
+                    sessionContainer,
+                    partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null).Object,
+                    globalEndpointManager: globalEndpointManager.Object);
+
+                Assert.AreEqual($"{childPKRangeId}:{tokenWithAllMax}", documentServiceRequestToChild.Headers[HttpConstants.HttpHeaders.SessionToken]);
+            });
         }
 
         private class MockMessageHandler : HttpMessageHandler

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Azure.Cosmos
         /// Use the session token of the parent if request comes for a child
         /// </summary>
         [TestMethod]
-        public void TestResolveSessionTokenFromParent_AfterSplit()
+        public void TestResolveSessionTokenFromParent_Gateway_AfterSplit()
         {
             SessionContainer sessionContainer = new SessionContainer("127.0.0.1");
 
@@ -870,7 +870,7 @@ namespace Microsoft.Azure.Cosmos
         /// Use the session token of the parent if request comes for a child when 2 parents are present
         /// </summary>
         [TestMethod]
-        public void TestResolveSessionTokenFromParent_AfterMerge()
+        public void TestResolveSessionTokenFromParent_Gateway_AfterMerge()
         {
             SessionContainer sessionContainer = new SessionContainer("127.0.0.1");
 


### PR DESCRIPTION
## Description

> This PR only applies to users not passing the session token manually through the ItemRequestOptions

When the user does not pass session token but relies on the client to maintain the session, in Gateway mode, the current scoped session token logic uses the current targeted partition to send the cached token, if any.

### Splits

1. Cache contains entry for Partition 1, which splits into 2 and 3
2. A request comes for Partition 2
3. We lookup the cache entry for 2, and find none, but 2 has 1 as parent, so we use the cache entry for Partition 1.
4. Response comes and we store the response's token as an entry for Partition 2.

### Merge

1. Cache contains entry for Partition 1 and 2, which both merge into 3.
2. A request comes from Partition 3.
3. We lookup the cache entry for 3, and find none, following the same pattern as for Splits, we pick the first parents cache entry.

The problem is, picking just 1 parent's token is not completely correct. Each cache entry could have a different token value with different transactional identifier.

## Fix

We need to apply a **Merge operation** among the tokens of all the known parents:

1. Cache contains entry for Partition 1 and 2, which both merge into 3.
2. A request comes from Partition 3.
3. We lookup the cache entry for 3, and find none. 
4. Grab all the known tokens from parents (1 and 2) and merge them (generate a new token which contains the max transactional identifier from both).

The merge includes obtaining the max global LSN and regional local lsn for each region involved in the token (case of multi master).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update