### PR TITLE
[INTERNAL] Tests: Fixes ChangeFeedAsync test

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseConverter.cs
@@ -58,13 +58,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             if (value is DocumentServiceLeaseCore documentServiceLeaseCore)
             {
                 serializer.ContractResolver.ResolveContract(typeof(DocumentServiceLeaseCore)).Converter = null;
-                serializer.Serialize(writer, documentServiceLeaseCore);
+                serializer.Serialize(writer, documentServiceLeaseCore, typeof(DocumentServiceLeaseCore));
             }
 
             if (value is DocumentServiceLeaseCoreEpk documentServiceLeaseCoreEpk)
             {
                 serializer.ContractResolver.ResolveContract(typeof(DocumentServiceLeaseCoreEpk)).Converter = null;
-                serializer.Serialize(writer, documentServiceLeaseCoreEpk);
+                serializer.Serialize(writer, documentServiceLeaseCoreEpk, typeof(DocumentServiceLeaseCoreEpk));
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -313,7 +313,19 @@
                 await processor.StartAsync();
 
                 // Letting processor initialize
-                await Task.Delay(2000);
+                bool hasLeases = false;
+                while (!hasLeases)
+                {
+                    int leases = leaseContainer.GetItemLinqQueryable<JObject>(true).Count();
+                    if (leases > 1)
+                    {
+                        hasLeases = true;
+                    }
+                    else
+                    {
+                        await Task.Delay(1000);
+                    }
+                }
 
                 await processor.StopAsync();
 


### PR DESCRIPTION
The error in https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3221 points to a circular reference, but the type in itself has no circular references.

The only potential cause is that the Converter is at the abstract class level and not on the dedicated type. To remove the potential mixup, this PR adds the specific type to the the .`Serialize` call.

It also removes the time-bound dependency from the test, waiting 2 seconds is random and the initialization under resource constraints could take longer (depending on how stressed are the test machines).

Closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3221