### PR TITLE
Availability: Adds logic to avoid bad replica during cache refresh

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -195,6 +195,11 @@ namespace Microsoft.Azure.Cosmos.Routing
                         singleValueInitFunc: (currentCachedValue) =>
                         { 
                             staleAddressInfo = currentCachedValue;
+
+                            GatewayAddressCache.SetTransportAddressUrisToUnhealthy(
+                               currentCachedValue,
+                               request?.RequestContext?.FailedEndpoints);
+
                             return this.GetAddressesForRangeIdAsync(
                                 request,
                                 partitionKeyRangeIdentity.CollectionRid,
@@ -251,6 +256,32 @@ namespace Microsoft.Azure.Cosmos.Routing
                 }
 
                 throw;
+            }
+        }
+
+        private static void SetTransportAddressUrisToUnhealthy(
+            PartitionAddressInformation stalePartitionAddressInformation,
+            Lazy<HashSet<TransportAddressUri>> failedEndpoints)
+        {
+            if (stalePartitionAddressInformation == null ||
+                failedEndpoints == null ||
+                !failedEndpoints.IsValueCreated)
+            {
+                return;
+            }
+
+            IReadOnlyList<TransportAddressUri> perProtocolPartitionAddressInformation = stalePartitionAddressInformation.Get(Protocol.Tcp)?.ReplicaTransportAddressUris;
+            if (perProtocolPartitionAddressInformation == null)
+            {
+                return;
+            }
+
+            foreach (TransportAddressUri failed in perProtocolPartitionAddressInformation)
+            {
+                if (failedEndpoints.Value.Contains(failed))
+                {
+                    failed.SetUnhealthy();
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBadReplicaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBadReplicaTests.cs
@@ -1,0 +1,187 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using global::Azure.Core;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class CosmosBadReplicaTests
+    {
+        [TestMethod]
+        [Timeout(30000)]
+        public async Task TestGoneFromServiceScenarioAsync()
+        {
+            Mock<IHttpHandler> mockHttpHandler = new Mock<IHttpHandler>(MockBehavior.Strict);
+            Uri endpoint = MockSetupsHelper.SetupSingleRegionAccount(
+                "mockAccountInfo",
+                consistencyLevel: ConsistencyLevel.Session,
+                mockHttpHandler,
+                out string primaryRegionEndpoint);
+
+            string databaseName = "mockDbName";
+            string containerName = "mockContainerName";
+            string containerRid = "ccZ1ANCszwk=";
+            Documents.ResourceId cRid = Documents.ResourceId.Parse(containerRid);
+            MockSetupsHelper.SetupContainerProperties(
+                mockHttpHandler: mockHttpHandler,
+                regionEndpoint: primaryRegionEndpoint,
+                databaseName: databaseName,
+                containerName: containerName,
+                containerRid: containerRid);
+
+            MockSetupsHelper.SetupSinglePartitionKeyRange(
+                mockHttpHandler,
+                primaryRegionEndpoint,
+                cRid,
+                out IReadOnlyList<string> partitionKeyRanges);
+
+            List<string> replicaIds1 = new List<string>()
+            {
+                "11111111111111111",
+                "22222222222222222",
+                "33333333333333333",
+                "44444444444444444",
+            };
+
+            HttpResponseMessage replicaSet1 = MockSetupsHelper.CreateAddresses(
+                replicaIds1,
+                partitionKeyRanges.First(),
+                "eastus",
+                cRid);
+
+            // One replica changed on the refresh
+            List<string> replicaIds2 = new List<string>()
+            {
+                "11111111111111111",
+                "22222222222222222",
+                "33333333333333333",
+                "55555555555555555",
+            };
+
+            HttpResponseMessage replicaSet2 = MockSetupsHelper.CreateAddresses(
+                replicaIds2,
+                partitionKeyRanges.First(),
+                "eastus",
+                cRid);
+
+            bool delayCacheRefresh = true;
+
+            mockHttpHandler.SetupSequence(x => x.SendAsync(
+                It.Is<HttpRequestMessage>(r => r.RequestUri.ToString().Contains("addresses")), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(replicaSet1))
+                .Returns(async ()=>
+                {
+                    //block cache refresh to verify bad replica is not visited during refresh
+                    while (delayCacheRefresh)
+                    {
+                        await Task.Delay(TimeSpan.FromMilliseconds(20));
+                    }
+                    
+                    return replicaSet2;
+                });
+
+            int callBack = 0;
+            List<Documents.TransportAddressUri> urisVisited = new List<Documents.TransportAddressUri>();
+            Mock<Documents.TransportClient> mockTransportClient = new Mock<Documents.TransportClient>(MockBehavior.Strict);
+            mockTransportClient.Setup(x => x.InvokeResourceOperationAsync(It.IsAny<Documents.TransportAddressUri>(), It.IsAny<Documents.DocumentServiceRequest>()))
+                .Callback<Documents.TransportAddressUri, Documents.DocumentServiceRequest>((t, _) => urisVisited.Add(t))
+            .Returns(() =>
+            {
+                callBack++;
+                if (callBack == 1)
+                {
+                    throw Documents.Rntbd.TransportExceptions.GetGoneException(
+                        new Uri("https://localhost:8081"),
+                        Guid.NewGuid(),
+                        new Documents.TransportException(Documents.TransportErrorCode.ConnectionBroken,
+                        null,
+                        Guid.NewGuid(),
+                        new Uri("https://localhost:8081"),
+                        "Mock",
+                        userPayload: true,
+                        payloadSent: false));
+                }
+
+                return Task.FromResult(new Documents.StoreResponse()
+                {
+                    Status = 200,
+                    Headers = new Documents.Collections.StoreResponseNameValueCollection()
+                    {
+                        ActivityId = Guid.NewGuid().ToString(),
+                        LSN = "12345",
+                        PartitionKeyRangeId = "0",
+                        GlobalCommittedLSN = "12345",
+                        SessionToken = "1#12345#1=12345"
+                    },
+                    ResponseBody = new MemoryStream()
+                });
+            });
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+                HttpClientFactory = () => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object)),
+                TransportClientHandlerFactory = (original) => mockTransportClient.Object,
+            };
+
+            using (CosmosClient customClient = new CosmosClient(
+                endpoint.ToString(),
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
+                cosmosClientOptions))
+            {
+                try
+                {
+                    Container container = customClient.GetContainer(databaseName, containerName);
+
+                    for (int i = 0; i < 20; i++)
+                    {
+                        ResponseMessage response = await container.ReadItemStreamAsync(Guid.NewGuid().ToString(), new Cosmos.PartitionKey(Guid.NewGuid().ToString()));
+                        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    }
+
+                    mockTransportClient.VerifyAll();
+                    mockHttpHandler.VerifyAll();
+
+                    Documents.TransportAddressUri failedReplica = urisVisited.First();
+                    Assert.AreEqual(1, urisVisited.Count(x => x.Equals(failedReplica)));
+
+                    urisVisited.Clear();
+                    delayCacheRefresh = false;
+                    await Task.Delay(TimeSpan.FromMilliseconds(100));
+
+                    for (int i = 0; i < 20; i++)
+                    {
+                        ResponseMessage response = await container.ReadItemStreamAsync(Guid.NewGuid().ToString(), new Cosmos.PartitionKey(Guid.NewGuid().ToString()));
+                        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    }
+
+                    Assert.AreEqual(4, urisVisited.ToHashSet().Count());
+
+                    // Clears all the setups. No network calls should be done on the next operation.
+                    mockHttpHandler.Reset();
+                    mockTransportClient.Reset();
+                }
+                finally
+                {
+                    mockTransportClient.Setup(x => x.Dispose());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description
Current design:
If the SDK get's a 410 or other failure that signals a replica has moved to a different machine an address cache refresh is triggered. The cache refresh returns the stale information until the new address list is returned, because the 3 other replicas should still be valid and can complete requests. This still gives a 25% chance of a new replica going to the bad replica which can possibly take multiple seconds for the connection to timeout.

The solution:
The GatewayAddressCache individual addresses have a unhealthy flag. The unhealthy flag has a maximum of 1 minute. The guarantees that even if something goes wrong with a refresh at most a replica will be not be used for 1 minute. When a cache refresh is requested the bad replicas will be marked as unhealthy. When the SDK goes to pick a random replica it will always move the unhealthy replicas to the end of the list.
 
// Cache refresh design
```mermaid
sequenceDiagram
    participant Request1
    participant Request2
    Request1->>+GatewayAddressCache: Get partition key range 0
    GatewayAddressCache->>-Request1: Returns replicas[1,2,3,4]
    Request1->>+Replica2: Get item
    Replica2->>-Request1: Gone(410) represent replica moved
    Request1->>GatewayAddressCache: Start background refresh of addresses
    Request1->>+Replica1: Get item
    Replica1->>-Request1: Returns item
    GatewayAddressCache->>+Cosmos Gateway: Get addresses for range 0 with ForceRefresh
    Request2->>+GatewayAddressCache: Get partition key range 0 
    GatewayAddressCache->>-Request2: Stale [1,2,3,4]
    Request2->>+Replica3: Request2 use to have a 25% chance going to replica1 that moved. It now has 0% chance.
    Replica3->>-Request2: Gone(410) represent replica moved
    Cosmos Gateway->>-GatewayAddressCache: Return addresses [5,2,3,4]
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber