### PR TITLE
Patch test: Adds test for set on inner array

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -937,7 +937,7 @@ namespace Microsoft.Azure.Cosmos
 
             // Create the task to start the initialize task
             // Task will be awaited on in the EnsureValidClientAsync
-            Task t = this.initTaskCache.GetAsync(
+            _ = this.initTaskCache.GetAsync(
                        key: DocumentClient.DefaultInitTaskKey,
                        singleValueInitFunc: this.initializeTaskFactory,
                        forceRefresh: false,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1803,6 +1803,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
+                PatchOperation.Set("/children/0/description", "testSet"),
                 PatchOperation.Add("/children/1/pk", "patched"),
                 PatchOperation.Remove("/description"),
                 PatchOperation.Replace("/taskNum", newTaskNum),
@@ -1831,6 +1832,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
+            Assert.AreEqual("testSet", response.Resource.children[0].description);
             Assert.AreEqual("patched", response.Resource.children[1].pk);
             Assert.IsNull(response.Resource.description);
             Assert.AreEqual(newTaskNum, response.Resource.taskNum);


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a test based on a github issue. 

Final json after patch:
```json
{
    "id": "084995b1-069b-454c-824c-9a6fbf97353e",
    "taskNum": 43,
    "cost": 1.7976931348623157e+308,
    "pk": "TBD1c35b236-20ff-4b0d-bba8-a5aeb8f355fb",
    "CamelCase": "camelCase",
    "nullableInt": null,
    "valid": true,
    "children": [
        {
            "id": "child1",
            "taskNum": 30,
            "cost": 0,
            "description": "testSet",
            "pk": null,
            "CamelCase": null,
            "nullableInt": null,
            "valid": false,
            "children": null
        },
        {
            "id": "child2",
            "taskNum": 40,
            "cost": 0,
            "description": null,
            "pk": "patched",
            "CamelCase": null,
            "nullableInt": null,
            "valid": false,
            "children": null
        }
    ],
    "_rid": "-+0VAImYn-YBAAAAAAAAAA==",
    "_self": "dbs/-+0VAA==/colls/-+0VAImYn-Y=/docs/-+0VAImYn-YBAAAAAAAAAA==/",
    "_etag": "\"00000000-0000-0000-1e85-1fcf800401d8\"",
    "_attachments": "attachments/",
    "_ts": 1644501012
}
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3023