### PR TITLE
Benchmark: Fixes file not found from missing assembly CommandLineParser

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -156,8 +156,8 @@ namespace CosmosBenchmark
                 settings.AutoHelp = true;
             });
             parser.ParseArguments<BenchmarkConfig>(args)
-                .WithParsed<BenchmarkConfig>(e => options = e);
-            //    .WithNotParsed<BenchmarkConfig>(e => BenchmarkConfig.HandleParseError(e));
+                .WithParsed<BenchmarkConfig>(e => options = e)
+                .WithNotParsed<BenchmarkConfig>(e => BenchmarkConfig.HandleParseError(e));
 
             if (options.PublishResults)
             {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -156,8 +156,8 @@ namespace CosmosBenchmark
                 settings.AutoHelp = true;
             });
             parser.ParseArguments<BenchmarkConfig>(args)
-                .WithParsed<BenchmarkConfig>(e => options = e)
-                .WithNotParsed<BenchmarkConfig>(e => BenchmarkConfig.HandleParseError(e));
+                .WithParsed<BenchmarkConfig>(e => options = e);
+            //    .WithNotParsed<BenchmarkConfig>(e => BenchmarkConfig.HandleParseError(e));
 
             if (options.PublishResults)
             {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
@@ -17,7 +17,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="*" />
   </ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
@@ -6,7 +6,6 @@
     <AssemblyName>CosmosBenchmark</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <LangVersion>$(LangVersion)</LangVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -18,8 +17,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.5.0" />
-    <PackageReference Include="MathNet.Numerics" Version="4.12.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.0-preview1" />
+    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="*" />
   </ItemGroup>
 


### PR DESCRIPTION
# Pull Request Template

## Description

CopyLocalLockFileAssemblies causes the .NET 6 project to fail at runtime. It throws a FileNotFoundException for the CommandLineParser assembly. Bumping the dependency to the latest version.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber