### PR TITLE
[Internal] Subpartitioning: Adds a test to verify Partition Key delete operations for subpartitioned containers.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -108,13 +108,18 @@ namespace Microsoft.Azure.Cosmos
             this.ValidateRequiredProperties();
         }
 
-#if PREVIEW
         /// <summary>
         /// Initializes a new instance of the <see cref="ContainerProperties"/> class for the Azure Cosmos DB service.
         /// </summary>
         /// <param name="id">The Id of the resource in the Azure Cosmos service.</param>
         /// <param name="partitionKeyPaths">The path to the partition key. Example: /location</param>
-        public ContainerProperties(string id, IReadOnlyList<string> partitionKeyPaths)
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+
+        ContainerProperties(string id, IReadOnlyList<string> partitionKeyPaths)
         {
             this.Id = id;
 
@@ -123,7 +128,6 @@ namespace Microsoft.Azure.Cosmos
             this.ValidateRequiredProperties();
         }
 
-#endif
         /// <summary>
         /// Gets or sets the <see cref="Cosmos.PartitionKeyDefinitionVersion"/>
         ///
@@ -372,12 +376,16 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-#if PREVIEW
         /// <summary>
         /// JSON path used for containers partitioning
         /// </summary>
         [JsonIgnore]
-        public IReadOnlyList<string> PartitionKeyPaths
+#if PREVIEW
+        public
+#else 
+        internal
+#endif
+        IReadOnlyList<string> PartitionKeyPaths
         {
             get => this.PartitionKey?.Paths;
             set
@@ -403,7 +411,6 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-#endif
         /// <summary>
         /// Gets or sets the time to live base time stamp property path.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -762,10 +762,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string currentVersion = HttpConstants.Versions.CurrentVersion;
             HttpConstants.Versions.CurrentVersion = "2020-07-15";
-            CosmosClient client = TestCommon.CreateCosmosClient(true);
-            Cosmos.Database database = await client.CreateDatabaseIfNotExistsAsync("mydb");
+            Cosmos.Database database = null;
             try
             {
+                CosmosClient client = TestCommon.CreateCosmosClient(true);
+                
+                database = await client.CreateDatabaseIfNotExistsAsync("mydb");
+                
                 ContainerProperties containerProperties = new ContainerProperties("subpartitionedcontainer", new List<string> { "/Country", "/City" });
                 Container container = await database.CreateContainerAsync(containerProperties);
                 ContainerInternal containerInternal = (ContainerInternal)container;
@@ -825,14 +828,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.IsTrue(pKDeleteResponse.ErrorMessage.Contains("Partition key provided either doesn't correspond to definition in the collection or doesn't match partition key field values specified in the document."));
                 }
             }
-            catch (Exception)
-            {
-                Assert.Fail();
-            }
             finally
             {
-                await database.DeleteAsync();
                 HttpConstants.Versions.CurrentVersion = currentVersion;
+                if(database != null) await database.DeleteAsync();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -821,7 +821,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 using (ResponseMessage pKDeleteResponse = await containerInternal.DeleteAllItemsByPartitionKeyStreamAsync(partialPartitionKey))
                 {
                     Assert.AreEqual(pKDeleteResponse.StatusCode, HttpStatusCode.BadRequest);
-                    Assert.AreEqual(pKDeleteResponse.CosmosException.SubStatusCode, SubStatusCodes.PartitionKeyMismatch);
+                    Assert.AreEqual(pKDeleteResponse.CosmosException.SubStatusCode, (int)SubStatusCodes.PartitionKeyMismatch);
                     Assert.IsTrue(pKDeleteResponse.ErrorMessage.Contains("Partition key provided either doesn't correspond to definition in the collection or doesn't match partition key field values specified in the document."));
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -757,7 +757,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-#if PREVIEW
         [TestMethod]
         public async Task PartitionKeyDeleteTestForSubpartitionedContainer()
         {
@@ -836,7 +835,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 HttpConstants.Versions.CurrentVersion = currentVersion;
             }
         }
-#endif
 
         [TestMethod]
         public async Task ItemCustomSerialzierTest()


### PR DESCRIPTION
# Add test to verify partition key delete for subpartitioned containers.

## Description

1. Adds emulator tests to verify partition key delete operation succeeds for subpartitioned containers.
2. Adds a test to ensure Partition key delete operation fails for prefixed partitioned key.

## Type of change


## Closing issues

To automatically close an issue: closes #IssueNumber