### PR TITLE
Availability: Adds optimization to reduce metadata calls for addresses

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Net;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
@@ -113,6 +116,41 @@ namespace Microsoft.Azure.Cosmos.Tests
                 It.IsAny<RntbdConstants.RntdbEnumerationDirection>()
             )).Returns(Task.FromResult(true));
             return partitionRoutingHelperMock;
+        }
+
+        public static Task<HttpResponseMessage> CreateHttpResponseOfAddresses(List<string> physicalUris)
+        {
+            List<Address> addresses = new List<Address>();
+            for (int i = 0; i < physicalUris.Count; i++)
+            {
+                addresses.Add(new Address() 
+                { 
+                    IsPrimary = i == 0, 
+                    PhysicalUri = physicalUris[i], 
+                    Protocol = RuntimeConstants.Protocols.RNTBD, 
+                    PartitionKeyRangeId = "YxM9ANCZIwABAAAAAAAAAA==" 
+                });
+            };
+
+            FeedResource<Address> addressFeedResource = new FeedResource<Address>()
+            {
+                Id = "YxM9ANCZIwABAAAAAAAAAA==",
+                SelfLink = "dbs/YxM9AA==/colls/YxM9ANCZIwA=/docs/YxM9ANCZIwABAAAAAAAAAA==/",
+                Timestamp = DateTime.Now,
+                InnerCollection = new Collection<Address>(addresses),
+            };
+
+            StringBuilder feedResourceString = new StringBuilder();
+            addressFeedResource.SaveTo(feedResourceString);
+
+            StringContent content = new StringContent(feedResourceString.ToString());
+            HttpResponseMessage responseMessage = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = content,
+            };
+
+            return Task.FromResult(responseMessage);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

If multiple requests are running it's possible that one request refreshes the cache.
Old:
```mermaid
sequenceDiagram
    participant Request1
    participant Request2
    Request1->>GatewayAddressCache: Force refresh partition key range 0
    GatewayAddressCache->>Cosmos Gateway: Get addresses for range 0
    Request2->>GatewayAddressCache: Get partition key range 0
    GatewayAddressCache->>Request2: Return [1,2,3,4]
    Cosmos Gateway->>GatewayAddressCache: Return [1,2,3,5]
    GatewayAddressCache->>Request1: Return [1,2,3,5]
    Request2->>GatewayAddressCache: Force refresh partition key range 0
    GatewayAddressCache->>Cosmos Gateway: Get addresses for range 0
    Cosmos Gateway->>GatewayAddressCache: Return [1,2,3,5]
    GatewayAddressCache->>Request2: Return [1,2,3,5]
```

New optimized:
```mermaid
sequenceDiagram
    participant Request1
    participant Request2
    Request1->>GatewayAddressCache: Force refresh partition key range 0
    GatewayAddressCache->>Cosmos Gateway: Get addresses for range 0
    Request2->>GatewayAddressCache: Get partition key range 0
    GatewayAddressCache->>Request2: Return [1,2,3,4]
    Cosmos Gateway->>GatewayAddressCache: Return [1,2,3,5]
    GatewayAddressCache->>Request1: Return [1,2,3,5]
    Request2->>GatewayAddressCache: Force refresh partition key range 0
    GatewayAddressCache->>Request2: Return [1,2,3,5]
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber