### PR TITLE
[Internal] API Version: Updates DefaultAPIVersion to v2019_10_14 to indicate merge support

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Cosmos
 #if PREVIEW
             HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2020_07_15;
 #else
-            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2018_12_31;
+            HttpConstants.Versions.CurrentVersion = HttpConstants.Versions.v2019_10_14;
 #endif
             HttpConstants.Versions.CurrentVersionUTF8 = Encoding.UTF8.GetBytes(HttpConstants.Versions.CurrentVersion);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
@@ -27,8 +27,8 @@ namespace Microsoft.Azure.Cosmos.Contracts
             Assert.AreEqual(HttpConstants.Versions.v2020_07_15, HttpConstants.Versions.CurrentVersion);
             CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(HttpConstants.Versions.v2020_07_15), HttpConstants.Versions.CurrentVersionUTF8);
 #else
-            Assert.AreEqual(HttpConstants.Versions.v2018_12_31, HttpConstants.Versions.CurrentVersion);
-            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(HttpConstants.Versions.v2018_12_31), HttpConstants.Versions.CurrentVersionUTF8);
+            Assert.AreEqual(HttpConstants.Versions.v2019_10_14, HttpConstants.Versions.CurrentVersion);
+            CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(HttpConstants.Versions.v2019_10_14), HttpConstants.Versions.CurrentVersionUTF8);
 #endif
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Changing the API version to v2019_10_14, any version greater than or equal to this will indicate to cosmos db that SDK is capable of handling partition merge. We plan to block sdks that do not have support when partitionmerge feature will be turned on in the service.
 
## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber