### PR TITLE
HttpRetryPolicy: Fixes Request Timeout configuration in HttpTimeoutPolicyNoRetry

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Cosmos
                             return responseMessage;
                         }
 
-                        bool isOutOfRetries = CosmosHttpClientCore.IsOutOfRetries(timeoutPolicy, startDateTimeUtc, timeoutEnumerator);
+                        bool isOutOfRetries = timeoutPolicy is HttpTimeoutPolicyNoRetry || CosmosHttpClientCore.IsOutOfRetries(timeoutPolicy, startDateTimeUtc, timeoutEnumerator);
                         if (isOutOfRetries)
                         {
                             return responseMessage;

--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Cosmos
                             return responseMessage;
                         }
 
-                        bool isOutOfRetries = timeoutPolicy is HttpTimeoutPolicyNoRetry || CosmosHttpClientCore.IsOutOfRetries(timeoutPolicy, startDateTimeUtc, timeoutEnumerator);
+                        bool isOutOfRetries = CosmosHttpClientCore.IsOutOfRetries(timeoutPolicy, startDateTimeUtc, timeoutEnumerator);
                         if (isOutOfRetries)
                         {
                             return responseMessage;

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyNoRetry.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyNoRetry.cs
@@ -17,7 +17,10 @@ namespace Microsoft.Azure.Cosmos
         {
         }
 
-        private readonly IReadOnlyList<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> TimeoutsAndDelays = new List<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)>();
+        private readonly IReadOnlyList<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> TimeoutsAndDelays = new List<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)>()
+        {
+            (TimeSpan.FromSeconds(65), TimeSpan.Zero)
+        };
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyNoRetry.Name;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosHttpClientCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosHttpClientCoreTests.cs
@@ -265,6 +265,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             int count = 0;
             async Task<HttpResponseMessage> sendFunc(HttpRequestMessage request, CancellationToken cancellationToken)
             {
+                if(count == 0)
+                {
+                    Assert.IsFalse(cancellationToken.IsCancellationRequested);
+                }
                 count++;
 
                 throw new OperationCanceledException("API with exception");


### PR DESCRIPTION
## Description

Right Now, NoRetry policy does not have request timeout value which is leading to request cancellation. Fixing this issue as part this PR.


## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
