### PR TITLE
LINQ: preserve DateTime.Kind when passing to custom JsonConverter

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     else if (memberType == typeof(DateTime))
                     {
                         SqlStringLiteral serializedDateTime = (SqlStringLiteral)right.Literal;
-                        value = DateTime.Parse(serializedDateTime.Value);
+                        value = DateTime.Parse(serializedDateTime.Value, null, DateTimeStyles.RoundtripKind);
                     }
 
                     if (value != default(object))


### PR DESCRIPTION
## Description

This commit updates `ExpressionToSql.ApplyCustomConverter` to preserve the `DateTimeKind` when parsing a `DateTime` that is passed to a custom `JsonConverter`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #3222