### PR TITLE
Query: Fixes "System.ArgumentException: Stream was not readable." when using WithParameterStream

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosSqlQuerySpecJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosSqlQuerySpecJsonConverter.cs
@@ -44,11 +44,7 @@ namespace Microsoft.Azure.Cosmos
             // if the SqlParameter has stream value we dont pass it through the custom serializer.
             if (sqlParameter.Value is SerializedParameterValue serializedEncryptedData)
             {
-                using (StreamReader streamReader = new StreamReader(new MemoryStream(serializedEncryptedData.byteArrayValue)))
-                {
-                    string parameterValue = streamReader.ReadToEnd();
-                    writer.WriteRawValue(parameterValue);
-                }
+                writer.WriteRawValue(serializedEncryptedData.rawSerializedJsonValue);
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/CosmosSqlQuerySpecJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosSqlQuerySpecJsonConverter.cs
@@ -44,14 +44,11 @@ namespace Microsoft.Azure.Cosmos
             // if the SqlParameter has stream value we dont pass it through the custom serializer.
             if (sqlParameter.Value is SerializedParameterValue serializedEncryptedData)
             {
-                StreamReader streamReader = new StreamReader(serializedEncryptedData.valueStream);
-                string parameterValue = streamReader.ReadToEnd();
-                writer.WriteRawValue(parameterValue);
-
-                // once read need to move back the pointer to start.If it gets reused.
-                // Query plan will be serialized multiple times for cross partition queries and for scenarios where the query plan can not be generated locally.
-                // Note: this is a stream passed by user.
-                serializedEncryptedData.valueStream.Position = 0;
+                using (StreamReader streamReader = new StreamReader(new MemoryStream(serializedEncryptedData.byteArrayValue)))
+                {
+                    string parameterValue = streamReader.ReadToEnd();
+                    writer.WriteRawValue(parameterValue);
+                }
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -132,16 +132,16 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>An instance of <see cref="QueryDefinition"/>.</returns>
         public QueryDefinition WithParameterStream(string name, Stream valueStream)
         {
-            if (!(valueStream is MemoryStream memoryStream))
+            string rawSerializedJsonValue = null;
+            using (StreamReader streamReader = new StreamReader(valueStream))
             {
-                memoryStream = new MemoryStream();
-                valueStream.CopyTo(memoryStream);
+                rawSerializedJsonValue = streamReader.ReadToEnd();
             }
 
             // pack it into an internal type for identification.
             SerializedParameterValue serializedParameterValue = new SerializedParameterValue
             {
-                byteArrayValue = memoryStream.ToArray()
+                rawSerializedJsonValue = rawSerializedJsonValue
             };
 
             return this.WithParameter(name, serializedParameterValue);
@@ -206,6 +206,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal struct SerializedParameterValue
     {
-        internal byte[] byteArrayValue;
+        internal string rawSerializedJsonValue;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -132,10 +132,17 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>An instance of <see cref="QueryDefinition"/>.</returns>
         public QueryDefinition WithParameterStream(string name, Stream valueStream)
         {
+            if (!(valueStream is MemoryStream memoryStream))
+            {
+                memoryStream = new MemoryStream();
+                valueStream.CopyTo(memoryStream);
+                memoryStream.Position = 0;
+            }
+
             // pack it into an internal type for identification.
             SerializedParameterValue serializedParameterValue = new SerializedParameterValue
             {
-                valueStream = valueStream
+                byteArrayValue = memoryStream.ToArray()
             };
 
             return this.WithParameter(name, serializedParameterValue);
@@ -200,6 +207,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal struct SerializedParameterValue
     {
-        internal Stream valueStream;
+        internal byte[] byteArrayValue;
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 rawSerializedJsonValue = streamReader.ReadToEnd();
             }
-
+            
             // pack it into an internal type for identification.
             SerializedParameterValue serializedParameterValue = new SerializedParameterValue
             {

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -136,7 +136,6 @@ namespace Microsoft.Azure.Cosmos
             {
                 memoryStream = new MemoryStream();
                 valueStream.CopyTo(memoryStream);
-                memoryStream.Position = 0;
             }
 
             // pack it into an internal type for identification.

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 rawSerializedJsonValue = streamReader.ReadToEnd();
             }
-            
+
             // pack it into an internal type for identification.
             SerializedParameterValue serializedParameterValue = new SerializedParameterValue
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1091,6 +1091,36 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(pageCount, fromStreamCount);
             }
 
+            // get result across pages,multiple requests by setting MaxItemCount to 1.
+            foreach (QueryDefinition queryDefinition in queryDefinitions)
+            {
+                toStreamCount = 0;
+                fromStreamCount = 0;
+
+                List<dynamic> allItems = new List<dynamic>();
+                int pageCount = 0;
+                using (FeedIterator<dynamic> feedIterator = containerSerializer.GetItemQueryIterator<dynamic>(
+                    queryDefinition: queryDefinition,
+                    requestOptions: new QueryRequestOptions { MaxItemCount = 1 }))
+                {
+                    while (feedIterator.HasMoreResults)
+                    {
+                        // Only need once to verify correct serialization of the query definition
+                        FeedResponse<dynamic> response = await feedIterator.ReadNextAsync(this.cancellationToken);
+                        Assert.AreEqual(response.Count, response.Count());
+                        allItems.AddRange(response);
+                        pageCount++;
+                    }
+                }
+
+                Assert.AreEqual(2, allItems.Count, $"missing query results. Only found: {allItems.Count} items for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+
+                // There should be no call to custom serializer since the parameter values are already serialized.
+                Assert.AreEqual(0, toStreamCount, $"missing to stream call. Expected: 0 , Actual: {toStreamCount} for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+                Assert.AreEqual(pageCount, fromStreamCount);
+            }
+
+
             // Standard Cosmos Serializer Used
 
             CosmosClient clientStandardSerializer = TestCommon.CreateCosmosClient(useCustomSeralizer: false);


### PR DESCRIPTION
## Description

The query definition holds the memory stream passed in by the user (this was introduced to support query on encrypted properties). That stream is then read and disposed to send the query over the wire. The issue is the query plan will be serialized multiple times for cases like cross partition queries and for scenarios where the query plan cannot be generated locally. Reserializing the query plan seems to be by design because the query plan can rewrite the query.

The fix reads the stream upfront to a string which is stored and later passed.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3152