### PR TITLE
CosmosClient Constructor: Fixes NullReferenceException when AzMetadata.Compute is null

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>machine id</returns>
         internal static string GetMachineId()
         {
-            if (VmMetadataApiHandler.azMetadata != null && VmMetadataApiHandler.azMetadata.Compute != null)
+            if (VmMetadataApiHandler.azMetadata?.Compute?.VMId != null)
             {
                 return VmMetadataApiHandler.azMetadata.Compute.VMId;
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>machine id</returns>
         internal static string GetMachineId()
         {
-            if (VmMetadataApiHandler.azMetadata?.Compute?.VMId != null)
+            if (!String.IsNullOrWhiteSpace(VmMetadataApiHandler.azMetadata?.Compute?.VMId))
             {
                 return VmMetadataApiHandler.azMetadata.Compute.VMId;
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>machine id</returns>
         internal static string GetMachineId()
         {
-            if (VmMetadataApiHandler.azMetadata != null)
+            if (VmMetadataApiHandler.azMetadata != null && VmMetadataApiHandler.azMetadata.Compute != null)
             {
                 return VmMetadataApiHandler.azMetadata.Compute.VMId;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -60,6 +60,30 @@ namespace Microsoft.Azure.Cosmos
         }
 
         [TestMethod]
+        public async Task GetVMMachineIdWithNullComputeTest()
+        {
+            static Task<HttpResponseMessage> sendFunc(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                object jsonObject = JsonConvert.DeserializeObject("{\"compute\":null}");
+                string payload = JsonConvert.SerializeObject(jsonObject);
+                HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(payload, Encoding.UTF8, "application/json")
+                };
+                return Task.FromResult(response);
+            }
+
+            HttpMessageHandler messageHandler = new MockMessageHandler(sendFunc);
+            CosmosHttpClient cosmoshttpClient = MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler));
+
+            VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
+
+            await Task.Delay(2000);
+            Assert.IsNull(VmMetadataApiHandler.GetMachineInfo());
+            Assert.IsNotNull(VmMetadataApiHandler.GetMachineId());
+        }
+
+        [TestMethod]
         public async Task GetHashedMachineNameAsMachineIdTest()
         {
             string expectedMachineId = "hashedMachineName:" + VmMetadataApiHandler.ComputeHash(Environment.MachineName);


### PR DESCRIPTION
# Pull Request Template

## Description

When AzMetadata.Compute is null for the VMMetadataApiHandler, the GetMachineId method does not work as intended. This PR fixes that to not allow a null reference to exist.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #3237 