### PR TITLE
Query: Fixes DllNotFoundException when running on Windows/x64

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Cosmos
             ServiceInteropWrapper.AssembliesExist = new Lazy<bool>(() =>
             {
                 // Attemp to create an instance of the ServiceInterop assembly
-                TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.CreateServiceProvider("{}");
+                TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.TryCreateServiceProvider("{}");
                 if (tryCreateServiceProvider.Failed)
                 {
                     // Failed, either the DLL is not present or one of its dependencies

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
     using System.Linq;
     using System.Runtime.InteropServices;
     using System.Text;
+    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Routing;
@@ -290,11 +291,17 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                                 queryEngineConfiguration,
                                 out serviceProvider);
                 Exception exception = Marshal.GetExceptionForHR((int)errorCode);
-                if (exception != null) return TryCatch<IntPtr>.FromException(exception);
+                if (exception != null)
+                {
+                    DefaultTrace.TraceWarning("QueryPartitionProvider.TryCreateServiceProvider failed with exception {0}", exception);
+                    return TryCatch<IntPtr>.FromException(exception);
+                }
+                
                 return TryCatch<IntPtr>.FromResult(serviceProvider);
             }
             catch (Exception ex)
             {
+                DefaultTrace.TraceWarning("QueryPartitionProvider.TryCreateServiceProvider failed with exception {0}", ex);
                 return TryCatch<IntPtr>.FromException(ex);
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             return TryCatch<PartitionedQueryExecutionInfoInternal>.FromResult(queryInfoInternal);
         }
 
-        internal static TryCatch<IntPtr> CreateServiceProvider(string queryEngineConfiguration)
+        internal static TryCatch<IntPtr> TryCreateServiceProvider(string queryEngineConfiguration)
         {
             try
             {
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                                 queryEngineConfiguration,
                                 out serviceProvider);
                 Exception exception = Marshal.GetExceptionForHR((int)errorCode);
-                if (exception != null) throw exception;
+                if (exception != null) return TryCatch<IntPtr>.FromException(exception);
                 return TryCatch<IntPtr>.FromResult(serviceProvider);
             }
             catch (Exception ex)
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     {
                         if (!this.disposed && this.serviceProvider == IntPtr.Zero)
                         {
-                            TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.CreateServiceProvider(this.queryengineConfiguration);
+                            TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.TryCreateServiceProvider(this.queryengineConfiguration);
                             if (tryCreateServiceProvider.Failed)
                             {
                                 throw ExceptionWithStackTraceException.UnWrapMonadExcepion(tryCreateServiceProvider.Exception, NoOpTrace.Singleton);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
     using System;
+    using System.Runtime.InteropServices;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
@@ -116,6 +117,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
             using (ITrace gatewayQueryPlanTrace = trace.StartChild("Gateway QueryPlan", TraceComponent.Query, TraceLevel.Info))
             {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                            && Documents.ServiceInteropWrapper.Is64BitProcess)
+                {
+                    // It's Windows and x64, should have loaded the DLL
+                    gatewayQueryPlanTrace.AddDatum("ServiceInterop unavailable", true);
+                }
+                
                 return queryContext.ExecuteQueryPlanRequestAsync(
                     resourceLink,
                     ResourceType.Document,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
@@ -2924,6 +2924,7 @@
     }
 
     ITrace traceForest = TraceJoiner.JoinTraces(traces);
+    Documents.ServiceInteropWrapper.AssembliesExist = currentLazy;
 ]]></Setup>
     </Input>
     <Output>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.QueryAsync.xml
@@ -2905,4 +2905,823 @@
 }]]></Json>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description>Query - Without ServiceInterop</Description>
+      <Setup><![CDATA[
+    Lazy<bool> currentLazy = Documents.ServiceInteropWrapper.AssembliesExist;
+    Documents.ServiceInteropWrapper.AssembliesExist = new Lazy<bool>(() => false);
+    FeedIterator<JToken> feedIterator = container.GetItemQueryIterator<JToken>(
+        queryText: "SELECT * FROM c");
+
+    List<ITrace> traces = new List<ITrace>();
+
+    while (feedIterator.HasMoreResults)
+    {
+        FeedResponse<JToken> responseMessage = await feedIterator.ReadNextAsync(cancellationToken: default);
+        ITrace trace = ((CosmosTraceDiagnostics)responseMessage.Diagnostics).Value;
+        traces.Add(trace);
+    }
+
+    ITrace traceForest = TraceJoiner.JoinTraces(traces);
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace Forest(00000000-0000-0000-0000-000000000000)  Unknown-Component  12:00:00:000  0.00 milliseconds  
+    ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │       [Query Correlated ActivityId]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── Create Query Pipeline(00000000-0000-0000-0000-000000000000)  Query-Component  12:00:00:000  0.00 milliseconds  
+    │   │   ├── Get Container Properties(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │   └── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │   ├── Gateway QueryPlan(00000000-0000-0000-0000-000000000000)  Query-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │       (
+    │   │   │           [ServiceInterop unavailable]
+    │   │   │           Redacted To Not Change The Baselines From Run To Run
+    │   │   │       )
+    │   │   ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │       │   (
+    │   │   │       │       [System Info]
+    │   │   │       │       Redacted To Not Change The Baselines From Run To Run
+    │   │   │       │   )
+    │   │   │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │                   └── Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │   │                           (
+    │   │   │                               [Client Side Request Stats]
+    │   │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │   │                               [PointOperationStatisticsTraceDatum]
+    │   │   │                               Redacted To Not Change The Baselines From Run To Run
+    │   │   │                           )
+    │   │   └── Get Partition Key Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │       └── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │   ├── Prefetching(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │   └── [,05C1CFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │       └── Prefetch(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │           └── [,05C1CFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   (
+    │   │               │       [Query Metrics]
+    │   │               │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │   )
+    │   │               ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │       │   (
+    │   │               │       │       [System Info]
+    │   │               │       │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │       │   )
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
+    │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  12:00:00:000  0.00 milliseconds  
+    │   └── Query Response Serialization(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │       [Query Correlated ActivityId]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │   └── [05C1CFFFFFFFF8,05C1DFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │       └── Prefetch(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │           └── [05C1CFFFFFFFF8,05C1DFFFFFFFF8) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   (
+    │   │               │       [Query Metrics]
+    │   │               │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │   )
+    │   │               ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │       │   (
+    │   │               │       │       [System Info]
+    │   │               │       │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │       │   )
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
+    │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  12:00:00:000  0.00 milliseconds  
+    │   └── Query Response Serialization(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    ├── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │   (
+    │   │       [Client Configuration]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │       [Query Correlated ActivityId]
+    │   │       Redacted To Not Change The Baselines From Run To Run
+    │   │   )
+    │   ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │   └── [05C1DFFFFFFFF8,05C1E7FFFFFFFA) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │       └── Prefetch(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │           └── [05C1DFFFFFFFF8,05C1E7FFFFFFFA) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   (
+    │   │               │       [Query Metrics]
+    │   │               │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │   )
+    │   │               ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │       │   (
+    │   │               │       │       [System Info]
+    │   │               │       │       Redacted To Not Change The Baselines From Run To Run
+    │   │               │       │   )
+    │   │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    │   │               │                           (
+    │   │               │                               [Client Side Request Stats]
+    │   │               │                               Redacted To Not Change The Baselines From Run To Run
+    │   │               │                           )
+    │   │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  12:00:00:000  0.00 milliseconds  
+    │   └── Query Response Serialization(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+    └── Typed FeedIterator ReadNextAsync(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+        │   (
+        │       [Client Configuration]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │       [Query Correlated ActivityId]
+        │       Redacted To Not Change The Baselines From Run To Run
+        │   )
+        ├── MoveNextAsync(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+        │   └── [05C1E7FFFFFFFA,FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+        │       └── Prefetch(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+        │           └── [05C1E7FFFFFFFA,FF) move next(00000000-0000-0000-0000-000000000000)  Pagination-Component  12:00:00:000  0.00 milliseconds  
+        │               │   (
+        │               │       [Query Metrics]
+        │               │       Redacted To Not Change The Baselines From Run To Run
+        │               │   )
+        │               ├── Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+        │               │   ├── Get Collection Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+        │               │   ├── Get Partition Key Range Cache(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+        │               │   ├── Try Get Overlapping Ranges(00000000-0000-0000-0000-000000000000)  Routing-Component  12:00:00:000  0.00 milliseconds  
+        │               │   └── Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+        │               │       │   (
+        │               │       │       [System Info]
+        │               │       │       Redacted To Not Change The Baselines From Run To Run
+        │               │       │   )
+        │               │       └── Microsoft.Azure.Cosmos.Handlers.RetryHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+        │               │           └── Microsoft.Azure.Cosmos.Handlers.RouterHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+        │               │               └── Microsoft.Azure.Cosmos.Handlers.TransportHandler(00000000-0000-0000-0000-000000000000)  RequestHandler-Component  12:00:00:000  0.00 milliseconds  
+        │               │                   └── Microsoft.Azure.Documents.ServerStoreModel Transport Request(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+        │               │                           (
+        │               │                               [Client Side Request Stats]
+        │               │                               Redacted To Not Change The Baselines From Run To Run
+        │               │                           )
+        │               └── Get Cosmos Element Response(00000000-0000-0000-0000-000000000000)  Json-Component  12:00:00:000  0.00 milliseconds  
+        └── Query Response Serialization(00000000-0000-0000-0000-000000000000)  Transport-Component  12:00:00:000  0.00 milliseconds  
+]]></Text>
+      <Json><![CDATA[{
+  "Summary": {},
+  "name": "Trace Forest",
+  "id": "00000000-0000-0000-0000-000000000000",
+  "start time": "12:00:00:000",
+  "duration in milliseconds": 0,
+  "children": [
+    {
+      "name": "Typed FeedIterator ReadNextAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run",
+        "Query Correlated ActivityId": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "Create Query Pipeline",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "Get Container Properties",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Get Collection Cache",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0
+                }
+              ]
+            },
+            {
+              "name": "Gateway QueryPlan",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "data": {
+                "ServiceInterop unavailable": "Redacted To Not Change The Baselines From Run To Run"
+              }
+            },
+            {
+              "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "data": {
+                    "System Info": "Redacted To Not Change The Baselines From Run To Run"
+                  },
+                  "children": [
+                    {
+                      "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "children": [
+                                {
+                                  "name": "Microsoft.Azure.Cosmos.GatewayStoreModel Transport Request",
+                                  "id": "00000000-0000-0000-0000-000000000000",
+                                  "start time": "12:00:00:000",
+                                  "duration in milliseconds": 0,
+                                  "data": {
+                                    "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run",
+                                    "PointOperationStatisticsTraceDatum": "Redacted To Not Change The Baselines From Run To Run"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "name": "Get Partition Key Ranges",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Try Get Overlapping Ranges",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "MoveNextAsync",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "Prefetching",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0
+            },
+            {
+              "name": "[,05C1CFFFFFFFF8) move next",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Prefetch",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "children": [
+                    {
+                      "name": "[,05C1CFFFFFFFF8) move next",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {
+                        "Query Metrics": "Redacted To Not Change The Baselines From Run To Run"
+                      },
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Get Collection Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Get Partition Key Range Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Try Get Overlapping Ranges",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "System Info": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": [
+                                {
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+                                  "id": "00000000-0000-0000-0000-000000000000",
+                                  "start time": "12:00:00:000",
+                                  "duration in milliseconds": 0,
+                                  "children": [
+                                    {
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                                      "id": "00000000-0000-0000-0000-000000000000",
+                                      "start time": "12:00:00:000",
+                                      "duration in milliseconds": 0,
+                                      "children": [
+                                        {
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                                          "id": "00000000-0000-0000-0000-000000000000",
+                                          "start time": "12:00:00:000",
+                                          "duration in milliseconds": 0,
+                                          "children": [
+                                            {
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                                              "id": "00000000-0000-0000-0000-000000000000",
+                                              "start time": "12:00:00:000",
+                                              "duration in milliseconds": 0,
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "Get Cosmos Element Response",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Query Response Serialization",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    },
+    {
+      "name": "Typed FeedIterator ReadNextAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run",
+        "Query Correlated ActivityId": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "MoveNextAsync",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "[05C1CFFFFFFFF8,05C1DFFFFFFFF8) move next",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Prefetch",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "children": [
+                    {
+                      "name": "[05C1CFFFFFFFF8,05C1DFFFFFFFF8) move next",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {
+                        "Query Metrics": "Redacted To Not Change The Baselines From Run To Run"
+                      },
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Get Collection Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Get Partition Key Range Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Try Get Overlapping Ranges",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "System Info": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": [
+                                {
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+                                  "id": "00000000-0000-0000-0000-000000000000",
+                                  "start time": "12:00:00:000",
+                                  "duration in milliseconds": 0,
+                                  "children": [
+                                    {
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                                      "id": "00000000-0000-0000-0000-000000000000",
+                                      "start time": "12:00:00:000",
+                                      "duration in milliseconds": 0,
+                                      "children": [
+                                        {
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                                          "id": "00000000-0000-0000-0000-000000000000",
+                                          "start time": "12:00:00:000",
+                                          "duration in milliseconds": 0,
+                                          "children": [
+                                            {
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                                              "id": "00000000-0000-0000-0000-000000000000",
+                                              "start time": "12:00:00:000",
+                                              "duration in milliseconds": 0,
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "Get Cosmos Element Response",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Query Response Serialization",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    },
+    {
+      "name": "Typed FeedIterator ReadNextAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run",
+        "Query Correlated ActivityId": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "MoveNextAsync",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "[05C1DFFFFFFFF8,05C1E7FFFFFFFA) move next",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Prefetch",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "children": [
+                    {
+                      "name": "[05C1DFFFFFFFF8,05C1E7FFFFFFFA) move next",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {
+                        "Query Metrics": "Redacted To Not Change The Baselines From Run To Run"
+                      },
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Get Collection Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Get Partition Key Range Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Try Get Overlapping Ranges",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "System Info": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": [
+                                {
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+                                  "id": "00000000-0000-0000-0000-000000000000",
+                                  "start time": "12:00:00:000",
+                                  "duration in milliseconds": 0,
+                                  "children": [
+                                    {
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                                      "id": "00000000-0000-0000-0000-000000000000",
+                                      "start time": "12:00:00:000",
+                                      "duration in milliseconds": 0,
+                                      "children": [
+                                        {
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                                          "id": "00000000-0000-0000-0000-000000000000",
+                                          "start time": "12:00:00:000",
+                                          "duration in milliseconds": 0,
+                                          "children": [
+                                            {
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                                              "id": "00000000-0000-0000-0000-000000000000",
+                                              "start time": "12:00:00:000",
+                                              "duration in milliseconds": 0,
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "Get Cosmos Element Response",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Query Response Serialization",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    },
+    {
+      "name": "Typed FeedIterator ReadNextAsync",
+      "id": "00000000-0000-0000-0000-000000000000",
+      "start time": "12:00:00:000",
+      "duration in milliseconds": 0,
+      "data": {
+        "Client Configuration": "Redacted To Not Change The Baselines From Run To Run",
+        "Query Correlated ActivityId": "Redacted To Not Change The Baselines From Run To Run"
+      },
+      "children": [
+        {
+          "name": "MoveNextAsync",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0,
+          "children": [
+            {
+              "name": "[05C1E7FFFFFFFA,FF) move next",
+              "id": "00000000-0000-0000-0000-000000000000",
+              "start time": "12:00:00:000",
+              "duration in milliseconds": 0,
+              "children": [
+                {
+                  "name": "Prefetch",
+                  "id": "00000000-0000-0000-0000-000000000000",
+                  "start time": "12:00:00:000",
+                  "duration in milliseconds": 0,
+                  "children": [
+                    {
+                      "name": "[05C1E7FFFFFFFA,FF) move next",
+                      "id": "00000000-0000-0000-0000-000000000000",
+                      "start time": "12:00:00:000",
+                      "duration in milliseconds": 0,
+                      "data": {
+                        "Query Metrics": "Redacted To Not Change The Baselines From Run To Run"
+                      },
+                      "children": [
+                        {
+                          "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0,
+                          "children": [
+                            {
+                              "name": "Get Collection Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Get Partition Key Range Cache",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Try Get Overlapping Ranges",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0
+                            },
+                            {
+                              "name": "Microsoft.Azure.Cosmos.Handlers.DiagnosticsHandler",
+                              "id": "00000000-0000-0000-0000-000000000000",
+                              "start time": "12:00:00:000",
+                              "duration in milliseconds": 0,
+                              "data": {
+                                "System Info": "Redacted To Not Change The Baselines From Run To Run"
+                              },
+                              "children": [
+                                {
+                                  "name": "Microsoft.Azure.Cosmos.Handlers.RetryHandler",
+                                  "id": "00000000-0000-0000-0000-000000000000",
+                                  "start time": "12:00:00:000",
+                                  "duration in milliseconds": 0,
+                                  "children": [
+                                    {
+                                      "name": "Microsoft.Azure.Cosmos.Handlers.RouterHandler",
+                                      "id": "00000000-0000-0000-0000-000000000000",
+                                      "start time": "12:00:00:000",
+                                      "duration in milliseconds": 0,
+                                      "children": [
+                                        {
+                                          "name": "Microsoft.Azure.Cosmos.Handlers.TransportHandler",
+                                          "id": "00000000-0000-0000-0000-000000000000",
+                                          "start time": "12:00:00:000",
+                                          "duration in milliseconds": 0,
+                                          "children": [
+                                            {
+                                              "name": "Microsoft.Azure.Documents.ServerStoreModel Transport Request",
+                                              "id": "00000000-0000-0000-0000-000000000000",
+                                              "start time": "12:00:00:000",
+                                              "duration in milliseconds": 0,
+                                              "data": {
+                                                "Client Side Request Stats": "Redacted To Not Change The Baselines From Run To Run"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "name": "Get Cosmos Element Response",
+                          "id": "00000000-0000-0000-0000-000000000000",
+                          "start time": "12:00:00:000",
+                          "duration in milliseconds": 0
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Query Response Serialization",
+          "id": "00000000-0000-0000-0000-000000000000",
+          "start time": "12:00:00:000",
+          "duration in milliseconds": 0
+        }
+      ]
+    }
+  ]
+}]]></Json>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.Contracts
             IntPtr provider;
             TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.CreateServiceProvider(configJson);
             Assert.IsFalse(tryCreateServiceProvider.Failed);
+            // Don't leak on tests
             Marshal.Release(tryCreateServiceProvider.Result);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
@@ -9,8 +9,11 @@ namespace Microsoft.Azure.Cosmos.Contracts
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Runtime.InteropServices;
     using System.Text;
     using System.Text.RegularExpressions;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -35,7 +38,9 @@ namespace Microsoft.Azure.Cosmos.Contracts
 
             string configJson = "{}";
             IntPtr provider;
-            uint result = ServiceInteropWrapper.CreateServiceProvider(configJson, out provider);
+            TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.CreateServiceProvider(configJson);
+            Assert.IsFalse(tryCreateServiceProvider.Failed);
+            Marshal.Release(tryCreateServiceProvider.Result);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DirectContractTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Contracts
 
             string configJson = "{}";
             IntPtr provider;
-            TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.CreateServiceProvider(configJson);
+            TryCatch<IntPtr> tryCreateServiceProvider = QueryPartitionProvider.TryCreateServiceProvider(configJson);
             Assert.IsFalse(tryCreateServiceProvider.Failed);
             // Don't leak on tests
             Marshal.Release(tryCreateServiceProvider.Result);


### PR DESCRIPTION
## Problem

This PR changes the behavior of the SDK on **Windows/x64** scenarios when the ServiceInterop.dll is not available.

Currently when it is not available, we throw:

```
Unhandled exception. System.DllNotFoundException: Unable to load DLL 'Microsoft.Azure.Cosmos.ServiceInterop.dll' or one of its dependencies: The specified module could not be found. (0x8007007E)
   at Microsoft.Azure.Documents.ServiceInteropWrapper.CreateServiceProvider(String configJsonString, IntPtr& serviceProvider)
   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.Initialize()
   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfoInternal(String querySpecJsonString, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)
   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPartitionProvider.TryGetPartitionedQueryExecutionInfo(String querySpecJsonString, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount)
   at Microsoft.Azure.Cosmos.CosmosQueryClientCore.TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, ResourceType resourceType, PartitionKeyDefinition partitionKeyDefinition, Boolean requireFormattableOrderByQuery, Boolean isContinuationExpected, Boolean allowNonValueAggregateQuery, Boolean hasLogicalPartitionKey, Boolean allowDCount, CancellationToken cancellationToken)
   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPlanHandler.TryGetQueryPlanAsync(SqlQuerySpec sqlQuerySpec, ResourceType resourceType, PartitionKeyDefinition partitionKeyDefinition, QueryFeatures supportedQueryFeatures, Boolean hasLogicalPartitionKey, CancellationToken cancellationToken)
   at Microsoft.Azure.Cosmos.Query.Core.QueryPlan.QueryPlanRetriever.GetQueryPlanWithServiceInteropAsync(CosmosQueryClient queryClient, SqlQuerySpec sqlQuerySpec, ResourceType resourceType, PartitionKeyDefinition partitionKeyDefinition, Boolean hasLogicalPartitionKey, ITrace trace, CancellationToken cancellationToken)
   at Microsoft.Azure.Cosmos.Query.Core.ExecutionContext.CosmosQueryExecutionContextFactory.TryCreateCoreContextAsync(DocumentContainer documentContainer, CosmosQueryContext cosmosQueryContext, InputParameters inputParameters, ITrace trace, CancellationToken cancellationToken)
```

Customers can only fix this by correctly placing the ServiceInterop.dll and its dependencies, on the expected folder (same as SDK DLL).

There are however, some customers for which this is impossible due to deployment constraints (for example, they cannot deploy or pack native DLLs like ServiceInterop).

## Proposed solution

This is one of the proposed solutions in https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3225 - Automatic fallback.

The SDK will now automatically fallback to Gateway mode if the DLLs are not available on Windows x64. 

This obviously poses a latency/performance issue for the user. 

This PR adds this information on the diagnostics:

```
{
	"name": "Gateway QueryPlan",
	"id": "1ffd15dd-6d0f-418d-93e6-9fbbd0d75065",
	"start time": "09:36:54:025",
	"duration in milliseconds": 27.1973,
	"data": {
		"ServiceInterop unavailable": "True"
	}
},
```

Which with the right documentation enables users (and automation) to detect the case and understand how to mitigate it (copy the DLLs) if possible. If they can't, they are not broken, but know what is the reason.

## Closing issues

Closes #3225
Closes #2366