### PR TITLE
Availability: Adds non-blocking cache to partition key ranges

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -369,7 +369,6 @@ namespace Microsoft.Azure.Cosmos
                     collectionRid: collection.ResourceId,
                     previousValue: null,
                     request: request,
-                    cancellationToken: CancellationToken.None,
                     NoOpTrace.Singleton);
 
                 if (refreshCache && collectionRoutingMap != null)
@@ -378,7 +377,6 @@ namespace Microsoft.Azure.Cosmos
                         collectionRid: collection.ResourceId,
                         previousValue: collectionRoutingMap,
                         request: request,
-                        cancellationToken: CancellationToken.None,
                         NoOpTrace.Singleton);
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
@@ -121,16 +121,20 @@ namespace Microsoft.Azure.Cosmos
                     AuthorizationTokenType.PrimaryMasterKey))
                 {
                     ContainerProperties collection = await this.collectionCache.ResolveCollectionAsync(request, cancellationToken, this.trace);
-                    CollectionRoutingMap routingMap = await this.partitionKeyRangeCache.TryLookupAsync(collection.ResourceId, null, request, cancellationToken, this.trace);
+                    CollectionRoutingMap routingMap = await this.partitionKeyRangeCache.TryLookupAsync(
+                        collectionRid: collection.ResourceId,
+                        previousValue: null,
+                        request: request,
+                        trace: this.trace);
+
                     if (routingMap != null)
                     {
                         // Force refresh.
                         await this.partitionKeyRangeCache.TryLookupAsync(
-                                collection.ResourceId,
-                                routingMap,
-                                request,
-                                cancellationToken,
-                                this.trace);
+                            collectionRid: collection.ResourceId,
+                            previousValue: routingMap,
+                            request: request,
+                            trace: this.trace);
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -508,7 +508,6 @@ namespace Microsoft.Azure.Cosmos
                 collectionRid,
                 previousValue: null,
                 request: null,
-                cancellationToken,
                 NoOpTrace.Singleton);
 
             // Not found.
@@ -523,7 +522,6 @@ namespace Microsoft.Azure.Cosmos
                     collectionRid,
                     previousValue: null,
                     request: null,
-                    cancellationToken,
                     NoOpTrace.Singleton);
             }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -82,8 +82,11 @@ namespace Microsoft.Azure.Cosmos.Routing
             ContainerProperties collection,
             CancellationToken cancellationToken)
         {
-            CollectionRoutingMap routingMap =
-                await this.routingMapProvider.TryLookupAsync(collection.ResourceId, null, null, cancellationToken, NoOpTrace.Singleton);
+            CollectionRoutingMap routingMap = await this.routingMapProvider.TryLookupAsync(
+                    collectionRid: collection.ResourceId,
+                    previousValue: null,
+                    request: null,
+                    trace: NoOpTrace.Singleton);
 
             if (routingMap == null)
             {

--- a/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Cosmos.Common
             string collectionRid,
             CollectionRoutingMap previousValue,
             DocumentServiceRequest request,
-            CancellationToken cancellationToken,
             ITrace trace);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -154,13 +154,24 @@ namespace Microsoft.Azure.Cosmos.Routing
             CollectionRoutingMap previousValue,
             CollectionRoutingMap currentValue)
         {
-            // No need to refresh because it's a new cache value
-            if (previousValue == null || currentValue == null)
+            // Previous is null then no need to force a refresh
+            // The request didn't access the cache before
+            if (previousValue == null)
             {
                 return false;
             }
 
-            // If none values match so no changes have occurred
+            // currentValue is null then the value just got initialized so
+            // is not possible for it to be stale
+            if (currentValue == null)
+            {
+                return false;
+            }
+
+            // CollectionRoutingMap uses changefeed to update the cache. The ChangeFeedNextIfNoneMatch
+            // is the continuation token for the changefeed operation. If the values do not match
+            // then another operation has already refresh the cache since this request was sent. So
+            // there is no reason to do another refresh.
             return previousValue.ChangeFeedNextIfNoneMatch == currentValue.ChangeFeedNextIfNoneMatch; 
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Routing
     {
         private const string PageSizeString = "-1";
 
-        private readonly AsyncCache<string, CollectionRoutingMap> routingMapCache;
+        private readonly AsyncCacheNonBlocking<string, CollectionRoutingMap> routingMapCache;
 
         private readonly ICosmosAuthorizationTokenProvider authorizationTokenProvider;
         private readonly IStoreModel storeModel;
@@ -36,9 +36,8 @@ namespace Microsoft.Azure.Cosmos.Routing
             IStoreModel storeModel,
             CollectionCache collectionCache)
         {
-            this.routingMapCache = new AsyncCache<string, CollectionRoutingMap>(
-                    EqualityComparer<CollectionRoutingMap>.Default,
-                    StringComparer.Ordinal);
+            this.routingMapCache = new AsyncCacheNonBlocking<string, CollectionRoutingMap>(
+                    keyEqualityComparer: StringComparer.Ordinal);
             this.authorizationTokenProvider = authorizationTokenProvider;
             this.storeModel = storeModel;
             this.collectionCache = collectionCache;
@@ -54,12 +53,19 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 Debug.Assert(ResourceId.TryParse(collectionRid, out ResourceId collectionRidParsed), "Could not parse CollectionRid from ResourceId.");
 
-                CollectionRoutingMap routingMap =
-                    await this.TryLookupAsync(collectionRid, null, null, CancellationToken.None, childTrace);
+                CollectionRoutingMap routingMap = await this.TryLookupAsync(
+                    collectionRid: collectionRid,
+                    previousValue: null,
+                    request: null,
+                    trace: childTrace);
 
                 if (forceRefresh && routingMap != null)
                 {
-                    routingMap = await this.TryLookupAsync(collectionRid, routingMap, null, CancellationToken.None, childTrace);
+                    routingMap = await this.TryLookupAsync(
+                        collectionRid: collectionRid,
+                        previousValue: routingMap,
+                        request: null,
+                        trace: childTrace);
                 }
 
                 if (routingMap == null)
@@ -78,15 +84,21 @@ namespace Microsoft.Azure.Cosmos.Routing
             ITrace trace,
             bool forceRefresh = false)
         {
-            ResourceId collectionRidParsed;
-            Debug.Assert(ResourceId.TryParse(collectionResourceId, out collectionRidParsed), "Could not parse CollectionRid from ResourceId.");
+            Debug.Assert(ResourceId.TryParse(collectionResourceId, out _), "Could not parse CollectionRid from ResourceId.");
 
-            CollectionRoutingMap routingMap =
-                await this.TryLookupAsync(collectionResourceId, null, null, CancellationToken.None, trace);
+            CollectionRoutingMap routingMap = await this.TryLookupAsync(
+                collectionRid: collectionResourceId,
+                previousValue: null,
+                request: null,
+                trace: trace);
 
             if (forceRefresh && routingMap != null)
             {
-                routingMap = await this.TryLookupAsync(collectionResourceId, routingMap, null, CancellationToken.None, trace);
+                routingMap = await this.TryLookupAsync(
+                    collectionRid: collectionResourceId,
+                    previousValue: routingMap,
+                    request: null,
+                    trace: trace);
             }
 
             if (routingMap == null)
@@ -102,20 +114,19 @@ namespace Microsoft.Azure.Cosmos.Routing
             string collectionRid,
             CollectionRoutingMap previousValue,
             DocumentServiceRequest request,
-            CancellationToken cancellationToken,
             ITrace trace)
         {
             try
             {
                 return await this.routingMapCache.GetAsync(
-                    collectionRid,
-                    previousValue,
-                    () => this.GetRoutingMapForCollectionAsync(collectionRid, 
-                                            previousValue, 
-                                            trace,
-                                            request?.RequestContext?.ClientRequestStatistics,
-                                            cancellationToken),
-                    CancellationToken.None);
+                    key: collectionRid,
+                    singleValueInitFunc: () => this.GetRoutingMapForCollectionAsync(
+                        collectionRid, 
+                        previousValue, 
+                        trace,
+                        request?.RequestContext?.ClientRequestStatistics),
+                    forceRefresh: (currentValue) => PartitionKeyRangeCache.ShouldForceRefresh(previousValue, currentValue),
+                    callBackOnForceRefresh: null);
             }
             catch (DocumentClientException ex)
             {
@@ -139,6 +150,20 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
+        private static bool ShouldForceRefresh(
+            CollectionRoutingMap previousValue,
+            CollectionRoutingMap currentValue)
+        {
+            // No need to refresh because it's a new cache value
+            if (previousValue == null || currentValue == null)
+            {
+                return false;
+            }
+
+            // If none values match so no changes have occurred
+            return previousValue.ChangeFeedNextIfNoneMatch == currentValue.ChangeFeedNextIfNoneMatch; 
+        }
+
         public async Task<PartitionKeyRange> TryGetRangeByPartitionKeyRangeIdAsync(string collectionRid, 
                             string partitionKeyRangeId, 
                             ITrace trace,
@@ -147,10 +172,14 @@ namespace Microsoft.Azure.Cosmos.Routing
             try
             {
                 CollectionRoutingMap routingMap = await this.routingMapCache.GetAsync(
-                    collectionRid,
-                    null,
-                    () => this.GetRoutingMapForCollectionAsync(collectionRid, null, trace, clientSideRequestStatistics, CancellationToken.None),
-                    CancellationToken.None);
+                    key: collectionRid,
+                    singleValueInitFunc: () => this.GetRoutingMapForCollectionAsync(
+                        collectionRid: collectionRid,
+                        previousRoutingMap: null,
+                        trace: trace,
+                        clientSideRequestStatistics: clientSideRequestStatistics),
+                    forceRefresh: (_) => false,
+                    callBackOnForceRefresh: null);
 
                 return routingMap.TryGetRangeByPartitionKeyRangeId(partitionKeyRangeId);
             }
@@ -169,11 +198,10 @@ namespace Microsoft.Azure.Cosmos.Routing
             string collectionRid,
             CollectionRoutingMap previousRoutingMap,
             ITrace trace,
-            IClientSideRequestStatistics clientSideRequestStatistics,
-            CancellationToken cancellationToken)
+            IClientSideRequestStatistics clientSideRequestStatistics)
         {
             List<PartitionKeyRange> ranges = new List<PartitionKeyRange>();
-            string changeFeedNextIfNoneMatch = previousRoutingMap == null ? null : previousRoutingMap.ChangeFeedNextIfNoneMatch;
+            string changeFeedNextIfNoneMatch = previousRoutingMap?.ChangeFeedNextIfNoneMatch;
 
             HttpStatusCode lastStatusCode = HttpStatusCode.OK;
             do
@@ -190,8 +218,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 RetryOptions retryOptions = new RetryOptions();
                 using (DocumentServiceResponse response = await BackoffRetryUtility<DocumentServiceResponse>.ExecuteAsync(
                     () => this.ExecutePartitionKeyRangeReadChangeFeedAsync(collectionRid, headers, trace, clientSideRequestStatistics),
-                    new ResourceThrottleRetryPolicy(retryOptions.MaxRetryAttemptsOnThrottledRequests, retryOptions.MaxRetryWaitTimeInSeconds),
-                    cancellationToken))
+                    new ResourceThrottleRetryPolicy(retryOptions.MaxRetryAttemptsOnThrottledRequests, retryOptions.MaxRetryWaitTimeInSeconds)))
                 {
                     lastStatusCode = response.StatusCode;
                     changeFeedNextIfNoneMatch = response.Headers[HttpConstants.HttpHeaders.ETag];

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/PartitionKeyRangeCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/PartitionKeyRangeCacheTests.cs
@@ -3,17 +3,235 @@
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.TransportClientHelper;
 
     [TestClass]
     public class PartitionKeyRangeCacheTests
     {
+        private bool loopBackgroundOperaitons = false;
+
         [TestMethod]
-        [Owner("flnarenj")]
+        public async Task VerifyPkRangeCacheRefreshOnSplitWithErrorsAsync()
+        {
+            this.loopBackgroundOperaitons = false;
+
+            int throwOnPkRefreshCount = 3;
+            int pkRangeCalls = 0;
+            bool causeSplitExceptionInRntbdCall = false;
+            HttpClientHandlerHelper httpHandlerHelper = new();
+            List<string> ifNoneMatchValues = new();
+            string failedIfNoneMatchValue = null;
+            httpHandlerHelper.RequestCallBack = (request, cancellationToken) =>
+            {
+                if (!request.RequestUri.ToString().EndsWith("pkranges"))
+                {
+                    return null;
+                }
+
+                ifNoneMatchValues.Add(request.Headers.IfNoneMatch.ToString());
+
+                pkRangeCalls++;
+
+                if (pkRangeCalls == throwOnPkRefreshCount)
+                {
+                    failedIfNoneMatchValue = request.Headers.IfNoneMatch.ToString();
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError));
+                }
+
+                return null;
+            };
+
+            int countSplitExceptions = 0;
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                HttpClientFactory = () => new HttpClient(httpHandlerHelper),
+                TransportClientHandlerFactory = (transportClient) => new TransportClientWrapper(
+                    transportClient,
+                    (uri, resource, dsr) =>
+                    {
+                        if (dsr.OperationType == Documents.OperationType.Read &&
+                            dsr.ResourceType == Documents.ResourceType.Document &&
+                            causeSplitExceptionInRntbdCall)
+                        {
+                            countSplitExceptions++;
+                            causeSplitExceptionInRntbdCall = false;
+                            throw new Documents.Routing.PartitionKeyRangeIsSplittingException("Test");
+                        }
+                    })
+            };
+
+            CosmosClient resourceClient = TestCommon.CreateCosmosClient(clientOptions);
+
+            string dbName = Guid.NewGuid().ToString();
+            string containerName = nameof(PartitionKeyRangeCacheTests);
+
+            Database db = await resourceClient.CreateDatabaseIfNotExistsAsync(dbName);
+            Container container = await db.CreateContainerIfNotExistsAsync(
+                containerName,
+                "/pk",
+                400);
+
+            // Start a background job that loops forever
+            List<Exception> exceptions = new();
+            Task backgroundItemOperatios = Task.Factory.StartNew(() => this.CreateAndReadItemBackgroundLoop(container, exceptions));
+
+            // Wait for the background job to start
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            while (!this.loopBackgroundOperaitons && stopwatch.Elapsed.TotalSeconds < 30)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(.5));
+            }
+
+            Assert.IsTrue(this.loopBackgroundOperaitons);
+            Assert.AreEqual(2, pkRangeCalls);
+
+            // Cause direct call to hit a split exception and wait for the background job to hit it
+            causeSplitExceptionInRntbdCall = true;
+            stopwatch = Stopwatch.StartNew();
+            while (causeSplitExceptionInRntbdCall && stopwatch.Elapsed.TotalSeconds < 10)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(.5));
+            }
+            Assert.IsFalse(causeSplitExceptionInRntbdCall);
+            Assert.AreEqual(3, pkRangeCalls);
+
+            // Cause another direct call split exception
+            causeSplitExceptionInRntbdCall = true;
+            stopwatch = Stopwatch.StartNew();
+            while (causeSplitExceptionInRntbdCall && stopwatch.Elapsed.TotalSeconds < 10)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(.5));
+            }
+
+            Assert.IsFalse(causeSplitExceptionInRntbdCall);
+
+            Assert.AreEqual(4, pkRangeCalls);
+
+            Assert.AreEqual(1, ifNoneMatchValues.Count(x => string.IsNullOrEmpty(x)));
+            Assert.AreEqual(3, ifNoneMatchValues.Count(x => x == failedIfNoneMatchValue), $"3 request with same if none value. 1 initial, 2 from the split errors. split exception count: {countSplitExceptions}; {string.Join(';', ifNoneMatchValues)}");
+
+            HashSet<string> verifyUniqueIfNoneHeaderValues = new HashSet<string>();
+            foreach (string ifNoneValue in ifNoneMatchValues)
+            {
+                if (!verifyUniqueIfNoneHeaderValues.Contains(ifNoneValue))
+                {
+                    verifyUniqueIfNoneHeaderValues.Add(ifNoneValue);
+                }
+                else if (ifNoneValue != failedIfNoneMatchValue)
+                {
+                    Assert.AreEqual(failedIfNoneMatchValue, ifNoneValue, $"Multiple duplicates; split exception count: {countSplitExceptions}; {string.Join(';', ifNoneMatchValues)}");
+                }
+            }
+
+            Assert.AreEqual(0, exceptions.Count, $"Unexpected exceptions: {string.Join(';', exceptions)}");
+        }
+
+        private async Task CreateAndReadItemBackgroundLoop(Container container, List<Exception> exceptions)
+        {
+            this.loopBackgroundOperaitons = true;
+
+            while (this.loopBackgroundOperaitons)
+            {
+                ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
+                try
+                {
+                    await container.CreateItemAsync<ToDoActivity>(toDoActivity);
+                    await container.ReadItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.pk));
+                }
+                catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.InternalServerError)
+                {
+                    // Expected exception caused by failure on pk range refresh
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task VerifyPkRangeCacheRefreshOnThrottlesAsync()
+        {
+            int pkRangeCalls = 0;
+            bool causeSplitExceptionInRntbdCall = false;
+            HttpClientHandlerHelper httpHandlerHelper = new();
+            List<string> ifNoneMatchValues = new();
+            httpHandlerHelper.RequestCallBack = (request, cancellationToken) =>
+            {
+                if (!request.RequestUri.ToString().EndsWith("pkranges"))
+                {
+                    return null;
+                }
+
+                ifNoneMatchValues.Add(request.Headers.IfNoneMatch.ToString());
+
+                pkRangeCalls++;
+
+                // Cause throttle on the init call
+                if (pkRangeCalls <= 3)
+                {
+                    return Task.FromResult(new HttpResponseMessage(HttpStatusCode.TooManyRequests));
+                }
+
+                return null;
+            };
+
+            int countSplitExceptions = 0;
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                HttpClientFactory = () => new HttpClient(httpHandlerHelper),
+                TransportClientHandlerFactory = (transportClient) => new TransportClientWrapper(
+                    transportClient,
+                    (uri, resource, dsr) =>
+                    {
+                        if (dsr.ResourceType == Documents.ResourceType.Document &&
+                            causeSplitExceptionInRntbdCall)
+                        {
+                            countSplitExceptions++;
+                            causeSplitExceptionInRntbdCall = false;
+                            throw new Documents.Routing.PartitionKeyRangeIsSplittingException("Test");
+                        }
+                    })
+            };
+
+            CosmosClient resourceClient = TestCommon.CreateCosmosClient(clientOptions);
+
+            string dbName = Guid.NewGuid().ToString();
+            string containerName = nameof(PartitionKeyRangeCacheTests);
+
+            Database db = await resourceClient.CreateDatabaseIfNotExistsAsync(dbName);
+            Container container = await db.CreateContainerIfNotExistsAsync(
+                containerName,
+                "/pk",
+                400);
+
+            ToDoActivity toDoActivity = ToDoActivity.CreateRandomToDoActivity();
+            await container.CreateItemAsync<ToDoActivity>(toDoActivity);
+            Assert.AreEqual(5, pkRangeCalls);
+
+            Assert.AreEqual(4, ifNoneMatchValues.Count(x => string.IsNullOrEmpty(x)), "First 3 calls are throttled and 4 succeeds");
+
+            string lastIfNoneMatchValue = ifNoneMatchValues.Last();
+            ifNoneMatchValues.Clear();
+
+            pkRangeCalls = 0;
+            causeSplitExceptionInRntbdCall = true;
+            await container.ReadItemAsync<ToDoActivity>(toDoActivity.id, new PartitionKey(toDoActivity.pk));
+            Assert.AreEqual(4, pkRangeCalls);
+
+            Assert.AreEqual(0, ifNoneMatchValues.Count(x => string.IsNullOrEmpty(x)), "The cache is already init. It should never re-initialize the cache.");
+        }
+
+        [TestMethod]
         public async Task TestRidRefreshOnNotFoundAsync()
         {
             CosmosClient resourceClient = TestCommon.CreateCosmosClient();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -188,7 +188,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
                             It.IsAny<string>(),
                             It.IsAny<CollectionRoutingMap>(),
                             It.IsAny<DocumentServiceRequest>(),
-                            It.IsAny<CancellationToken>(),
                             It.IsAny<ITrace>()
                         )
                 ).Returns(Task.FromResult<CollectionRoutingMap>(routingMap));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new Mock<ICosmosAuthorizationTokenProvider>().Object,
                 new Mock<IStoreModel>().Object,
                 collectionCache.Object);
-            partitionKeyRangeCache.Setup(c => c.TryLookupAsync(collectionRid, null, It.IsAny<DocumentServiceRequest>(), default, trace))
+            partitionKeyRangeCache.Setup(c => c.TryLookupAsync(collectionRid, null, It.IsAny<DocumentServiceRequest>(), trace))
                 .ReturnsAsync(collectionRoutingMap);
 
             string collectionLink = "dbs/DvZRAA==/colls/DvZRAOvLgDM=/";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -232,7 +232,6 @@ JsonConvert.DeserializeObject<Dictionary<string, object>>("{\"maxSqlQueryInputLe
                             It.IsAny<string>(),
                             It.IsAny<CollectionRoutingMap>(),
                             It.IsAny<DocumentServiceRequest>(),
-                            It.IsAny<CancellationToken>(),
                             It.IsAny<ITrace>()
                         )
                 ).Returns(Task.FromResult<CollectionRoutingMap>(null));


### PR DESCRIPTION
# Pull Request Template

## Description

Issues being fixed:
1. The current implementation is once a refresh occurs all other requests are blocked until the refresh completes. Even if they have 1000 partitions and only 1 is splitting all 999 partitions will be blocked until the refresh completes.
2. If the refresh fails the old cache value is lost. Then the SDK has to reload the entire which cause additional load to the service on the meta data requests.
3. Removed cancellation token being passed in. Most scenario it was already set to none. The cancellation should not be passed into cache because multiple other requests are likely to be waiting on that result. If the first request cancels it would negatively impact the rest of the requests. It's better to let the cache finish then let the request fail after.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3060