### PR TITLE
Diagnostics: Adds Application region into Client Configuration Trace

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                                                 cosmosClientContext.ClientOptions.AllowBulkExecution);
 
             this.ConsistencyConfig = new ConsistencyConfig(cosmosClientContext.ClientOptions.ConsistencyLevel,
-                                                    cosmosClientContext.ClientOptions.ApplicationPreferredRegions);
+                                                    cosmosClientContext.ClientOptions.ApplicationPreferredRegions, cosmosClientContext.ClientOptions.ApplicationRegion);
 
             this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
             this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ConsistencyConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ConsistencyConfig.cs
@@ -12,19 +12,23 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
     {
         public ConsistencyConfig(
             ConsistencyLevel? consistencyLevel,
-            IReadOnlyList<string> preferredRegions)
+            IReadOnlyList<string> preferredRegions,
+            string applicationRegion)
         {
             this.ConsistencyLevel = consistencyLevel;
             this.PreferredRegions = preferredRegions;
+            this.ApplicationRegion = applicationRegion;
             this.lazyString = new Lazy<string>(() => string.Format(CultureInfo.InvariantCulture,
-                                "(consistency: {0}, prgns:[{1}])",
+                                "(consistency: {0}, prgns:[{1}], apprgn: {2})",
                                 consistencyLevel?.ToString() ?? "NotSet",
-                                ConsistencyConfig.PreferredRegionsInternal(preferredRegions)));
+                                ConsistencyConfig.PreferredRegionsInternal(preferredRegions),
+                                applicationRegion));
             this.lazyJsonString = new Lazy<string>(() => Newtonsoft.Json.JsonConvert.SerializeObject(this));
         }
 
         public ConsistencyLevel? ConsistencyLevel { get; }
         public IReadOnlyList<string> PreferredRegions { get; }
+        public string ApplicationRegion { get; }
 
         private readonly Lazy<string> lazyString;
         private readonly Lazy<string> lazyJsonString;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -86,6 +86,7 @@
 
             ClientConfigurationTraceDatum clientConfig = new ClientConfigurationTraceDatum(context, DateTime.UtcNow);
             Assert.AreEqual(clientConfig.ConsistencyConfig.ApplicationRegion, "East US");
+            Assert.IsNull(clientConfig.ConsistencyConfig.PreferredRegions);
 
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -81,14 +81,16 @@
         {
             List<string> preferredRegions = new List<string> { "EastUS", "WestUs" };
             ConsistencyLevel consistencyLevel = ConsistencyLevel.Session;
+            string appRegion = "EastUS";
 
-            ConsistencyConfig consistencyConfig = new ConsistencyConfig(consistencyLevel, preferredRegions);
-            Assert.AreEqual(consistencyConfig.ToString(), "(consistency: Session, prgns:[EastUS, WestUs])");
+            ConsistencyConfig consistencyConfig = new ConsistencyConfig(consistencyLevel, preferredRegions, appRegion);
+            Assert.AreEqual(consistencyConfig.ToString(), "(consistency: Session, prgns:[EastUS, WestUs], apprgn: EastUS)");
 
             ConsistencyConfig consistencyConfigWithNull = new ConsistencyConfig(consistencyLevel: null,
-                                                                                preferredRegions: null);
+                                                                                preferredRegions: null,
+                                                                                applicationRegion: null);
 
-            Assert.AreEqual(consistencyConfigWithNull.ToString(), "(consistency: NotSet, prgns:[])");
+            Assert.AreEqual(consistencyConfigWithNull.ToString(), "(consistency: NotSet, prgns:[], apprgn: )");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -74,6 +74,19 @@
 
             ConsistencyConfig consistencyConfig = cosmosClient.ClientConfigurationTraceDatum.ConsistencyConfig;
             Assert.AreEqual(consistencyConfig.ConsistencyLevel.Value, ConsistencyLevel.Session);
+
+            CosmosClientOptions clientOptions = new CosmosClientOptions 
+            {
+                ApplicationRegion = "East US"
+            };
+
+            CosmosClientContext context = ClientContextCore.Create(
+                cosmosClient,
+                clientOptions);
+
+            ClientConfigurationTraceDatum clientConfig = new ClientConfigurationTraceDatum(context, DateTime.UtcNow);
+            Assert.AreEqual(clientConfig.ConsistencyConfig.ApplicationRegion, "East US");
+
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description
Logs the application region into the client configuration trace for diagnostics.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues
closes #3198