### PR TITLE
3.25.0-preview: Adds missing changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#3049](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3049) ClientEncryption: Adds algorithm to EncryptionKeyWrapMetadata
 
 ### <a name="3.25.0-preview"/> [3.25.0-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.25.0-preview) - 2022-02-18
+
+#### Added
+- [#2948](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/2948) Partition Key Delete: Adds DeleteAllItemsByPartitionKeyStreamAsync to container
+
 ### <a name="3.25.0"/> [3.25.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.25.0) - 2022-02-18
 
 #### Added


### PR DESCRIPTION
# Pull Request Template

## Description
The 3.25.0-preview release missed the partition key delete in the changelog. The contract file shows the change. This is just fixing the changelog.

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/releases/3.25.0-preview/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs

Original PR:
https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3041

<img width="848" alt="image" src="https://user-images.githubusercontent.com/8868107/161989478-7b4dd809-474c-4197-a649-625375e0ad90.png">

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber