### PR TITLE
ClientEncryption: Adds algorithm to EncryptionKeyWrapMetadata

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 DataEncryptionKeyCacheTimeToLive = null
             };
 
-            metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "key1", "tempmetadata1");
-            metadata2 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "key2", "tempmetadata2");
+            metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "key1", "tempmetadata1");
+            metadata2 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "key2", "tempmetadata2");
 
             MdeEncryptionTests.encryptionCosmosClient = MdeEncryptionTests.client.WithEncryption(testEncryptionKeyWrapProvider);
             MdeEncryptionTests.database = await MdeEncryptionTests.encryptionCosmosClient.CreateDatabaseAsync(Guid.NewGuid().ToString());
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 metadata2);
 
 
-            EncryptionKeyWrapMetadata revokedKekmetadata = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "revokedKek", "revokedKek-metadata");
+            EncryptionKeyWrapMetadata revokedKekmetadata = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "revokedKek", "revokedKek-metadata");
             await database.CreateClientEncryptionKeyAsync(
                 "keywithRevokedKek",
                 DataEncryptionKeyAlgorithm.AeadAes256CbcHmacSha256,
@@ -257,18 +257,18 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
         {
             string cekId = "anotherCek";
 			
-            EncryptionKeyWrapMetadata metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
+            EncryptionKeyWrapMetadata metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
 			
             ClientEncryptionKeyProperties clientEncryptionKeyProperties = await MdeEncryptionTests.CreateClientEncryptionKeyAsync(
                 cekId,
                 metadata1);
 
             Assert.AreEqual(
-                new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: metadata1.Value),
+                MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: metadata1.Value),
                 clientEncryptionKeyProperties.EncryptionKeyWrapMetadata);
 
             // creating another key with same id should fail
-            metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata2");
+            metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata2");
 
             try
             {
@@ -289,22 +289,22 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
         public async Task EncryptionRewrapClientEncryptionKey()
         {
             string cekId = "rewrapkeytest";
-            EncryptionKeyWrapMetadata metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
+            EncryptionKeyWrapMetadata metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
             ClientEncryptionKeyProperties clientEncryptionKeyProperties = await MdeEncryptionTests.CreateClientEncryptionKeyAsync(
                 cekId,
                 metadata1);
 
             Assert.AreEqual(
-                new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: metadata1.Value),
+                MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: metadata1.Value),
                 clientEncryptionKeyProperties.EncryptionKeyWrapMetadata);
 
-            EncryptionKeyWrapMetadata updatedMetaData = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, metadata1 + "updatedmetadata");
+            EncryptionKeyWrapMetadata updatedMetaData = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, metadata1 + "updatedmetadata");
             clientEncryptionKeyProperties = await MdeEncryptionTests.RewarpClientEncryptionKeyAsync(
                 cekId,
                 updatedMetaData);
 
             Assert.AreEqual(
-                new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: updatedMetaData.Value),
+                MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, name: cekId, value: updatedMetaData.Value),
                 clientEncryptionKeyProperties.EncryptionKeyWrapMetadata);
 
         }
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
             try
             {
                 string cekId = "testingcekID";
-                EncryptionKeyWrapMetadata metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
+                EncryptionKeyWrapMetadata metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1");
 
                 ClientEncryptionKeyResponse clientEncrytionKeyResponse = await databaseForRestrictedUser.CreateClientEncryptionKeyAsync(
                        cekId,
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
             try
             {
                 string cekId = "testingcekID";
-                EncryptionKeyWrapMetadata metadata1 = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1" + "updated");
+                EncryptionKeyWrapMetadata metadata1 = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, cekId, "testmetadata1" + "updated");
 
                 ClientEncryptionKeyResponse clientEncrytionKeyResponse = await databaseForRestrictedUser.RewrapClientEncryptionKeyAsync(
                        cekId,
@@ -1549,7 +1549,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                 DataEncryptionKeyCacheTimeToLive = TimeSpan.FromMinutes(30),
             };
 
-            EncryptionKeyWrapMetadata keyWrapMetadata = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "myCek", "mymetadata1");
+            EncryptionKeyWrapMetadata keyWrapMetadata = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider.ProviderName, "myCek", "mymetadata1");
             CosmosClient encryptionCosmosClient = mainClient.WithEncryption(testEncryptionKeyWrapProvider);
             Database mainDatabase = await encryptionCosmosClient.CreateDatabaseAsync("databaseToBeDeleted");
 
@@ -1615,7 +1615,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
 
             mainDatabase = await encryptionCosmosClient.CreateDatabaseAsync("databaseToBeDeleted");
 
-            keyWrapMetadata = new EncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider2.ProviderName, "myCek", "mymetadata2");
+            keyWrapMetadata = MdeEncryptionTests.CreateEncryptionKeyWrapMetadata(testEncryptionKeyWrapProvider2.ProviderName, "myCek", "mymetadata2");
             clientEncrytionKeyResponse = await mainDatabase.CreateClientEncryptionKeyAsync(
                    keyWrapMetadata.Name,
                    DataEncryptionKeyAlgorithm.AeadAes256CbcHmacSha256,
@@ -2981,6 +2981,15 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
                     Assert.IsTrue(propertiesDecrypted >= expectedPropertiesDecryptedCount);
                 }
             }
+        }
+
+        private static EncryptionKeyWrapMetadata CreateEncryptionKeyWrapMetadata(string type, string name, string value)
+        {
+#if SDKPROJECTREF
+            return new EncryptionKeyWrapMetadata(type, name, value, "algo");
+#else
+            return new  EncryptionKeyWrapMetadata(type, name, value);
+#endif
         }
 
         public class TestDoc

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientEncryptionKey/EncryptionKeyWrapMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientEncryptionKey/EncryptionKeyWrapMetadata.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Azure.Cosmos
     using Newtonsoft.Json.Linq;
 
     /// <summary>
-    /// Metadata that a key wrapping provider can use to wrap/unwrap data encryption keys.
+    /// Metadata that can be used to wrap/unwrap a Data Encryption Key using a Customer Managed Key.
+    /// See https://aka.ms/CosmosClientEncryption for more information on client-side encryption support in Azure Cosmos DB.
     /// </summary>
 #if PREVIEW
     public
@@ -27,14 +28,16 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Creates a new instance of key wrap metadata.
         /// </summary> 
-        /// <param name="type">ProviderName of KeyStoreProvider.</param>
-        /// <param name="name">Name of the metadata.</param>
-        /// <param name="value">Value of the metadata.</param>
-        public EncryptionKeyWrapMetadata(string type, string name, string value)
+        /// <param name="type">Identifier for the key resolver.</param>
+        /// <param name="name">Identifier for the customer managed key.</param>
+        /// <param name="value">Path to the customer managed key.</param>
+        /// <param name="algorithm">Algorithm used in wrapping and unwrapping of the data encryption key.</param>
+        public EncryptionKeyWrapMetadata(string type, string name, string value, string algorithm)
         {
             this.Type = type ?? throw new ArgumentNullException(nameof(type));
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Value = value ?? throw new ArgumentNullException(nameof(value));
+            this.Algorithm = algorithm ?? throw new ArgumentNullException(nameof(algorithm));
         }
 
         /// <summary>
@@ -42,7 +45,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="source">Existing instance from which to initialize.</param>
         public EncryptionKeyWrapMetadata(EncryptionKeyWrapMetadata source)
-            : this(source?.Type, source?.Name, source?.Value)
+            : this(source?.Type, source?.Name, source?.Value, source?.Algorithm)
         {
         }
 
@@ -71,6 +74,14 @@ namespace Microsoft.Azure.Cosmos
         public string Value { get; private set; }
 
         /// <summary>
+        /// Serialized form of metadata.
+        /// Note: This value is saved in the Cosmos DB service.
+        /// Implementors of derived implementations should ensure that this does not have (private) key material or credential information.
+        /// </summary>
+        [JsonProperty(PropertyName = "algorithm", NullValueHandling = NullValueHandling.Ignore)]
+        public string Algorithm { get; private set; }
+
+        /// <summary>
         /// This contains additional values for scenarios where the SDK is not aware of new fields. 
         /// This ensures that if resource is read and updated none of the fields will be lost in the process.
         /// </summary>
@@ -91,6 +102,7 @@ namespace Microsoft.Azure.Cosmos
             hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Type);
             hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Name);
             hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Value);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Algorithm);
             return hashCode;
         }
 
@@ -107,6 +119,7 @@ namespace Microsoft.Azure.Cosmos
                    this.Type == other.Type &&
                    this.Name == other.Name &&
                    this.Value == other.Value &&
+                   this.Algorithm == other.Algorithm &&
                    this.AdditionalProperties.EqualsTo(other.AdditionalProperties);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -639,16 +639,20 @@ namespace Microsoft.Azure.Cosmos
         ///     ("Id3", new PartitionKey("pkValue3"))
         /// };
         /// 
-        /// using (ResponseMessage responseMessage = await this.Container.ReadManyItemsStreamAsync(itemList))
+        /// using (ResponseMessage response = await this.Container.ReadManyItemsStreamAsync(itemList))
         /// {
-        ///     using (Stream stream = response.ReadBodyAsync())
+        ///     if (!response.IsSuccessStatusCode)
         ///     {
-        ///         //Read or do other operations with the stream
-        ///         using (StreamReader streamReader = new StreamReader(stream))
-        ///         {
-        ///             string content = streamReader.ReadToEndAsync();
-        ///         }
+        ///         //Handle and log exception
+        ///         return;
         ///     }
+        ///
+        ///     //Read or do other operations with the stream
+        ///     using (StreamReader streamReader = new StreamReader(response.Content))
+        ///     {
+        ///         string content = streamReader.ReadToEndAsync();
+        ///     }
+        ///     
         /// }
         /// ]]>
         /// </code>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosDatabaseTests.cs
@@ -416,7 +416,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(cekProperties.ResourceId);
 
             Assert.AreEqual(
-                new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"),
+                new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue", "algo"),
                 cekProperties.EncryptionKeyWrapMetadata);
 
             // Use a different client instance to avoid (unintentional) cache impact
@@ -433,7 +433,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(cekProperties.ResourceId);
 
             Assert.AreEqual(
-                new EncryptionKeyWrapMetadata("custom", "metadataName", "updatedMetadataValue"),
+                new EncryptionKeyWrapMetadata("custom", "metadataName", "updatedMetadataValue", "algo"),
                 cekProperties.EncryptionKeyWrapMetadata);
 
             // Use a different client instance to avoid (unintentional) cache impact
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Generate random bytes cryptographically.
             byte[] rawCek = RandomNumberGenerator.GetBytes(32);
 
-            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
+            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue", "algo"));
 
             ClientEncryptionKeyResponse cekResponse = await databaseCore.CreateClientEncryptionKeyAsync(cekProperties);
 
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Generate random bytes cryptographically.
             byte[] rawCek = RandomNumberGenerator.GetBytes(32);
 
-            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "updatedMetadataValue"));
+            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek, new EncryptionKeyWrapMetadata("custom", "metadataName", "updatedMetadataValue", "algo"));
 
             ClientEncryptionKeyResponse cekResponse = await cek.ReplaceAsync(cekProperties);
             Assert.AreEqual(HttpStatusCode.OK, cekResponse.StatusCode);
@@ -501,7 +501,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Generate random bytes cryptographically.
             byte[] rawCek1 = RandomNumberGenerator.GetBytes(32);
 
-            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek1, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
+            ClientEncryptionKeyProperties cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek1, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue", "algo"));
 
             ClientEncryptionKeyResponse cekResponse = await databaseCore.CreateClientEncryptionKeyAsync(cekProperties);
 
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Generate random bytes cryptographically.
             byte[] rawCek2 = RandomNumberGenerator.GetBytes(32);
 
-            cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek2, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue"));
+            cekProperties = new ClientEncryptionKeyProperties(cekId, "AEAD_AES_256_CBC_HMAC_SHA256", rawCek2, new EncryptionKeyWrapMetadata("custom", "metadataName", "metadataValue", "algo"));
 
             cekResponse = await databaseCore.CreateClientEncryptionKeyAsync(cekProperties);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -369,7 +369,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string dekId,
             DatabaseInlineCore databaseInlineCore)
         {
-            EncryptionKeyWrapMetadata metadata = new EncryptionKeyWrapMetadata("custom", dekId, "tempMetadata");
+            EncryptionKeyWrapMetadata metadata = new EncryptionKeyWrapMetadata("custom", dekId, "tempMetadata", "algo");
 
             // Generate random bytes cryptographically.
             byte[] wrappedDataEncryptionKey =  RandomNumberGenerator.GetBytes(32);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -649,6 +649,20 @@
           "Attributes": [],
           "MethodInfo": "Int32 GetHashCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.String Algorithm[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"algorithm\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "System.String Algorithm;CanRead:True;CanWrite:True;System.String get_Algorithm();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String get_Algorithm()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Algorithm();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "System.String get_Name()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -696,10 +710,10 @@
           "Attributes": [],
           "MethodInfo": "[Void .ctor(Microsoft.Azure.Cosmos.EncryptionKeyWrapMetadata), Void .ctor(Microsoft.Azure.Cosmos.EncryptionKeyWrapMetadata)]"
         },
-        "Void .ctor(System.String, System.String, System.String)": {
+        "Void .ctor(System.String, System.String, System.String, System.String)": {
           "Type": "Constructor",
           "Attributes": [],
-          "MethodInfo": "[Void .ctor(System.String, System.String, System.String), Void .ctor(System.String, System.String, System.String)]"
+          "MethodInfo": "[Void .ctor(System.String, System.String, System.String, System.String), Void .ctor(System.String, System.String, System.String, System.String)]"
         }
       },
       "NestedTypes": {}


### PR DESCRIPTION
## Description

Adds algorithm into the EncryptionKeyWrapMetadata to be able to save the algorithm used for key wrapping, instead of assuming a hard coded value. Saving the algorithm since it can vary is mandatory from the security perspective.

## Type of change
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
