### PR TITLE
Availability: Adds retry on 408s to gateway calls for metadata operations

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -261,9 +261,20 @@ namespace Microsoft.Azure.Cosmos
                         {
                             return responseMessage;
                         }
-                       
+
+                        if (!timeoutPolicy.IsSafeToRetry(requestMessage.Method))
+                        {
+                            return responseMessage;
+                        }
+
+                        // Limit retry on timeouts to only control plane hot path operations
+                        if (!(timeoutPolicy is HttpTimeoutPolicyControlPlaneRetriableHotPath))
+                        {
+                            return responseMessage;
+                        }
+
                         bool isOutOfRetries = CosmosHttpClientCore.IsOutOfRetries(timeoutPolicy, startDateTimeUtc, timeoutEnumerator);
-                        if (isOutOfRetries || !timeoutPolicy.IsSafeToRetry(requestMessage.Method))
+                        if (isOutOfRetries)
                         {
                             return responseMessage;
                         }

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicy.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Cosmos
         public abstract IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator();
         public abstract bool IsSafeToRetry(HttpMethod httpMethod);
 
+        public abstract bool ShouldRetryBasedOnResponse(HttpMethod requestHttpMethod, HttpResponseMessage responseMessage);
+
         public static HttpTimeoutPolicy GetTimeoutPolicy(
            DocumentServiceRequest documentServiceRequest)
         {

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRead.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRead.cs
@@ -39,5 +39,10 @@ namespace Microsoft.Azure.Cosmos
         {
             return true;
         }
+
+        public override bool ShouldRetryBasedOnResponse(HttpMethod requestHttpMethod, HttpResponseMessage responseMessage)
+        {
+            return false;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
@@ -41,5 +41,25 @@ namespace Microsoft.Azure.Cosmos
         {
             return true;
         }
+
+        public override bool ShouldRetryBasedOnResponse(HttpMethod requestHttpMethod, HttpResponseMessage responseMessage)
+        { 
+            if (responseMessage == null)
+            {
+                return false;
+            }
+
+            if (responseMessage.StatusCode != System.Net.HttpStatusCode.RequestTimeout)
+            {
+                return false;
+            }
+
+            if (!this.IsSafeToRetry(requestHttpMethod))
+            {
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
@@ -41,5 +41,10 @@ namespace Microsoft.Azure.Cosmos
         {
             return httpMethod == HttpMethod.Get;
         }
+
+        public override bool ShouldRetryBasedOnResponse(HttpMethod requestHttpMethod, HttpResponseMessage responseMessage)
+        {
+            return false;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosHttpClientCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosHttpClientCoreTests.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     clientSideRequestStatistics: new ClientSideRequestStatisticsTraceDatum(DateTime.UtcNow),
                     cancellationToken: default);
              
-            Assert.AreEqual(HttpStatusCode.RequestTimeout, responseMessage.StatusCode);
+            Assert.AreEqual(HttpStatusCode.RequestTimeout, responseMessage.StatusCode, "Should be a request timeout");
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

This applies the same retry logic for a 408 from gateway that is already applied if the a timeout occurs trying to connect to the gateway. This will improve availability to customers because the SDK will not automatically retry on a timeout from gateway for metadata operation. This will only be used for cache operations where multiple requests are waiting on the result and a single timeout would result in multiple failures.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber