### PR TITLE
Session: Fixes NotFound/ReadSessionNotAvailable (404/1002) errors due to inconsistencies on internal caches on collection-recreate scenario for query-only workloads

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 partitionKeyRanges = await partitionKeyRangeCache.TryGetOverlappingRangesAsync(
-                    containerRId,
+                    refreshedContainerRId,
                     ContainerCore.allRanges,
                     trace,
                     forceRefresh: true);

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -23,7 +23,11 @@ namespace Microsoft.Azure.Cosmos.Routing
         private readonly IRetryPolicyFactory retryPolicy;
         private readonly ISessionContainer sessionContainer;
 
-        public ClientCollectionCache(ISessionContainer sessionContainer, IStoreModel storeModel, ICosmosAuthorizationTokenProvider tokenProvider, IRetryPolicyFactory retryPolicy)
+        public ClientCollectionCache(
+            ISessionContainer sessionContainer,
+            IStoreModel storeModel,
+            ICosmosAuthorizationTokenProvider tokenProvider, 
+            IRetryPolicyFactory retryPolicy)
         {
             this.storeModel = storeModel ?? throw new ArgumentNullException("storeModel");
             this.tokenProvider = tokenProvider;
@@ -38,9 +42,15 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(this.sessionContainer, this.retryPolicy.GetRequestPolicy());
+            IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(
+                this.sessionContainer, this.retryPolicy.GetRequestPolicy());
             return TaskHelper.InlineIfPossible(
-                  () => this.ReadCollectionAsync(PathsHelper.GeneratePath(ResourceType.Collection, collectionRid, false), retryPolicyInstance, trace, clientSideRequestStatistics, cancellationToken),
+                  () => this.ReadCollectionAsync(
+                      PathsHelper.GeneratePath(ResourceType.Collection, collectionRid, false), 
+                      retryPolicyInstance, 
+                      trace,
+                      clientSideRequestStatistics, 
+                      cancellationToken),
                   retryPolicyInstance,
                   cancellationToken);
         }
@@ -52,18 +62,82 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                 CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(this.sessionContainer, this.retryPolicy.GetRequestPolicy());
+            IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(
+                this.sessionContainer, this.retryPolicy.GetRequestPolicy());
             return TaskHelper.InlineIfPossible(
-                () => this.ReadCollectionAsync(resourceAddress, retryPolicyInstance, trace, clientSideRequestStatistics, cancellationToken),
+                () => this.ReadCollectionAsync(
+                    resourceAddress, retryPolicyInstance, trace, clientSideRequestStatistics, cancellationToken),
                 retryPolicyInstance,
                 cancellationToken);
         }
 
