### PR TITLE
Direct: Adds direct package version 3.24.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.23.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.23.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.23.1</DirectVersion>
+		<DirectVersion>3.24.1</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV19</EncryptionVersion>
 		<CustomEncryptionVersion>1.0.0-preview02</CustomEncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>

--- a/Microsoft.Azure.Cosmos/src/Regions.cs
+++ b/Microsoft.Azure.Cosmos/src/Regions.cs
@@ -329,5 +329,10 @@ namespace Microsoft.Azure.Cosmos
         /// Name of the Azure Sweden South region in the Azure Cosmos DB service.
         /// </summary>
         public const string SwedenSouth = "Sweden South";
+
+        /// <summary>
+        /// Name of the Azure Qatar Central region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string QatarCentral = "Qatar Central";
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
@@ -119,7 +119,7 @@
             ITrace trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
             SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(trace);
             Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value.Keys.Count, 2);
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(410, 0)], 3);
+            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(410, (int)SubStatusCodes.TransportGenerated410)], 3);
             Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(201, 0)], 1);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
             string message = responseMessage.ErrorMessage;
             Assert.AreEqual(message, responseMessage.CosmosException.Message);
-            Assert.IsTrue(message.Contains("ServiceUnavailable (503); Substatus: 0; ActivityId:"));
+            Assert.IsTrue(message.Contains($"ServiceUnavailable (503); Substatus: {(int)SubStatusCodes.TransportGenerated503}; ActivityId:")); 
             Assert.IsTrue(message.Contains("Reason: (Message: Channel is closed"), "Should contain exception message");
             string diagnostics = responseMessage.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -389,7 +389,22 @@
                   "startTimeUtc": "2021-12-31T23:59:59.06Z",
                   "durationInMs": 0
                 }
-              ]
+              ],
+              "serviceEndpointStats": {
+                "inflightRequests": 2,
+                "openConnections": 1
+              },
+              "connectionStats": {
+                "waitforConnectionInit": "True",
+                "callsPendingReceive": 1,
+                "lastSendAttempt": "2021-12-31T23:59:59.059Z",
+                "lastSend": "2021-12-31T23:59:59.059Z",
+                "lastReceive": "2021-12-31T23:59:59.059Z"
+              },
+              "requestSizeInBytes": 2,
+              "requestBodySizeInBytes": 1,
+              "responseMetadataSizeInBytes": 1,
+              "responseBodySizeInBytes": 1
             },
             "TransportException": null
           }
@@ -582,7 +597,22 @@
                   "startTimeUtc": "2021-12-31T23:59:59.06Z",
                   "durationInMs": 0
                 }
-              ]
+              ],
+              "serviceEndpointStats": {
+                "inflightRequests": 2,
+                "openConnections": 1
+              },
+              "connectionStats": {
+                "waitforConnectionInit": "True",
+                "callsPendingReceive": 1,
+                "lastSendAttempt": "2021-12-31T23:59:59.059Z",
+                "lastSend": "2021-12-31T23:59:59.059Z",
+                "lastReceive": "2021-12-31T23:59:59.059Z"
+              },
+              "requestSizeInBytes": 2,
+              "requestBodySizeInBytes": 1,
+              "responseMetadataSizeInBytes": 1,
+              "responseBodySizeInBytes": 1
             },
             "TransportException": null
           }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CancellationTokenTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Cosmos
                         Assert.Fail("There should only be 1 TCP request that triggers an address resolution.");
                     }
 
-                    throw new GoneException(new TransportException(TransportErrorCode.ConnectFailed, null, Guid.NewGuid(), new Uri("http://one.com"), "description", true, true));
+                    throw new GoneException(new TransportException(TransportErrorCode.ConnectFailed, null, Guid.NewGuid(), new Uri("http://one.com"), "description", true, true), SubStatusCodes.Unknown);
                 }
 
                 using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosExceptionTests.cs
@@ -297,7 +297,8 @@ namespace Microsoft.Azure.Cosmos
             {
                 throw new ServiceUnavailableException(
                     message: errorMessage,
-                    innerException: transportException);
+                    innerException: transportException,
+                    SubStatusCodes.Unknown);
             }
             catch (DocumentClientException exception)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             TransportAddressUri physicalUri)
         {
             mockTransportClient.Setup(x => x.InvokeResourceOperationAsync(physicalUri, It.IsAny<DocumentServiceRequest>()))
-                .Returns(() => throw new ServiceUnavailableException($"Mock write forbidden exception on URI:{physicalUri}", physicalUri.Uri));
+                .Returns(() => throw new ServiceUnavailableException($"Mock write forbidden exception on URI:{physicalUri}", SubStatusCodes.Unknown, physicalUri.Uri));
         }
 
         internal static void SetupRequestTimeoutException(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -754,6 +754,19 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
 
             field = transportRequestStats.GetType().GetField("requestCompletedTime", BindingFlags.NonPublic | BindingFlags.Instance);
             field.SetValue(transportRequestStats, TimeSpan.FromMilliseconds(1));
+
+            transportRequestStats.RequestSizeInBytes = 2;
+            transportRequestStats.RequestBodySizeInBytes = 1;
+            transportRequestStats.ResponseBodySizeInBytes = 1;
+            transportRequestStats.ResponseMetadataSizeInBytes = 1;
+
+            transportRequestStats.NumberOfInflightRequestsToEndpoint = 2;
+            transportRequestStats.NumberOfOpenConnectionsToEndpoint = 1;
+            transportRequestStats.NumberOfInflightRequestsInConnection = 1;
+            transportRequestStats.RequestWaitingForConnectionInitialization = true;
+            transportRequestStats.ConnectionLastSendTime = defaultDateTime;
+            transportRequestStats.ConnectionLastSendAttemptTime = defaultDateTime;
+            transportRequestStats.ConnectionLastReceiveTime = defaultDateTime;
             return transportRequestStats;
         }
 


### PR DESCRIPTION
## Improvements

- Sub status: Adds SDK generated substatus codes for 503's
- Diagnostics: Captures diagnostics for Splits and RequestTimeoutExcpetion
- Performance: Reduces the size of the Rntbd buffer
- Diagnostics: Adds ServiceEndpoint and Connection Stats to the diagnostics
- Availability: Direct mode removes blocking call on broken connection exception
- Availability: Fixes the SDK to ensure it does not retry on replica that previously failed with 410, 408 and >= 500 status codes
- Session: Fixes scoped session tokens on partition splits and multiple write endpoints enabled.
- DefaultTraceListener: Removes DefaultTraceListener by default unless there is a debugger attached to it.
- Diagnostics: Resetting thread starvation status once it is detected.
- Hierarchical Partitioning: Provides an EPK range for partial partition key specification.
- Session: Fixes gateway session scope during merges