### PR TITLE
Documentation: Fixes method descriptions with sql query text vs definition

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -889,7 +889,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
@@ -942,7 +941,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for databases under an Cosmos DB Account using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>

--- a/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/IDocumentClient.cs
@@ -3412,7 +3412,7 @@ namespace Microsoft.Azure.Cosmos
         IQueryable<dynamic> CreateStoredProcedureQuery(string collectionLink, string sqlExpression, FeedOptions feedOptions = null);
 
         /// <summary>
-        /// Overloaded. This method creates a query for stored procedures under a collection in an Azure Cosmos DB database using a SQL statement using a SQL statement with parameterized values. It returns an IQueryable{dynamic}.
+        /// Overloaded. This method creates a query for stored procedures under a collection in an Azure Cosmos DB database using a SQL statement with parameterized values. It returns an IQueryable{dynamic}.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="SqlQuerySpec"/>.
         /// </summary>
         /// <param name="collectionLink">The link to the parent collection resource.</param>

--- a/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/DocumentClientQueryable.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Overloaded. This method creates a query for stored procedures under a collection in an Azure Cosmos DB database using a SQL statement using a SQL statement with parameterized values. It returns an IQueryable{dynamic}.
+        /// Overloaded. This method creates a query for stored procedures under a collection in an Azure Cosmos DB database using a SQL statement with parameterized values. It returns an IQueryable{dynamic}.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="SqlQuerySpec"/>.
         /// </summary>
         /// <param name="collectionLink">The link to the parent collection resource.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -938,7 +938,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
@@ -1015,7 +1015,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement with parameterized values. It returns a FeedIterator.
+        ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement. It returns a FeedIterator.
         ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -939,7 +939,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement. It returns a FeedIterator.
-        ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -1016,7 +1015,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         ///  This method creates a query for items under a container in an Azure Cosmos database using a SQL statement. It returns a FeedIterator.
-        ///  For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/>.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -619,7 +619,7 @@ namespace Microsoft.Azure.Cosmos
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
@@ -659,7 +659,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for containers under an database using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The Cosmos SQL query definition.</param>
@@ -908,7 +908,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for users under an database using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The Cosmos SQL query definition.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -731,7 +731,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -788,7 +787,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for containers under an database using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">The continuation token in the Azure Cosmos DB service.</param>
@@ -858,7 +856,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for users under an database using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The Cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
@@ -145,7 +145,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -178,7 +177,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -607,7 +605,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -640,7 +637,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -873,7 +869,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>
@@ -906,7 +901,6 @@ namespace Microsoft.Azure.Cosmos.Scripts
 
         /// <summary>
         /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
                     CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for stored procedures under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for stored procedures under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
@@ -531,7 +531,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
@@ -565,7 +565,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for triggers under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for triggers under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
@@ -797,7 +797,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>
@@ -831,7 +831,7 @@ namespace Microsoft.Azure.Cosmos.Scripts
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for user defined functions under a container using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for user defined functions under a container using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryDefinition">The cosmos SQL query definition.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
@@ -153,7 +153,6 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// This method creates a query for permission under a user using a SQL statement. It returns a FeedIterator.
-        /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <param name="queryText">The cosmos SQL query text.</param>
         /// <param name="continuationToken">(Optional) The continuation token in the Azure Cosmos DB service.</param>

--- a/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/User/User.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Cosmos
             QueryRequestOptions requestOptions = null);
 
         /// <summary>
-        /// This method creates a query for permissions under a database using a SQL statement. It returns a FeedIterator.
+        /// This method creates a query for permissions under a database using a SQL statement with parameterized values. It returns a FeedIterator.
         /// For more information on preparing SQL statements with parameterized values, please see <see cref="QueryDefinition"/> overload.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
## Description

The description for method overloads that accept a sql query as a `string` vs a `QueryDefinition` object are misleading for some 
as discussed in [this issue](https://github.com/Azure/azure-sdk-for-net/issues/25878).

This PR fixes them.

## Type of change

Documentation

## Closing issues

resolves Azure/azure-sdk-for-net#25878