-        private async Task<ContainerProperties> ReadCollectionAsync(string collectionLink,
-                                                                    IDocumentClientRetryPolicy retryPolicyInstance,
-                                                                    ITrace trace,
-                                                                    IClientSideRequestStatistics clientSideRequestStatistics,
-                                                                    CancellationToken cancellationToken)
+        internal override Task<ContainerProperties> ResolveByNameAsync(
+            string apiVersion,
+            string resourceAddress,
+            bool forceRefesh,
+            ITrace trace,
+            IClientSideRequestStatistics clientSideRequestStatistics,
+            CancellationToken cancellationToken)
+        {
+            if (forceRefesh && this.sessionContainer != null)
+            {
+                string resourceFullName = PathsHelper.GetCollectionPath(resourceAddress);
+                this.sessionContainer.ClearTokenByCollectionFullname(resourceFullName);
+            }
+
+            return TaskHelper.InlineIfPossible(
+                () => base.ResolveByNameAsync(
+                    apiVersion, resourceAddress, forceRefesh, trace, clientSideRequestStatistics, cancellationToken),
+                retryPolicy: null,
+                cancellationToken);
+        }
+
+        public override Task<ContainerProperties> ResolveCollectionAsync(
+            DocumentServiceRequest request, CancellationToken cancellationToken, ITrace trace)
+        {
+            return TaskHelper.InlineIfPossible(
+                () => this.ResolveCollectionWithSessionContainerCleanupAsync(
+                    request,
+                    () => base.ResolveCollectionAsync(request, cancellationToken, trace)),
+                retryPolicy: null,
+                cancellationToken);
+        }
+
+        public override Task<ContainerProperties> ResolveCollectionAsync(
+            DocumentServiceRequest request, TimeSpan refreshAfter, CancellationToken cancellationToken, ITrace trace)
+        {
+            return TaskHelper.InlineIfPossible(
+                () => this.ResolveCollectionWithSessionContainerCleanupAsync(
+                    request,
+                    () => base.ResolveCollectionAsync(request, refreshAfter, cancellationToken, trace)),
+                retryPolicy: null,
+                cancellationToken);
+        }
+
+        private async Task<ContainerProperties> ResolveCollectionWithSessionContainerCleanupAsync(
+            DocumentServiceRequest request,
+            Func<Task<ContainerProperties>> resolveContainerProvider)
+        {
+            string previouslyResolvedCollectionRid = request?.RequestContext?.ResolvedCollectionRid;
+
+            ContainerProperties properties = await resolveContainerProvider();
+
+            if (this.sessionContainer != null &&
+                previouslyResolvedCollectionRid != null && 
+                previouslyResolvedCollectionRid != properties.ResourceId)
+            {
+                this.sessionContainer.ClearTokenByResourceId(previouslyResolvedCollectionRid);
+            }
+
+            return properties;
+        }
+
+        private async Task<ContainerProperties> ReadCollectionAsync(
+            string collectionLink,
+            IDocumentClientRetryPolicy retryPolicyInstance,
+            ITrace trace,
+            IClientSideRequestStatistics clientSideRequestStatistics,
+            CancellationToken cancellationToken)
         {
             using (ITrace childTrace = trace.StartChild("Read Collection", TraceComponent.Transport, TraceLevel.Info))
             { 
@@ -78,10 +152,13 @@ namespace Microsoft.Azure.Cosmos.Routing
                 {
                     request.Headers[HttpConstants.HttpHeaders.XDate] = DateTime.UtcNow.ToString("r");
 
-                    request.RequestContext.ClientRequestStatistics = clientSideRequestStatistics ?? new ClientSideRequestStatisticsTraceDatum(DateTime.UtcNow);
+                    request.RequestContext.ClientRequestStatistics = 
+                        clientSideRequestStatistics ?? new ClientSideRequestStatisticsTraceDatum(DateTime.UtcNow);
                     if (clientSideRequestStatistics == null)
                     {
-                        childTrace.AddDatum("Client Side Request Stats", request.RequestContext.ClientRequestStatistics);
+                        childTrace.AddDatum(
+                            "Client Side Request Stats",
+                            request.RequestContext.ClientRequestStatistics);
                     }
 
                     string authorizationToken = await this.tokenProvider.GetUserAuthorizationTokenAsync(
@@ -100,7 +177,8 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                         try
                         {
-                            using (DocumentServiceResponse response = await this.storeModel.ProcessMessageAsync(request))
+                            using (DocumentServiceResponse response =
+                                await this.storeModel.ProcessMessageAsync(request))
                             {
                                 return CosmosResource.FromStream<ContainerProperties>(response);
                             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemSessionTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemSessionTokenTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Net;
     using System.Threading;
     using Microsoft.Azure.Cosmos.Routing;
+    using Newtonsoft.Json.Linq;
 
     [TestClass]
     public class CosmosItemSessionTokenTests : BaseCosmosClientHelper
@@ -47,13 +48,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task CreateDropItemTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
             ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync<ToDoActivity>(item: testItem);
             Assert.IsNotNull(response);
             Assert.IsNotNull(response.Resource);
             Assert.IsNotNull(response.Diagnostics);
-            long? lsnAfterCreate = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterCreate = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterCreate);
             CosmosTraceDiagnostics diagnostics = (CosmosTraceDiagnostics)response.Diagnostics;
             Assert.IsFalse(diagnostics.IsGoneExceptionHit());
@@ -66,7 +69,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(response.Diagnostics);
             Assert.IsFalse(string.IsNullOrEmpty(response.Diagnostics.ToString()));
             Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
-            long? lsnAfterRead = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterRead = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterRead);
             Assert.AreEqual(lsnAfterCreate.Value, lsnAfterRead.Value);
 
@@ -77,7 +81,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(response.Diagnostics);
             Assert.IsFalse(string.IsNullOrEmpty(response.Diagnostics.ToString()));
             Assert.IsTrue(response.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
-            long? lsnAfterDelete = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterDelete = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterDelete);
             Assert.IsTrue(lsnAfterDelete.Value > lsnAfterCreate.Value);
         }
@@ -86,8 +91,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ReplaceItemStreamTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
@@ -99,11 +105,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             }
 
-            long? lsnAfterCreate = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterCreate = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterCreate);
 
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             using (Stream stream = TestCommon.SerializerCore.ToStream<ToDoActivity>(testItem))
             {
@@ -118,14 +126,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode, response.ErrorMessage);
 
                     // Session token should be captured for NotFound with SubStatusCode 0
-                    long? lsnAfterNotFound = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+                    long? lsnAfterNotFound = await GetLSNFromSessionContainer(
+                        this.Container, this.containerSettings, new PartitionKey(testItem.pk));
                     Assert.IsNotNull(lsnAfterNotFound);
                     Assert.AreEqual(lsnAfterCreate.Value, lsnAfterNotFound.Value);
                 }
             }
 
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
             
             //Updated the taskNum field
             testItem.taskNum = 9001;
@@ -137,7 +147,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 }
 
-                long? lsnAfterReplace= await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+                long? lsnAfterReplace= await GetLSNFromSessionContainer(
+                    this.Container, this.containerSettings, new PartitionKey(testItem.pk));
                 Assert.IsNotNull(lsnAfterReplace);
                 Assert.IsTrue(lsnAfterReplace.Value > lsnAfterCreate.Value);
 
@@ -147,7 +158,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(deleteResponse.StatusCode, HttpStatusCode.NoContent);
                 }
 
-                long? lsnAfterDelete = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+                long? lsnAfterDelete = await GetLSNFromSessionContainer(
+                    this.Container, this.containerSettings, new PartitionKey(testItem.pk));
                 Assert.IsNotNull(lsnAfterDelete);
                 Assert.IsTrue(lsnAfterDelete.Value > lsnAfterReplace.Value);
             }
@@ -157,18 +169,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task UpsertItemTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             ItemResponse<ToDoActivity> response = await this.Container.UpsertItemAsync(testItem, partitionKey: new Cosmos.PartitionKey(testItem.pk));
             Assert.IsNotNull(response);
             Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             Assert.IsNotNull(response.Headers.Session);
-            long? lsnAfterCreate = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterCreate = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterCreate);
 
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             //Updated the taskNum field
             testItem.taskNum = 9001;
@@ -178,7 +193,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Headers.Session);
 
-            long? lsnAfterUpsert = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterUpsert = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterUpsert);
             Assert.IsTrue(lsnAfterUpsert.Value > lsnAfterCreate.Value);
         }
@@ -187,8 +203,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task NoSessionTokenCaptureForThrottledUpsertRequestsTest()
         {
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync<ToDoActivity>(item: testItem);
             Assert.IsNotNull(response);
@@ -197,11 +214,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string sessionTokenHeaderValue = response.Headers[HttpConstants.HttpHeaders.SessionToken];
             Assert.IsNotNull(sessionTokenHeaderValue);
             
-            long? lsnAfterCreate = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterCreate = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNotNull(lsnAfterCreate);
 
-            this.ResetSessionToken();
-            Assert.IsNull(await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk)));
+            ResetSessionToken(this.Container);
+            Assert.IsNull(await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk)));
 
             Container throttledContainer = TransportClientHelper.GetContainerWithIntercepter(
                 this.database.Id,
@@ -230,22 +249,238 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.TooManyRequests, cosmosException.StatusCode);
             }
 
-            long? lsnAfterThrottledRequest = await this.GetLSNFromSessionContainer(new PartitionKey(testItem.pk));
+            long? lsnAfterThrottledRequest = await GetLSNFromSessionContainer(
+                this.Container, this.containerSettings, new PartitionKey(testItem.pk));
             Assert.IsNull(lsnAfterThrottledRequest);
         }
 
-        private async Task<string> GetPKRangeIdForPartitionKey(PartitionKey pkValue)
+        /// <summary>
+        /// This test functions as regression coverage for  an issue seen in a CRI - 
+        ///     https://portal.microsofticm.com/imp/v3/incidents/details/292305626/home
+        /// 
+        /// SCENARIO
+        /// - App using .Net SDK running queries against Container_1 or Container_2
+        /// - Every 24 hours the app chnages reading between the two of them
+        /// - Before switching the query app to a new Container of either name the Container was deleted, 
+        ///   re-created and data was ingested via a Spark job from a different process
+        /// - Customer was seeing 404/1002 Not Found/Read Session not available regularly
+        /// 
+        /// ROOT CAUSE
+        /// - SessionContainer and CollectionCache have both Dictionaries for a CollectionName to CollectionRid lookup
+        /// - In some places where a stale collection name was identified,  not both dictionaries were updated
+        /// - Therefore it was possible that the CollectionCache was updated so CollectionRid on DocumentServiceRequest
+        ///   was populated correctly (for the new container) but SessionContainer still mapped the container name to 
+        ///   the old CollectionRid - and as such still found the SessionToken captured from the old container
+        /// - This could result in either using a stale LSN (LSN captured on old container less than current LSN
+        ///   on new container - which would not be an issue - or LSN captured on old container was higher than the 
+        ///   latest LSN on the new container - so all subsequent queries would fail with 404/1002
+        ///   
+        /// IMPACT
+        /// - This would only permanently leave the CosmosClient in bad state when 
+        ///     - Session consistency is used, 
+        ///     - container deletes and recreates are happening,
+        ///     - no point operations are used with the same CosmsoClient instance (for point operations the 
+        ///       RenameCollectionAwareClientRetryPolicy would have recovered the client instance because the session
+        ///       cache would have been purged)
+        ///     - A CollectionCache refresh is happening after the recreation without also updating the
+        ///       SessionContainer (for example via Container.GetFeedRanges - which refreshed ColectionCache 
+        ///       but not SessionContainer). If both caches are still stale, a query would trigger a 
+        ///       410/1000 (Gone/NameCacheIsStale) for which the retry policy
+        ///       would have purged the session container and collection cache.
+        ///       
+        /// TEST COVERAGE
+        /// - Without PR xxx this test was consistently failing (either due to 404/1022 or because the requested 
+        ///   session token was lower than the latest session token captured on the new container (meaning 
+        ///   possible risk of returning outdated data and violating read your own write semantic in theory
+        ///   because the requested session token was the last session token seen on the old container 
+        ///   (but sent to backend with CollectionRid of new container which might have had further updates)
+        /// </summary>
+        /// <returns>The task representing the asynchronously processed operation</returns>
+        [TestMethod]
+        public async Task InvalidSessionTokenAfterContainerRecreationAndCollectionCacheRefreshReproTest()
         {
-            CollectionRoutingMap collectionRoutingMap = await ((ContainerInternal)this.Container).GetRoutingMapAsync(CancellationToken.None);
-            string effectivePK = pkValue.InternalKey.GetEffectivePartitionKeyString(this.containerSettings.PartitionKey);
+            // ingestionClinet is dedicated client simulating the writes / container recreation in
+            // the separate process - like Spark job
+            using CosmosClient ingestionClient = TestCommon.CreateCosmosClient();
+            Cosmos.Database ingestionDatabase = ingestionClient.GetDatabase(this.database.Id);
+
+            ContainerProperties multiPartitionContainerSettings =
+                new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: "/pk");
+            Container ingestionContainer = 
+                await ingestionDatabase.CreateContainerAsync(multiPartitionContainerSettings);
+
+            const int itemCountToBeIngested = 10;
+            string pk = Guid.NewGuid().ToString("N");
+            long? latestLsn = null;
+            Console.WriteLine("INGEST DOCUMENTS");
+            for (int i = 0; i < itemCountToBeIngested; i++)
+            {
+                ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+                testItem.pk = pk;
+
+                ItemResponse<ToDoActivity> response = 
+                    await ingestionContainer.CreateItemAsync<ToDoActivity>(item: testItem);
+                Assert.IsNotNull(response);
+                Assert.IsNotNull(response.Resource);
+                Assert.IsNotNull(response.Diagnostics);
+                long? lsnAfterCreate = await GetLSNFromSessionContainer(
+                    ingestionContainer, multiPartitionContainerSettings, new PartitionKey(pk));
+                Assert.IsNotNull(lsnAfterCreate);
+                Assert.IsTrue(latestLsn == null || lsnAfterCreate.Value > latestLsn.Value);
+                latestLsn = lsnAfterCreate;
+                CosmosTraceDiagnostics diagnostics = (CosmosTraceDiagnostics)response.Diagnostics;
+                Assert.IsFalse(diagnostics.IsGoneExceptionHit());
+                Assert.IsFalse(string.IsNullOrEmpty(diagnostics.ToString()));
+                Assert.IsTrue(diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+            }
+
+            // Dedciated query client used only for queries simulating the customer's app
+            string lastRequestedSessionToken = null;
+            Container queryContainer = TransportClientHelper.GetContainerWithIntercepter(
+                this.database.Id,
+                ingestionContainer.Id,
+                (uri, operation, request) =>
+                {
+                    if (request.ResourceType == ResourceType.Document &&
+                        request.OperationType == OperationType.Query)
+                    {
+                        lastRequestedSessionToken = request.Headers[HttpConstants.HttpHeaders.SessionToken];
+                    }
+                },
+                false,
+                null);
+
+            long? lsnAfterQueryOnOldContainer = null;
+
+            // Issueing two queries - first won't use session tokens yet
+            // second will provide session tokens captured from first request in the request to the backend
+            for (int i = 0; i < 2; i++)
+            {
+                Console.WriteLine("RUN QUERY ON OLD CONTAINER ({0})", i);
+                using FeedIterator<JObject> queryIteratorOldContainer = queryContainer.GetItemQueryIterator<JObject>(
+                    new QueryDefinition("Select c.id FROM c"),
+                    continuationToken: null,
+                    new QueryRequestOptions
+                    {
+                        ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+                        PartitionKey = new Cosmos.PartitionKey(pk)
+                    });
+                int itemCountOldContainer = 0;
+                while (queryIteratorOldContainer.HasMoreResults)
+                {
+                    FeedResponse<JObject> response = await queryIteratorOldContainer.ReadNextAsync();
+                    itemCountOldContainer += response.Count;
+                }
+
+                Assert.AreEqual(itemCountToBeIngested, itemCountOldContainer);
+                lsnAfterQueryOnOldContainer = await GetLSNFromSessionContainer(
+                        queryContainer, multiPartitionContainerSettings, new PartitionKey(pk));
+                Assert.IsNotNull(lsnAfterQueryOnOldContainer);
+                Assert.AreEqual(latestLsn.Value, lsnAfterQueryOnOldContainer.Value);
+                if (i == 0)
+                {
+                    Assert.IsNull(lastRequestedSessionToken);
+                }
+                else
+                {
+                    Assert.IsNotNull(lastRequestedSessionToken);
+                    Assert.AreEqual(latestLsn.Value, SessionTokenHelper.Parse(lastRequestedSessionToken).LSN);
+                }
+            }
+            
+            Console.WriteLine(
+                "DELETE CONTAINER {0}",
+                (await queryContainer.ReadContainerAsync()).Resource.ResourceId);
+            await ingestionContainer.DeleteContainerAsync();
+
+            Console.WriteLine("RECREATING CONTAINER...");
+            ContainerResponse ingestionContainerResponse =
+                await ingestionDatabase.CreateContainerAsync(multiPartitionContainerSettings);
+            ingestionContainer = ingestionContainerResponse.Container;
+
+            string responseSessionTokenValue = 
+                ingestionContainerResponse.Headers[HttpConstants.HttpHeaders.SessionToken];
+            long? lsnAfterRecreatingContainerFromIngestionClient = responseSessionTokenValue != null ?
+                            SessionTokenHelper.Parse(responseSessionTokenValue).LSN : null;
+            Console.WriteLine(
+                "RECREATED CONTAINER with new CollectionRid: {0} - LSN: {1}",
+                ingestionContainerResponse.Resource.ResourceId,
+                lsnAfterRecreatingContainerFromIngestionClient);
+
+            // validates that the query container still uses the LSN captured from the old LSN
+            long? lsnAfterCreatingNewContainerFromQueryClient = await GetLSNFromSessionContainer(
+                    queryContainer, multiPartitionContainerSettings, new PartitionKey(pk));
+            Assert.IsNotNull(lsnAfterCreatingNewContainerFromQueryClient);
+            Assert.AreEqual(latestLsn.Value, lsnAfterCreatingNewContainerFromQueryClient.Value);
+
+            Console.WriteLine("GET FEED RANGES");
+            // this will force a CollectionCache refresh - because no pk ranegs can be identified
+            // for the old container anymore
+            _ = await queryContainer.GetFeedRangesAsync();
+
+
+            Console.WriteLine("RUN QUERY ON NEW CONTAINER");
+            int itemCountNewContainer = 0;
+            using FeedIterator<JObject> queryIteratorNewContainer = queryContainer.GetItemQueryIterator<JObject>(
+                new QueryDefinition("Select c.id FROM c"),
+                continuationToken: null,
+                new QueryRequestOptions
+                {
+                    ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+                    PartitionKey = new Cosmos.PartitionKey(pk),
+                });
+            Console.WriteLine("Query iterator created");
+            while (queryIteratorNewContainer.HasMoreResults)
+            {
+                Console.WriteLine("Retrieving first page");
+                try
+                {
+                    FeedResponse<JObject> response = await queryIteratorNewContainer.ReadNextAsync();
+                    Console.WriteLine("Request Diagnostics for query against new container: {0}",
+                        response.Diagnostics.ToString());
+                    itemCountNewContainer += response.Count;
+                }
+                catch (CosmosException cosmosException)
+                {
+                    Console.WriteLine("COSMOS EXCEPTION: {0}", cosmosException);
+                    throw;
+                }
+            }
+
+            Assert.AreEqual(0, itemCountNewContainer);
+            long? lsnAfterQueryOnNewContainer = await GetLSNFromSessionContainer(
+                    queryContainer, multiPartitionContainerSettings, new PartitionKey(pk));
+            Assert.IsNotNull(lsnAfterQueryOnNewContainer);
+            Assert.IsTrue(
+                lastRequestedSessionToken == null || 
+                SessionTokenHelper.Parse(lastRequestedSessionToken).LSN == 
+                    lsnAfterRecreatingContainerFromIngestionClient,
+                $"The requested session token {lastRequestedSessionToken} on the last query request should be null " +
+                $"or have LSN '{lsnAfterRecreatingContainerFromIngestionClient}' (which is the LSN after " +
+                "re-creating the container) if the session cache or the new CollectionName to Rid mapping was " +
+                "correctly populated in the SessionCache.");
+        }
+
+        private static async Task<string> GetPKRangeIdForPartitionKey(
+            Container container,
+            ContainerProperties containerProperties,
+            PartitionKey pkValue)
+        {
+            CollectionRoutingMap collectionRoutingMap = 
+                await ((ContainerInternal)container).GetRoutingMapAsync(CancellationToken.None);
+            string effectivePK = 
+                pkValue.InternalKey.GetEffectivePartitionKeyString(containerProperties.PartitionKey);
 
             return collectionRoutingMap.GetRangeByEffectivePartitionKey(effectivePK).Id;
         }
 
-        private async Task<Nullable<long>> GetLSNFromSessionContainer(PartitionKey pkValue)
+        private static async Task<Nullable<long>> GetLSNFromSessionContainer(
+            Container container,
+            ContainerProperties containerProperties,
+            PartitionKey pkValue)
         {
-            string path = $"dbs/{this.Container.Database.Id}/colls/{this.Container.Id}";
-            string pkRangeId = await this.GetPKRangeIdForPartitionKey(pkValue);
+            string path = $"dbs/{container.Database.Id}/colls/{container.Id}";
+            string pkRangeId = await GetPKRangeIdForPartitionKey(container, containerProperties, pkValue);
             DocumentServiceRequest dummyRequest = new DocumentServiceRequest(
                 OperationType.Read,
                 ResourceType.Document,
@@ -254,17 +489,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 AuthorizationTokenType.PrimaryMasterKey,
                 headers: null);
 
-            ISessionToken sessionToken = this.cosmosClient.DocumentClient.sessionContainer.ResolvePartitionLocalSessionToken(
-                dummyRequest,
-                pkRangeId);
+            ISessionToken sessionToken = container
+                .Database
+                .Client
+                .DocumentClient
+                .sessionContainer
+                .ResolvePartitionLocalSessionToken(
+                    dummyRequest,
+                    pkRangeId);
 
             return sessionToken?.LSN;
         }
 
-        private void ResetSessionToken()
+        private static void ResetSessionToken(Container container)
         {
-            string path = $"dbs/{this.Container.Database.Id}/colls/{this.Container.Id}";
-            this.cosmosClient.DocumentClient.sessionContainer.ClearTokenByCollectionFullname(path);
+            string path = $"dbs/{container.Database.Id}/colls/{container.Id}";
+            container.Database.Client.DocumentClient.sessionContainer.ClearTokenByCollectionFullname(path);
 
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemSessionTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemSessionTokenTests.cs
@@ -260,17 +260,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// 
         /// SCENARIO
         /// - App using .Net SDK running queries against Container_1 or Container_2
-        /// - Every 24 hours the app chnages reading between the two of them
+        /// - Every 24 hours the app changes reading between the two of them
         /// - Before switching the query app to a new Container of either name the Container was deleted, 
         ///   re-created and data was ingested via a Spark job from a different process
         /// - Customer was seeing 404/1002 Not Found/Read Session not available regularly
         /// 
         /// ROOT CAUSE
         /// - SessionContainer and CollectionCache have both Dictionaries for a CollectionName to CollectionRid lookup
-        /// - In some places where a stale collection name was identified,  not both dictionaries were updated
-        /// - Therefore it was possible that the CollectionCache was updated so CollectionRid on DocumentServiceRequest
-        ///   was populated correctly (for the new container) but SessionContainer still mapped the container name to 
-        ///   the old CollectionRid - and as such still found the SessionToken captured from the old container
+        /// - In some places where a stale collection name was identified, not both dictionaries were updated
+        /// - Therefore, it was possible that the CollectionCache was updated so CollectionRid on
+        ///   DocumentServiceRequest was populated correctly (for the new container) but SessionContainer still mapped 
+        ///   the container name to the old CollectionRid - and as such still found the SessionToken captured from 
+        ///   the old container
         /// - This could result in either using a stale LSN (LSN captured on old container less than current LSN
         ///   on new container - which would not be an issue - or LSN captured on old container was higher than the 
         ///   latest LSN on the new container - so all subsequent queries would fail with 404/1002
@@ -279,7 +280,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         /// - This would only permanently leave the CosmosClient in bad state when 
         ///     - Session consistency is used, 
         ///     - container deletes and recreates are happening,
-        ///     - no point operations are used with the same CosmsoClient instance (for point operations the 
+        ///     - no point operations are used with the same CosmosClient instance (for point operations the 
         ///       RenameCollectionAwareClientRetryPolicy would have recovered the client instance because the session
         ///       cache would have been purged)
         ///     - A CollectionCache refresh is happening after the recreation without also updating the
@@ -289,7 +290,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         ///       would have purged the session container and collection cache.
         ///       
         /// TEST COVERAGE
-        /// - Without PR xxx this test was consistently failing (either due to 404/1022 or because the requested 
+        /// - Without PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3119 this test was consistently 
+        ///   failing (either due to 404/1022 or because the requested 
         ///   session token was lower than the latest session token captured on the new container (meaning 
         ///   possible risk of returning outdated data and violating read your own write semantic in theory
         ///   because the requested session token was the last session token seen on the old container 


### PR DESCRIPTION
# Pull Request Template

## Description

**SCENARIO**
- App using .Net SDK running queries against Container_1 or Container_2
- Every 24 hours the app changes reading between the two of them
- Before switching the query app to a new Container of either name the Container was deleted, re-created and data was ingested via a Spark job from a different process
- Customer was seeing 404/1002 Not Found/Read Session not available regularly

**ROOT CAUSE**
- SessionContainer and CollectionCache have both Dictionaries for a CollectionName to CollectionRid lookup
- In some places where a stale collection name was identified, not both dictionaries were updated
- Therefore, it was possible that the CollectionCache was updated so CollectionRid on DocumentServiceRequest was populated correctly (for the new container) but SessionContainer still mapped the container name to the old CollectionRid - and as such still found the SessionToken captured from the old container
- This could result in either using a stale LSN (LSN captured on old container less than current LSN on new container - which would not be an issue - or LSN captured on old container was higher than the latest LSN on the new container - so all subsequent queries would fail with 404/1002

**IMPACT**
- This would only permanently leave the CosmosClient in bad state when 
  - Session consistency is used, 
  - container deletes and recreates are happening,
  - no point operations are used with the same CosmosClient instance (for point operations the RenameCollectionAwareClientRetryPolicy would have recovered the client instance because the session cache would have been purged)
  - A CollectionCache refresh is happening after the recreation without also updating the SessionContainer (for example via Container.GetFeedRanges - which refreshed ColectionCache  but not SessionContainer). If both caches are still stale, a query would trigger a 410/1000 (Gone/NameCacheIsStale) for which the retry policy would have purged the session container and collection cache.
   
**TEST COVERAGE**
- Without this PR this test was consistently failing (either due to 404/1022 or because the requested session token was lower than the latest session token captured on the new container (meaning possible risk of returning outdated data and violating read your own write semantic in theory because the requested session token was the last session token seen on the old container (but sent to backend with CollectionRid of new container which might have had further updates)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber