### PR TITLE
Diagnostics: Adds Connection Mode to Client Configuration

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
             this.cachedSerializedJson = this.GetSerializedDatum();
             this.ProcessorCount = Environment.ProcessorCount;
+            this.ConnectionMode = cosmosClientContext.ClientOptions.ConnectionMode;
         }
 
         public DateTime ClientCreatedDateTimeUtc { get; }
@@ -46,6 +47,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         public ConsistencyConfig ConsistencyConfig { get; }
 
         public int ProcessorCount { get; }
+
+        public ConnectionMode ConnectionMode { get; }
 
         public ReadOnlyMemory<byte> SerializedJson
         {
@@ -91,6 +94,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             jsonTextWriter.WriteNumber64Value(this.cachedNumberOfClientCreated);
             jsonTextWriter.WriteFieldName("NumberOfActiveClients");
             jsonTextWriter.WriteNumber64Value(this.cachedNumberOfActiveClient);
+            jsonTextWriter.WriteFieldName("ConnectionMode");
+            jsonTextWriter.WriteStringValue(this.ConnectionMode.ToString());
             jsonTextWriter.WriteFieldName("User Agent");
             jsonTextWriter.WriteStringValue(this.cachedUserAgentString);
 

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
@@ -482,6 +482,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
                     stringBuilder.AppendLine($"Machine Id: {VmMetadataApiHandler.GetMachineId()}");
                     stringBuilder.AppendLine($"Number Of Clients Created: {CosmosClient.numberOfClientsCreated}");
                     stringBuilder.AppendLine($"Number Of Active Clients: {CosmosClient.NumberOfActiveClients}");
+                    stringBuilder.AppendLine($"Connection Mode: {clientConfigurationTraceDatum.ConnectionMode}");
                     stringBuilder.AppendLine($"User Agent: {clientConfigurationTraceDatum.UserAgentContainer.UserAgent}");
                     stringBuilder.AppendLine("Connection Config:");
                     stringBuilder.AppendLine($"{space}'gw': {clientConfigurationTraceDatum.GatewayConnectionConfig}");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -88,6 +89,13 @@
             Assert.AreEqual(clientConfig.ConsistencyConfig.ApplicationRegion, "East US");
             Assert.IsNull(clientConfig.ConsistencyConfig.PreferredRegions);
 
+            Assert.AreEqual(clientConfig.ConnectionMode, ConnectionMode.Direct);
+            clientOptions.ConnectionMode = ConnectionMode.Gateway;
+            context = ClientContextCore.Create(
+                cosmosClient,
+                clientOptions);
+            clientConfig = new ClientConfigurationTraceDatum(context, DateTime.UtcNow);
+            Assert.AreEqual(clientConfig.ConnectionMode, ConnectionMode.Gateway);
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

Adds Connection Mode into Client Configuration section of diagnostics to aid in troubleshooting and to be consistent with the Java SDK.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

closes #3230