### PR TITLE
Telemetry: Fixes Trace error when not using Azure VMs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -899,7 +899,7 @@ namespace Microsoft.Azure.Cosmos
                 this.receivedResponse);
 
             // Loading VM Information (non blocking call and initialization won't fail if this call fails)
-            Task task = VmMetadataApiHandler.TryInitializeAsync(this.httpClient);
+            VmMetadataApiHandler.TryInitialize(this.httpClient);
 
             if (sessionContainer != null)
             {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -899,7 +899,7 @@ namespace Microsoft.Azure.Cosmos
                 this.receivedResponse);
 
             // Loading VM Information (non blocking call and initialization won't fail if this call fails)
-            VmMetadataApiHandler.TryInitialize(this.httpClient);
+            Task task = VmMetadataApiHandler.TryInitializeAsync(this.httpClient);
 
             if (sessionContainer != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -44,9 +44,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 DefaultTrace.TraceInformation("Initializing VM Metadata API ");
 
                 VmMetadataApiHandler.isInitialized = true;
+
+                _ = Task.Run(() => MetadataApiCallAsync(httpClient), default);
             }
 
-            _ = Task.Run(() => MetadataApiCallAsync(httpClient), default);
         }
 
         private static async Task MetadataApiCallAsync(CosmosHttpClient httpClient)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -118,7 +118,6 @@ namespace Microsoft.Azure.Cosmos
 
             void TraceHandler(string message)
             {
-                Console.WriteLine(message);
                 if (message.Contains(expectedMsg))
                 {
                     manualResetEvent.Set();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
             HttpMessageHandler messageHandler = new MockMessageHandler(sendFunc);
             CosmosHttpClient cosmoshttpClient = MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler));
 
-            await VmMetadataApiHandler.TryInitializeAsync(cosmoshttpClient);
+            VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
             Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", VmMetadataApiHandler.GetMachineId());
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
             HttpMessageHandler messageHandler = new MockMessageHandler(sendFunc);
             CosmosHttpClient cosmoshttpClient = MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler));
 
-            await VmMetadataApiHandler.TryInitializeAsync(cosmoshttpClient);
+            VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
             Assert.AreEqual(expectedMachineId, VmMetadataApiHandler.GetMachineId());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
             HttpMessageHandler messageHandler = new MockMessageHandler(sendFunc);
             CosmosHttpClient cosmoshttpClient = MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler));
 
-            VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
+            await VmMetadataApiHandler.TryInitializeAsync(cosmoshttpClient);
 
             await Task.Delay(2000);
             Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", VmMetadataApiHandler.GetMachineId());
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
             HttpMessageHandler messageHandler = new MockMessageHandler(sendFunc);
             CosmosHttpClient cosmoshttpClient = MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler));
 
-            VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
+            await VmMetadataApiHandler.TryInitializeAsync(cosmoshttpClient);
 
             await Task.Delay(2000);
             Assert.AreEqual(expectedMachineId, VmMetadataApiHandler.GetMachineId());


### PR DESCRIPTION
# Pull Request Template

## Description

When a client is initialized without using an Azure VM, an exception is logged that causes confusion for the user. This PR fixes that by logging an informational message instead. It also refactors the use of ContinueWith with await/async in the relevant method.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #3220