### PR TITLE
[Internal] AsyncCacheNonBlocking: Removes call back on force refresh

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -187,17 +187,22 @@ namespace Microsoft.Azure.Cosmos.Routing
                 }
 
                 PartitionAddressInformation addresses;
+                PartitionAddressInformation staleAddressInfo = null;
                 if (forceRefreshPartitionAddresses || request.ForceCollectionRoutingMapRefresh)
                 {
                     addresses = await this.serverPartitionAddressCache.GetAsync(
                         key: partitionKeyRangeIdentity,
-                        singleValueInitFunc: () => this.GetAddressesForRangeIdAsync(
+                        singleValueInitFunc: (staleAddresses) => this.GetAddressesForRangeIdAsync(
                             request,
                             partitionKeyRangeIdentity.CollectionRid,
                             partitionKeyRangeIdentity.PartitionKeyRangeId,
                             forceRefresh: forceRefreshPartitionAddresses),
-                        forceRefresh: (_) => true,
-                        callBackOnForceRefresh: (old, updated) => GatewayAddressCache.LogPartitionCacheRefresh(request.RequestContext.ClientRequestStatistics, old, updated));
+                        forceRefresh: (_) => true);
+
+                    if (staleAddressInfo != null)
+                    {
+                        GatewayAddressCache.LogPartitionCacheRefresh(request.RequestContext.ClientRequestStatistics, staleAddressInfo, addresses);
+                    }
 
                     this.suboptimalServerPartitionTimestamps.TryRemove(partitionKeyRangeIdentity, out DateTime ignoreDateTime);
                 }
@@ -205,13 +210,12 @@ namespace Microsoft.Azure.Cosmos.Routing
                 {
                     addresses = await this.serverPartitionAddressCache.GetAsync(
                         key: partitionKeyRangeIdentity,
-                        singleValueInitFunc: () => this.GetAddressesForRangeIdAsync(
+                        singleValueInitFunc: (_) => this.GetAddressesForRangeIdAsync(
                             request,
                             partitionKeyRangeIdentity.CollectionRid,
                             partitionKeyRangeIdentity.PartitionKeyRangeId,
                             forceRefresh: false),
-                        forceRefresh: (_) => false,
-                        callBackOnForceRefresh: (old, updated) => GatewayAddressCache.LogPartitionCacheRefresh(request.RequestContext.ClientRequestStatistics, old, updated));
+                        forceRefresh: (_) => false);
                 }
 
                 int targetReplicaSetSize = this.serviceConfigReader.UserReplicationPolicy.MaxReplicaSetSize;
@@ -298,13 +302,12 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             return await this.serverPartitionAddressCache.GetAsync(
                        key: partitionKeyRangeIdentity,
-                       singleValueInitFunc: () => this.GetAddressesForRangeIdAsync(
+                       singleValueInitFunc: (_) => this.GetAddressesForRangeIdAsync(
                            null,
                            partitionKeyRangeIdentity.CollectionRid,
                            partitionKeyRangeIdentity.PartitionKeyRangeId,
                            forceRefresh: true),
-                       forceRefresh: (_) => true,
-                       callBackOnForceRefresh: null);
+                       forceRefresh: (_) => true);
         }
 
         private async Task<Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation>> ResolveMasterAsync(DocumentServiceRequest request, bool forceRefresh)

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -192,11 +192,15 @@ namespace Microsoft.Azure.Cosmos.Routing
                 {
                     addresses = await this.serverPartitionAddressCache.GetAsync(
                         key: partitionKeyRangeIdentity,
-                        singleValueInitFunc: (staleAddresses) => this.GetAddressesForRangeIdAsync(
-                            request,
-                            partitionKeyRangeIdentity.CollectionRid,
-                            partitionKeyRangeIdentity.PartitionKeyRangeId,
-                            forceRefresh: forceRefreshPartitionAddresses),
+                        singleValueInitFunc: (currentCachedValue) =>
+                        { 
+                            staleAddressInfo = currentCachedValue;
+                            return this.GetAddressesForRangeIdAsync(
+                                request,
+                                partitionKeyRangeIdentity.CollectionRid,
+                                partitionKeyRangeIdentity.PartitionKeyRangeId,
+                                forceRefresh: forceRefreshPartitionAddresses);
+                        },
                         forceRefresh: (_) => true);
 
                     if (staleAddressInfo != null)

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -120,13 +120,12 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 return await this.routingMapCache.GetAsync(
                     key: collectionRid,
-                    singleValueInitFunc: () => this.GetRoutingMapForCollectionAsync(
+                    singleValueInitFunc: (_) => this.GetRoutingMapForCollectionAsync(
                         collectionRid, 
                         previousValue, 
                         trace,
                         request?.RequestContext?.ClientRequestStatistics),
-                    forceRefresh: (currentValue) => PartitionKeyRangeCache.ShouldForceRefresh(previousValue, currentValue),
-                    callBackOnForceRefresh: null);
+                    forceRefresh: (currentValue) => PartitionKeyRangeCache.ShouldForceRefresh(previousValue, currentValue));
             }
             catch (DocumentClientException ex)
             {
@@ -184,13 +183,12 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 CollectionRoutingMap routingMap = await this.routingMapCache.GetAsync(
                     key: collectionRid,
-                    singleValueInitFunc: () => this.GetRoutingMapForCollectionAsync(
+                    singleValueInitFunc: (_) => this.GetRoutingMapForCollectionAsync(
                         collectionRid: collectionRid,
                         previousRoutingMap: null,
                         trace: trace,
                         clientSideRequestStatistics: clientSideRequestStatistics),
-                    forceRefresh: (_) => false,
-                    callBackOnForceRefresh: null);
+                    forceRefresh: (_) => false);
 
                 return routingMap.TryGetRangeByPartitionKeyRangeId(partitionKeyRangeId);
             }


### PR DESCRIPTION
# Pull Request Template

## Description

Most places don't use the call back and now can be accessed with other methods. Passing in the cached value on the refresh will be used in a future PR to only do network calls if the cache is the same as it was on the request.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber