### PR TITLE
Direct: Adds version 3.28.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.27.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.27.1</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.28.1</DirectVersion>
+		<DirectVersion>3.28.2</DirectVersion>
 		<EncryptionOfficialVersion>1.0.0</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>1.0.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview20</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExceptionToCosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExceptionToCosmosException.cs
@@ -115,9 +115,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core
 
             public override CosmosException Visit(MalformedContinuationTokenException malformedContinuationTokenException, ITrace trace)
             {
+                Headers headers = new Headers()
+                {
+                    SubStatusCode = Documents.SubStatusCodes.MalformedContinuationToken
+                }; 
                 return CosmosExceptionFactory.CreateBadRequestException(
                     message: malformedContinuationTokenException.Message,
-                    headers: new Headers(),
+                    headers: headers,
                     stackTrace: malformedContinuationTokenException.StackTrace,
                     innerException: malformedContinuationTokenException,
                     trace: trace);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -98,7 +98,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string message = responseMessage.ErrorMessage;
             Assert.AreEqual(message, responseMessage.CosmosException.Message);
             Assert.IsTrue(message.Contains($"ServiceUnavailable (503); Substatus: {(int)SubStatusCodes.Channel_Closed}; ActivityId:"));
-            Debug.WriteLine(message);
             Assert.IsTrue(message.Contains("Reason: (Channel is closed"), "Should contain exception message");
             string diagnostics = responseMessage.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TransportWrapperTests.cs
@@ -97,8 +97,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.ServiceUnavailable, responseMessage.StatusCode);
             string message = responseMessage.ErrorMessage;
             Assert.AreEqual(message, responseMessage.CosmosException.Message);
-            Assert.IsTrue(message.Contains($"ServiceUnavailable (503); Substatus: {(int)SubStatusCodes.TransportGenerated503}; ActivityId:"));
-            Assert.IsTrue(message.Contains("Reason: (Message: Channel is closed"), "Should contain exception message");
+            Assert.IsTrue(message.Contains($"ServiceUnavailable (503); Substatus: {(int)SubStatusCodes.Channel_Closed}; ActivityId:"));
+            Debug.WriteLine(message);
+            Assert.IsTrue(message.Contains("Reason: (Channel is closed"), "Should contain exception message");
             string diagnostics = responseMessage.Diagnostics.ToString();
             Assert.IsNotNull(diagnostics);
             Assert.IsTrue(diagnostics.Contains("TransportException: A client transport error occurred: The connection failed"));


### PR DESCRIPTION
## Description
* Adds Direct version 3.28.2 which targets the EN20220301 release branch.
* Diagnostics: Fixes Exception caused when checking OS version of some Android Devices. Closes #3249 
* MalformedContinuationTokenException: Adds the use of a new substatus code when throwing to programmatically determine the cause of the BadRequest. Closes #3074 
* Diagnostics: Fixes CPU NaN value causing broken json formatting on some devices. Closes #3235 
* ServiceUnavailableException: Adds custom messages corresponding to different substatus codes and Creates factory model for exception creation. Closes #3051 and Closes #3098

## Type of change
- [] New feature (non-breaking change which adds functionality)