### PR TITLE
Client Telemetry: Adds a limit on retry count of Job Failure

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -134,6 +134,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     if (this.numberOfFailures == allowedNumberOfFailures)
                     {
                         this.Dispose();
+                        break;
                     }
 
                     // Load account information if not available, cache is already implemented
@@ -350,6 +351,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 } 
                 else
                 {
+                    this.numberOfFailures = 0; // Ressetting failure counts on success call.
                     DefaultTrace.TraceInformation("Telemetry data sent successfully.");
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal class ClientTelemetry : IDisposable
     {
+        private const int allowedNumberOfFailures = 3;
+
         private static readonly Uri endpointUrl = ClientTelemetryOptions.GetClientTelemetryEndpoint();
         private static readonly TimeSpan observingWindow = ClientTelemetryOptions.GetScheduledTimeSpan();
 
@@ -43,6 +45,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         private ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoMap 
             = new ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)>();
+
+        private int numberOfFailures = 0;
 
         /// <summary>
         /// Factory method to intiakize telemetry object and start observer task
@@ -127,6 +131,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 while (!this.cancellationTokenSource.IsCancellationRequested)
                 {
+                    if (this.numberOfFailures == allowedNumberOfFailures)
+                    {
+                        this.Dispose();
+                    }
+
                     // Load account information if not available, cache is already implemented
                     if (String.IsNullOrEmpty(this.clientTelemetryInfo.GlobalDatabaseAccountName))
                     {
@@ -335,6 +344,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
                 if (!response.IsSuccessStatusCode)
                 {
+                    this.numberOfFailures++;
+
                     DefaultTrace.TraceError("Juno API response not successful. Status Code : {0},  Message : {1}", response.StatusCode, response.ReasonPhrase);
                 } 
                 else
@@ -345,6 +356,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
+                this.numberOfFailures++;
+
                 DefaultTrace.TraceError("Exception while sending telemetry data : {0}", ex.Message);
             }
             finally
@@ -367,9 +380,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         public void Dispose()
         {
-            this.cancellationTokenSource.Cancel();
-            this.cancellationTokenSource.Dispose();
-            
+            if (!this.cancellationTokenSource.IsCancellationRequested)
+            {
+                this.cancellationTokenSource.Cancel();
+                this.cancellationTokenSource.Dispose();
+            }
             this.telemetryTask = null;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -990,13 +990,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Read an Item
             ItemResponse<ToDoActivity> response = await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.id));
 
-            Console.WriteLine(response.Diagnostics.ToString());
-
             await Task.Delay(1500);
 
             response = await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.id));
-
-            Console.WriteLine(response.Diagnostics.ToString());
 
             await Task.Delay(3500);
 


### PR DESCRIPTION
## Description

Right now, client telemetry get enabled at VM level, so if there are calls to different accounts (which include non-allowed accounts). With current design, Telemetry job will keep running in background even it is failing continuously (for non-allowed accounts).
So, This PR will stop the client telemetry job after 3 continuous failures.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues
To automatically close an issue: closes #3157 