### PR TITLE
Query: Fixes invalid query text exception losing error details

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/Encryption/Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/Encryption/Encryption.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.5.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Encryption" Version="1.0.0-previewV20" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Encryption" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     Exception originalException = ExceptionWithStackTraceException.UnWrapMonadExcepion(tryGetQueryPlan.Exception, serviceInteropTrace);
                     if (originalException is CosmosException)
                     {
-                        throw tryGetQueryPlan.Exception;
+                        throw originalException;
                     }
 
                     throw CosmosExceptionFactory.CreateBadRequestException(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -69,15 +69,17 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
                 if (!tryGetQueryPlan.Succeeded)
                 {
-                    if (tryGetQueryPlan.Exception is CosmosException)
+                    Exception originalException = ExceptionWithStackTraceException.UnWrapMonadExcepion(tryGetQueryPlan.Exception, serviceInteropTrace);
+                    if (originalException is CosmosException)
                     {
                         throw tryGetQueryPlan.Exception;
                     }
 
                     throw CosmosExceptionFactory.CreateBadRequestException(
-                        message: tryGetQueryPlan.Exception.ToString(),
+                        message: originalException.ToString(),
                         headers: new Headers(),
-                        stackTrace: tryGetQueryPlan.Exception.StackTrace,
+                        stackTrace: originalException.StackTrace,
+                        innerException: originalException,
                         trace: trace);
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     throw CosmosExceptionFactory.CreateBadRequestException(
                         message: originalException.ToString(),
                         headers: new Headers(),
-                        stackTrace: originalException.StackTrace,
+                        stackTrace: tryGetQueryPlan.Exception.StackTrace,
                         innerException: originalException,
                         trace: trace);
                 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     }
 
                     throw CosmosExceptionFactory.CreateBadRequestException(
-                        message: originalException.ToString(),
+                        message: originalException.Message,
                         headers: new Headers(),
                         stackTrace: tryGetQueryPlan.Exception.StackTrace,
                         innerException: originalException,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
@@ -106,7 +106,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -122,7 +122,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -138,7 +138,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -158,7 +158,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":136,"end":154},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -225,7 +225,7 @@ FROM (
                                                                             WHERE (ARRAY_LENGTH(r0["Children"]) > 2) 
                                                                             OFFSET 1 LIMIT 10) AS r8) AS r9
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":230,"end":247},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":366,"end":391},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":518,"end":534},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":641,"end":646},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":699,"end":724},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":868,"end":893},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":894,"end":912},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1065,"end":1089},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1090,"end":1115},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1173,"end":1190},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateAvg.xml
@@ -106,7 +106,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -122,7 +122,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -138,7 +138,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -158,7 +158,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -225,7 +225,7 @@ FROM (
                                                                             WHERE (ARRAY_LENGTH(r0["Children"]) > 2) 
                                                                             OFFSET 1 LIMIT 10) AS r8) AS r9
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
@@ -107,7 +107,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":63,"end":89},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -123,7 +123,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -139,7 +139,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":63,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -159,7 +159,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":87,"end":103},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":137,"end":155},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -201,7 +201,7 @@ FROM (
                                     OFFSET 1 LIMIT 20) AS r4 
                                     OFFSET 1 LIMIT 10) AS r5
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":202,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":339,"end":355},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":442,"end":447},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":502,"end":527},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":543,"end":560},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":568,"end":585},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -264,7 +264,7 @@ FROM (
                                                     OFFSET 1 LIMIT 10) AS r8 
                                                     WHERE ((r8["v0"] + r8["v1"]) > (r8["v2"] + r8["v3"]))
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":215,"end":240},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":368,"end":384},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":487,"end":492},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":547,"end":572},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":726,"end":751},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":752,"end":770},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":908,"end":932},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":933,"end":958},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":974,"end":991},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":999,"end":1016},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateCount.xml
@@ -107,7 +107,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -123,7 +123,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -139,7 +139,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -159,7 +159,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -201,7 +201,7 @@ FROM (
                                     OFFSET 1 LIMIT 20) AS r4 
                                     OFFSET 1 LIMIT 10) AS r5
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -264,7 +264,7 @@ FROM (
                                                     OFFSET 1 LIMIT 10) AS r8 
                                                     WHERE ((r8["v0"] + r8["v1"]) > (r8["v2"] + r8["v3"]))
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
@@ -104,7 +104,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -120,7 +120,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -136,7 +136,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":136,"end":154},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -220,7 +220,7 @@ FROM (
                                                                         OFFSET 1 LIMIT 20) AS r7 
                                                                         OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":456,"end":472},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":579,"end":584},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":641,"end":666},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":814,"end":839},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":840,"end":858},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1015,"end":1039},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1040,"end":1065},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1082,"end":1099},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1107,"end":1124},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMax.xml
@@ -104,7 +104,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -120,7 +120,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -136,7 +136,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -220,7 +220,7 @@ FROM (
                                                                         OFFSET 1 LIMIT 20) AS r7 
                                                                         OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
@@ -104,7 +104,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -120,7 +120,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -136,7 +136,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":136,"end":154},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -220,7 +220,7 @@ FROM (
                                                                         OFFSET 1 LIMIT 20) AS r7 
                                                                         OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":300,"end":325},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":456,"end":472},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":579,"end":584},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":641,"end":666},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":814,"end":839},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":840,"end":858},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1015,"end":1039},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1040,"end":1065},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1082,"end":1099},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1107,"end":1124},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateMin.xml
@@ -104,7 +104,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -120,7 +120,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -136,7 +136,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -220,7 +220,7 @@ FROM (
                                                                         OFFSET 1 LIMIT 20) AS r7 
                                                                         OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
@@ -101,7 +101,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -117,7 +117,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -133,7 +133,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -153,7 +153,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -212,7 +212,7 @@ FROM (
                                                     OFFSET 1 LIMIT 20) AS r7 
                                                     OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAggregateSum.xml
@@ -101,7 +101,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 2147483647) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":88},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -117,7 +117,7 @@ FROM (
     FROM root 
     OFFSET 90 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":79},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -133,7 +133,7 @@ FROM (
     FROM root 
     OFFSET 5 LIMIT 5) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":78},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -153,7 +153,7 @@ FROM (
         JOIN c0 IN r0["Children"] 
         OFFSET 10 LIMIT 20) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":86,"end":102},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":136,"end":154},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -212,7 +212,7 @@ FROM (
                                                     OFFSET 1 LIMIT 20) AS r7 
                                                     OFFSET 1 LIMIT 10) AS r8
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":268,"end":293},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":404,"end":420},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":507,"end":512},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":569,"end":594},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":722,"end":747},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":748,"end":766},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":903,"end":927},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":928,"end":953},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":969,"end":986},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":994,"end":1011},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
@@ -11,7 +11,7 @@ FROM (
     SELECT VALUE root 
     FROM root) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -27,7 +27,7 @@ FROM (
     FROM root 
     WHERE root["Flag"]) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -43,7 +43,7 @@ FROM (
     FROM root 
     WHERE (NOT root["Flag"])) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -58,7 +58,7 @@ FROM (
     SELECT VALUE root["Number"] 
     FROM root) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -75,7 +75,7 @@ FROM (
     JOIN m0 IN root["Multiples"] 
     WHERE ((m0 % 3) = 0)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -91,7 +91,7 @@ FROM (
     FROM root 
     WHERE root["Flag"]) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -107,7 +107,7 @@ FROM (
     FROM root 
     WHERE (root["Number"] < -7)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -123,7 +123,7 @@ FROM (
     FROM root 
     WHERE (root["Number"] < -13)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -145,7 +145,7 @@ FROM (
             JOIN v0 IN r0) AS v1 
             WHERE (v1 > 5)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -173,7 +173,7 @@ FROM (
                     JOIN c IN r0) AS v1 
                     WHERE (v1 > 150)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -189,7 +189,7 @@ FROM (
     FROM root 
     OFFSET 20 LIMIT 1) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -206,7 +206,7 @@ FROM (
     JOIN v0 IN root["Children"] 
     OFFSET 4 LIMIT 2147483647) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -276,7 +276,7 @@ FROM (
                                                                     OFFSET 1 LIMIT 20) AS r3 
                                                                     OFFSET 1 LIMIT 10) AS v26
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAggregateFunctionBaselineTests.TestAny.xml
@@ -11,7 +11,7 @@ FROM (
     SELECT VALUE root 
     FROM root) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -27,7 +27,7 @@ FROM (
     FROM root 
     WHERE root["Flag"]) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -43,7 +43,7 @@ FROM (
     FROM root 
     WHERE (NOT root["Flag"])) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -58,7 +58,7 @@ FROM (
     SELECT VALUE root["Number"] 
     FROM root) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -75,7 +75,7 @@ FROM (
     JOIN m0 IN root["Multiples"] 
     WHERE ((m0 % 3) = 0)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -91,7 +91,7 @@ FROM (
     FROM root 
     WHERE root["Flag"]) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -107,7 +107,7 @@ FROM (
     FROM root 
     WHERE (root["Number"] < -7)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -123,7 +123,7 @@ FROM (
     FROM root 
     WHERE (root["Number"] < -13)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -145,7 +145,7 @@ FROM (
             JOIN v0 IN r0) AS v1 
             WHERE (v1 > 5)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -173,7 +173,7 @@ FROM (
                     JOIN c IN r0) AS v1 
                     WHERE (v1 > 150)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"Errors":["Compositions of aggregates and other expressions are not allowed."]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -189,7 +189,7 @@ FROM (
     FROM root 
     OFFSET 20 LIMIT 1) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":63,"end":80},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -206,7 +206,7 @@ FROM (
     JOIN v0 IN root["Children"] 
     OFFSET 4 LIMIT 2147483647) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":89,"end":114},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -276,7 +276,7 @@ FROM (
                                                                     OFFSET 1 LIMIT 20) AS r3 
                                                                     OFFSET 1 LIMIT 10) AS v26
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":285,"end":310},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":408,"end":424},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":497,"end":502},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":557,"end":582},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":697,"end":722},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":723,"end":741},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":865,"end":889},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":890,"end":915},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1059,"end":1083},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":1084,"end":1109},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1199,"end":1215},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":958,"end":963},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":1233,"end":1250},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."},{"severity":"Error","location":{"start":1258,"end":1275},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
@@ -147,7 +147,7 @@ FROM (
     SELECT TOP 10 VALUE root["Int"] 
     FROM root) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -187,7 +187,7 @@ FROM (
     FROM root) AS r1 
     ORDER BY r1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -203,7 +203,7 @@ FROM (
     FROM root 
     ORDER BY root["Int"] ASC) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":73,"end":97},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":38,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -463,7 +463,7 @@ FROM (
         WHERE ((LENGTH(v2["FamilyName"]) > 10) AND (LENGTH(v2["FamilyName"]) < 20)) 
         ORDER BY v2 ASC) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":223,"end":238},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -503,7 +503,7 @@ FROM (
         WHERE (LENGTH(v2["FamilyName"]) > 10) 
         ORDER BY v2 ASC) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":185,"end":200},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -540,7 +540,7 @@ FROM (
         JOIN v0 IN root["Parents"]) AS v2 
         WHERE (LENGTH(v2["FamilyName"]) > 10)) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":47,"end":52},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestDistinctTranslation.xml
@@ -147,7 +147,7 @@ FROM (
     SELECT TOP 10 VALUE root["Int"] 
     FROM root) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -187,7 +187,7 @@ FROM (
     FROM root) AS r1 
     ORDER BY r1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -203,7 +203,7 @@ FROM (
     FROM root 
     ORDER BY root["Int"] ASC) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -463,7 +463,7 @@ FROM (
         WHERE ((LENGTH(v2["FamilyName"]) > 10) AND (LENGTH(v2["FamilyName"]) < 20)) 
         ORDER BY v2 ASC) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -503,7 +503,7 @@ FROM (
         WHERE (LENGTH(v2["FamilyName"]) > 10) 
         ORDER BY v2 ASC) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -540,7 +540,7 @@ FROM (
         JOIN v0 IN root["Parents"]) AS v2 
         WHERE (LENGTH(v2["FamilyName"]) > 10)) AS r0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
@@ -234,7 +234,7 @@ JOIN (
         JOIN v0 IN root["Children"]) AS r0 
         WHERE (LENGTH(r0["FamilyName"]) > 10)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -255,7 +255,7 @@ JOIN (
         ORDER BY c0["Grade"] ASC) AS r0 
         WHERE (LENGTH(r0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":114,"end":138},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":61,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSelectMany.xml
@@ -234,7 +234,7 @@ JOIN (
         JOIN v0 IN root["Children"]) AS r0 
         WHERE (LENGTH(r0["FamilyName"]) > 10)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -255,7 +255,7 @@ JOIN (
         ORDER BY c0["Grade"] ASC) AS r0 
         WHERE (LENGTH(r0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
@@ -36,7 +36,7 @@ FROM (
     ORDER BY root ASC) AS r1 
     ORDER BY LENGTH(r1) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -53,7 +53,7 @@ FROM (
     ORDER BY ARRAY_LENGTH(root["Children"]) ASC) AS r1 
     ORDER BY ARRAY_LENGTH(r1["Parents"]) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -70,7 +70,7 @@ FROM (
     ORDER BY ARRAY_LENGTH(root["Children"]) ASC) AS r0 
     ORDER BY ARRAY_LENGTH(r0["Parents"]) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -86,7 +86,7 @@ FROM (
     FROM root) AS r0 
     ORDER BY r0["FamilyId"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -108,7 +108,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r1["Parents"]) > 0)) AS r2 
             WHERE (LENGTH(r2["FamilyId"]) > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -129,7 +129,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r0["Children"]) > 0)) AS r1) AS r2 
             WHERE (LENGTH(r2["f"]["FamilyId"]) > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -150,7 +150,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r1["f"]["Children"]) > 0)) AS r2 
             WHERE (ARRAY_LENGTH(r2["f"]["Parents"]) > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSimpleSubquery.xml
@@ -36,7 +36,7 @@ FROM (
     ORDER BY root ASC) AS r1 
     ORDER BY LENGTH(r1) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":75,"end":92},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -53,7 +53,7 @@ FROM (
     ORDER BY ARRAY_LENGTH(root["Children"]) ASC) AS r1 
     ORDER BY ARRAY_LENGTH(r1["Parents"]) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -70,7 +70,7 @@ FROM (
     ORDER BY ARRAY_LENGTH(root["Children"]) ASC) AS r0 
     ORDER BY ARRAY_LENGTH(r0["Parents"]) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":62,"end":105},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":35,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -86,7 +86,7 @@ FROM (
     FROM root) AS r0 
     ORDER BY r0["FamilyId"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -108,7 +108,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r1["Parents"]) > 0)) AS r2 
             WHERE (LENGTH(r2["FamilyId"]) > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":85,"end":91},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":57,"end":62},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -129,7 +129,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r0["Children"]) > 0)) AS r1) AS r2 
             WHERE (LENGTH(r2["f"]["FamilyId"]) > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":95,"end":101},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -150,7 +150,7 @@ FROM (
             WHERE (ARRAY_LENGTH(r1["f"]["Children"]) > 0)) AS r2 
             WHERE (ARRAY_LENGTH(r2["f"]["Parents"]) > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":57,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
@@ -32,7 +32,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":105,"end":142},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -50,7 +50,7 @@ JOIN (
         FROM root 
         JOIN v0 IN root["Children"])) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -172,7 +172,7 @@ JOIN (
         JOIN c0 IN root["Children"])) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -190,7 +190,7 @@ JOIN (
     JOIN c0 IN root["Children"]) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -209,7 +209,7 @@ JOIN (
     WHERE (c0["Grade"] > 90)) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -262,7 +262,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY c0["GivenName"]["Length"] ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":124,"end":162},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -317,7 +317,7 @@ JOIN (
         WHERE (c0["Grade"] > 50) 
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":136,"end":173},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -336,7 +336,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         WHERE (c0["Grade"] > 50))) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -355,7 +355,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         WHERE (c0["Grade"] > 50))) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -392,7 +392,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY c0["Grade"] ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":121,"end":145},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":58,"end":63},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -413,7 +413,7 @@ JOIN (
             JOIN c0 IN root["Children"] 
             ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC) AS r0)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":150,"end":187},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":88,"end":93},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -489,7 +489,7 @@ JOIN (
         WHERE (r0["Grade"] > 80)) AS v1 
         WHERE (v1 > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":159,"end":183},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":69,"end":74},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -509,7 +509,7 @@ JOIN (
         WHERE (ARRAY_LENGTH(c0["Pets"]) > 1))) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -528,7 +528,7 @@ JOIN (
     WHERE (ARRAY_LENGTH(c0["Pets"]) > 3)) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -546,7 +546,7 @@ JOIN (
     JOIN c0 IN root["Children"]) AS v1 
     ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -567,7 +567,7 @@ JOIN (
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC) AS r0) AS v1 
         ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":130,"end":167},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":77,"end":82},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -930,7 +930,7 @@ JOIN (
             WHERE (c1["Grade"] > 20))) AS v1 
             WHERE (v0 >= 2)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":13,"end":53},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -996,7 +996,7 @@ JOIN (
     WHERE (ARRAY_LENGTH(c0["Pets"]) > 0)) AS v0 
     ORDER BY LOG(v0) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1039,7 +1039,7 @@ FROM (
             WHERE ((r0["FamilyId"] > "ABC") AND (ARRAY_LENGTH(r0["SmartChildren"]) > 0)) 
             ORDER BY r0["ChildrenCount"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1081,7 +1081,7 @@ FROM (
                                             WHERE STARTSWITH(r0["FamilyId"], a))) AS v5)) AS v6 
                                             WHERE (r0["FirstChild"] != null)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":399,"end":404},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1221,7 +1221,7 @@ JOIN (
                 WHERE (v0 AND root["IsRegistered"]) 
                 ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1312,7 +1312,7 @@ JOIN (
                 ORDER BY c0["Grade"] ASC)) AS v3 
                 WHERE (ARRAY_LENGTH(root["Children"]) > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":110,"end":115},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":250,"end":274},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1760,7 +1760,7 @@ JOIN (
         WHERE (ARRAY_LENGTH(c0["Pets"]) > 3))) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1777,7 +1777,7 @@ JOIN (
     FROM root 
     JOIN v0 IN root["Children"]) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1795,7 +1795,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     ORDER BY c0["Grade"] ASC) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":86,"end":110},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1813,7 +1813,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     WHERE (LENGTH(c0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1831,7 +1831,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     WHERE (LENGTH(c0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":39,"end":44},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestSubquery.xml
@@ -32,7 +32,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC)) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -50,7 +50,7 @@ JOIN (
         FROM root 
         JOIN v0 IN root["Children"])) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -172,7 +172,7 @@ JOIN (
         JOIN c0 IN root["Children"])) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -190,7 +190,7 @@ JOIN (
     JOIN c0 IN root["Children"]) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -209,7 +209,7 @@ JOIN (
     WHERE (c0["Grade"] > 90)) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -262,7 +262,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY c0["GivenName"]["Length"] ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -317,7 +317,7 @@ JOIN (
         WHERE (c0["Grade"] > 50) 
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -336,7 +336,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         WHERE (c0["Grade"] > 50))) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -355,7 +355,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         WHERE (c0["Grade"] > 50))) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -392,7 +392,7 @@ JOIN (
         JOIN c0 IN root["Children"] 
         ORDER BY c0["Grade"] ASC)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -413,7 +413,7 @@ JOIN (
             JOIN c0 IN root["Children"] 
             ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC) AS r0)) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -489,7 +489,7 @@ JOIN (
         WHERE (r0["Grade"] > 80)) AS v1 
         WHERE (v1 > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -509,7 +509,7 @@ JOIN (
         WHERE (ARRAY_LENGTH(c0["Pets"]) > 1))) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -528,7 +528,7 @@ JOIN (
     WHERE (ARRAY_LENGTH(c0["Pets"]) > 3)) AS v0 
     ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -546,7 +546,7 @@ JOIN (
     JOIN c0 IN root["Children"]) AS v1 
     ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -567,7 +567,7 @@ JOIN (
         ORDER BY ARRAY_LENGTH(c0["Pets"]) ASC) AS r0) AS v1 
         ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -930,7 +930,7 @@ JOIN (
             WHERE (c1["Grade"] > 20))) AS v1 
             WHERE (v0 >= 2)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -996,7 +996,7 @@ JOIN (
     WHERE (ARRAY_LENGTH(c0["Pets"]) > 0)) AS v0 
     ORDER BY LOG(v0) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1039,7 +1039,7 @@ FROM (
             WHERE ((r0["FamilyId"] > "ABC") AND (ARRAY_LENGTH(r0["SmartChildren"]) > 0)) 
             ORDER BY r0["ChildrenCount"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1081,7 +1081,7 @@ FROM (
                                             WHERE STARTSWITH(r0["FamilyId"], a))) AS v5)) AS v6 
                                             WHERE (r0["FirstChild"] != null)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1221,7 +1221,7 @@ JOIN (
                 WHERE (v0 AND root["IsRegistered"]) 
                 ORDER BY v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1312,7 +1312,7 @@ JOIN (
                 ORDER BY c0["Grade"] ASC)) AS v3 
                 WHERE (ARRAY_LENGTH(root["Children"]) > 0)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1760,7 +1760,7 @@ JOIN (
         WHERE (ARRAY_LENGTH(c0["Pets"]) > 3))) AS v0 
         ORDER BY v0 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1777,7 +1777,7 @@ JOIN (
     FROM root 
     JOIN v0 IN root["Children"]) AS v2
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1795,7 +1795,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     ORDER BY c0["Grade"] ASC) AS v0
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1813,7 +1813,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     WHERE (LENGTH(c0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -1831,7 +1831,7 @@ JOIN (
     JOIN c0 IN root["Children"] 
     WHERE (LENGTH(c0["FamilyName"]) > 10)) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
@@ -63,7 +63,7 @@ JOIN (
     WHERE (c0["Grade"] > 100)) AS v0 
     ORDER BY v0 ASC, root["Int"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -82,7 +82,7 @@ JOIN (
     WHERE (p0["GivenName"]["Length"] > 10)) AS v0 
     ORDER BY root["FamilyId"] ASC, v0 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -106,7 +106,7 @@ JOIN (
         WHERE (p0["GivenName"]["Length"] > 10)) AS v1 
         ORDER BY v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ JOIN (
         WHERE (c1["Grade"] > 100)) AS v1 
         ORDER BY v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -169,7 +169,7 @@ JOIN (
 SELECT VALUE root 
 FROM root 
 ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -182,7 +182,7 @@ ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC]]></SqlQue
 SELECT VALUE root 
 FROM root 
 ORDER BY (NOT IS_DEFINED(root["NullableInt"])) ASC, (ARRAY_LENGTH(root["Tags"]) % 2) DESC]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -201,7 +201,7 @@ JOIN (
         JOIN t0 IN root["Records"]["Transactions"])) AS v0 
         ORDER BY (root["IsRegistered"] ? root["FamilyId"] : root["Int"]) DESC, (v0[0] % 1000) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -249,7 +249,7 @@ JOIN (
         WHERE (p0["GivenName"]["Length"] > 10)) AS v1 
         ORDER BY v0 ASC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -273,7 +273,7 @@ JOIN (
         WHERE (c0["Grade"] > 100)) AS v1 
         ORDER BY root["FamilyId"] ASC, v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -293,7 +293,7 @@ JOIN (
         ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v0 
         ORDER BY root["FamilyId"] ASC, v0 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":141,"end":192},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -319,7 +319,7 @@ JOIN (
                 ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v1 
                 ORDER BY v0 ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":107,"end":156},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":278,"end":329},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -339,7 +339,7 @@ JOIN (
         ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v1 
         ORDER BY root["FamilyId"] ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":147,"end":198},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":65},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -368,7 +368,7 @@ JOIN (
                     ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v2 
                     ORDER BY v1 ASC, v2 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":136,"end":186},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":82,"end":88},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":194,"end":241},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":363,"end":414},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -413,7 +413,7 @@ JOIN (
             WHERE (p0["GivenName"]["Length"] > 5)) AS v0) AS r0 
             ORDER BY r0["FamilyId"] ASC, r0["FamilyNumber"] ASC) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":372,"end":423},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -461,7 +461,7 @@ FROM (
                 JOIN t0 IN root["Records"]["Transactions"]) AS v1) AS r0 
                 ORDER BY ARRAY_LENGTH(r0["ChildrenWithPets"]) DESC, r0["TotalExpenses"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -494,7 +494,7 @@ FROM (
                         JOIN c2 IN c1["Pets"]) AS r1) AS v3) AS r2 
                         ORDER BY r2["GoodChildrenCount"] DESC, r2["UniquePetsNameCount"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -522,7 +522,7 @@ FROM root
 JOIN f0 IN root["Children"] 
 WHERE (ARRAY_LENGTH(root["Children"]) > 0) 
 ORDER BY f0["Grade"] ASC, ARRAY_LENGTH(f0["Pets"]) DESC]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -549,7 +549,7 @@ FROM (
             WHERE (p0["GivenName"]["Length"] > 10)) AS v2 
             WHERE (v2 > 0)) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":163,"end":209},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":210,"end":227},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -571,7 +571,7 @@ FROM (
         OFFSET 5 LIMIT 2147483647) AS r2 
         ORDER BY r2["Length"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":170,"end":225},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":60,"end":66},"code":"SC2203","message":"'TOP' is not supported in subqueries."},{"severity":"Error","location":{"start":233,"end":258},"code":"SC2204","message":"'OFFSET LIMIT' clause is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -602,7 +602,7 @@ FROM (
     FROM root) AS r0 
     ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -619,7 +619,7 @@ FROM (
     ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC 
     OFFSET 5 LIMIT 2147483647
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":29,"end":36},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -654,7 +654,7 @@ FROM (
         WHERE (ARRAY_LENGTH(root["Children"]) > 0)) AS r0 
         ORDER BY r0["Name"] DESC, r0["PetWithLongNames"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -680,7 +680,7 @@ JOIN (
                 WHERE (p0["GivenName"]["Length"] > 10))) AS v1 
                 ORDER BY v0 ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -713,7 +713,7 @@ JOIN (
                             JOIN t1 IN root["Records"]["Transactions"])) AS v3 
                             ORDER BY v0[0] ASC, v1[0] DESC, v2 ASC, v3[0] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","code":2206,"message":"Unsupported ORDER BY clause. ORDER BY item expression could not be mapped to a document path."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqGeneralBaselineTests.TestThenByTranslation.xml
@@ -63,7 +63,7 @@ JOIN (
     WHERE (c0["Grade"] > 100)) AS v0 
     ORDER BY v0 ASC, root["Int"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -82,7 +82,7 @@ JOIN (
     WHERE (p0["GivenName"]["Length"] > 10)) AS v0 
     ORDER BY root["FamilyId"] ASC, v0 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -106,7 +106,7 @@ JOIN (
         WHERE (p0["GivenName"]["Length"] > 10)) AS v1 
         ORDER BY v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -156,7 +156,7 @@ JOIN (
         WHERE (c1["Grade"] > 100)) AS v1 
         ORDER BY v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -169,7 +169,7 @@ JOIN (
 SELECT VALUE root 
 FROM root 
 ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -182,7 +182,7 @@ ORDER BY (root["Int"] * 2) ASC, SUBSTRING(root["FamilyId"], 2, 3) ASC]]></SqlQue
 SELECT VALUE root 
 FROM root 
 ORDER BY (NOT IS_DEFINED(root["NullableInt"])) ASC, (ARRAY_LENGTH(root["Tags"]) % 2) DESC]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -201,7 +201,7 @@ JOIN (
         JOIN t0 IN root["Records"]["Transactions"])) AS v0 
         ORDER BY (root["IsRegistered"] ? root["FamilyId"] : root["Int"]) DESC, (v0[0] % 1000) ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -249,7 +249,7 @@ JOIN (
         WHERE (p0["GivenName"]["Length"] > 10)) AS v1 
         ORDER BY v0 ASC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -273,7 +273,7 @@ JOIN (
         WHERE (c0["Grade"] > 100)) AS v1 
         ORDER BY root["FamilyId"] ASC, v0 DESC, v1 ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -293,7 +293,7 @@ JOIN (
         ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v0 
         ORDER BY root["FamilyId"] ASC, v0 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -319,7 +319,7 @@ JOIN (
                 ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v1 
                 ORDER BY v0 ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -339,7 +339,7 @@ JOIN (
         ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v1 
         ORDER BY root["FamilyId"] ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -368,7 +368,7 @@ JOIN (
                     ORDER BY p0["FamilyName"] ASC, p0["GivenName"] DESC)) AS v2 
                     ORDER BY v1 ASC, v2 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -413,7 +413,7 @@ JOIN (
             WHERE (p0["GivenName"]["Length"] > 5)) AS v0) AS r0 
             ORDER BY r0["FamilyId"] ASC, r0["FamilyNumber"] ASC) AS v1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -461,7 +461,7 @@ FROM (
                 JOIN t0 IN root["Records"]["Transactions"]) AS v1) AS r0 
                 ORDER BY ARRAY_LENGTH(r0["ChildrenWithPets"]) DESC, r0["TotalExpenses"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -494,7 +494,7 @@ FROM (
                         JOIN c2 IN c1["Pets"]) AS r1) AS v3) AS r2 
                         ORDER BY r2["GoodChildrenCount"] DESC, r2["UniquePetsNameCount"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -522,7 +522,7 @@ FROM root
 JOIN f0 IN root["Children"] 
 WHERE (ARRAY_LENGTH(root["Children"]) > 0) 
 ORDER BY f0["Grade"] ASC, ARRAY_LENGTH(f0["Pets"]) DESC]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -549,7 +549,7 @@ FROM (
             WHERE (p0["GivenName"]["Length"] > 10)) AS v2 
             WHERE (v2 > 0)) AS r1
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -571,7 +571,7 @@ FROM (
         OFFSET 5 LIMIT 2147483647) AS r2 
         ORDER BY r2["Length"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -602,7 +602,7 @@ FROM (
     FROM root) AS r0 
     ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -619,7 +619,7 @@ FROM (
     ORDER BY r0["IsRegistered"] ASC, r0["Int"] DESC 
     OFFSET 5 LIMIT 2147483647
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -654,7 +654,7 @@ FROM (
         WHERE (ARRAY_LENGTH(root["Children"]) > 0)) AS r0 
         ORDER BY r0["Name"] DESC, r0["PetWithLongNames"] ASC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -680,7 +680,7 @@ JOIN (
                 WHERE (p0["GivenName"]["Length"] > 10))) AS v1 
                 ORDER BY v0 ASC, v1 DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -713,7 +713,7 @@ JOIN (
                             JOIN t1 IN root["Records"]["Transactions"])) AS v3 
                             ORDER BY v0[0] ASC, v1[0] DESC, v2 ASC, v3[0] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
@@ -169,7 +169,7 @@ FROM root]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3))]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -226,7 +226,7 @@ FROM root]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3))]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqSQLTranslationBaselineTest.ValidateSQLTranslation.xml
@@ -169,7 +169,7 @@ FROM root]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3))]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -226,7 +226,7 @@ FROM root]]></SqlQuery>
 SELECT VALUE [1, 2, 3][root["x"]] 
 FROM root 
 WHERE ((root["x"] >= 0) AND (root["x"] < 3))]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":13,"end":33},"code":"SC2990","message":"The specified query includes 'member indexer' which is currently not supported."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
@@ -106,7 +106,7 @@ FROM (
     JOIN number0 IN r0["EnumerableField"] 
     WHERE (number0 > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":95,"end":127},"code":"SC2202","message":"'ORDER BY' is not supported in subqueries."},{"severity":"Error","location":{"start":34,"end":40},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectManyWithFilters.xml
@@ -106,7 +106,7 @@ FROM (
     JOIN number0 IN r0["EnumerableField"] 
     WHERE (number0 > 10)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
@@ -83,7 +83,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -99,7 +99,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -115,7 +115,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0 > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -131,7 +131,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0 > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -148,7 +148,7 @@ FROM (
     WHERE (r0["NumericField"] > 100) 
     ORDER BY r0["NumericField"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -197,7 +197,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[Status Code: BadRequest]]></ErrorMessage>
+      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestSelectTop.xml
@@ -83,7 +83,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -99,7 +99,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":45,"end":50},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -115,7 +115,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0 > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -131,7 +131,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0 > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":29,"end":34},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -148,7 +148,7 @@ FROM (
     WHERE (r0["NumericField"] > 100) 
     ORDER BY r0["NumericField"] DESC
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":45,"end":51},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -197,7 +197,7 @@ FROM (
     FROM root) AS r0 
     WHERE (r0["NumericField"] > 100)
 ]]></SqlQuery>
-      <ErrorMessage><![CDATA[0x800A0B00]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":41},"code":"SC2203","message":"'TOP' is not supported in subqueries."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAggregateFunctionsBaselineTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests;
     using Microsoft.Azure.Documents;
     using System.Threading.Tasks;
+    using System.Text;
 
     [Microsoft.Azure.Cosmos.SDK.EmulatorTests.TestClass]
     public class LinqAggregateFunctionBaselineTests : BaselineTests<LinqAggregateInput, LinqAggregateOutput>
@@ -534,20 +535,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             }
             catch (Exception e)
             {
-                while (e.InnerException != null) e = e.InnerException;
-
-                if (e is CosmosException cosmosException)
-                {
-                    errorMessage = $"Status Code: {cosmosException.StatusCode}";
-                }
-                else if (e is DocumentClientException documentClientException)
-                {
-                    errorMessage = documentClientException.RawErrorMessage;
-                }
-                else
-                {
-                    errorMessage = e.Message;
-                }
+                errorMessage = LinqTestsCommon.BuildExceptionMessageForTest(e);
             }
 
             return new LinqAggregateOutput(query, errorMessage);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTestsCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTestsCommon.cs
@@ -515,24 +515,37 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             }
             catch (Exception e)
             {
-                while (e.InnerException != null) e = e.InnerException;
+                return new LinqTestOutput(querySqlStr, LinqTestsCommon.BuildExceptionMessageForTest(e));
+            }
+        }
 
-                string message;
-                if (e is CosmosException cosmosException)
+        public static string BuildExceptionMessageForTest(Exception ex)
+        {
+            StringBuilder message = new StringBuilder();
+            do
+            {
+                if (ex is CosmosException cosmosException)
                 {
-                    message = $"Status Code: {cosmosException.StatusCode}";
+                    message.Append($"Status Code: {cosmosException.StatusCode}");
                 }
-                else if(e is DocumentClientException documentClientException)
+                else if (ex is DocumentClientException documentClientException)
                 {
-                    message = documentClientException.RawErrorMessage;
+                    message.Append(documentClientException.RawErrorMessage);
                 }
                 else
                 {
-                    message = e.Message;
+                    message.Append(ex.Message);
                 }
 
-                return new LinqTestOutput(querySqlStr, message);
+                ex = ex.InnerException;
+                if (ex != null)
+                {
+                    message.Append(",");
+                }
             }
+            while (ex != null);
+
+            return message.ToString();
         }
     }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
         [TestMethod]
         public async Task ServiceInterop_BadRequestContainsOriginalCosmosException()
         {
-            CosmosException actualException = new CosmosException("Some message", (HttpStatusCode)429, (int)Documents.SubStatusCodes.Unknown, Guid.NewGuid().ToString(), 0);
+            CosmosException expectedException = new CosmosException("Some message", (HttpStatusCode)429, (int)Documents.SubStatusCodes.Unknown, Guid.NewGuid().ToString(), 0);
             Mock<CosmosQueryClient> queryClient = new Mock<CosmosQueryClient>();
 
             queryClient.Setup(c => c.TryGetPartitionedQueryExecutionInfoAsync(
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
-                It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(actualException));
+                It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(expectedException));
 
             Mock<ITrace> trace = new Mock<ITrace>();
             CosmosException cosmosException = await Assert.ThrowsExceptionAsync<CosmosException>(() => QueryPlanRetriever.GetQueryPlanWithServiceInteropAsync(
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 trace.Object,
                 default));
 
-            Assert.AreEqual(actualException, cosmosException);
+            Assert.AreEqual(expectedException, cosmosException);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
@@ -1,0 +1,55 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Query
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class QueryPlanRetrieverTests
+    {
+        [TestMethod]
+        public async Task ServiceInterop_BadRequestContainsInnerException()
+        {
+            ExpectedQueryPartitionProviderException innerException = new ExpectedQueryPartitionProviderException("some parsing error");
+            Mock<CosmosQueryClient> queryClient = new Mock<CosmosQueryClient>();
+
+            queryClient.Setup(c => c.TryGetPartitionedQueryExecutionInfoAsync(
+                It.IsAny<SqlQuerySpec>(),
+                It.IsAny<Documents.PartitionKeyDefinition>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(innerException));
+
+            Mock<ITrace> trace = new Mock<ITrace>();
+            CosmosException cosmosException = await Assert.ThrowsExceptionAsync<CosmosException>(() => QueryPlanRetriever.GetQueryPlanWithServiceInteropAsync(
+                queryClient.Object,
+                new SqlQuerySpec("selectttttt * from c"),
+                new Documents.PartitionKeyDefinition() { Paths = new Collection<string>() { "/id" } },
+                hasLogicalPartitionKey: false,
+                trace.Object,
+                default));
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, cosmosException.StatusCode);
+            Assert.AreEqual(innerException, cosmosException.InnerException);
+            Assert.IsNotNull(cosmosException.Trace);
+            Assert.IsNotNull(cosmosException.Diagnostics);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

When the SDK is on Direct mode, the SDK attempts to generate the query plan locally (see https://docs.microsoft.com/en-us/azure/cosmos-db/sql/performance-tips-query-sdk?tabs=v3&pivots=programming-language-csharp#use-local-query-plan-generation). If it detects that the query is malformed, it returns a Bad Request (HTTP 400) exception.

The problem was that the code was using Monads and throwing the Monad exception, leaving the InnerException `null` and adding a lot of Monad related information to the exception Message that was irrelevant to the users, making the discovery of the actual parsing error very difficult.

The PR maintains the Stack Trace and Diagnostics, and adds the InnerException pointing to the real error, and reduces the clutter on the Message.

### Original exception

**Message**
```
"Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: (Microsoft.Azure.Cosmos.Query.Core.Monads.ExceptionWithStackTraceException: TryCatch resulted in an exception. ---> Microsoft.Azure.Cosmos.Query.Core.Monads.ExceptionWithStackTraceException: TryCatch resulted in an exception. ---> Microsoft.Azure.Cosmos.Query.Core.Exceptions.ExpectedQueryPartitionProviderException: {\"errors\":[{\"severity\":\"Error\",\"location\":{\"start\":0,\"end\":9},\"code\":\"SC1001\",\"message\":\"Syntax error, incorrect syntax near 'selectttt'.\"}]}\r\n ---> System.Runtime.InteropServices.COMException (0x800A0B00): 0x800A0B00\r\n   --- End of inner exception stack trace ---\r\n   --- End of inner exception stack trace ---\r\n   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfoInternal(SqlQuerySpec querySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Bool
ean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)\r\n   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfo(SqlQuerySpec querySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)\r\n   at Microsoft.Azure.Cosmos.CosmosQueryClientCore.TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount, CancellationToken cancellationToken)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)\r\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallb
ack callback, Object state)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.<>c.<OutputWaitEtwEvents>b__12_0(Action innerContinuation, Task innerTask)\r\n   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.ContinuationWrapper.Invoke()\r\n   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(Action action, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)\r\n   at System.Threading.Tasks.UnwrapPromise`1.TrySetFromTask(Task task, Boolean lookForOce)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessInnerTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessComplete
dOuterTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.Invoke(Task completingTask)\r\n   at System.Threading.Tasks.Task.RunOrQueueCompletionAction(ITaskCompletionAction completionAction, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task.FinishStageThree()\r\n   at System.Threading.Tasks.Task.FinishStageTwo()\r\n   at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)\r\n   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)\r\n   at System.Threading.ThreadPoolWorkQueue.Dispatch()\r\n   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()\r\n   at System.Threading.Thread.StartCallback()\r\n\r\n   --- En
d of inner exception stack trace ---\r\n   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfo(SqlQuerySpec querySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)\r\n   at Microsoft.Azure.Cosmos.CosmosQueryClientCore.TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount, CancellationToken cancellationToken)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)\r\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\r\n   at System.Runti
me.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.<>c.<OutputWaitEtwEvents>b__12_0(Action innerContinuation, Task innerTask)\r\n   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.ContinuationWrapper.Invoke()\r\n   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(Action action, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)\r\n   at System.Threading.Tasks.UnwrapPromise`1.TrySetFromTask(Task task, Boolean lookForOce)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessInnerTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessCompletedOuterTask(Task task)\r\n   at System.Threading.T
asks.UnwrapPromise`1.Invoke(Task completingTask)\r\n   at System.Threading.Tasks.Task.RunOrQueueCompletionAction(ITaskCompletionAction completionAction, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task.FinishStageThree()\r\n   at System.Threading.Tasks.Task.FinishStageTwo()\r\n   at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)\r\n   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)\r\n   at System.Threading.ThreadPoolWorkQueue.Dispatch()\r\n   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()\r\n   at System.Threading.Thread.StartCallback()\r\n);"
```

**InnerException**
`null`

**StackTrace**
```
at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfo(SqlQuerySpec querySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)\r\n   at Microsoft.Azure.Cosmos.CosmosQueryClientCore.TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount, CancellationToken cancellationToken)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)\r\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuil
der`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.<>c.<OutputWaitEtwEvents>b__12_0(Action innerContinuation, Task innerTask)\r\n   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.ContinuationWrapper.Invoke()\r\n   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(Action action, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)\r\n   at System.Threading.Tasks.UnwrapPromise`1.TrySetFromTask(Task task, Boolean lookForOce)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessInnerTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessCompletedOuterTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.Invoke(Task comple
tingTask)\r\n   at System.Threading.Tasks.Task.RunOrQueueCompletionAction(ITaskCompletionAction completionAction, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task.FinishStageThree()\r\n   at System.Threading.Tasks.Task.FinishStageTwo()\r\n   at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)\r\n   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)\r\n   at System.Threading.ThreadPoolWorkQueue.Dispatch()\r\n   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()\r\n   at System.Threading.Thread.StartCallback()\r\n
```

**Diagnostics**
```
{\"Summary\":{\"GatewayCalls\":{\"(200, 0)\":1}},\"name\":\"Typed FeedIterator ReadNextAsync\",\"id\":\"b27594ff-8a8d-4498-8e18-5cfb3a3a5148\",\"start time\":\"10:06:35:460\",\"duration in milliseconds\":3049.7607,\"data\":{\"Client Configuration\":{\"Client Created Time Utc\":\"2022-04-08T22:06:35.3311174Z\",\"NumberOfClientsCreated\":1,\"NumberOfActiveClients\":1,\"User Agent\":\"cosmos-netstandard-sdk/3.26.1|3.30.900|1|X64|Microsoft Windows 10.0.19044|.NET 6.0.3|N|\",\"ConnectionConfig\":{\"gw\":\"(cps:50, urto:10, p:False, httpf: False)\",\"rntbd\":\"(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: True, pr: ReuseUnicastPort)\",\"other\":\"(ed:False, be:False)\"},\"ConsistencyConfig\":\"(consistency: NotSet, prgns:[])\"},\"Query Correlated ActivityId\":\"a2e7d88d-5c61-4d80-9612-0f7846023674\"},\"children\":[{\"name\":\"Create Query Pipeline\",\"id\":\"114eb6d0-7d51-49c9-b3b1-d6038dfd456f\",\"start time\":\"10:06:35:487\",\"duration in milliseconds\":2128.8746,\"children\":[{\"name\":\"Get Container Properti
es\",\"id\":\"0e323e68-60e3-42d8-9583-b63cb0376b74\",\"start time\":\"10:06:35:490\",\"duration in milliseconds\":1841.3228,\"children\":[{\"name\":\"Get Collection Cache\",\"id\":\"68087684-8d35-40a4-837d-d974f7346681\",\"start time\":\"10:06:35:491\",\"duration in milliseconds\":1019.067,\"children\":[{\"name\":\"Waiting for Initialization of client to complete\",\"id\":\"5a7c153a-69f8-48b2-b19b-03a6f96edb96\",\"start time\":\"10:06:35:492\",\"duration in milliseconds\":1018.0061}]},{\"name\":\"Read Collection\",\"id\":\"ab66c5bb-5c95-42af-bd5f-94dbbac7b7b5\",\"start time\":\"10:06:36:584\",\"duration in milliseconds\":739.0342,\"data\":{\"Client Side Request Stats\":{\"Id\":\"AggregatedClientSideRequestStatistics\",\"ContactedReplicas\":[],\"RegionsContacted\":[],\"FailedReplicas\":[],\"AddressResolutionStatistics\":[],\"StoreResponseStatistics\":[],\"HttpResponseStats\":[{\"StartTimeUTC\":\"2022-04-08T22:06:36.6095348Z\",\"DurationInMs\":632.2959,\"RequestUri\":\"https://maquaran-custrepro-westus.documents
.azure.com/dbs/test/colls/test\",\"ResourceType\":\"Collection\",\"HttpMethod\":\"GET\",\"ActivityId\":\"488c4dab-f5f9-4a24-a9d5-8897fe0f6489\",\"StatusCode\":\"OK\"}]}}}]},{\"name\":\"Service Interop Query Plan\",\"id\":\"1dd4a168-6972-4296-977f-d5a6a45cf252\",\"start time\":\"10:06:37:338\",\"duration in milliseconds\":186.2282}]},{\"name\":\"POCO Materialization\",\"id\":\"03f9d450-1ec5-44a6-ae01-5b45636142e1\",\"start time\":\"10:06:38:357\",\"duration in milliseconds\":153.3713}]}
```


### Exception after this PR

**Message**
```
"Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: ({\"errors\":[{\"severity\":\"Error\",\"location\":{\"start\":0,\"end\":9},\"code\":\"SC1001\",\"message\":\"Syntax error, incorrect syntax near 'selectttt'.\"}]});"

```

**InnerException**
```
Microsoft.Azure.Cosmos.Query.Core.Exceptions.ExpectedQueryPartitionProviderException: {"errors":[{"severity":"Error","location":{"start":0,"end":9},"code":"SC1001","message":"Syntax error, incorrect syntax near 'selectttt'."}]}
```

**StackTrace**
```
at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfo(SqlQuerySpec querySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)\r\n   at Microsoft.Azure.Cosmos.CosmosQueryClientCore.TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount, CancellationToken cancellationToken)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.ExecutionContextCallback(Object s)\r\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuil
der`1.AsyncStateMachineBox`1.MoveNext(Thread threadPoolThread)\r\n   at System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1.MoveNext()\r\n   at System.Runtime.CompilerServices.TaskAwaiter.<>c.<OutputWaitEtwEvents>b__12_0(Action innerContinuation, Task innerTask)\r\n   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.ContinuationWrapper.Invoke()\r\n   at System.Threading.Tasks.AwaitTaskContinuation.RunOrScheduleAction(Action action, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task`1.TrySetResult(TResult result)\r\n   at System.Threading.Tasks.UnwrapPromise`1.TrySetFromTask(Task task, Boolean lookForOce)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessInnerTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.ProcessCompletedOuterTask(Task task)\r\n   at System.Threading.Tasks.UnwrapPromise`1.Invoke(Task comple
tingTask)\r\n   at System.Threading.Tasks.Task.RunOrQueueCompletionAction(ITaskCompletionAction completionAction, Boolean allowInlining)\r\n   at System.Threading.Tasks.Task.RunContinuations(Object continuationObject)\r\n   at System.Threading.Tasks.Task.FinishContinuations()\r\n   at System.Threading.Tasks.Task.FinishStageThree()\r\n   at System.Threading.Tasks.Task.FinishStageTwo()\r\n   at System.Threading.Tasks.Task.FinishSlow(Boolean userDelegateExecute)\r\n   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteEntryUnsafe(Thread threadPoolThread)\r\n   at System.Threading.Tasks.Task.ExecuteFromThreadPool(Thread threadPoolThread)\r\n   at System.Threading.ThreadPoolWorkQueue.Dispatch()\r\n   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()\r\n   at System.Threading.Thread.StartCallback()\r\n
```

**Diagnostics**
```
{\"Summary\":{\"GatewayCalls\":{\"(200, 0)\":1}},\"name\":\"Typed FeedIterator ReadNextAsync\",\"id\":\"cf35bebb-459c-40b0-a860-0fc9706f7107\",\"start time\":\"10:10:34:126\",\"duration in milliseconds\":1958.407,\"data\":{\"Client Configuration\":{\"Client Created Time Utc\":\"2022-04-08T22:10:33.8452038Z\",\"NumberOfClientsCreated\":1,\"NumberOfActiveClients\":1,\"User Agent\":\"cosmos-netstandard-sdk/3.26.1|3.30.900|1|X64|Microsoft Windows 10.0.19044|.NET 6.0.3|N|\",\"ConnectionConfig\":{\"gw\":\"(cps:50, urto:10, p:False, httpf: False)\",\"rntbd\":\"(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: True, pr: ReuseUnicastPort)\",\"other\":\"(ed:False, be:False)\"},\"ConsistencyConfig\":\"(consistency: NotSet, prgns:[])\"},\"Query Correlated ActivityId\":\"78e2f2b8-207e-41ed-91fc-b7699fa223a3\"},\"children\":[{\"name\":\"Create Query Pipeline\",\"id\":\"6fe5b3e9-821e-4e50-b104-3adeec910c78\",\"start time\":\"10:10:34:148\",\"duration in milliseconds\":1364.5434,\"children\":[{\"name\":\"Get Container Propertie
s\",\"id\":\"52e916fc-0f34-445b-b648-d3788672f0cb\",\"start time\":\"10:10:34:151\",\"duration in milliseconds\":1167.2648,\"children\":[{\"name\":\"Get Collection Cache\",\"id\":\"f24eaba6-6543-48f9-bcf3-ab5b7fffcf2c\",\"start time\":\"10:10:34:152\",\"duration in milliseconds\":658.9873,\"children\":[{\"name\":\"Waiting for Initialization of client to complete\",\"id\":\"f5b97719-1253-4d4e-8b50-fa35c81c1f96\",\"start time\":\"10:10:34:153\",\"duration in milliseconds\":657.4638}]},{\"name\":\"Read Collection\",\"id\":\"3efd2ea6-356c-478f-b8ad-0eb32086315e\",\"start time\":\"10:10:34:836\",\"duration in milliseconds\":474.7224,\"data\":{\"Client Side Request Stats\":{\"Id\":\"AggregatedClientSideRequestStatistics\",\"ContactedReplicas\":[],\"RegionsContacted\":[],\"FailedReplicas\":[],\"AddressResolutionStatistics\":[],\"StoreResponseStatistics\":[],\"HttpResponseStats\":[{\"StartTimeUTC\":\"2022-04-08T22:10:34.8656288Z\",\"DurationInMs\":395.9182,\"RequestUri\":\"https://maquaran-custrepro-westus.documents.a
zure.com/dbs/test/colls/test\",\"ResourceType\":\"Collection\",\"HttpMethod\":\"GET\",\"ActivityId\":\"b867a262-3ba3-486f-aeb4-3938ff3adf00\",\"StatusCode\":\"OK\"}]}}}]},{\"name\":\"Service Interop Query Plan\",\"id\":\"c6b5d1e3-3d6b-4f41-a8ca-e78bfcde9671\",\"start time\":\"10:10:35:322\",\"duration in milliseconds\":125.3667}]},{\"name\":\"POCO Materialization\",\"id\":\"3b2233d5-cfb2-41bd-a4c9-c0100cf562c0\",\"start time\":\"10:10:35:949\",\"duration in milliseconds\":135.2378}]}
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

Closes #1910