### PR TITLE
ClientEncryption: Adds support for preview and non-preview version of Cosmos SDK in Encryption package.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,13 +4,15 @@
 		<ClientOfficialVersion>3.25.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.26.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
+		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>
 		<DirectVersion>3.24.1</DirectVersion>
-		<EncryptionVersion>1.0.0-previewV19</EncryptionVersion>
+		<EncryptionOfficialVersion>1.0.0</EncryptionOfficialVersion>
+		<EncryptionPreviewVersion>1.0.0</EncryptionPreviewVersion>
 		<CustomEncryptionVersion>1.0.0-preview02</CustomEncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>
 		<LangVersion>9.0</LangVersion>
 		<AboveDirBuildProps>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))</AboveDirBuildProps>
-		<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW</DefineConstants>
+		<DefineConstants Condition=" '$(IsNightly)' == 'true' or '$(IsPreview)' == 'true' ">$(DefineConstants);PREVIEW;ENCRYPTIONPREVIEW</DefineConstants>
 	</PropertyGroup>
 	<Import Project="$(AboveDirBuildProps)" Condition=" '$(AboveDirBuildProps)' != '' " />
 </Project>

--- a/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/src/EncryptionContainer.cs
@@ -454,46 +454,6 @@ namespace Microsoft.Azure.Cosmos.Encryption
             return this.container.GetFeedRangesAsync(cancellationToken);
         }
 
-        public override Task<IEnumerable<string>> GetPartitionKeyRangesAsync(
-            FeedRange feedRange,
-            CancellationToken cancellationToken = default)
-        {
-            return this.container.GetPartitionKeyRangesAsync(feedRange, cancellationToken);
-        }
-
-        public override FeedIterator GetItemQueryStreamIterator(
-            FeedRange feedRange,
-            QueryDefinition queryDefinition,
-            string continuationToken,
-            QueryRequestOptions requestOptions = null)
-        {
-            QueryRequestOptions clonedRequestOptions = requestOptions != null ? (QueryRequestOptions)requestOptions.ShallowCopy() : new QueryRequestOptions();
-
-            return new EncryptionFeedIterator(
-                this.container.GetItemQueryStreamIterator(
-                    feedRange,
-                    queryDefinition,
-                    continuationToken,
-                    clonedRequestOptions),
-                this,
-                clonedRequestOptions);
-        }
-
-        public override FeedIterator<T> GetItemQueryIterator<T>(
-            FeedRange feedRange,
-            QueryDefinition queryDefinition,
-            string continuationToken = null,
-            QueryRequestOptions requestOptions = null)
-        {
-            return new EncryptionFeedIterator<T>(
-                (EncryptionFeedIterator)this.GetItemQueryStreamIterator(
-                    feedRange,
-                    queryDefinition,
-                    continuationToken,
-                    requestOptions),
-                this.ResponseFactory);
-        }
-
         public override ChangeFeedEstimator GetChangeFeedEstimator(
             string processorName,
             Container leaseContainer)
@@ -731,6 +691,56 @@ namespace Microsoft.Azure.Cosmos.Encryption
         }
 
 #if SDKPROJECTREF
+        public override Task<ResponseMessage> DeleteAllItemsByPartitionKeyStreamAsync(
+               Cosmos.PartitionKey partitionKey,
+               RequestOptions requestOptions = null,
+               CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+#endif
+
+#if ENCRYPTIONPREVIEW
+        public override Task<IEnumerable<string>> GetPartitionKeyRangesAsync(
+           FeedRange feedRange,
+           CancellationToken cancellationToken = default)
+        {
+            return this.container.GetPartitionKeyRangesAsync(feedRange, cancellationToken);
+        }
+
+        public override FeedIterator GetItemQueryStreamIterator(
+            FeedRange feedRange,
+            QueryDefinition queryDefinition,
+            string continuationToken,
+            QueryRequestOptions requestOptions = null)
+        {
+            QueryRequestOptions clonedRequestOptions = requestOptions != null ? (QueryRequestOptions)requestOptions.ShallowCopy() : new QueryRequestOptions();
+
+            return new EncryptionFeedIterator(
+                this.container.GetItemQueryStreamIterator(
+                    feedRange,
+                    queryDefinition,
+                    continuationToken,
+                    clonedRequestOptions),
+                this,
+                clonedRequestOptions);
+        }
+
+        public override FeedIterator<T> GetItemQueryIterator<T>(
+            FeedRange feedRange,
+            QueryDefinition queryDefinition,
+            string continuationToken = null,
+            QueryRequestOptions requestOptions = null)
+        {
+            return new EncryptionFeedIterator<T>(
+                (EncryptionFeedIterator)this.GetItemQueryStreamIterator(
+                    feedRange,
+                    queryDefinition,
+                    continuationToken,
+                    requestOptions),
+                this.ResponseFactory);
+        }
+
         public override Task<ResponseMessage> DeleteAllItemsByPartitionKeyStreamAsync(
                Cosmos.PartitionKey partitionKey,
                RequestOptions requestOptions = null,

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -1,13 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyName>Microsoft.Azure.Cosmos.Encryption</AssemblyName>
+	<AssemblyName>Microsoft.Azure.Cosmos.Encryption</AssemblyName>
     <RootNamespace>Microsoft.Azure.Cosmos.Encryption</RootNamespace>
     <LangVersion>$(LangVersion)</LangVersion>
-    <IsPreview>true</IsPreview>
-    
+    <EncryptionVersion Condition=" '$(IsPreview)' != 'true' ">$(EncryptionOfficialVersion)</EncryptionVersion>
+    <EncryptionVersion Condition=" '$(IsPreview)' == 'true' ">$(EncryptionPreviewVersion)</EncryptionVersion>
+    <EncryptionVersionSuffix Condition=" '$(IsPreview)' == 'true' ">$(EncryptionPreviewSuffixVersion)</EncryptionVersionSuffix>
+    <Version Condition=" '$(EncryptionVersionSuffix)' == '' ">$(EncryptionVersion)</Version>
+    <Version Condition=" '$(EncryptionVersionSuffix)' != '' ">$(EncryptionVersion)-$(EncryptionVersionSuffix)</Version>
     <CurrentDate>$([System.DateTime]::Now.ToString(yyyyMMdd))</CurrentDate>
-    <Version>$(EncryptionVersion)</Version>
     <Company>Microsoft Corporation</Company>
     <Authors>Microsoft</Authors>
     <Description>This library provides an implementation for client-side encryption for Azure Cosmos's SQL API. For more information, refer to https://aka.ms/CosmosClientEncryption</Description>
@@ -19,22 +21,26 @@
     <PackageProjectUrl>https://github.com/Azure/azure-cosmos-dotnet-v3</PackageProjectUrl>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
     <PackageTags>microsoft;azure;cosmos;cosmosdb;documentdb;docdb;nosql;azureofficial;dotnetcore;netcore;netstandard;client;encryption;byok</PackageTags>
-  </PropertyGroup>
-  <ItemGroup>
-    <AdditionalFiles Include="..\..\Microsoft.Azure.Cosmos\src\stylecop.json" Link="stylecop.json" />
+	</PropertyGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="..\..\Microsoft.Azure.Cosmos\src\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
+	
+  <ItemGroup Condition=" '$(SdkProjectRef)' != 'True' AND '$(IsPreview)' != 'True' ">
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0-MyNP" />
   </ItemGroup>
-	
-	<ItemGroup Condition=" '$(SdkProjectRef)' != 'True' ">
-		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.23.0-preview" />
-	</ItemGroup>
 
-	<ItemGroup Condition=" '$(SdkProjectRef)' == 'True' ">
-		<ProjectReference Include="..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
-	</ItemGroup>
-	
+  <ItemGroup Condition=" '$(SdkProjectRef)' != 'True' AND '$(IsPreview)' == 'True' ">
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.25.0-MyPre" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(SdkProjectRef)' == 'True' ">
+    <ProjectReference Include="..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
-     <PackageReference Include="Azure.Core" Version="1.19.0" />
-     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />     
+    <PackageReference Include="Azure.Core" Version="1.19.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,15 +59,17 @@
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
-  
+
   <PropertyGroup>
     <SigningType>Product</SigningType>
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>..\..\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition=" '$(SdkProjectRef)' == 'True' ">
     <DefineConstants>$(DefineConstants);SDKPROJECTREF</DefineConstants>
   </PropertyGroup>
+	
 </Project>

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -2929,11 +2929,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
 
         private static EncryptionKeyWrapMetadata CreateEncryptionKeyWrapMetadata(string type, string name, string value)
         {
-#if SDKPROJECTREF
             return new EncryptionKeyWrapMetadata(type, name, value, "algo");
-#else
-            return new  EncryptionKeyWrapMetadata(type, name, value);
-#endif
         }
 
         public class TestDoc

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+	<add key="local-packages" value="Microsoft.Azure.Cosmos.Encryption\localfeed\" />
  </packageSources>
 </configuration>

--- a/templates/build-preview.yml
+++ b/templates/build-preview.yml
@@ -60,6 +60,26 @@ jobs:
       arguments: -p:Optimize=true -p:IsPreview=true;SdkProjectRef=true
       versioningScheme: OFF
 
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption Project Official
+    inputs: 
+      command: build  
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.sln 
+      arguments: -p:Optimize=true -p:IsPreview=false;
+      versioningScheme: OFF
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption Project Preview
+    inputs: 
+      command: build  
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.sln 
+      arguments: -p:Optimize=true -p:IsPreview=true;
+      versioningScheme: OFF
+
 - job:
   displayName: Encryption.Custom Project Ref SDK Preview ${{ parameters.BuildConfiguration }} 
   pool:


### PR DESCRIPTION
## Description

Adds support for both preview and non-preview version of Cosmos SDK in Encryption package and adds the pipeline to build the preview and non preview nuget packages.

## Type of change

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update
