### PR TITLE
[Internal] PartitionKeyDelete: Removes Ignore flag from PartitionKeyDeleteTest

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -704,7 +704,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(itemIds.Count, 0);
         }
 
-        [Ignore] // https://github.com/Azure/azure-cosmos-dotnet-v3/issues/2981
         [TestMethod]
         public async Task PartitionKeyDeleteTest()
         {


### PR DESCRIPTION
This PR enables PartitionKeyDeleteTest by removing Ignore flag. This test now works fine with the latest emulator.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #2981 