### PR TITLE
UserAgent: Removes direct version

### DIFF
--- a/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
+++ b/Microsoft.Azure.Cosmos/src/EnvironmentInformation.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class EnvironmentInformation
     {
         private static readonly string clientSDKVersion;
-        private static readonly string directPackageVersion;
         private static readonly string framework;
         private static readonly string architecture;
         private static readonly string os;
@@ -19,8 +18,6 @@ namespace Microsoft.Azure.Cosmos
         {
             Version sdkVersion = Assembly.GetAssembly(typeof(CosmosClient)).GetName().Version;
             EnvironmentInformation.clientSDKVersion = $"{sdkVersion.Major}.{sdkVersion.Minor}.{sdkVersion.Build}";
-            Version directVersion = Assembly.GetAssembly(typeof(Documents.UserAgentContainer)).GetName().Version;
-            EnvironmentInformation.directPackageVersion = $"{directVersion.Major}.{directVersion.Minor}.{directVersion.Build}";
             EnvironmentInformation.framework = RuntimeInformation.FrameworkDescription;
             EnvironmentInformation.architecture = RuntimeInformation.ProcessArchitecture.ToString();
             EnvironmentInformation.os = RuntimeInformation.OSDescription;
@@ -29,11 +26,6 @@ namespace Microsoft.Azure.Cosmos
         public EnvironmentInformation()
         {
         }
-
-        /// <summary>
-        /// Version of the current direct package.
-        /// </summary>
-        public string DirectVersion => EnvironmentInformation.directPackageVersion;
 
         /// <summary>
         /// Version of the current client.

--- a/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/UserAgentContainer.cs
@@ -33,14 +33,12 @@ namespace Microsoft.Azure.Cosmos
 
         protected virtual void GetEnvironmentInformation(
             out string clientVersion,
-            out string directVersion,
             out string processArchitecture,
             out string operatingSystem,
             out string runtimeFramework)
         {
             EnvironmentInformation environmentInformation = new EnvironmentInformation();
             clientVersion = environmentInformation.ClientVersion;
-            directVersion = environmentInformation.DirectVersion;
             processArchitecture = environmentInformation.ProcessArchitecture;
             operatingSystem = environmentInformation.OperatingSystem;
             runtimeFramework = environmentInformation.RuntimeFramework;
@@ -52,7 +50,6 @@ namespace Microsoft.Azure.Cosmos
         {
             this.GetEnvironmentInformation(
                 out string clientVersion,
-                out string directVersion,
                 out string processArchitecture,
                 out string operatingSystem,
                 out string runtimeFramework);
@@ -68,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
 #if PREVIEW
             previewFlag = "P";
 #endif
-            string baseUserAgent = $"cosmos-netstandard-sdk/{clientVersion}" + previewFlag + Regex.Replace($"|{directVersion}|{this.clientId}|{processArchitecture}|{operatingSystem}|{runtimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
+            string baseUserAgent = $"cosmos-netstandard-sdk/{clientVersion}" + previewFlag + Regex.Replace($"|{this.clientId}|{processArchitecture}|{operatingSystem}|{runtimeFramework}|", @"[^0-9a-zA-Z\.\|\-]+", " ");
             if (!string.IsNullOrEmpty(regionConfiguration))
             {
                 baseUserAgent += $"{regionConfiguration}|";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -93,7 +93,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             previewFlag = "P";
 #endif
             Assert.AreEqual($"cosmos-netstandard-sdk/{envInfo.ClientVersion}" + previewFlag, values[0]);
-            Assert.AreEqual(envInfo.DirectVersion, values[1]);
             Assert.AreEqual("0", values[2]);
             Assert.AreEqual(envInfo.ProcessArchitecture, values[3]);
             Assert.AreEqual(envInfo.OperatingSystem, values[4]);
@@ -377,7 +376,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             protected override void GetEnvironmentInformation(
                 out string clientVersion,
-                out string directVersion,
                 out string processArchitecture,
                 out string operatingSystem,
                 out string runtimeFramework)
@@ -387,7 +385,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 base.GetEnvironmentInformation(
                     clientVersion: out clientVersion,
-                    directVersion: out directVersion,
                     processArchitecture: out processArchitecture,
                     operatingSystem: out _,
                     runtimeFramework: out runtimeFramework);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/UserAgentTests.cs
@@ -93,10 +93,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             previewFlag = "P";
 #endif
             Assert.AreEqual($"cosmos-netstandard-sdk/{envInfo.ClientVersion}" + previewFlag, values[0]);
-            Assert.AreEqual("0", values[2]);
-            Assert.AreEqual(envInfo.ProcessArchitecture, values[3]);
-            Assert.AreEqual(envInfo.OperatingSystem, values[4]);
-            Assert.AreEqual(envInfo.RuntimeFramework, values[5]);
+            Assert.AreEqual("0", values[1]);
+            Assert.AreEqual(envInfo.ProcessArchitecture, values[2]);
+            Assert.AreEqual(envInfo.OperatingSystem, values[3]);
+            Assert.AreEqual(envInfo.RuntimeFramework, values[4]);
         }
 
         [TestMethod]
@@ -192,11 +192,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     string userAgentString = client.DocumentClient.ConnectionPolicy.UserAgentContainer.UserAgent;
                     if (i <= max)
                     {
-                        Assert.AreEqual(userAgentString.Split('|')[2], i.ToString());
+                        Assert.AreEqual(userAgentString.Split('|')[1], i.ToString());
                     }
                     else
                     {
-                        Assert.AreEqual(userAgentString.Split('|')[2], max.ToString());
+                        Assert.AreEqual(userAgentString.Split('|')[1], max.ToString());
                     }
                 }
             }
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             await Task.WhenAll(tasks);
             List<int> actual = tasks.Select(r => 
-                        int.Parse(r.Result.DocumentClient.ConnectionPolicy.UserAgentContainer.UserAgent.Split('|')[2])).ToList();
+                        int.Parse(r.Result.DocumentClient.ConnectionPolicy.UserAgentContainer.UserAgent.Split('|')[1])).ToList();
             actual.Sort();
             CollectionAssert.AreEqual(expected, actual);
         }
@@ -405,7 +405,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             Cosmos.UserAgentContainer userAgentContainer = client.ClientOptions.GetConnectionPolicy(client.ClientId).UserAgentContainer;
             string userAgentString = userAgentContainer.UserAgent;
-            string clientId = userAgentString.Split('|')[2];
+            string clientId = userAgentString.Split('|')[1];
             return clientId;
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Remove direct version from user agent to as it is unnecessary. The direct version dll is copied into the nuget folder rather than being referenced as a nuget so customers can not change it.

## Type of change
- New feature (non-breaking change which adds functionality)


## Closing issues
closes #3160