### PR TITLE
Samples and tests: Refactors to use .NET 6

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos.Encryption.Tests</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionDatabaseResponse.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionDatabaseResponse.cs
@@ -9,6 +9,10 @@ namespace Microsoft.Azure.Cosmos.Encryption
 
     internal sealed class EncryptionDatabaseResponse : DatabaseResponse
     {
+        private readonly DatabaseResponse databaseResponse;
+
+        private readonly EncryptionCosmosClient encryptionCosmosClient;
+
         public EncryptionDatabaseResponse(
             DatabaseResponse databaseResponse,
             EncryptionCosmosClient encryptionCosmosClient)
@@ -18,10 +22,6 @@ namespace Microsoft.Azure.Cosmos.Encryption
         }
 
         public override Database Database => new EncryptionDatabase(this.databaseResponse.Database, this.encryptionCosmosClient);
-
-        private readonly DatabaseResponse databaseResponse;
-
-        private readonly EncryptionCosmosClient encryptionCosmosClient;
 
         public override Headers Headers => this.databaseResponse.Headers;
 

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionProcessor.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
                 return input;
             }
 
-            Debug.Assert(input.CanSeek);
+            Debug.Assert(input.CanSeek, "DecryptAsync input.CanSeek false");
 
             operationDiagnostics?.Begin(Constants.DiagnosticsDecryptOperation);
             JObject itemJObj = RetrieveItem(input);
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
             EncryptionSettings encryptionSettings,
             CancellationToken cancellationToken)
         {
-            Debug.Assert(document != null);
+            Debug.Assert(document != null,  "DecryptAsync document null");
 
             int propertiesDecryptedCount = await DecryptObjectAsync(
                 document,
@@ -399,7 +399,7 @@ namespace Microsoft.Azure.Cosmos.Encryption
         private static JObject RetrieveItem(
             Stream input)
         {
-            Debug.Assert(input != null);
+            Debug.Assert(input != null, "RetrieveItem input stream null");
 
             JObject itemJObj;
             using (StreamReader sr = new StreamReader(input, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: 1024, leaveOpen: true))

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos.Encryption.EmulatorTests</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Microsoft.Azure.Cosmos.Encryption.Tests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/Microsoft.Azure.Cosmos.Encryption.Tests.csproj
@@ -1,10 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos.Encryption.Tests</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>CosmosBenchmark</RootNamespace>
     <AssemblyName>CosmosBenchmark</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CosmosCTL.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>CosmosCTL</RootNamespace>
     <AssemblyName>CosmosCTL</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/AzureFunctions/AzureFunctions.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/AzureFunctions/AzureFunctions.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
     <AssemblyName>Cosmos.Samples.AzureFunctions</AssemblyName>
     <RootNamespace>Cosmos.Samples.AzureFunctions</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/BulkExecutorMigration/BulkExecutorMigration.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/BulkExecutorMigration/BulkExecutorMigration.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.BulkExecutorMigration</AssemblyName>
     <RootNamespace>Cosmos.Samples.BulkExecutorMigration</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/BulkSupport/BulkSupport.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/BulkSupport/BulkSupport.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.BulkSupport</AssemblyName>
     <RootNamespace>Cosmos.Samples.BulkSupport</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/ChangeFeed.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ChangeFeed/ChangeFeed.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.ChangeFeed</AssemblyName>
     <RootNamespace>Cosmos.Samples.ChangeFeed</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ContainerManagement/ContainerManagement.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ContainerManagement/ContainerManagement.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos.Samples/Usage/CustomSerialization/CustomSerialization.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/CustomSerialization/CustomSerialization.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/DatabaseManagement/DatabaseManagement.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/DatabaseManagement/DatabaseManagement.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos.Samples/Usage/Encryption/Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Encryption/Encryption.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.Encryption</AssemblyName>
     <RootNamespace>Cosmos.Samples.Encryption</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/Geospatial/Geospatial.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Geospatial/Geospatial.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/Handlers/HandlerSample.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Handlers/HandlerSample.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Cosmos.Samples.Handlers</AssemblyName>
     <RootNamespace>Cosmos.Samples.Handlers</RootNamespace>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/HttpClientFactory.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/HttpClientFactory/HttpClientFactory.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/IndexManagement/IndexManagement.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/IndexManagement/IndexManagement.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ItemManagement/ItemManagement.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ItemManagement/ItemManagement.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/NonPartitionContainerMigration/NonPartitionContainerMigration.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/NonPartitionContainerMigration/NonPartitionContainerMigration.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellRestApi.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/PowerShellRestApi/PowerShellRestApi.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/Queries/Queries.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Queries/Queries.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ReEncryption/ReEncryption.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ReEncryption/ReEncryption.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.ReEncryption</AssemblyName>
     <RootNamespace>Cosmos.Samples.ReEncryption</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/ServerSideScripts/ServerSideScripts.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/ServerSideScripts/ServerSideScripts.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.SystemTextJson</AssemblyName>
     <RootNamespace>Cosmos.Samples.SystemTextJson</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/TransactionalBatch.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/TransactionalBatch/TransactionalBatch.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Cosmos.Samples.TransactionalBatch</AssemblyName>
     <RootNamespace>Cosmos.Samples.TransactionalBatch</RootNamespace>
     <LangVersion>latest</LangVersion>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/UserManagement/UserManagement.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/UserManagement/UserManagement.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -447,12 +447,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private static async Task<ClientEncryptionKeyProperties> CreateCekAsync(DatabaseInlineCore databaseCore, string cekId)
         {
-            byte[] rawCek = new byte[32];
             // Generate random bytes cryptographically.
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
-            {
-                rngCsp.GetBytes(rawCek);
-            }
+            byte[] rawCek = RandomNumberGenerator.GetBytes(32);
 
             ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
 
@@ -475,12 +471,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             ClientEncryptionKeyCore cek = (ClientEncryptionKeyInlineCore)databaseCore.GetClientEncryptionKey(cekId);
 
-            byte[] rawCek = new byte[32];
             // Generate random bytes cryptographically.
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
-            {
-                rngCsp.GetBytes(rawCek);
-            }
+            byte[] rawCek = RandomNumberGenerator.GetBytes(32);
 
             ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "updatedMetadataValue"));
 
@@ -506,12 +498,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             string cekId = "Cek1";
 
-            byte[] rawCek1 = new byte[32];
             // Generate random bytes cryptographically.
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
-            {
-                rngCsp.GetBytes(rawCek1);
-            }
+            byte[] rawCek1 = RandomNumberGenerator.GetBytes(32);
 
             ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek1, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
 
@@ -521,12 +509,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             cekId = "Cek2";
 
-            byte[] rawCek2 = new byte[32];
             // Generate random bytes cryptographically.
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
-            {
-                rngCsp.GetBytes(rawCek2);
-            }
+            byte[] rawCek2 = RandomNumberGenerator.GetBytes(32);
 
             cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek2, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -1293,9 +1293,9 @@
                                 .Select(x => x != string.Empty ? x.Substring("            ".Length) : string.Empty))
                     + Environment.NewLine;
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    throw ex;
+                    throw;
                 }
                 xmlWriter.WriteCData(setup ?? "asdf");
                 xmlWriter.WriteEndElement();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -371,12 +371,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             EncryptionKeyWrapMetadata metadata = new EncryptionKeyWrapMetadata("custom", dekId, "tempMetadata");
 
-            byte[] wrappedDataEncryptionKey = new byte[32];
             // Generate random bytes cryptographically.
-            using (RNGCryptoServiceProvider rngCsp = new RNGCryptoServiceProvider())
-            {
-                rngCsp.GetBytes(wrappedDataEncryptionKey);
-            }
+            byte[] wrappedDataEncryptionKey =  RandomNumberGenerator.GetBytes(32);
 
             ClientEncryptionKeyProperties clientEncryptionKeyProperties = new ClientEncryptionKeyProperties(
                 dekId,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Microsoft.Azure.Cosmos.Performance.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Microsoft.Azure.Cosmos.Performance.Tests.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos</RootNamespace>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/BatchResponsePayloadWriter.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/BatchResponsePayloadWriter.cs
@@ -95,13 +95,10 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
                 }
             }
 
-            if (result.RetryAfter != null)
+            r = writer.WriteUInt32("retryAfterMilliseconds", (uint)result.RetryAfter.TotalMilliseconds);
+            if (r != Result.Success)
             {
-                r = writer.WriteUInt32("retryAfterMilliseconds", (uint)result.RetryAfter.TotalMilliseconds);
-                if (r != Result.Success)
-                {
-                    return r;
-                }
+                return r;
             }
 
             r = writer.WriteFloat64("requestCharge", result.RequestCharge);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchResponsePayloadWriter.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchResponsePayloadWriter.cs
@@ -90,13 +90,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                 }
             }
 
-            if (result.RetryAfter != null)
+            r = writer.WriteUInt32("retryAfterMilliseconds", (uint)result.RetryAfter.TotalMilliseconds);
+            if (r != Result.Success)
             {
-                r = writer.WriteUInt32("retryAfterMilliseconds", (uint)result.RetryAfter.TotalMilliseconds);
-                if (r != Result.Success)
-                {
-                    return r;
-                }
+                return r;
             }
 
             r = writer.WriteFloat64("requestCharge", result.RequestCharge);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -170,7 +170,9 @@ namespace Microsoft.Azure.Cosmos
                 CosmosOperationCanceledException ex = await Assert.ThrowsExceptionAsync<CosmosOperationCanceledException>(() => client.GetContainer("test", "test").ReadItemAsync<dynamic>("id", partitionKey: new Cosmos.PartitionKey("id"), cancellationToken: cancellationToken),
                     "Should have surfaced OperationCanceledException because the token was canceled.");
                 Assert.IsTrue(ex.CancellationToken.IsCancellationRequested);
-                Assert.ReferenceEquals(cancellationToken, ex.CancellationToken);
+                Assert.AreEqual(cancellationToken.IsCancellationRequested, ex.CancellationToken.IsCancellationRequested);
+                Assert.AreEqual(cancellationToken.CanBeCanceled, ex.CancellationToken.CanBeCanceled);
+                Assert.AreEqual(cancellationToken.WaitHandle, ex.CancellationToken.WaitHandle);
 
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.MarkEndpointUnavailableForRead(It.IsAny<Uri>()), Times.Once, "Should had marked the endpoint unavailable");
                 ((MockDocumentClient)client.DocumentClient).MockGlobalEndpointManager.Verify(gep => gep.RefreshLocationAsync(false), Times.Once, "Should had refreshed the account information");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseTests.cs
@@ -64,13 +64,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 Properties = new Dictionary<string, string> { { "key", "value" } }
             };
 
-            byte[] buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
-
-            formatter.Serialize(stream1, originalLease);
-            var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);
+            string json = JsonConvert.SerializeObject(originalLease);
+            DocumentServiceLeaseCore lease = JsonConvert.DeserializeObject<DocumentServiceLeaseCore>(json);
 
             Assert.AreEqual(originalLease.Id, lease.Id);
             Assert.AreEqual(originalLease.ETag, lease.ETag);
@@ -87,13 +82,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateSerialization_NullFields()
         {
             DocumentServiceLeaseCore originalLease = new DocumentServiceLeaseCore();
-            byte[]buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
-
-            formatter.Serialize(stream1, originalLease);
-            var lease = (DocumentServiceLeaseCore)formatter.Deserialize(stream2);
+            string json = JsonConvert.SerializeObject(originalLease);
+            DocumentServiceLeaseCore lease = JsonConvert.DeserializeObject<DocumentServiceLeaseCore>(json);
 
             Assert.IsNull(lease.Id);
             Assert.IsNull(lease.ETag);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/LeaseLostExceptionTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using Newtonsoft.Json;
 
     [TestClass]
     [TestCategory("ChangeFeed")]
@@ -63,13 +64,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         {
             DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore() { LeaseId = "id" };
             LeaseLostException originalException = new LeaseLostException(lease, new Exception("foo"), true);
-            byte[] buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
 
-            formatter.Serialize(stream1, originalException);
-            LeaseLostException deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+            string serialized = JsonConvert.SerializeObject(originalException);
+            LeaseLostException deserializedException = JsonConvert.DeserializeObject<LeaseLostException>(serialized);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
@@ -82,13 +79,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateSerialization_NullFields()
         {
             LeaseLostException originalException = new LeaseLostException("message");
-            byte[] buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
 
-            formatter.Serialize(stream1, originalException);
-            LeaseLostException deserializedException = (LeaseLostException)formatter.Deserialize(stream2);
+            string serialized = JsonConvert.SerializeObject(originalException);
+            LeaseLostException deserializedException = JsonConvert.DeserializeObject<LeaseLostException>(serialized);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.IsNull(deserializedException.InnerException);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/Exceptions/ObserverExceptionTests.cs
@@ -7,9 +7,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using System;
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
+    using System.Text;
     using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
+    using Newtonsoft.Json;
 
     [TestClass]
     [TestCategory("ChangeFeed")]
@@ -37,13 +39,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             ChangeFeedProcessorContextCore changeFeedProcessorContext = new ChangeFeedProcessorContextCore(observerContext);
             Exception exception = new Exception("randomMessage");
             ChangeFeedProcessorUserException originalException = new ChangeFeedProcessorUserException(exception, changeFeedProcessorContext);
-            byte[] buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
 
-            formatter.Serialize(stream1, originalException);
-            ChangeFeedProcessorUserException deserializedException = (ChangeFeedProcessorUserException)formatter.Deserialize(stream2);
+            string json = JsonConvert.SerializeObject(originalException);
+            ChangeFeedProcessorUserException deserializedException = JsonConvert.DeserializeObject<ChangeFeedProcessorUserException>(json);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.AreEqual(originalException.InnerException.Message, deserializedException.InnerException.Message);
@@ -54,13 +52,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public void ValidateSerialization_NullFields()
         {
             ChangeFeedProcessorUserException originalException = new ChangeFeedProcessorUserException(null, null);
-            byte[] buffer = new byte[4096];
-            BinaryFormatter formatter = new BinaryFormatter();
-            MemoryStream stream1 = new MemoryStream(buffer);
-            MemoryStream stream2 = new MemoryStream(buffer);
-
-            formatter.Serialize(stream1, originalException);
-            ChangeFeedProcessorUserException deserializedException = (ChangeFeedProcessorUserException)formatter.Deserialize(stream2);
+            string json = JsonConvert.SerializeObject(originalException);
+            ChangeFeedProcessorUserException deserializedException = JsonConvert.DeserializeObject<ChangeFeedProcessorUserException>(json);
 
             Assert.AreEqual(originalException.Message, deserializedException.Message);
             Assert.IsNull(deserializedException.InnerException);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup>
     <Platform>AnyCPU</Platform>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Microsoft.Azure.Cosmos.Tests</RootNamespace>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/MockQueryPipelineStage.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices.WindowsRuntime;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
@@ -1465,11 +1465,6 @@
 
         public override bool Equals(object obj)
         {
-            if (object.ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-
             if (obj is GetPartitionedQueryExecutionInfoOptions other)
             {
                 return this.AllowNonValueAggregateQuery == other.AllowNonValueAggregateQuery

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -849,9 +849,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                                 .Select(x => x != string.Empty ? x.Substring("            ".Length) : string.Empty))
                     + Environment.NewLine;
                 }
-                catch(Exception ex)
+                catch(Exception)
                 {
-                    throw ex;
+                    throw;
                 }
                 xmlWriter.WriteCData(setup ?? "asdf");
                 xmlWriter.WriteEndElement();

--- a/UpdateDotNetVersion.ps1
+++ b/UpdateDotNetVersion.ps1
@@ -1,0 +1,11 @@
+﻿# Script to update all the csproj .NET target framework version
+$projFiles = Get-ChildItem . *.csproj -rec
+
+foreach ($file in $projFiles)
+{
+    $content = (Get-Content $file.PSPath)
+    if($content -match "<TargetFramework>netcoreapp3.1</TargetFramework>"){
+    
+        $content -replace "<TargetFramework>netcoreapp3.1</TargetFramework>", "<TargetFramework>net6.0</TargetFramework>" | Set-Content $file.PSPath
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

.NET core 3.1 support will end this year. Bumping to .NET 6 which is the latest LTS version.
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

Added a script to help bump version in the future.

RNGCryptoServiceProvider is now obsolete. Converted to use: RandomNumberGenerator
https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.rngcryptoserviceprovider?view=net-6.0

BinaryFormatter is obsolete and not safe. Switched to use newtonsoft instead.
https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide

Fixed other small warnings. Like removing unnecessary null checks, adding messages to debug asserts, fixing field orders, etc...
## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber