### PR TITLE
Query: Adds aggressive prefetching for scalar aggregates

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/CrossPartitionChangeFeedAsyncEnumerator.cs
@@ -158,10 +158,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                     documentContainer,
                     changeFeedPaginationOptions,
                     cancellationToken),
-                comparer: default /* this uses a regular queue instead of prioirty queue */,
+                comparer: default /* this uses a regular queue instead of priority queue */,
                 maxConcurrency: default,
-                cancellationToken,
-                state);
+                prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
+                cancellationToken: cancellationToken,
+                state: state);
 
             CrossPartitionChangeFeedAsyncEnumerator enumerator = new CrossPartitionChangeFeedAsyncEnumerator(
                 crossPartitionEnumerator,

--- a/Microsoft.Azure.Cosmos/src/Pagination/BufferedPartitionRangePageAsyncEnumeratorBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/BufferedPartitionRangePageAsyncEnumeratorBase.cs
@@ -1,0 +1,22 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Pagination
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing;
+
+    internal abstract class BufferedPartitionRangePageAsyncEnumeratorBase<TPage, TState> : PartitionRangePageAsyncEnumerator<TPage, TState>, IPrefetcher
+        where TPage : Page<TState>
+        where TState : State
+    {
+        protected BufferedPartitionRangePageAsyncEnumeratorBase(FeedRangeState<TState> feedRangeState, CancellationToken cancellationToken)
+            : base(feedRangeState, cancellationToken)
+        {
+        }
+
+        public abstract ValueTask PrefetchAsync(ITrace trace, CancellationToken cancellationToken);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/CrossPartitionRangePageAsyncEnumerator.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 BufferedPartitionRangePageAsyncEnumeratorBase<TPage, TState> bufferedEnumerator = policy switch
                 {
                     PrefetchPolicy.PrefetchSinglePage => new BufferedPartitionRangePageAsyncEnumerator<TPage, TState>(enumerator, cancellationToken),
-                    PrefetchPolicy.PrefetchAll => new BufferedPartitionRangePageAsyncEnumerator<TPage, TState>(enumerator, cancellationToken),
+                    PrefetchPolicy.PrefetchAll => new FullyBufferedPartitionRangeAsyncEnumerator<TPage, TState>(enumerator, cancellationToken),
                     _ => throw new ArgumentOutOfRangeException(nameof(policy)),
                 };
                 bufferedEnumerators.Add(bufferedEnumerator);

--- a/Microsoft.Azure.Cosmos/src/Pagination/FullyBufferedPartitionRangeAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/FullyBufferedPartitionRangeAsyncEnumerator.cs
@@ -1,0 +1,97 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Pagination
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Tracing;
+
+    internal sealed class FullyBufferedPartitionRangeAsyncEnumerator<TPage, TState> : BufferedPartitionRangePageAsyncEnumeratorBase<TPage, TState>
+        where TPage : Page<TState>
+        where TState : State
+    {
+        private readonly PartitionRangePageAsyncEnumerator<TPage, TState> enumerator;
+        private readonly List<TPage> bufferedPages;
+        private int index;
+        private Exception exception;
+
+        private bool HasPrefetched => this.exception != null || this.bufferedPages.Count > 0;
+
+        public FullyBufferedPartitionRangeAsyncEnumerator(PartitionRangePageAsyncEnumerator<TPage, TState> enumerator, CancellationToken cancellationToken)
+            : base(enumerator.FeedRangeState, cancellationToken)
+        {
+            this.enumerator = enumerator ?? throw new ArgumentNullException(nameof(enumerator));
+            this.bufferedPages = new List<TPage>();
+            this.index = 0;
+            this.exception = null;
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            return this.enumerator.DisposeAsync();
+        }
+
+        public override async ValueTask PrefetchAsync(ITrace trace, CancellationToken cancellationToken)
+        {
+            if (trace == null)
+            {
+                throw new ArgumentNullException(nameof(trace));
+            }
+
+            if (this.HasPrefetched)
+            {
+                return;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            using (ITrace prefetchTrace = trace.StartChild("Prefetch", TraceComponent.Pagination, TraceLevel.Info))
+            {
+                while (this.exception == null && await this.enumerator.MoveNextAsync(prefetchTrace))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    TryCatch<TPage> current = this.enumerator.Current;
+                    if (current.Succeeded)
+                    {
+                        this.bufferedPages.Add(current.Result);
+                    }
+                    else
+                    {
+                        this.exception = current.Exception;
+                    }
+                }
+            }
+        }
+
+        protected override async Task<TryCatch<TPage>> GetNextPageAsync(ITrace trace, CancellationToken cancellationToken)
+        {
+            TryCatch<TPage> result;
+            if (this.index < this.bufferedPages.Count)
+            {
+                result = TryCatch<TPage>.FromResult(this.bufferedPages[this.index]);
+            }
+            else if (this.index == this.bufferedPages.Count && this.exception != null)
+            {
+                result = TryCatch<TPage>.FromException(this.exception);
+            }
+            else
+            {
+                await this.enumerator.MoveNextAsync(trace);
+                result = this.enumerator.Current;
+            }
+
+            ++this.index;
+            return result;
+        }
+
+        public override void SetCancellationToken(CancellationToken cancellationToken)
+        {
+            base.SetCancellationToken(cancellationToken);
+            this.enumerator.SetCancellationToken(cancellationToken);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Pagination/PrefetchPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/PrefetchPolicy.cs
@@ -1,0 +1,11 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Pagination
+{
+    internal enum PrefetchPolicy
+    {
+        PrefetchSinglePage,
+        PrefetchAll
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -379,6 +379,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 queryPaginationOptions: new QueryPaginationOptions(
                     pageSizeHint: inputParameters.MaxItemCount),
                 partitionKey: inputParameters.PartitionKey,
+                prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 maxConcurrency: inputParameters.MaxConcurrency,
                 cancellationToken: cancellationToken,
                 continuationToken: inputParameters.InitialUserContinuationToken);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             Cosmos.PartitionKey? partitionKey,
             QueryPaginationOptions queryPaginationOptions,
             int maxConcurrency,
+            PrefetchPolicy prefetchPolicy,
             CosmosElement continuationToken,
             CancellationToken cancellationToken)
         {
@@ -159,10 +160,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             CrossFeedRangeState<QueryState> state = monadicExtractState.Result;
 
             CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState> crossPartitionPageEnumerator = new CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState>(
-                documentContainer,
-                ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, queryPaginationOptions, partitionKey, cancellationToken),
+                feedRangeProvider: documentContainer,
+                createPartitionRangeEnumerator: ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, queryPaginationOptions, partitionKey, cancellationToken),
                 comparer: Comparer.Singleton,
-                maxConcurrency,
+                maxConcurrency: maxConcurrency,
+                prefetchPolicy: prefetchPolicy,
                 state: state,
                 cancellationToken: cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -188,10 +188,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
             {
                 return PrefetchPolicy.PrefetchAll;
             }
-            else
-            {
-                return PrefetchPolicy.PrefetchSinglePage;
-            }
+
+            return PrefetchPolicy.PrefetchSinglePage;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
 
             sqlQuerySpec = !string.IsNullOrEmpty(queryInfo.RewrittenQuery) ? new SqlQuerySpec(queryInfo.RewrittenQuery, sqlQuerySpec.Parameters) : sqlQuerySpec;
 
+            PrefetchPolicy prefetchPolicy = DeterminePrefetchPolicy(queryInfo);
+
             MonadicCreatePipelineStage monadicCreatePipelineStage;
             if (queryInfo.HasOrderBy)
             {
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     targetRanges: targetRanges,
                     queryPaginationOptions: queryPaginationOptions,
                     partitionKey: partitionKey,
+                    prefetchPolicy: prefetchPolicy,
                     maxConcurrency: maxConcurrency,
                     continuationToken: continuationToken,
                     cancellationToken: cancellationToken);
@@ -177,6 +180,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
 
             return monadicCreatePipelineStage(requestContinuationToken, requestCancellationToken)
                 .Try<IQueryPipelineStage>(onSuccess: (stage) => new SkipEmptyPageQueryPipelineStage(stage, requestCancellationToken));
+        }
+
+        private static PrefetchPolicy DeterminePrefetchPolicy(QueryInfo queryInfo)
+        {
+            if (!queryInfo.HasDCount && queryInfo.HasAggregates && !queryInfo.HasGroupBy)
+            {
+                return PrefetchPolicy.PrefetchAll;
+            }
+            else
+            {
+                return PrefetchPolicy.PrefetchSinglePage;
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/CrossPartitionReadFeedAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadFeed/Pagination/CrossPartitionReadFeedAsyncEnumerator.cs
@@ -104,6 +104,7 @@ namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
                     cancellationToken),
                 comparer: comparer,
                 maxConcurrency: default,
+                prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 cancellationToken,
                 crossFeedRangeState);
 
@@ -116,11 +117,14 @@ namespace Microsoft.Azure.Cosmos.ReadFeed.Pagination
         private static CreatePartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState> MakeCreateFunction(
             IReadFeedDataSource readFeedDataSource,
             ReadFeedPaginationOptions readFeedPaginationOptions,
-            CancellationToken cancellationToken) => (FeedRangeState<ReadFeedState> feedRangeState) => new ReadFeedPartitionRangeEnumerator(
+            CancellationToken cancellationToken)
+        {
+            return (FeedRangeState<ReadFeedState> feedRangeState) => new ReadFeedPartitionRangeEnumerator(
                 readFeedDataSource,
                 feedRangeState,
                 readFeedPaginationOptions,
                 cancellationToken);
+        }
 
         private sealed class PartitionRangePageAsyncEnumeratorComparerForward : IComparer<PartitionRangePageAsyncEnumerator<ReadFeedPage, ReadFeedState>>
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.ScenariosAsync.xml
@@ -1471,7 +1471,6 @@
     │   │       └── [,FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
     │   │           └── Query Transport(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
     │   ├── [,FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
-    │   │   └── Prefetch(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
     │   ├── Get Child Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
     │   └── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
     │       └── [,1F-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
@@ -1589,15 +1588,7 @@
           "name": "[,FF) move next",
           "id": "00000000-0000-0000-0000-000000000000",
           "start time": "12:00:00:000",
-          "duration in milliseconds": 0,
-          "children": [
-            {
-              "name": "Prefetch",
-              "id": "00000000-0000-0000-0000-000000000000",
-              "start time": "12:00:00:000",
-              "duration in milliseconds": 0
-            }
-          ]
+          "duration in milliseconds": 0
         },
         {
           "name": "Get Child Ranges",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/BufferedPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/BufferedPartitionRangeEnumeratorTests.cs
@@ -203,7 +203,7 @@
                 return page.GetRecords();
             }
 
-            public override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
+            protected override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
                 ReadFeedState state = null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 createPartitionRangeEnumerator: createEnumerator,
                 comparer: null,
                 maxConcurrency: 0,
+                prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 cancellationToken: default,
                 state: new CrossFeedRangeState<ReadFeedState>(
                     new FeedRangeState<ReadFeedState>[]
@@ -132,6 +133,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 feedRangeProvider: feedRangeProvider.Object,
                 createPartitionRangeEnumerator: createEnumerator,
                 comparer: null,
+                prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 maxConcurrency: 0,
                 cancellationToken: default,
                 state: new CrossFeedRangeState<ReadFeedState>(
@@ -377,6 +379,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     createPartitionRangeEnumerator: createEnumerator,
                     comparer: PartitionRangePageAsyncEnumeratorComparer.Singleton,
                     maxConcurrency: 10,
+                    prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                     trace: NoOpTrace.Singleton,
                     state: state ?? new CrossFeedRangeState<ReadFeedState>(
                         new FeedRangeState<ReadFeedState>[]
@@ -403,6 +406,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         createPartitionRangeEnumerator: createEnumerator,
                         comparer: PartitionRangePageAsyncEnumeratorComparer.Singleton,
                         maxConcurrency: 10,
+                        prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                         cancellationToken: cancellationToken,
                         state: state ?? new CrossFeedRangeState<ReadFeedState>(
                             new FeedRangeState<ReadFeedState>[]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/CrossPartitionPartitionRangeEnumeratorTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         public async Task TestSplitAndMergeAsync(bool useState, bool allowSplits, bool allowMerges)
         {
             Implementation implementation = new Implementation(singlePartition: false);
-            await implementation.TestSplitAndMergeImplementationAsync(useState, allowSplits, allowMerges);
+            await implementation.TestSplitAndMergeImplementationAsync(useState, allowSplits, allowMerges, false);
         }
 
         private sealed class Implementation : PartitionRangeEnumeratorTests<CrossFeedRangePage<ReadFeedPage, ReadFeedState>, CrossFeedRangeState<ReadFeedState>>
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 Assert.AreEqual(numItems, identifiers.Count);
             }
 
-            public async Task TestSplitAndMergeImplementationAsync(bool useState, bool allowSplits, bool allowMerges)
+            public async Task TestSplitAndMergeImplementationAsync(bool useState, bool allowSplits, bool allowMerges, bool aggressivePrefetch)
             {
                 int numItems = 1000;
                 IDocumentContainer inMemoryCollection = await this.CreateDocumentContainerAsync(numItems);
@@ -363,7 +363,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 Assert.AreEqual(numItems, identifiers.Count);
             }
 
-            public override IAsyncEnumerable<TryCatch<CrossFeedRangePage<ReadFeedPage, ReadFeedState>>> CreateEnumerable(
+            protected override IAsyncEnumerable<TryCatch<CrossFeedRangePage<ReadFeedPage, ReadFeedState>>> CreateEnumerable(
                 IDocumentContainer inMemoryCollection,
                 CrossFeedRangeState<ReadFeedState> state = null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     using ResourceIdentifier = Cosmos.Pagination.ResourceIdentifier;
 
     // Collection useful for mocking requests and repartitioning (splits / merge).
-    internal sealed class InMemoryContainer : IMonadicDocumentContainer
+    internal class InMemoryContainer : IMonadicDocumentContainer
     {
         private readonly PartitionKeyDefinition partitionKeyDefinition;
         private readonly Dictionary<int, (int, int)> parentToChildMapping;
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             }
         }
 
-        public Task<TryCatch<QueryPage>> MonadicQueryAsync(
+        public virtual Task<TryCatch<QueryPage>> MonadicQueryAsync(
             SqlQuerySpec sqlQuerySpec,
             FeedRangeState<QueryState> feedRangeState,
             QueryPaginationOptions queryPaginationOptions,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
@@ -27,7 +27,13 @@
             int numItems = 100;
             IDocumentContainer inMemoryCollection = await this.CreateDocumentContainerAsync(numItems);
             CancellationTokenSource cts = new CancellationTokenSource();
-            IAsyncEnumerator<TryCatch<TPage>> enumerator = this.CreateEnumerator(inMemoryCollection, cancellationToken: cts.Token);
+            IAsyncEnumerator<TryCatch<TPage>> enumerator = await this.CreateEnumeratorAsync(
+                inMemoryCollection,
+                aggressivePrefetch: false,
+                exercisePrefetch: false,
+                state: null,
+                cancellationToken: cts.Token);
+
             cts.Cancel();
             await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
         }
@@ -43,22 +49,22 @@
         }
 
         [TestMethod]
-        public async Task TestResumingFromStateAsync()
+        public async Task TestResumingFromStateAsync(bool aggressivePrefetch, bool exercisePrefetch)
         {
             int numItems = 1000;
             IDocumentContainer inMemoryCollection = await this.CreateDocumentContainerAsync(numItems);
 
-            IAsyncEnumerator<TryCatch<TPage>> enumerator = this.CreateEnumerator(inMemoryCollection);
+            IAsyncEnumerator<TryCatch<TPage>> enumerator = await this.CreateEnumeratorAsync(inMemoryCollection, aggressivePrefetch, exercisePrefetch);
             (HashSet<string> firstDrainResults, TState state) = await this.PartialDrainAsync(enumerator, numIterations: 3);
 
-            IAsyncEnumerable<TryCatch<TPage>> enumerable = this.CreateEnumerable(inMemoryCollection, false, state);
+            IAsyncEnumerable<TryCatch<TPage>> enumerable = this.CreateEnumerable(inMemoryCollection, aggressivePrefetch, state);
             HashSet<string> secondDrainResults = await this.DrainFullyAsync(enumerable);
 
             Assert.AreEqual(numItems, firstDrainResults.Count + secondDrainResults.Count);
         }
 
         [TestMethod]
-        public async Task Test429sAsync()
+        public async Task Test429sAsync(bool aggressivePrefetch)
         {
             int numItems = 100;
             IDocumentContainer inMemoryCollection = await this.CreateDocumentContainerAsync(
@@ -67,7 +73,7 @@
                     inject429s: true,
                     injectEmptyPages: false));
 
-            IAsyncEnumerable<TryCatch<TPage>> enumerable = this.CreateEnumerable(inMemoryCollection);
+            IAsyncEnumerable<TryCatch<TPage>> enumerable = this.CreateEnumerable(inMemoryCollection, aggressivePrefetch);
 
             HashSet<string> identifiers = new HashSet<string>();
             await foreach (TryCatch<TPage> tryGetPage in enumerable)
@@ -99,7 +105,7 @@
         }
 
         [TestMethod]
-        public async Task Test429sWithContinuationsAsync()
+        public async Task Test429sWithContinuationsAsync(bool aggressivePrefetch, bool exercisePrefetch)
         {
             int numItems = 100;
             IDocumentContainer inMemoryCollection = await this.CreateDocumentContainerAsync(
@@ -108,7 +114,10 @@
                     inject429s: true,
                     injectEmptyPages: false));
 
-            IAsyncEnumerator<TryCatch<TPage>> enumerator = this.CreateEnumerator(inMemoryCollection);
+            IAsyncEnumerator<TryCatch<TPage>> enumerator = await this.CreateEnumeratorAsync(
+                inMemoryCollection,
+                aggressivePrefetch,
+                exercisePrefetch);
 
             HashSet<string> identifiers = new HashSet<string>();
             TState state = default;
@@ -130,7 +139,7 @@
                     }
 
                     // Create a new enumerator from that state to simulate when the user want's to start resume later from a continuation token.
-                    enumerator = this.CreateEnumerator(inMemoryCollection, false, state);
+                    enumerator = await this.CreateEnumeratorAsync(inMemoryCollection, false, false, state);
                 }
                 else
                 {
@@ -168,9 +177,10 @@
             bool aggressivePrefetch = false,
             TState state = null);
 
-        protected abstract IAsyncEnumerator<TryCatch<TPage>> CreateEnumerator(
+        protected abstract Task<IAsyncEnumerator<TryCatch<TPage>>> CreateEnumeratorAsync(
                 IDocumentContainer inMemoryCollection,
                 bool aggressivePrefetch = false,
+                bool exercisePrefetch = false,
                 TState state = null,
                 CancellationToken cancellationToken = default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
@@ -163,7 +163,9 @@
 
         public abstract IReadOnlyList<Record> GetRecordsFromPage(TPage page);
 
-        public abstract IAsyncEnumerable<TryCatch<TPage>> CreateEnumerable(IDocumentContainer documentContainer, TState state = null);
+        protected abstract IAsyncEnumerable<TryCatch<TPage>> CreateEnumerable(
+            IDocumentContainer documentContainer,
+            TState state = null);
 
         public abstract IAsyncEnumerator<TryCatch<TPage>> CreateEnumerator(IDocumentContainer documentContainer, TState state = null, CancellationToken cancellationToken= default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/PartitionRangeEnumeratorTests.cs
@@ -29,7 +29,7 @@
             CancellationTokenSource cts = new CancellationTokenSource();
             IAsyncEnumerator<TryCatch<TPage>> enumerator = this.CreateEnumerator(inMemoryCollection, cancellationToken: cts.Token);
             cts.Cancel();
-            await Assert.ThrowsExceptionAsync<TaskCanceledException>(async () => await enumerator.MoveNextAsync());
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () => await enumerator.MoveNextAsync());
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         public async Task TestDrainFullyAsync()
         {
             Implementation implementation = new Implementation();
-            await implementation.TestDrainFullyAsync();
+            await implementation.TestDrainFullyAsync(false);
         }
 
         [TestMethod]
         public async Task TestEmptyPages()
         {
             Implementation implementation = new Implementation();
-            await implementation.TestEmptyPages();
+            await implementation.TestEmptyPages(false);
         }
 
         [TestMethod]
@@ -124,6 +124,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
             protected override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
+                bool aggressivePrefetch = false,
                 ReadFeedState state = null)
             {
                 return new PartitionRangePageAsyncEnumerable<ReadFeedPage, ReadFeedState>(
@@ -131,15 +132,18 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     new FeedRangePartitionKeyRange(partitionKeyRangeId: "0"),
                         state ?? ReadFeedState.Beginning()),
                         (feedRangeState) => new ReadFeedPartitionRangeEnumerator(
-                        documentContainer,
-                        feedRangeState: feedRangeState,
-                        readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
-                        cancellationToken: default),
+                            documentContainer,
+                            feedRangeState: feedRangeState,
+                            readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
+                            cancellationToken: default),
                     trace: NoOpTrace.Singleton);
             }
 
-            public override IAsyncEnumerator<TryCatch<ReadFeedPage>> CreateEnumerator(
-                IDocumentContainer inMemoryCollection,  ReadFeedState state = null, CancellationToken cancellationToken = default)
+            protected override IAsyncEnumerator<TryCatch<ReadFeedPage>> CreateEnumerator(
+                IDocumentContainer inMemoryCollection,
+                bool aggressivePrefetch = false,
+                ReadFeedState state = null,
+                CancellationToken cancellationToken = default)
             {
                 return new TracingAsyncEnumerator<TryCatch<ReadFeedPage>>(
                     new ReadFeedPartitionRangeEnumerator(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 return page.GetRecords();
             }
 
-            public override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
+            protected override IAsyncEnumerable<TryCatch<ReadFeedPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
                 ReadFeedState state = null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/SinglePartitionPartitionRangeEnumeratorTests.cs
@@ -22,14 +22,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         public async Task Test429sAsync()
         {
             Implementation implementation = new Implementation();
-            await implementation.Test429sAsync();
+            await implementation.Test429sAsync(false);
         }
 
         [TestMethod]
         public async Task Test429sWithContinuationsAsync()
         {
             Implementation implementation = new Implementation();
-            await implementation.Test429sWithContinuationsAsync();
+            await implementation.Test429sWithContinuationsAsync(false, false);
         }
 
         [TestMethod]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         public async Task TestResumingFromStateAsync()
         {
             Implementation implementation = new Implementation();
-            await implementation.TestResumingFromStateAsync();
+            await implementation.TestResumingFromStateAsync(false, false);
         }
 
         [TestMethod]
@@ -139,13 +139,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                     trace: NoOpTrace.Singleton);
             }
 
-            protected override IAsyncEnumerator<TryCatch<ReadFeedPage>> CreateEnumerator(
+            protected override Task<IAsyncEnumerator<TryCatch<ReadFeedPage>>> CreateEnumeratorAsync(
                 IDocumentContainer inMemoryCollection,
                 bool aggressivePrefetch = false,
+                bool exercisePrefetch = false,
                 ReadFeedState state = null,
                 CancellationToken cancellationToken = default)
             {
-                return new TracingAsyncEnumerator<TryCatch<ReadFeedPage>>(
+                IAsyncEnumerator<TryCatch<ReadFeedPage>> enumerator = new TracingAsyncEnumerator<TryCatch<ReadFeedPage>>(
                     new ReadFeedPartitionRangeEnumerator(
                         inMemoryCollection,
                         feedRangeState: new FeedRangeState<ReadFeedState>(
@@ -154,6 +155,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         readFeedPaginationOptions: new ReadFeedPaginationOptions(pageSizeHint: 10),
                         cancellationToken: cancellationToken),
                     trace: NoOpTrace.Singleton);
+
+                return Task.FromResult(enumerator);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 throw new NotImplementedException();
             }
 
-            public override IAsyncEnumerable<TryCatch<OrderByQueryPage>> CreateEnumerable(IDocumentContainer documentContainer, QueryState state = null)
+            protected override IAsyncEnumerable<TryCatch<OrderByQueryPage>> CreateEnumerable(IDocumentContainer documentContainer, QueryState state = null)
             {
                 throw new NotImplementedException();
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
@@ -36,13 +36,19 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 throw new NotImplementedException();
             }
 
-            protected override IAsyncEnumerable<TryCatch<OrderByQueryPage>> CreateEnumerable(IDocumentContainer documentContainer, QueryState state = null)
+            protected override IAsyncEnumerable<TryCatch<OrderByQueryPage>> CreateEnumerable(
+                IDocumentContainer documentContainer,
+                bool aggressivePrefetch = false,
+                QueryState state = null)
             {
                 throw new NotImplementedException();
             }
 
-            public override IAsyncEnumerator<TryCatch<OrderByQueryPage>> CreateEnumerator(
-                IDocumentContainer documentContainer, QueryState state = null, CancellationToken cancellationToken = default)
+            protected override IAsyncEnumerator<TryCatch<OrderByQueryPage>> CreateEnumerator(
+                IDocumentContainer documentContainer,
+                bool aggressivePrefetch = false,
+                QueryState state = null,
+                CancellationToken cancellationToken = default)
             {
                 List<FeedRangeEpk> ranges = documentContainer.GetFeedRangesAsync(
                     trace: NoOpTrace.Singleton,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OrderByQueryPartitionRangePageAsyncEnumeratorTests.cs
@@ -44,9 +44,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 throw new NotImplementedException();
             }
 
-            protected override IAsyncEnumerator<TryCatch<OrderByQueryPage>> CreateEnumerator(
+            protected override Task<IAsyncEnumerator<TryCatch<OrderByQueryPage>>> CreateEnumeratorAsync(
                 IDocumentContainer documentContainer,
                 bool aggressivePrefetch = false,
+                bool exercisePrefetch = false,
                 QueryState state = null,
                 CancellationToken cancellationToken = default)
             {
@@ -54,7 +55,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                     trace: NoOpTrace.Singleton,
                     cancellationToken: cancellationToken).Result;
                 Assert.AreEqual(1, ranges.Count);
-                return new TracingAsyncEnumerator<TryCatch<OrderByQueryPage>>(
+                
+                IAsyncEnumerator<TryCatch<OrderByQueryPage>> enumerator = new TracingAsyncEnumerator<TryCatch<OrderByQueryPage>>(
                     new OrderByQueryPartitionRangePageAsyncEnumerator(
                         queryDataSource: documentContainer,
                         sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
@@ -64,6 +66,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                         filter: "filter",
                         cancellationToken: cancellationToken),
                     NoOpTrace.Singleton);
+
+                return Task.FromResult(enumerator);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggressivePrefetchPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggressivePrefetchPipelineTests.cs
@@ -168,6 +168,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 this.semaphore = new SemaphoreSlim(0, maxConcurrency);
                 this.cancellationToken = cancellationToken;
             }
+
             public override async Task<TryCatch<QueryPage>> MonadicQueryAsync(
                 SqlQuerySpec sqlQuerySpec,
                 FeedRangeState<QueryState> feedRangeState,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggressivePrefetchPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/AggressivePrefetchPipelineTests.cs
@@ -1,0 +1,201 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Tests.Pagination;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class AggressivePrefetchPipelineTests
+    {
+        public static readonly TimeSpan Timeout = TimeSpan.FromSeconds(3);
+
+        private static readonly TimeSpan PollingInterval = TimeSpan.FromMilliseconds(25);
+
+        [TestMethod]
+        [Owner("ndeshpan")]
+        public async Task BasicTests()
+        {
+
+        }
+
+        private AggressivePrefetchTestCase MakeTest(string query, IReadOnlyList<CosmosObject> documents, MonadicQueryDelegate queryDelegate, CosmosElement expectedDocument)
+        {
+            return new AggressivePrefetchTestCase(query, documents, queryDelegate, expectedDocument);
+        }
+
+        private struct AggressivePrefetchTestCase
+        {
+            public string Query { get; }
+
+            public IReadOnlyList<CosmosObject> Documents { get; }
+
+            public int CountPartitions { get; }
+
+            public MonadicQueryDelegate QueryDelegate { get; }
+
+            public CosmosElement ExpectedDocument { get; }
+
+            public AggressivePrefetchTestCase(
+                string query,
+                IReadOnlyList<CosmosObject> documents,
+                int countPartitions,
+                MonadicQueryDelegate queryDelegate,
+                CosmosElement expectedDocument)
+            {
+                this.Query = query ?? throw new ArgumentNullException(nameof(query));
+                this.Documents = documents ?? throw new ArgumentNullException(nameof(documents));
+                this.CountPartitions = countPartitions;
+                this.QueryDelegate = queryDelegate ?? throw new ArgumentNullException(nameof(queryDelegate));
+                this.ExpectedDocument = expectedDocument ?? throw new ArgumentNullException(nameof(expectedDocument));
+            }
+        }
+
+        private static async Task RunTest(AggressivePrefetchTestCase testCase)
+        {
+            CancellationTokenSource cts = new CancellationTokenSource(Timeout);
+
+            MockQueryDataSource queryDataSource = new MockQueryDataSource(
+                testCase.QueryDelegate,
+                testCase.CountPartitions,
+                cts.Token);
+
+            IMonadicDocumentContainer monadicDocumentContainer = new MockDocumentContainer(
+                FullPipelineTests.partitionKeyDefinition,
+                queryDataSource);
+
+            IDocumentContainer documentContainer = await FullPipelineTests.CreateDocumentContainerAsync(
+                testCase.Documents,
+                monadicDocumentContainer,
+                testCase.CountPartitions);
+
+            Task<List<CosmosElement>> resultTask = FullPipelineTests.ExecuteQueryAsync(
+                testCase.Query,
+                testCase.Documents,
+                documentContainer);
+
+            while (queryDataSource.CountWaiters < testCase.CountPartitions && !cts.IsCancellationRequested)
+            {
+                await Task.Delay(PollingInterval);
+            }
+
+            queryDataSource.Release(testCase.CountPartitions);
+
+            IReadOnlyList<CosmosElement> actualDocuments = await resultTask;
+            actualDocuments.Should().HaveCount(1);
+            actualDocuments.First().Should().Be(testCase.ExpectedDocument);
+        }
+
+        private delegate Task<TryCatch<QueryPage>> MonadicQueryDelegate(
+            SqlQuerySpec sqlQuerySpec,
+            FeedRangeState<QueryState> feedRangeState,
+            QueryPaginationOptions queryPaginationOptions,
+            ITrace trace,
+            CancellationToken cancellationToken);
+
+        private sealed class MockQueryDataSource : IMonadicQueryDataSource, IDisposable
+        {
+            private readonly SemaphoreSlim semaphore;
+
+            private readonly CancellationToken cancellationToken;
+
+            private readonly int maxConcurrency;
+
+            private readonly int continuationCount;
+
+            private bool disposedValue;
+
+            public MonadicQueryDelegate QueryDelegate { get; }
+
+            public int CountWaiters => this.maxConcurrency - this.semaphore.CurrentCount;
+
+            public MockQueryDataSource(
+                MonadicQueryDelegate queryDelegate,
+                int continuationCount,
+                int maxConcurrency,
+                CancellationToken cancellationToken)
+            {
+                this.continuationCount = continuationCount;
+                this.maxConcurrency = maxConcurrency;
+                this.semaphore = new SemaphoreSlim(0, maxConcurrency);
+                this.cancellationToken = cancellationToken;
+                this.QueryDelegate = queryDelegate ?? throw new ArgumentNullException(nameof(queryDelegate));
+            }
+
+            public void Release(int count)
+            {
+                this.semaphore.Release(count);
+            }
+
+            public async Task<TryCatch<QueryPage>> MonadicQueryAsync(
+                SqlQuerySpec sqlQuerySpec,
+                FeedRangeState<QueryState> feedRangeState,
+                QueryPaginationOptions queryPaginationOptions,
+                ITrace trace,
+                CancellationToken cancellationToken)
+            {
+                await this.semaphore.WaitAsync(this.cancellationToken);
+
+                Number64 continuationToken = feedRangeState.State.Value as Number64;
+
+                return await this.QueryDelegate(sqlQuerySpec, feedRangeState, queryPaginationOptions, trace, cancellationToken);
+            }
+
+            private void Dispose(bool disposing)
+            {
+                if (!this.disposedValue)
+                {
+                    if (disposing)
+                    {
+                        this.semaphore.Dispose();
+                    }
+
+                    this.disposedValue = true;
+                }
+            }
+
+            public void Dispose()
+            {
+                // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+                this.Dispose(disposing: true);
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        private sealed class MockDocumentContainer : InMemoryContainer
+        {
+            private readonly IMonadicQueryDataSource queryDataSource;
+
+            public MockDocumentContainer(PartitionKeyDefinition partitionKeyDefinition, IMonadicQueryDataSource queryDataSource)
+                : base(partitionKeyDefinition)
+            {
+                this.queryDataSource = queryDataSource ?? throw new ArgumentNullException(nameof(queryDataSource));
+            }
+
+            public override Task<TryCatch<QueryPage>> MonadicQueryAsync(
+                SqlQuerySpec sqlQuerySpec,
+                FeedRangeState<QueryState> feedRangeState,
+                QueryPaginationOptions queryPaginationOptions,
+                ITrace trace,
+                CancellationToken cancellationToken)
+            {
+                return this.queryDataSource.MonadicQueryAsync(sqlQuerySpec, feedRangeState, queryPaginationOptions, trace, cancellationToken);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/CrossPartitionRangePageAsyncEnumerable.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/CrossPartitionRangePageAsyncEnumerable.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         private readonly IComparer<PartitionRangePageAsyncEnumerator<TPage, TState>> comparer;
         private readonly IFeedRangeProvider feedRangeProvider;
         private readonly int maxConcurrency;
+        private readonly PrefetchPolicy prefetchPolicy;
         private readonly ITrace trace;
 
         public CrossPartitionRangePageAsyncEnumerable(
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             CreatePartitionRangePageAsyncEnumerator<TPage, TState> createPartitionRangeEnumerator,
             IComparer<PartitionRangePageAsyncEnumerator<TPage, TState>> comparer,
             int maxConcurrency,
+            PrefetchPolicy prefetchPolicy,
             ITrace trace,
             CrossFeedRangeState<TState> state = default)
         {
@@ -36,6 +38,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             this.comparer = comparer ?? throw new ArgumentNullException(nameof(comparer));
             this.state = state;
             this.maxConcurrency = maxConcurrency < 0 ? throw new ArgumentOutOfRangeException(nameof(maxConcurrency)) : maxConcurrency;
+            this.prefetchPolicy = prefetchPolicy;
             this.trace = trace ?? throw new ArgumentNullException(nameof(trace));
         }
 
@@ -49,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     this.createPartitionRangeEnumerator,
                     this.comparer,
                     this.maxConcurrency,
+                    this.prefetchPolicy,
                     cancellationToken,
                     this.state),
                 this.trace);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -162,8 +162,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         [TestMethod]
         public async Task Aggregates()
         {
+            const int DocumentCount = 250;
             List<CosmosObject> documents = new List<CosmosObject>();
-            for (int i = 0; i < 250; i++)
+            for (int i = 0; i < DocumentCount; i++)
             {
                 documents.Add(CosmosObject.Parse($"{{\"pk\" : {i} }}"));
             }
@@ -173,6 +174,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 documents: documents);
 
             Assert.AreEqual(expected: 1, actual: documentsQueried.Count);
+            if (documentsQueried[0] is CosmosNumber number)
+            {
+                Assert.AreEqual(expected: DocumentCount, actual: Number64.ToLong(number.Value));
+            }
+            else
+            {
+                Assert.Fail();
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
@@ -127,7 +127,7 @@
                 return records;
             }
 
-            public override IAsyncEnumerable<TryCatch<QueryPage>> CreateEnumerable(
+            protected override IAsyncEnumerable<TryCatch<QueryPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
                 QueryState state = null)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
@@ -36,14 +36,14 @@
         public async Task TestDrainFullyAsync()
         {
             Implementation implementation = new Implementation();
-            await implementation.TestDrainFullyAsync();
+            await implementation.TestDrainFullyAsync(false);
         }
 
         [TestMethod]
         public async Task TestEmptyPages()
         {
             Implementation implementation = new Implementation();
-            await implementation.TestEmptyPages();
+            await implementation.TestEmptyPages(false);
         }
 
         [TestMethod]
@@ -129,6 +129,7 @@
 
             protected override IAsyncEnumerable<TryCatch<QueryPage>> CreateEnumerable(
                 IDocumentContainer documentContainer,
+                bool aggressivePrefetch = false,
                 QueryState state = null)
             {
                 List<FeedRangeEpk> ranges = documentContainer.GetFeedRangesAsync(
@@ -147,8 +148,9 @@
                     trace: NoOpTrace.Singleton);
             }
 
-            public override IAsyncEnumerator<TryCatch<QueryPage>> CreateEnumerator(
+            protected override IAsyncEnumerator<TryCatch<QueryPage>> CreateEnumerator(
                 IDocumentContainer documentContainer,
+                bool aggressivePrefetch = false,
                 QueryState state = default,
                 CancellationToken cancellationToken = default)
             {


### PR DESCRIPTION
## Description
The query pipeline incorporates a Parallel Prefetch phase during its creation. After creation, the query pipeline runs sequentially.  for scalar aggregates, we can afford to aggressively prefetch all pages, since the total memory overhead of doing so is very low.
This change implements such functionality.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

