### PR TITLE
Change Feed Processor: Fixes noisy error notification when lease is stolen by other host

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
             catch (LeaseLostException)
             {
-                await this.monitor.NotifyLeaseReleaseAsync(lease.CurrentLeaseToken);
                 DefaultTrace.TraceVerbose("Lease with token {0}: taken by another host during release");
             }
             catch (Exception ex)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
             catch (LeaseLostException)
             {
+                await this.monitor.NotifyLeaseReleaseAsync(lease.CurrentLeaseToken);
                 DefaultTrace.TraceVerbose("Lease with token {0}: taken by another host during release");
             }
             catch (Exception ex)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -111,6 +111,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
 
                 await this.monitor.NotifyLeaseReleaseAsync(lease.CurrentLeaseToken);
             }
+            catch (LeaseLostException)
+            {
+                DefaultTrace.TraceVerbose("Lease with token {0}: taken by another host during release");
+            }
             catch (Exception ex)
             {
                 await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, ex);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
             catch (Exception ex)
             {
-                await this.RemoveLeaseAsync(lease).ConfigureAwait(false);
+                await this.RemoveLeaseAsync(lease: lease, wasAcquired: false).ConfigureAwait(false);
                 await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, ex);
                 throw;
             }
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             await Task.WhenAll(addLeaseTasks.ToArray()).ConfigureAwait(false);
         }
 
-        private async Task RemoveLeaseAsync(DocumentServiceLease lease)
+        private async Task RemoveLeaseAsync(DocumentServiceLease lease, bool wasAcquired)
         {
             if (!this.currentlyOwnedPartitions.TryRemove(lease.CurrentLeaseToken, out TaskCompletionSource<bool> worker))
             {
@@ -113,6 +113,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
             catch (LeaseLostException)
             {
+                if (wasAcquired)
+                {
+                    await this.monitor.NotifyLeaseReleaseAsync(lease.CurrentLeaseToken);
+                }
+
                 DefaultTrace.TraceVerbose("Lease with token {0}: taken by another host during release");
             }
             catch (Exception ex)
@@ -146,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
                 DefaultTrace.TraceWarning("Lease with token {0}: processing failed", lease.CurrentLeaseToken);
             }
 
-            await this.RemoveLeaseAsync(lease).ConfigureAwait(false);
+            await this.RemoveLeaseAsync(lease: lease, wasAcquired: true).ConfigureAwait(false);
         }
 
         private async Task HandlePartitionGoneAsync(DocumentServiceLease lease, string lastContinuationToken)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -399,7 +399,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 .Verify(m => m.NotifyLeaseAcquireAsync(this.lease.CurrentLeaseToken), Times.Never);
 
             this.healthMonitor
-                .Verify(m => m.NotifyLeaseReleaseAsync(this.lease.CurrentLeaseToken), Times.Once);
+                .Verify(m => m.NotifyLeaseReleaseAsync(this.lease.CurrentLeaseToken), Times.Never);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerTests.cs
@@ -329,6 +329,80 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         [TestMethod]
+        public async Task AddLease_ShouldNotify_IfLeaseReleaseThrowsUnknown()
+        {
+            Mock.Get(this.partitionProcessor)
+                .Reset();
+
+            Mock.Get(this.leaseManager)
+                .Reset();
+
+            // Fail on Acquire to trigger Release
+            Mock.Get(this.leaseManager)
+                .Setup(manager => manager.AcquireAsync(this.lease))
+                .ThrowsAsync(new NullReferenceException());
+
+            // Fail on Release
+            Mock.Get(this.leaseManager)
+                .Setup(manager => manager.ReleaseAsync(this.lease))
+                .ThrowsAsync(new ArgumentException());
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => this.sut.AddOrUpdateLeaseAsync(this.lease)).ConfigureAwait(false);
+
+            Mock.Get(this.partitionProcessor)
+                .Verify(processor => processor.RunAsync(It.IsAny<CancellationToken>()), Times.Never);
+
+            // Notify the Acquire error
+            this.healthMonitor
+                .Verify(m => m.NotifyErrorAsync(this.lease.CurrentLeaseToken, It.Is<Exception>(ex => ex is NullReferenceException)), Times.Once);
+
+            // Notify the Release error
+            this.healthMonitor
+                .Verify(m => m.NotifyErrorAsync(this.lease.CurrentLeaseToken, It.Is<Exception>(ex => ex is ArgumentException)), Times.Once);
+
+            this.healthMonitor
+                .Verify(m => m.NotifyLeaseAcquireAsync(this.lease.CurrentLeaseToken), Times.Never);
+
+            this.healthMonitor
+                .Verify(m => m.NotifyLeaseReleaseAsync(this.lease.CurrentLeaseToken), Times.Never);
+        }
+
+        [TestMethod]
+        public async Task AddLease_ShouldNotify_IfLeaseReleaseThrowsLeaseLost()
+        {
+            Mock.Get(this.partitionProcessor)
+                .Reset();
+
+            Mock.Get(this.leaseManager)
+                .Reset();
+
+            // Fail on Acquire to trigger Release
+            Mock.Get(this.leaseManager)
+                .Setup(manager => manager.AcquireAsync(this.lease))
+                .ThrowsAsync(new NullReferenceException());
+
+            // Fail on Release
+            Mock.Get(this.leaseManager)
+                .Setup(manager => manager.ReleaseAsync(this.lease))
+                .ThrowsAsync(new Exceptions.LeaseLostException());
+
+            await Assert.ThrowsExceptionAsync<NullReferenceException>(() => this.sut.AddOrUpdateLeaseAsync(this.lease)).ConfigureAwait(false);
+
+            Mock.Get(this.partitionProcessor)
+                .Verify(processor => processor.RunAsync(It.IsAny<CancellationToken>()), Times.Never);
+
+            // Notify the Acquire error
+            this.healthMonitor
+                .Verify(m => m.NotifyErrorAsync(this.lease.CurrentLeaseToken, It.Is<Exception>(ex => ex is NullReferenceException)), Times.Once);
+
+            this.healthMonitor
+                .Verify(m => m.NotifyLeaseAcquireAsync(this.lease.CurrentLeaseToken), Times.Never);
+
+            this.healthMonitor
+                .Verify(m => m.NotifyLeaseReleaseAsync(this.lease.CurrentLeaseToken), Times.Once);
+        }
+
+        [TestMethod]
         public async Task Shutdown_ShouldNotify_Monitor()
         {
             Mock.Get(this.leaseManager)


### PR DESCRIPTION
## Description

During lease rebalancing, multiple hosts might try to acquire the same lease. Whoever acquires it first wins and the others get a LeaseLostException.

This LeaseLostException was getting sent through the Life Cycle Notifications and bubbled up to users unnecessarily, it is not an error or a condition they need to worry or act upon, but a normal flow of events based on the CFP design.

This PR removes the noisy notification and ensures NotifyRelease is called.