### PR TITLE
Availability: Adds logic to avoid unnecessary partition refreshes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.26.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.26.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.24.1</DirectVersion>
+		<DirectVersion>3.27.0</DirectVersion>
 		<EncryptionVersion>1.0.0-previewV20</EncryptionVersion>
 		<CustomEncryptionVersion>1.0.0-preview02</CustomEncryptionVersion>
 		<HybridRowVersion>1.1.0-preview3</HybridRowVersion>

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -367,18 +367,9 @@ namespace Microsoft.Azure.Cosmos
             {
                 CollectionRoutingMap collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
                     collectionRid: collection.ResourceId,
-                    previousValue: null,
                     request: request,
-                    NoOpTrace.Singleton);
-
-                if (refreshCache && collectionRoutingMap != null)
-                {
-                    collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
-                        collectionRid: collection.ResourceId,
-                        previousValue: collectionRoutingMap,
-                        request: request,
-                        NoOpTrace.Singleton);
-                }
+                    trace: NoOpTrace.Singleton,
+                    forceRefresh: refreshCache);
 
                 if (collectionRoutingMap != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
@@ -123,19 +123,9 @@ namespace Microsoft.Azure.Cosmos
                     ContainerProperties collection = await this.collectionCache.ResolveCollectionAsync(request, cancellationToken, this.trace);
                     CollectionRoutingMap routingMap = await this.partitionKeyRangeCache.TryLookupAsync(
                         collectionRid: collection.ResourceId,
-                        previousValue: null,
                         request: request,
-                        trace: this.trace);
-
-                    if (routingMap != null)
-                    {
-                        // Force refresh.
-                        await this.partitionKeyRangeCache.TryLookupAsync(
-                            collectionRid: collection.ResourceId,
-                            previousValue: routingMap,
-                            request: request,
-                            trace: this.trace);
-                    }
+                        trace: this.trace,
+                        forceRefresh: true);
                 }
 
                 this.retried = true;

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -506,9 +506,9 @@ namespace Microsoft.Azure.Cosmos
             PartitionKeyRangeCache partitionKeyRangeCache = await this.ClientContext.Client.DocumentClient.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton);
             CollectionRoutingMap collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
                 collectionRid,
-                previousValue: null,
                 request: null,
-                NoOpTrace.Singleton);
+                trace: NoOpTrace.Singleton,
+                forceRefresh: false);
 
             // Not found.
             if (collectionRoutingMap == null)
@@ -520,9 +520,9 @@ namespace Microsoft.Azure.Cosmos
 
                 collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
                     collectionRid,
-                    previousValue: null,
                     request: null,
-                    NoOpTrace.Singleton);
+                    trace: NoOpTrace.Singleton,
+                    forceRefresh: false);
             }
 
             return collectionRoutingMap;

--- a/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
@@ -290,5 +290,15 @@ namespace Microsoft.Azure.Cosmos.Routing
             return this.goneRanges.Contains(partitionKeyRangeId);
         }
 
+        public override int GetHashCode()
+        {
+            if (this.CollectionUniqueId == null || this.ChangeFeedNextIfNoneMatch == null)
+            {
+                return base.GetHashCode();
+            }
+
+            return HashCode.Combine(this.CollectionUniqueId, this.ChangeFeedNextIfNoneMatch);
+        }
+
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -84,9 +84,9 @@ namespace Microsoft.Azure.Cosmos.Routing
         {
             CollectionRoutingMap routingMap = await this.routingMapProvider.TryLookupAsync(
                     collectionRid: collection.ResourceId,
-                    previousValue: null,
                     request: null,
-                    trace: NoOpTrace.Singleton);
+                    trace: NoOpTrace.Singleton,
+                    forceRefresh: false);
 
             if (routingMap == null)
             {

--- a/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ICollectionRoutingMapCache.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Azure.Cosmos.Common
     {
         Task<CollectionRoutingMap> TryLookupAsync(
             string collectionRid,
-            CollectionRoutingMap previousValue,
             DocumentServiceRequest request,
-            ITrace trace);
+            ITrace trace,
+            bool forceRefresh);
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
@@ -16,7 +16,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> RequestCallBack { get; set; }
-
+        public Action<HttpRequestMessage, HttpResponseMessage> ResponseCallBack { get; set; }
+         
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             if(this.RequestCallBack != null)
@@ -32,7 +33,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             }
             
-            return await base.SendAsync(request, cancellationToken);
+            HttpResponseMessage httpResponseMessage = await base.SendAsync(request, cancellationToken);
+            this.ResponseCallBack?.Invoke(request, httpResponseMessage);
+            return httpResponseMessage;;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TransportClientHelper.cs
@@ -180,18 +180,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             private readonly Action<Uri, ResourceOperation, DocumentServiceRequest> interceptor;
             private readonly Func<Uri, ResourceOperation, DocumentServiceRequest, StoreResponse> interceptorWithStoreResult;
             private readonly Func<DocumentServiceRequest, StoreResponse, StoreResponse> interceptorAfterResult;
+            private readonly Func<Uri, ResourceOperation, DocumentServiceRequest, Task> interceptorAsync;
 
             internal TransportClientWrapper(
                 TransportClient client,
                 Action<Uri, ResourceOperation, DocumentServiceRequest> interceptor = null,
                 Func<Uri, ResourceOperation, DocumentServiceRequest, StoreResponse> interceptorWithStoreResult = null,
-                Func<DocumentServiceRequest, StoreResponse, StoreResponse> interceptorAfterResult = null)
+                Func<DocumentServiceRequest, StoreResponse, StoreResponse> interceptorAfterResult = null,
+                Func<Uri, ResourceOperation, DocumentServiceRequest, Task> interceptorAsync = null)
             {
                 Debug.Assert(client != null);
                 this.baseClient = client;
                 this.interceptor = interceptor;
                 this.interceptorWithStoreResult = interceptorWithStoreResult;
                 this.interceptorAfterResult = interceptorAfterResult;
+                this.interceptorAsync = interceptorAsync;
             }
 
             internal TransportClientWrapper(
@@ -211,6 +214,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 DocumentServiceRequest request)
             {
                 this.interceptor?.Invoke(physicalAddress, resourceOperation, request);
+                if(this.interceptorAsync != null)
+                {
+                    await this.interceptorAsync(physicalAddress, resourceOperation, request);
+                }
 
                 if (this.interceptorWithStoreResult != null)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -186,9 +186,9 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             this.partitionKeyRangeCache.Setup(
                         m => m.TryLookupAsync(
                             It.IsAny<string>(),
-                            It.IsAny<CollectionRoutingMap>(),
                             It.IsAny<DocumentServiceRequest>(),
-                            It.IsAny<ITrace>()
+                            It.IsAny<ITrace>(),
+                            It.IsAny<bool>()
                         )
                 ).Returns(Task.FromResult<CollectionRoutingMap>(routingMap));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new Mock<ICosmosAuthorizationTokenProvider>().Object,
                 new Mock<IStoreModel>().Object,
                 collectionCache.Object);
-            partitionKeyRangeCache.Setup(c => c.TryLookupAsync(collectionRid, null, It.IsAny<DocumentServiceRequest>(), trace))
+            partitionKeyRangeCache.Setup(c => c.TryLookupAsync(collectionRid, It.IsAny<DocumentServiceRequest>(), trace, It.IsAny<bool>()))
                 .ReturnsAsync(collectionRoutingMap);
 
             string collectionLink = "dbs/DvZRAA==/colls/DvZRAOvLgDM=/";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -230,9 +230,9 @@ JsonConvert.DeserializeObject<Dictionary<string, object>>("{\"maxSqlQueryInputLe
             this.partitionKeyRangeCache.Setup(
                         m => m.TryLookupAsync(
                             It.IsAny<string>(),
-                            It.IsAny<CollectionRoutingMap>(),
                             It.IsAny<DocumentServiceRequest>(),
-                            It.IsAny<ITrace>()
+                            It.IsAny<ITrace>(), 
+                            It.IsAny<bool>()
                         )
                 ).Returns(Task.FromResult<CollectionRoutingMap>(null));
             this.partitionKeyRangeCache.Setup(


### PR DESCRIPTION
# Pull Request Template

## Description

Issue: 
Request A -> goes to partition 0 -> split exception -> force refresh the cache -> gets latest value -> retry
Request B -> goes to partition 0 -> split exception -> force refresh the cache -> cache already refresh from A. Request B does a force refresh again -> retry 

This cause the SDK to do extra network calls when other requests have already updated the cache value. To solve this the hash of the cache is stored on the request. If a force refresh is requested it is only done if the cache is the same as it was on the original request. If it is different then assume the cache was already updated so there is no need to do another network call.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber