### PR TITLE
[CosmosDB] Fixes Azure/azure-sdk-for-net#28906

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -845,7 +845,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// ItemResponse item = await this.container.DeleteItemAsync<ToDoActivity>("partitionKey", "id");
+        /// ItemResponse item = await this.container.DeleteItemAsync<ToDoActivity>("id", "partitionKey");
         /// ]]>
         /// </code>
         /// </example>


### PR DESCRIPTION
The id and partition key arguments are swapped in the code sample. It should be id, partitionkey, not vice versa.

Content: https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.container.deleteitemasync

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber