### PR TITLE
Documentation: Adds remark to clarify delete behavior

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -828,7 +828,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ItemResponse{T}"/> which will contain information about the request issued.</returns>
         /// <remarks>
-        /// The deleted item is never returned, even when <see cref="ItemRequestOptions.EnableContentResponseOnWrite"/> is set to true.
+        /// <see cref="ItemResponse{T}.Resource"/> is <see href="https://docs.microsoft.com/rest/api/cosmos-db/delete-a-document#body">always null</see>
         /// </remarks>
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#typed-api</exception>
         /// <example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -827,6 +827,9 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="requestOptions">(Optional) The options for the item request.</param>
         /// <param name="cancellationToken">(Optional) <see cref="CancellationToken"/> representing request cancellation.</param>
         /// <returns>A <see cref="Task"/> containing a <see cref="ItemResponse{T}"/> which will contain information about the request issued.</returns>
+        /// <remarks>
+        /// The deleted item is never returned, even when <see cref="ItemRequestOptions.EnableContentResponseOnWrite"/> is set to true.
+        /// </remarks>
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#typed-api</exception>
         /// <example>
         /// <code language="c#">


### PR DESCRIPTION
## Description

The [`DeleteItemAsync<T>`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.container.deleteitemasync?view=azure-dotnet) method never returns the delete item, even when `ItemRequestOptions.EnableContentResponseOnWrite` is set to true. But the return type of the methos is `ItemResponse<T>` which could be confusing to users as pointed out [this issue](https://github.com/Azure/azure-sdk-for-net/issues/26739).

## Type of change

Documentation Update

## Closing issues

resolves Azure/azure-sdk-for-net#26739