### PR TITLE
fix: Ensure that we don't crash when attempting to generate SQL for a LINQ expression which performs static field or property access

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestMemberAccess.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestMemberAccess.xml
@@ -35,4 +35,40 @@ FROM root
 WHERE (root["NumericField"] = 3)]]></SqlQuery>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Filter on Static Field value]]></Description>
+      <Expression><![CDATA[query.Where(doc => (doc.NumericField == AmbientContextObject.StaticFieldAccess))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE (root["NumericField"] = 4)]]></SqlQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Filter on Static Property value]]></Description>
+      <Expression><![CDATA[query.Where(doc => (doc.NumericField == AmbientContextObject.StaticPropertyAccess))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE (root["NumericField"] = 5)]]></SqlQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Filter on Const value]]></Description>
+      <Expression><![CDATA[query.Where(doc => (doc.NumericField == 6))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE (root["NumericField"] = 6)]]></SqlQuery>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqTranslationBaselineTests.cs
@@ -151,7 +151,16 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
             public double PropertyAccess { get; set; }
 
-            public double MethodAccess() => 1.0;
+            public double MethodAccess()
+            {
+                return 1.0;
+            }
+
+            public static double StaticFieldAccess = 4.0;
+
+            public static double StaticPropertyAccess => 5.0;
+
+            public const double ConstAccess = 6.0;
         }
 
         [TestMethod]
@@ -560,6 +569,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 // performance boost, especially under highly concurrent workloads).
                 new LinqTestInput("Filter on Field value", b => getQuery(b).Where(doc => doc.NumericField == ambientContext.FieldAccess)),
                 new LinqTestInput("Filter on Property value", b => getQuery(b).Where(doc => doc.NumericField == ambientContext.PropertyAccess)),
+                new LinqTestInput("Filter on Static Field value", b => getQuery(b).Where(doc => doc.NumericField == AmbientContextObject.StaticFieldAccess)),
+                new LinqTestInput("Filter on Static Property value", b => getQuery(b).Where(doc => doc.NumericField == AmbientContextObject.StaticPropertyAccess)),
+                new LinqTestInput("Filter on Const value", b => getQuery(b).Where(doc => doc.NumericField == AmbientContextObject.ConstAccess)),
             };
             this.ExecuteTestSuite(inputs);
         }


### PR DESCRIPTION
## Description
This PR should fix the issue raised in #3188 in which attempts to access a static field or property (such as `DateTime.UtcNow`) within a LINQ-to-SQL expression will result in a `NullReferenceException`. It does so by correctly handling the presence of a `null` member expression when evaluating field and property access.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #3188