### PR TITLE
Client Telemetry: Adds Assertion message to the test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -172,12 +172,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestCleanup]
         public async Task Cleanup()
         {
-            var isInitializedField = typeof(VmMetadataApiHandler).GetField("isInitialized",
+            FieldInfo isInitializedField = typeof(VmMetadataApiHandler).GetField("isInitialized",
                BindingFlags.Static |
                BindingFlags.NonPublic);
             isInitializedField.SetValue(null, false);
 
-            var azMetadataField = typeof(VmMetadataApiHandler).GetField("azMetadata",
+            FieldInfo azMetadataField = typeof(VmMetadataApiHandler).GetField("azMetadata",
                BindingFlags.Static |
                BindingFlags.NonPublic);
             azMetadataField.SetValue(null, null);
@@ -944,17 +944,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             }
 
-            Assert.AreEqual(1, machineId.Count);
+            Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
 
             if(isAzureInstance.HasValue)
             {
                 if (isAzureInstance.Value)
                 {
-                    Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.ToList()[0]);
+                    Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
                 else
                 {
-                    Assert.AreNotEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.ToList()[0]);
+                    Assert.AreNotEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
             }
 


### PR DESCRIPTION
## Description

We have Flaky test failure in Client Telemetry Test. Adding assertion message in order to get clear picture what really happening in pipeline. As this issue is not replicating in local.